### PR TITLE
fix(streaming): improve CLI output formatting and error propagation

### DIFF
--- a/src/maverick/agents/utils.py
+++ b/src/maverick/agents/utils.py
@@ -222,17 +222,17 @@ def _shorten_path(path: str, max_length: int = 50) -> str:
 
 # Tool emoji mapping for visual scanning in streaming output
 _TOOL_EMOJIS: dict[str, str] = {
-    "Read": "\U0001F4D6",  # 📖
-    "Write": "\U0001F4DD",  # 📝
-    "Edit": "\u270F\uFE0F",  # ✏️
-    "Glob": "\U0001F50D",  # 🔍
-    "Grep": "\U0001F50D",  # 🔍
-    "Bash": "\U0001F4BB",  # 💻
-    "Task": "\U0001F916",  # 🤖
-    "WebFetch": "\U0001F310",  # 🌐
-    "WebSearch": "\U0001F310",  # 🌐
+    "Read": "\U0001f4d6",  # 📖
+    "Write": "\U0001f4dd",  # 📝
+    "Edit": "\u270f\ufe0f",  # ✏️
+    "Glob": "\U0001f50d",  # 🔍
+    "Grep": "\U0001f50d",  # 🔍
+    "Bash": "\U0001f4bb",  # 💻
+    "Task": "\U0001f916",  # 🤖
+    "WebFetch": "\U0001f310",  # 🌐
+    "WebSearch": "\U0001f310",  # 🌐
 }
-_DEFAULT_TOOL_EMOJI = "\U0001F527"  # 🔧
+_DEFAULT_TOOL_EMOJI = "\U0001f527"  # 🔧
 
 
 def _format_tool_call(tool_name: str, tool_input: dict[str, Any]) -> str:

--- a/src/maverick/dsl/serialization/executor/handlers/agent_step.py
+++ b/src/maverick/dsl/serialization/executor/handlers/agent_step.py
@@ -141,14 +141,14 @@ async def execute_agent_step(
     if has_event_callback and has_stream_attr:
         # Tool emojis used to detect tool call output
         tool_emojis = {
-            "\U0001F4D6",  # 📖 Read
-            "\U0001F4DD",  # 📝 Write
-            "\u270F\uFE0F",  # ✏️ Edit
-            "\U0001F50D",  # 🔍 Glob/Grep
-            "\U0001F4BB",  # 💻 Bash
-            "\U0001F916",  # 🤖 Task
-            "\U0001F310",  # 🌐 WebFetch/WebSearch
-            "\U0001F527",  # 🔧 Generic
+            "\U0001f4d6",  # 📖 Read
+            "\U0001f4dd",  # 📝 Write
+            "\u270f\ufe0f",  # ✏️ Edit
+            "\U0001f50d",  # 🔍 Glob/Grep
+            "\U0001f4bb",  # 💻 Bash
+            "\U0001f916",  # 🤖 Task
+            "\U0001f310",  # 🌐 WebFetch/WebSearch
+            "\U0001f527",  # 🔧 Generic
         }
 
         async def stream_text_callback(text: str) -> None:
@@ -183,6 +183,8 @@ async def execute_agent_step(
                 text=output_text,
                 chunk_type="output",
             )
+            # event_callback is guaranteed non-None here (checked at line 141)
+            assert event_callback is not None  # for mypy
             await event_callback(chunk_event)
 
         agent_instance.stream_callback = stream_text_callback

--- a/src/maverick/dsl/serialization/executor/handlers/python_step.py
+++ b/src/maverick/dsl/serialization/executor/handlers/python_step.py
@@ -77,6 +77,12 @@ async def execute_python_step(
     if inspect.iscoroutine(result):
         result = await result
 
+    # Check for failure in result dict (actions return {"success": False, "error": ...})
+    # This ensures actions that return failure dicts actually fail the step
+    if isinstance(result, dict) and result.get("success") is False:
+        error_msg = result.get("error", "Action returned success=False")
+        raise RuntimeError(f"Action '{step.action}' failed: {error_msg}")
+
     # Register rollback if specified
     if step.rollback:
         if not registry.actions.has(step.rollback):

--- a/src/maverick/dsl/serialization/executor/handlers/validate_step.py
+++ b/src/maverick/dsl/serialization/executor/handlers/validate_step.py
@@ -58,7 +58,7 @@ async def execute_validate_step(
     context: WorkflowContext,
     registry: ComponentRegistry,
     config: Any = None,
-    event_callback: "EventCallback | None" = None,
+    event_callback: EventCallback | None = None,
 ) -> Any:
     """Execute a validation step using ValidationRunner.
 

--- a/src/maverick/dsl/streaming.py
+++ b/src/maverick/dsl/streaming.py
@@ -26,22 +26,22 @@ if TYPE_CHECKING:
 
 # Tool emoji mapping for visual scanning in streaming output
 _TOOL_EMOJIS: dict[str, str] = {
-    "Read": "\U0001F4D6",  # 📖
-    "Write": "\U0001F4DD",  # 📝
-    "Edit": "\u270F\uFE0F",  # ✏️
-    "Glob": "\U0001F50D",  # 🔍
-    "Grep": "\U0001F50D",  # 🔍
-    "Bash": "\U0001F4BB",  # 💻
-    "Task": "\U0001F916",  # 🤖
-    "WebFetch": "\U0001F310",  # 🌐
-    "WebSearch": "\U0001F310",  # 🌐
+    "Read": "\U0001f4d6",  # 📖
+    "Write": "\U0001f4dd",  # 📝
+    "Edit": "\u270f\ufe0f",  # ✏️
+    "Glob": "\U0001f50d",  # 🔍
+    "Grep": "\U0001f50d",  # 🔍
+    "Bash": "\U0001f4bb",  # 💻
+    "Task": "\U0001f916",  # 🤖
+    "WebFetch": "\U0001f310",  # 🌐
+    "WebSearch": "\U0001f310",  # 🌐
     # Validation stages
-    "format": "\U0001F3A8",  # 🎨
-    "lint": "\U0001F9F9",  # 🧹
-    "typecheck": "\U0001F50D",  # 🔍
-    "test": "\U0001F9EA",  # 🧪
+    "format": "\U0001f3a8",  # 🎨
+    "lint": "\U0001f9f9",  # 🧹
+    "typecheck": "\U0001f50d",  # 🔍
+    "test": "\U0001f9ea",  # 🧪
 }
-_DEFAULT_TOOL_EMOJI = "\U0001F527"  # 🔧
+_DEFAULT_TOOL_EMOJI = "\U0001f527"  # 🔧
 
 
 def _shorten_path(path: str, max_length: int = 50) -> str:
@@ -152,7 +152,7 @@ class SupportsStreaming(Protocol):
         context: Any,
         registry: Any,
         config: Any | None = None,
-        event_callback: "EventCallback | None" = None,
+        event_callback: EventCallback | None = None,
     ) -> Any: ...
 
 
@@ -172,7 +172,7 @@ class StreamingContext:
 
     def __init__(
         self,
-        event_callback: "EventCallback | None",
+        event_callback: EventCallback | None,
         step_name: str,
         source_name: str | None = None,
     ) -> None:
@@ -189,7 +189,7 @@ class StreamingContext:
         self._last_was_tool = False
         self._has_output = False
 
-    async def __aenter__(self) -> "StreamingContext":
+    async def __aenter__(self) -> StreamingContext:
         """Enter the streaming context."""
         return self
 


### PR DESCRIPTION
## Summary
- Auto-detect TTY in logging to strip ANSI codes when piped
- Add stream_callback support to review_fix_loop action
- Fix step numbering overflow for subworkflows (track nesting depth)
- Propagate action failures when result dict has success=False
- Fix mypy assertion in agent_step handler

## Changes
The CLI now properly handles nested workflows:
- Top-level steps show [x/y] numbering
- Nested steps are indented without numbering
- Subworkflow completion shows inline duration

Actions returning `{"success": False, ...}` now fail the step instead of silently continuing.

## Test plan
- [x] Typecheck passes
- [x] 918 tests pass (2 pre-existing failures in checkpoint store)

🤖 Generated with [Claude Code](https://claude.ai/code)