### PR TITLE
feat: flight plan and work unit models (037)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,6 +551,8 @@ The `plugins/maverick/` directory contains the legacy Claude Code plugin impleme
 - Python 3.10+ (with `from __future__ import annotations`) + Claude Agent SDK (`claude-agent-sdk`), Click, Rich, Pydantic, PyYAML, structlog, tenacity, GitPython (035-python-workflow)
 - JSON files under `~/.maverick/checkpoints/` via `FileCheckpointStore` (035-python-workflow)
 - Python 3.10+ (with `from __future__ import annotations`) + Pydantic (config models), structlog (logging), Claude Agent SDK (agents) (036-prompt-config)
+- Python 3.10+ (with `from __future__ import annotations`) + Pydantic (frozen models, validators), PyYAML (frontmatter parsing), pathlib (file operations) (037-flight-plan-models)
+- Markdown+YAML files on disk (`flight-plan.md`, `###-slug.md`) (037-flight-plan-models)
 ## Recent Changes
 - 031-instructions-preset: Verified Claude Code preset + instructions pattern for all interactive agents
 - 030-typed-output-contracts: Added Pydantic-based typed output contracts for agents using Claude Agent SDK `output_format` structured output

--- a/specs/037-flight-plan-models/checklists/requirements.md
+++ b/specs/037-flight-plan-models/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Flight Plan and Work Unit Data Models
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec covers 4 user stories across 2 priority levels, 19 functional requirements, 7 key entities, and 7 edge cases.
+- No clarifications needed - the user description was sufficiently detailed to make informed decisions for all requirements.

--- a/specs/037-flight-plan-models/contracts/api.py
+++ b/specs/037-flight-plan-models/contracts/api.py
@@ -1,0 +1,189 @@
+"""API contracts for the maverick.flight package.
+
+This file defines the public API surface — the classes, functions, and types
+that consumers import and use. It serves as a contract specification, NOT
+executable code. See data-model.md for field details and validation rules.
+"""
+
+from __future__ import annotations
+
+
+# =============================================================================
+# Models (frozen Pydantic BaseModel, all in models.py)
+# =============================================================================
+
+# FlightPlan: The top-level planning document model.
+#   - Properties: name, version, created, tags, objective, success_criteria,
+#                 scope, context, constraints, notes, source_path
+#   - Computed:   completion -> CompletionStatus
+#   - Methods:    to_dict() -> dict[str, object]
+
+# WorkUnit: The actionable task document model.
+#   - Properties: id, flight_plan, sequence, parallel_group, depends_on,
+#                 task, acceptance_criteria, file_scope, instructions,
+#                 verification, provider_hints, source_path
+#   - Methods:    to_dict() -> dict[str, object]
+
+# SuccessCriterion: Individual criterion with checked state.
+#   - Properties: text, checked
+
+# CompletionStatus: Computed completion stats.
+#   - Properties: checked, total, percentage (float | None)
+
+# Scope: In/Out/Boundaries subsections.
+#   - Properties: in_scope, out_of_scope, boundaries (all tuple[str, ...])
+
+# AcceptanceCriterion: Individual criterion with optional trace ref.
+#   - Properties: text, trace_ref (str | None)
+
+# FileScope: Create/Modify/Protect file lists.
+#   - Properties: create, modify, protect (all tuple[str, ...])
+
+# ExecutionOrder: Resolved execution batches.
+#   - Properties: batches (tuple[ExecutionBatch, ...])
+
+# ExecutionBatch: Parallelizable work unit group.
+#   - Properties: units (tuple[WorkUnit, ...]), parallel_group (str | None)
+
+
+# =============================================================================
+# Parser (parser.py)
+# =============================================================================
+
+# parse_frontmatter(content: str) -> tuple[dict[str, Any], str]
+#   Splits Markdown+YAML content into (metadata_dict, markdown_body).
+#   Raises FlightPlanParseError on malformed input.
+
+# parse_flight_plan_sections(body: str) -> dict[str, str | dict[str, str]]
+#   Extracts named sections from Markdown body.
+#   Returns dict mapping section names to content strings.
+
+# parse_work_unit_sections(body: str) -> dict[str, str | dict[str, str]]
+#   Extracts named sections from Work Unit Markdown body.
+#   Returns dict mapping section names to content strings.
+
+# parse_checkbox_list(content: str) -> list[tuple[bool, str]]
+#   Parses checkbox lines into (checked, text) tuples.
+
+# parse_bullet_list(content: str) -> list[str]
+#   Parses bullet list lines into strings.
+
+
+# =============================================================================
+# Serializer (serializer.py)
+# =============================================================================
+
+# serialize_flight_plan(plan: FlightPlan) -> str
+#   Converts FlightPlan model to Markdown+YAML string.
+#   Output is valid for re-loading (round-trip fidelity).
+
+# serialize_work_unit(unit: WorkUnit) -> str
+#   Converts WorkUnit model to Markdown+YAML string.
+#   Output is valid for re-loading (round-trip fidelity).
+
+
+# =============================================================================
+# Loader (loader.py)
+# =============================================================================
+
+# FlightPlanFile: File loading facade for Flight Plans.
+#
+#   @classmethod
+#   def load(cls, path: Path) -> FlightPlan:
+#       """Load a Flight Plan from a Markdown file (synchronous)."""
+#
+#   @classmethod
+#   async def aload(cls, path: Path) -> FlightPlan:
+#       """Load a Flight Plan from a Markdown file (asynchronous)."""
+#
+#   @classmethod
+#   def save(cls, plan: FlightPlan, path: Path) -> None:
+#       """Save a Flight Plan to a Markdown file (synchronous)."""
+#
+#   @classmethod
+#   async def asave(cls, plan: FlightPlan, path: Path) -> None:
+#       """Save a Flight Plan to a Markdown file (asynchronous)."""
+
+# WorkUnitFile: File loading facade for Work Units.
+#
+#   @classmethod
+#   def load(cls, path: Path) -> WorkUnit:
+#       """Load a Work Unit from a Markdown file (synchronous)."""
+#
+#   @classmethod
+#   async def aload(cls, path: Path) -> WorkUnit:
+#       """Load a Work Unit from a Markdown file (asynchronous)."""
+#
+#   @classmethod
+#   def load_directory(cls, directory: Path) -> list[WorkUnit]:
+#       """Load all Work Units from a directory (synchronous).
+#       Discovers files matching ###-slug.md pattern."""
+#
+#   @classmethod
+#   async def aload_directory(cls, directory: Path) -> list[WorkUnit]:
+#       """Load all Work Units from a directory (asynchronous)."""
+#
+#   @classmethod
+#   def save(cls, unit: WorkUnit, path: Path) -> None:
+#       """Save a Work Unit to a Markdown file (synchronous)."""
+#
+#   @classmethod
+#   async def asave(cls, unit: WorkUnit, path: Path) -> None:
+#       """Save a Work Unit to a Markdown file (asynchronous)."""
+
+
+# =============================================================================
+# Resolver (resolver.py)
+# =============================================================================
+
+# resolve_execution_order(units: list[WorkUnit]) -> ExecutionOrder:
+#   Resolves dependency order using topological sort.
+#   Groups units by parallel_group within each dependency tier.
+#   Raises WorkUnitDependencyError on circular or missing dependencies.
+
+
+# =============================================================================
+# Errors (errors.py, re-exports from exceptions/flight.py)
+# =============================================================================
+
+# FlightError(MaverickError): Base error for flight package.
+# FlightPlanParseError(FlightError): YAML/Markdown parsing failure.
+# FlightPlanValidationError(FlightError): Model validation failure.
+# FlightPlanNotFoundError(FlightError): File not found.
+# WorkUnitValidationError(FlightError): Work Unit model validation failure.
+# WorkUnitDependencyError(FlightError): Dependency resolution failure.
+
+
+# =============================================================================
+# Package __init__.py exports
+# =============================================================================
+
+# __all__ = [
+#     # Models
+#     "FlightPlan",
+#     "WorkUnit",
+#     "SuccessCriterion",
+#     "CompletionStatus",
+#     "Scope",
+#     "AcceptanceCriterion",
+#     "FileScope",
+#     "ExecutionOrder",
+#     "ExecutionBatch",
+#     # Loader
+#     "FlightPlanFile",
+#     "WorkUnitFile",
+#     # Resolver
+#     "resolve_execution_order",
+#     # Serializer
+#     "serialize_flight_plan",
+#     "serialize_work_unit",
+#     # Parser
+#     "parse_frontmatter",
+#     # Errors
+#     "FlightError",
+#     "FlightPlanParseError",
+#     "FlightPlanValidationError",
+#     "FlightPlanNotFoundError",
+#     "WorkUnitValidationError",
+#     "WorkUnitDependencyError",
+# ]

--- a/specs/037-flight-plan-models/data-model.md
+++ b/specs/037-flight-plan-models/data-model.md
@@ -1,0 +1,156 @@
+# Data Model: Flight Plan and Work Unit
+
+**Feature**: 037-flight-plan-models
+**Date**: 2026-02-27
+
+## Entity Relationship Diagram
+
+```text
+FlightPlan (1) ──────< WorkUnit (*)
+    │                      │
+    ├── SuccessCriterion    ├── AcceptanceCriterion ──> SuccessCriterion (trace ref)
+    │   (*)                 │   (*)
+    ├── Scope (1)           ├── FileScope (1)
+    │   ├── in_scope        │   ├── create
+    │   ├── out_of_scope    │   ├── modify
+    │   └── boundaries      │   └── protect
+    │                       │
+    └── CompletionStatus    └── VerificationStep (*)
+        (computed)
+```
+
+## Entities
+
+### FlightPlan
+
+Frozen Pydantic model representing a Flight Plan document.
+
+| Field | Type | Required | Validation | Source |
+|-------|------|----------|------------|--------|
+| `name` | `str` | Yes | Non-empty | YAML frontmatter `name` |
+| `version` | `str` | Yes | Non-empty | YAML frontmatter `version` |
+| `created` | `date` | Yes | Valid date | YAML frontmatter `created` |
+| `tags` | `tuple[str, ...]` | Yes | Any strings | YAML frontmatter `tags` |
+| `objective` | `str` | Yes | - | `## Objective` section |
+| `success_criteria` | `tuple[SuccessCriterion, ...]` | Yes | - | `## Success Criteria` section |
+| `scope` | `Scope` | Yes | - | `## Scope` section |
+| `context` | `str` | No | - | `## Context` section |
+| `constraints` | `tuple[str, ...]` | No | - | `## Constraints` section |
+| `notes` | `str` | No | - | `## Notes` section |
+| `source_path` | `Path \| None` | No | - | Set by loader |
+
+**Computed properties**:
+- `completion` → `CompletionStatus`: Returns checked/total/percentage from success criteria.
+
+**Pydantic config**: `model_config = ConfigDict(frozen=True)`
+
+### SuccessCriterion
+
+Frozen Pydantic model for a single success criterion with checkbox state.
+
+| Field | Type | Required | Validation | Source |
+|-------|------|----------|------------|--------|
+| `text` | `str` | Yes | Non-empty | Checkbox line text |
+| `checked` | `bool` | Yes | - | `[x]` = True, `[ ]` = False |
+
+### CompletionStatus
+
+Frozen Pydantic model representing completion state (computed, not stored).
+
+| Field | Type | Required | Validation | Source |
+|-------|------|----------|------------|--------|
+| `checked` | `int` | Yes | `>= 0` | Count of checked criteria |
+| `total` | `int` | Yes | `>= 0` | Total criteria count |
+| `percentage` | `float \| None` | Yes | `0.0-100.0` or None | `checked/total*100`, None if total=0 |
+
+### Scope
+
+Frozen Pydantic model for the Scope section with three subsections.
+
+| Field | Type | Required | Validation | Source |
+|-------|------|----------|------------|--------|
+| `in_scope` | `tuple[str, ...]` | Yes | - | `### In` subsection bullets |
+| `out_of_scope` | `tuple[str, ...]` | Yes | - | `### Out` subsection bullets |
+| `boundaries` | `tuple[str, ...]` | Yes | - | `### Boundaries` subsection bullets |
+
+### WorkUnit
+
+Frozen Pydantic model representing a Work Unit document.
+
+| Field | Type | Required | Validation | Source |
+|-------|------|----------|------------|--------|
+| `id` | `str` | Yes | Kebab-case: `^[a-z0-9]+(-[a-z0-9]+)*$` | YAML frontmatter `work-unit` |
+| `flight_plan` | `str` | Yes | Non-empty | YAML frontmatter `flight-plan` |
+| `sequence` | `int` | Yes | Positive integer (`>= 1`) | YAML frontmatter `sequence` |
+| `parallel_group` | `str \| None` | No | - | YAML frontmatter `parallel-group` |
+| `depends_on` | `tuple[str, ...]` | No | Each must be kebab-case | YAML frontmatter `depends-on` |
+| `task` | `str` | Yes | - | `## Task` section |
+| `acceptance_criteria` | `tuple[AcceptanceCriterion, ...]` | Yes | - | `## Acceptance Criteria` section |
+| `file_scope` | `FileScope` | Yes | - | `## File Scope` section |
+| `instructions` | `str` | Yes | - | `## Instructions` section |
+| `verification` | `tuple[str, ...]` | Yes | - | `## Verification` section |
+| `provider_hints` | `str \| None` | No | - | `## Provider Hints` section |
+| `source_path` | `Path \| None` | No | - | Set by loader |
+
+### AcceptanceCriterion
+
+Frozen Pydantic model for a single acceptance criterion with optional traceability.
+
+| Field | Type | Required | Validation | Source |
+|-------|------|----------|------------|--------|
+| `text` | `str` | Yes | Non-empty | Bullet line text |
+| `trace_ref` | `str \| None` | No | `SC-\d+` format | `[SC-###]` suffix |
+
+### FileScope
+
+Frozen Pydantic model for the File Scope section with three file lists.
+
+| Field | Type | Required | Validation | Source |
+|-------|------|----------|------------|--------|
+| `create` | `tuple[str, ...]` | Yes | - | `### Create` subsection |
+| `modify` | `tuple[str, ...]` | Yes | - | `### Modify` subsection |
+| `protect` | `tuple[str, ...]` | Yes | - | `### Protect` subsection |
+
+### ExecutionOrder
+
+Frozen Pydantic model representing resolved execution order.
+
+| Field | Type | Required | Validation | Source |
+|-------|------|----------|------------|--------|
+| `batches` | `tuple[ExecutionBatch, ...]` | Yes | Non-empty | Resolver output |
+
+### ExecutionBatch
+
+Frozen Pydantic model for a group of Work Units eligible for concurrent execution.
+
+| Field | Type | Required | Validation | Source |
+|-------|------|----------|------------|--------|
+| `units` | `tuple[WorkUnit, ...]` | Yes | Non-empty | Topological sort batch |
+| `parallel_group` | `str \| None` | No | - | Shared group ID, if any |
+
+## State Transitions
+
+Flight Plan and Work Unit models are **immutable** (frozen Pydantic). State changes produce new instances via `model_copy(update={...})`.
+
+```text
+FlightPlan lifecycle:
+  Created (all criteria unchecked)
+    → In Progress (some criteria checked)
+      → Complete (all criteria checked)
+
+State is introspected via completion property, not stored as a field.
+```
+
+## Validation Rules
+
+| Rule | Entity | Field | Error Type |
+|------|--------|-------|------------|
+| Required field missing | FlightPlan | name, version, created, tags | `FlightPlanValidationError` |
+| Required field missing | WorkUnit | id, flight-plan, sequence | `WorkUnitValidationError` |
+| Invalid ID format | WorkUnit | id | `WorkUnitValidationError` |
+| Non-positive sequence | WorkUnit | sequence | `WorkUnitValidationError` |
+| Invalid frontmatter | Both | - | `FlightPlanParseError` |
+| Missing `---` delimiters | Both | - | `FlightPlanParseError` |
+| Circular dependency | Resolver | depends_on | `WorkUnitDependencyError` |
+| Missing dependency | Resolver | depends_on | `WorkUnitDependencyError` |
+| File not found | Loader | path | `FlightPlanNotFoundError` |

--- a/specs/037-flight-plan-models/plan.md
+++ b/specs/037-flight-plan-models/plan.md
@@ -1,0 +1,81 @@
+# Implementation Plan: Flight Plan and Work Unit Data Models
+
+**Branch**: `037-flight-plan-models` | **Date**: 2026-02-27 | **Spec**: `specs/037-flight-plan-models/spec.md`
+**Input**: Feature specification from `/specs/037-flight-plan-models/spec.md`
+
+## Summary
+
+Implement Pydantic-based data models for Flight Plans and Work Units with Markdown+YAML parsing/serialization, completion introspection, and topological dependency resolution. The `src/maverick/flight/` package follows the established top-level package pattern (`jj/`, `vcs/`, `workspace/`) using frozen Pydantic models, manual `---`-delimited YAML frontmatter parsing with PyYAML, and DFS-based topological sorting adapted from the existing `PrerequisiteRegistry`.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (with `from __future__ import annotations`)
+**Primary Dependencies**: Pydantic (frozen models, validators), PyYAML (frontmatter parsing), pathlib (file operations)
+**Storage**: Markdown+YAML files on disk (`flight-plan.md`, `###-slug.md`)
+**Testing**: pytest + pytest-asyncio (parallel via xdist)
+**Target Platform**: Linux (CLI application)
+**Project Type**: Single project — library package within `src/maverick/`
+**Performance Goals**: N/A (file parsing, not a hot path)
+**Constraints**: No new dependencies; frozen immutable models; `<500 LOC` per module
+**Scale/Scope**: Dozens of Work Units per Flight Plan (not thousands)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Async-First | PASS | `FlightPlanFile` and `WorkUnitFile` provide async loading via `asyncio.to_thread`. No blocking I/O in async paths. |
+| II. Separation of Concerns | PASS | Models are pure data. Parsers handle I/O. Resolver handles dependency logic. No agent or workflow logic. |
+| III. Dependency Injection | PASS | No global state. Loaders accept paths; resolver accepts Work Unit collections. |
+| IV. Fail Gracefully | PASS | Typed errors with context (field name, file path). No bare exceptions. |
+| V. Test-First | PASS | All modules have corresponding test files. Edge cases covered. |
+| VI. Type Safety | PASS | Frozen Pydantic models with validators. Typed contracts (`to_dict()`). No `dict[str, Any]` returns. |
+| VII. Simplicity & DRY | PASS | Shared `_parse_frontmatter()` utility. No premature abstractions. |
+| VIII. Relentless Progress | N/A | Library package, not an autonomous workflow. |
+| IX. Hardening | N/A | No external API calls. File I/O only. |
+| X. Guardrails | PASS | No subprocess calls. No TUI code. No agent logic. |
+| XI. Modularize Early | PASS | Six focused modules, each `<500 LOC`. |
+| XII. Ownership | PASS | Complete implementation with tests and error hierarchy. |
+
+No violations. No complexity tracking needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/037-flight-plan-models/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── contracts/           # Phase 1 output (Python API contracts)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/maverick/
+├── flight/                      # NEW PACKAGE
+│   ├── __init__.py              # Public API exports (__all__)
+│   ├── models.py                # Pydantic models (FlightPlan, WorkUnit, etc.)
+│   ├── errors.py                # Re-exports from exceptions.flight
+│   ├── parser.py                # Markdown+YAML frontmatter parser
+│   ├── serializer.py            # Model → Markdown+YAML serialization
+│   ├── loader.py                # FlightPlanFile, WorkUnitFile (sync+async load)
+│   └── resolver.py              # Topological sort + parallel group resolution
+├── exceptions/
+│   └── flight.py                # NEW: FlightError hierarchy
+
+tests/unit/flight/               # NEW TEST PACKAGE
+├── conftest.py                  # Fixtures: sample markdown, factories
+├── test_models.py               # Model construction, validation, computed props
+├── test_parser.py               # Frontmatter parsing, section extraction
+├── test_serializer.py           # Serialization + round-trip fidelity
+├── test_loader.py               # File loading (sync + async), error paths
+└── test_resolver.py             # Dependency resolution, cycles, parallel groups
+```
+
+**Structure Decision**: Dedicated `src/maverick/flight/` package following the `jj/`, `vcs/`, `workspace/` pattern. Six focused modules, each with a single responsibility. Error hierarchy in `src/maverick/exceptions/flight.py` following the `exceptions/jj.py` pattern.

--- a/specs/037-flight-plan-models/quickstart.md
+++ b/specs/037-flight-plan-models/quickstart.md
@@ -1,0 +1,178 @@
+# Quickstart: Flight Plan and Work Unit Models
+
+## Load a Flight Plan
+
+```python
+from pathlib import Path
+from maverick.flight import FlightPlanFile
+
+# Synchronous
+plan = FlightPlanFile.load(Path("flight-plan.md"))
+print(plan.name, plan.version)
+print(plan.objective)
+
+# Check completion
+status = plan.completion
+print(f"{status.checked}/{status.total} ({status.percentage}%)")
+
+# Asynchronous
+plan = await FlightPlanFile.aload(Path("flight-plan.md"))
+```
+
+## Load Work Units
+
+```python
+from maverick.flight import WorkUnitFile
+
+# Load a single Work Unit
+unit = WorkUnitFile.load(Path("001-setup-database.md"))
+print(unit.id, unit.sequence, unit.flight_plan)
+
+# Load all Work Units from a directory
+units = WorkUnitFile.load_directory(Path("work-units/"))
+for u in units:
+    print(f"{u.sequence}: {u.id} (depends on: {u.depends_on})")
+```
+
+## Resolve Execution Order
+
+```python
+from maverick.flight import WorkUnitFile, resolve_execution_order
+
+units = WorkUnitFile.load_directory(Path("work-units/"))
+order = resolve_execution_order(units)
+
+for batch in order.batches:
+    group = f" [{batch.parallel_group}]" if batch.parallel_group else ""
+    ids = ", ".join(u.id for u in batch.units)
+    print(f"Batch{group}: {ids}")
+```
+
+## Round-Trip Serialization
+
+```python
+from maverick.flight import FlightPlanFile, serialize_flight_plan
+
+# Load, modify, save
+plan = FlightPlanFile.load(Path("flight-plan.md"))
+updated = plan.model_copy(update={"notes": "Updated notes."})
+FlightPlanFile.save(updated, Path("flight-plan.md"))
+```
+
+## Error Handling
+
+```python
+from maverick.flight import (
+    FlightPlanFile,
+    FlightPlanNotFoundError,
+    FlightPlanParseError,
+    FlightPlanValidationError,
+)
+
+try:
+    plan = FlightPlanFile.load(Path("missing.md"))
+except FlightPlanNotFoundError as e:
+    print(f"File not found: {e}")
+except FlightPlanParseError as e:
+    print(f"Parse error: {e}")
+except FlightPlanValidationError as e:
+    print(f"Validation error: {e}")
+```
+
+## Sample Flight Plan Document
+
+```markdown
+---
+name: setup-authentication
+version: "1.0"
+created: 2026-02-27
+tags:
+  - auth
+  - security
+---
+
+## Objective
+
+Implement user authentication with JWT tokens.
+
+## Success Criteria
+
+- [x] Users can register with email and password
+- [ ] Users can log in and receive a JWT
+- [ ] Protected routes reject unauthenticated requests
+
+## Scope
+
+### In
+
+- Registration endpoint
+- Login endpoint
+- JWT middleware
+
+### Out
+
+- OAuth providers
+- Password reset flow
+
+### Boundaries
+
+- JWT tokens expire after 24 hours
+
+## Context
+
+Building on the existing Express.js API framework.
+
+## Constraints
+
+- Must use bcrypt for password hashing
+- Token secret from environment variable
+
+## Notes
+
+Consider adding refresh tokens in a follow-up.
+```
+
+## Sample Work Unit Document
+
+```markdown
+---
+work-unit: setup-database
+flight-plan: setup-authentication
+sequence: 1
+depends-on: []
+---
+
+## Task
+
+Create the users table and database connection module.
+
+## Acceptance Criteria
+
+- Database connection pool is configured [SC-001]
+- Users table has email, password_hash, created_at columns
+
+## File Scope
+
+### Create
+
+- src/db/connection.py
+- src/db/models/user.py
+
+### Modify
+
+- src/config.py
+
+### Protect
+
+- src/main.py
+
+## Instructions
+
+Use SQLAlchemy with async support. Follow existing patterns in the project.
+
+## Verification
+
+- make test-fast
+- make lint
+- make typecheck
+```

--- a/specs/037-flight-plan-models/research.md
+++ b/specs/037-flight-plan-models/research.md
@@ -1,0 +1,107 @@
+# Research: Flight Plan and Work Unit Data Models
+
+**Feature**: 037-flight-plan-models
+**Date**: 2026-02-27
+
+## R1: Pydantic Frozen Model Pattern
+
+**Decision**: Use `model_config = ConfigDict(frozen=True)` for all domain models. Use `@dataclass(frozen=True, slots=True)` only for simple value objects with no validation.
+
+**Rationale**: The codebase uses both patterns — frozen dataclasses in `jj/models.py` (result types with no validation) and Pydantic models in `models/issue_fix.py` (complex models with validators). Flight Plan models need field validators (e.g., kebab-case ID regex, positive integer sequence), so Pydantic is the better fit. Frozen Pydantic models support `model_copy(update={...})` for programmatic modifications.
+
+**Alternatives considered**:
+- Plain frozen dataclasses: No built-in validation; would need manual `__post_init__` validators.
+- Mutable Pydantic models: Risk of accidental mutation; spec clarification explicitly chose frozen.
+
+## R2: YAML Frontmatter Parsing Strategy
+
+**Decision**: Manual `---` delimiter splitting + `yaml.safe_load()`. Implement a shared `parse_frontmatter(content: str) -> tuple[dict[str, Any], str]` function in `parser.py`.
+
+**Rationale**: The project already depends on PyYAML. The `python-frontmatter` library adds an unnecessary dependency for a simple operation: find the first `---`, find the second `---`, extract the YAML between them, and treat everything after as the Markdown body.
+
+**Algorithm**:
+1. Strip leading whitespace. Content must start with `---`.
+2. Find the closing `---` (second occurrence).
+3. `yaml.safe_load()` the content between delimiters.
+4. Return `(metadata_dict, markdown_body)`.
+5. Raise `FlightPlanParseError` if delimiters missing or YAML invalid.
+
+**Alternatives considered**:
+- `python-frontmatter` library: Works well but adds a dependency for ~20 lines of code.
+- Regex-based parsing: Fragile with edge cases (YAML containing `---`).
+
+## R3: Markdown Section Extraction
+
+**Decision**: Parse Markdown body into sections by splitting on `## ` heading markers. Each section is identified by its heading text and contains everything until the next heading of the same or higher level.
+
+**Rationale**: Flight Plan and Work Unit documents use `## Section Name` for top-level sections and `### Subsection` for nested content (e.g., Scope has In/Out/Boundaries). A line-by-line parser that tracks heading levels is simple, predictable, and handles nested subsections.
+
+**Algorithm**:
+1. Split body into lines.
+2. Identify heading lines (`## `, `### `, etc.) and their levels.
+3. Build a dict mapping heading text to content between headings.
+4. For sections with subsections (Scope, File Scope), recursively parse.
+
+**Alternatives considered**:
+- `markdown` or `mistune` library: Full AST parsing is overkill for this structured format.
+- Regex-based splitting: Works but less readable than line-by-line.
+
+## R4: Topological Sort for Dependency Resolution
+
+**Decision**: Adapt the existing DFS-based topological sort from `PrerequisiteRegistry.get_all_dependencies()` in `src/maverick/dsl/prerequisites/registry.py:197-237`. Add parallel-group awareness.
+
+**Rationale**: The codebase already has a proven topological sort with cycle detection. The algorithm uses `visited` and `in_stack` sets for O(V+E) cycle detection. For Work Units, the adaptation needs:
+- Input: list of `WorkUnit` objects (not string names).
+- `depends_on` field maps to edges.
+- `parallel_group` groups units for concurrent execution batching.
+- Missing dependency detection (ID not found in the loaded set).
+
+**Algorithm**:
+1. Build adjacency map from Work Unit `depends_on` lists.
+2. Validate all referenced IDs exist; raise `WorkUnitDependencyError` if not.
+3. DFS with `in_stack` for cycle detection.
+4. Return `list[list[WorkUnit]]` — each inner list is a batch of parallelizable units.
+
+**Alternatives considered**:
+- Kahn's algorithm (BFS-based): Equally valid but DFS is the established pattern.
+- `graphlib.TopologicalSorter` (stdlib): Available in Python 3.9+ but lacks parallel group awareness and custom error messages.
+
+## R5: Success Criteria Checkbox Parsing
+
+**Decision**: Parse `- [x]` and `- [ ]` Markdown checkbox syntax into `SuccessCriterion` objects with `checked: bool` and `text: str` fields.
+
+**Rationale**: This is standard GitHub-flavored Markdown checkbox syntax. A simple regex `r'^\s*-\s*\[([ xX])\]\s*(.+)$'` per line handles all cases.
+
+**Algorithm**:
+1. Extract the Success Criteria section content.
+2. For each line matching the checkbox pattern, create a `SuccessCriterion`.
+3. `[x]` or `[X]` → `checked=True`; `[ ]` → `checked=False`.
+4. Compute `completion_percentage = checked_count / total * 100` (handle 0/0 as `None`).
+
+## R6: Acceptance Criteria Trace References
+
+**Decision**: Parse Work Unit acceptance criteria as lines with an optional `[SC-###]` trace reference suffix linking to Flight Plan Success Criteria.
+
+**Rationale**: The spec requires traceability links between Work Unit acceptance criteria and Flight Plan success criteria. Using a `[SC-###]` suffix pattern (e.g., `- Criterion text [SC-001]`) is human-readable and parseable. The trace reference is optional — not all acceptance criteria need to map to a specific success criterion.
+
+**Pattern**: `r'\[SC-(\d+)\]\s*$'` at end of line.
+
+## R7: File Scope Sublist Parsing
+
+**Decision**: Parse File Scope section with `### Create`, `### Modify`, `### Protect` subsections, each containing a bullet list of file paths.
+
+**Rationale**: Each sublist serves a distinct purpose (new files, changed files, protected files). The subsection pattern matches the Scope section's In/Out/Boundaries structure, providing consistency.
+
+## R8: Async File Loading
+
+**Decision**: Use `asyncio.to_thread()` for async file I/O, following the pattern in `src/maverick/dsl/checkpoint/store.py`.
+
+**Rationale**: File I/O is blocking. The codebase uses `asyncio.to_thread()` to offload blocking operations. Both `FlightPlanFile` and `WorkUnitFile` provide `load()` (sync) and `aload()` (async) class methods.
+
+**Pattern**:
+```python
+@classmethod
+async def aload(cls, path: Path) -> FlightPlan:
+    content = await asyncio.to_thread(path.read_text, encoding="utf-8")
+    return cls._parse(content, path)
+```

--- a/specs/037-flight-plan-models/spec.md
+++ b/specs/037-flight-plan-models/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: Flight Plan and Work Unit Data Models
+
+**Feature Branch**: `037-flight-plan-models`
+**Created**: 2026-02-27
+**Status**: Draft
+**Input**: User description: "Implement the Maverick Flight Plan and Work Unit data models with Pydantic schemas, Markdown+YAML parsers/serializers, and file classes for loading, introspection, and dependency resolution."
+
+## Clarifications
+
+### Session 2026-02-27
+
+- Q: What format should Work Unit IDs follow? → A: Kebab-case slugs (e.g., `setup-database`, `add-auth-middleware`). Must match regex `^[a-z0-9]+(-[a-z0-9]+)*$`.
+- Q: What file naming convention should Flight Plans and Work Units follow on disk? → A: `flight-plan.md` for the Flight Plan; `###-slug.md` for Work Units (e.g., `001-setup-database.md`) where `###` is the zero-padded sequence number.
+- Q: Should the Pydantic models be frozen (immutable) or mutable? → A: Frozen (immutable) with `model_copy(update={...})` for programmatic modifications.
+- Q: Where should these models be placed in the codebase? → A: `src/maverick/flight/` as a dedicated top-level package (analogous to `jj/`, `vcs/`, `workspace/`).
+- Q: What YAML frontmatter parsing approach should be used? → A: Manual split on `---` delimiters with PyYAML (no new dependency).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Author a Flight Plan (Priority: P1)
+
+A workflow author creates a Flight Plan document describing a development objective. The system reads this document, validates its structure, and makes it available as structured data for downstream workflow steps. The author can query the plan's completion status (how many success criteria are checked off) without manually counting checkboxes.
+
+**Why this priority**: Flight Plans are the foundational planning artifact. Without the ability to read and validate them, no downstream work unit processing can occur.
+
+**Independent Test**: Can be fully tested by creating a sample Flight Plan Markdown file, loading it into the system, and verifying all fields and sections are accessible as structured data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid Flight Plan Markdown file with YAML frontmatter and all required sections, **When** the system loads the file, **Then** all frontmatter fields (plan name, version, created date, tags) and section contents (Objective, Success Criteria, Scope, Context, Constraints, Notes) are accessible as structured data.
+2. **Given** a Flight Plan with some Success Criteria checkboxes checked and others unchecked, **When** the system inspects the plan's status, **Then** it reports the number of completed criteria, total criteria, and an overall completion percentage.
+3. **Given** a Flight Plan Markdown file missing a required frontmatter field, **When** the system attempts to load it, **Then** a clear validation error is raised identifying the missing field.
+4. **Given** a structured Flight Plan data object, **When** the system serializes it back to Markdown+YAML, **Then** the resulting file is a valid Flight Plan that can be re-loaded without data loss. *(Cross-ref: Tested as part of User Story 4 — Round-Trip Serialization. US1 is independently testable without this scenario.)*
+
+---
+
+### User Story 2 - Define and Load Work Units (Priority: P1)
+
+A workflow author breaks a Flight Plan into individual Work Units, each describing a discrete task with acceptance criteria, file scope, instructions, and verification steps. The system reads these documents, validates their structure, and links them back to their parent Flight Plan.
+
+**Why this priority**: Work Units are the actionable counterpart to Flight Plans. Both models are needed together to form a complete planning-to-execution pipeline.
+
+**Independent Test**: Can be fully tested by creating sample Work Unit Markdown files, loading them, and verifying all fields are accessible and linked to a Flight Plan reference.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid Work Unit Markdown file with YAML frontmatter (work-unit ID, flight-plan reference, sequence number, parallel-group, depends-on list) and all sections, **When** the system loads the file, **Then** all frontmatter fields and section contents (Task, Acceptance Criteria, File Scope, Instructions, Verification, Provider Hints) are accessible as structured data.
+2. **Given** a Work Unit with Acceptance Criteria referencing specific Flight Plan Success Criteria, **When** the system loads the Work Unit, **Then** the traceability links between Work Unit acceptance criteria and Flight Plan success criteria are preserved and queryable.
+3. **Given** a Work Unit with File Scope lists (Create, Modify, Protect), **When** the system loads the Work Unit, **Then** each list is separately accessible and files are categorized correctly.
+4. **Given** a Work Unit with Verification commands, **When** the system loads the Work Unit, **Then** the verification commands are available as an ordered list of executable command strings.
+
+---
+
+### User Story 3 - Resolve Work Unit Dependencies and Ordering (Priority: P2)
+
+A workflow system needs to determine the correct execution order for a set of Work Units. The system loads all Work Units from a directory, resolves their dependency relationships (using depends-on lists and sequence numbers), and provides a topologically sorted execution order that respects parallel groups.
+
+**Why this priority**: Correct execution ordering is essential for automated workflow execution but builds on the foundational loading capability from User Stories 1 and 2.
+
+**Independent Test**: Can be fully tested by creating a directory of Work Unit files with various dependency relationships and verifying the resolved order respects all constraints.
+
+**Acceptance Scenarios**:
+
+1. **Given** a directory containing multiple Work Unit files with declared dependencies, **When** the system loads and resolves them, **Then** it returns an execution order where every Work Unit appears after all its dependencies.
+2. **Given** Work Units that share the same parallel-group identifier, **When** the system resolves execution order, **Then** those Work Units are grouped together as eligible for concurrent execution.
+3. **Given** Work Units with circular dependencies, **When** the system attempts to resolve order, **Then** a clear error is raised identifying the cycle.
+4. **Given** a Work Unit that depends on a non-existent Work Unit ID, **When** the system attempts to resolve order, **Then** a clear error is raised identifying the missing dependency.
+
+---
+
+### User Story 4 - Round-Trip Serialization (Priority: P2)
+
+A workflow system modifies Flight Plans or Work Units programmatically (e.g., checking off success criteria, updating status) and writes them back to disk. The system serializes the structured data back to Markdown+YAML format, preserving the document structure and human readability.
+
+**Why this priority**: Enables programmatic updates to planning documents while keeping them human-editable, which is required for the iterative planning-execution cycle.
+
+**Independent Test**: Can be fully tested by loading a document, modifying it, serializing it, and verifying the output is valid and preserves all data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Flight Plan data object, **When** the system serializes it to Markdown+YAML, **Then** the output contains valid YAML frontmatter and properly structured Markdown sections with correct headings.
+2. **Given** a Work Unit data object, **When** the system serializes it to Markdown+YAML, **Then** the output contains valid YAML frontmatter and properly structured Markdown sections.
+3. **Given** any valid Flight Plan or Work Unit file, **When** the system loads and then re-serializes it, **Then** the re-serialized output can be loaded again with identical structured data (round-trip fidelity).
+
+---
+
+### Edge Cases
+
+- What happens when a Flight Plan file has no Success Criteria section? The system treats completion as 0/0 (undefined) and reports it accordingly.
+- What happens when a Work Unit has an empty depends-on list? It is treated as having no dependencies and is eligible for immediate execution.
+- What happens when the YAML frontmatter contains unexpected extra fields? The system ignores unrecognized fields without error, preserving forward compatibility.
+- What happens when a Work Unit directory is empty? The system returns an empty ordered list with no error.
+- What happens when Markdown section content contains YAML-like syntax? The parser correctly distinguishes frontmatter boundaries (delimited by `---`) from section content.
+- What happens when a Flight Plan file does not exist at the specified path? The system raises a clear file-not-found error.
+- What happens when parallel-group is not specified on a Work Unit? The system treats it as a standalone unit not part of any parallel group.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST parse Flight Plan documents consisting of YAML frontmatter and structured Markdown sections into validated, structured data.
+- **FR-002**: System MUST validate that Flight Plan frontmatter contains all required fields: plan name, version, created date, and tags list.
+- **FR-003**: System MUST extract and structure Flight Plan sections: Objective (free text), Success Criteria (checkbox list), Scope (with In/Out/Boundaries subsections), Context (free text), Constraints (list), and Notes (free text).
+- **FR-004**: System MUST parse Success Criteria as individual items with checked/unchecked state for status introspection.
+- **FR-005**: System MUST provide completion status for a Flight Plan as: count of checked criteria, total criteria count, and completion percentage.
+- **FR-006**: System MUST parse Work Unit documents consisting of YAML frontmatter and structured Markdown sections into validated, structured data.
+- **FR-007**: System MUST validate that Work Unit frontmatter contains all required fields: work-unit ID (kebab-case slug matching `^[a-z0-9]+(-[a-z0-9]+)*$`), flight-plan reference, and sequence number (positive integer). Optional fields: parallel-group and depends-on list.
+- **FR-008**: System MUST extract and structure Work Unit sections: Task (free text), Acceptance Criteria (list with flight plan trace references), File Scope (with Create/Modify/Protect sublists), Instructions (free text), Verification (list of executable commands), and Provider Hints (free text).
+- **FR-009**: System MUST serialize Flight Plan data back to valid Markdown+YAML format that preserves document structure.
+- **FR-010**: System MUST serialize Work Unit data back to valid Markdown+YAML format that preserves document structure.
+- **FR-011**: System MUST support round-trip fidelity: loading a document and re-serializing it produces output that, when loaded again, yields identical structured data.
+- **FR-012**: System MUST load all Work Unit files from a specified directory, discovering files matching the `###-slug.md` naming pattern (e.g., `001-setup-database.md`).
+- **FR-013**: System MUST resolve Work Unit execution order using topological sorting based on depends-on declarations.
+- **FR-014**: System MUST detect and report circular dependencies among Work Units.
+- **FR-015**: System MUST detect and report references to non-existent Work Unit IDs in depends-on lists.
+- **FR-016**: System MUST identify Work Units that share a parallel-group as eligible for concurrent execution.
+- **FR-017**: System MUST raise clear, descriptive validation errors when documents are malformed, missing required fields, or contain invalid data.
+- **FR-018**: System MUST ignore unrecognized fields in YAML frontmatter without raising errors (forward compatibility).
+- **FR-019**: System MUST support both synchronous and asynchronous file loading operations.
+
+### Key Entities
+
+- **Flight Plan**: A planning document that defines a development objective, success criteria (with completion tracking), scope boundaries, context, and constraints. Identified by a plan name and version. Contains a tags list for categorization. Stored as `flight-plan.md` in the feature directory.
+- **Success Criterion**: An individual success criterion within a Flight Plan. Has a text description and a checked/unchecked state for completion tracking.
+- **Scope**: A structured section within a Flight Plan containing three subsections: In (what is included), Out (what is excluded), and Boundaries (limits and constraints on scope).
+- **Work Unit**: An actionable task document linked to a Flight Plan. Identified by a unique work-unit ID (kebab-case slug, e.g., `setup-database`). Stored as `###-slug.md` (e.g., `001-setup-database.md`). Has a sequence number for ordering, an optional parallel-group for concurrency, and a depends-on list for dependency management.
+- **Acceptance Criterion**: An individual acceptance criterion within a Work Unit. Contains a text description and a trace reference linking it to a specific Flight Plan Success Criterion.
+- **File Scope**: A structured section within a Work Unit containing three file lists: Create (new files), Modify (existing files to change), and Protect (files that must not be altered).
+- **Verification Step**: An executable command string within a Work Unit used to verify that the task was completed correctly. Stored as plain strings in a tuple (not a separate model class), interpreted by the executing system.
+
+## Assumptions
+
+- Flight Plan and Work Unit documents follow a Markdown format with YAML frontmatter delimited by `---` markers, consistent with common Markdown+YAML conventions (e.g., Jekyll, Hugo, Obsidian).
+- Work Unit IDs are kebab-case slugs (matching `^[a-z0-9]+(-[a-z0-9]+)*$`), unique within a directory of Work Units belonging to the same Flight Plan.
+- The depends-on field in Work Units references Work Unit IDs within the same directory/flight plan scope, not across different Flight Plans.
+- Sequence numbers are positive integers used for default ordering when no explicit dependencies are declared.
+- Tags in Flight Plan frontmatter are a flat list of strings.
+- The version field in Flight Plan frontmatter is a string (e.g., "1.0", "2.1") rather than a structured semantic version.
+- Provider Hints is an optional free-text section that may or may not be present in every Work Unit.
+- Verification commands are plain strings (not structured objects), to be interpreted by the executing system.
+- All Pydantic models are frozen (immutable). Programmatic updates use `model_copy(update={...})`.
+- Flight Plan file is named `flight-plan.md`. Work Unit files follow `###-slug.md` naming (e.g., `001-setup-database.md`).
+- YAML frontmatter is parsed by manually splitting on `---` delimiters and passing to PyYAML (no `python-frontmatter` dependency).
+- Models are located in `src/maverick/flight/` package, following the same top-level package pattern as `jj/`, `vcs/`, and `workspace/`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of valid Flight Plan documents (conforming to the defined structure) are loaded without errors and all fields are accessible.
+- **SC-002**: 100% of valid Work Unit documents are loaded without errors and all fields are accessible, including traceability links to Flight Plan criteria.
+- **SC-003**: Round-trip serialization (load then save then reload) produces identical structured data for all valid documents.
+- **SC-004**: Dependency resolution correctly orders 100% of acyclic Work Unit sets, verified by checking that every Work Unit appears after all its declared dependencies.
+- **SC-005**: Circular dependency detection catches 100% of cycles and produces error messages that identify the involved Work Unit IDs.
+- **SC-006**: All validation errors include the specific field or section that failed and a human-readable description of the issue.
+- **SC-007**: Comprehensive automated test coverage for all functional requirements, including positive paths, validation failures, edge cases, and round-trip fidelity.

--- a/specs/037-flight-plan-models/tasks.md
+++ b/specs/037-flight-plan-models/tasks.md
@@ -1,0 +1,238 @@
+# Tasks: Flight Plan and Work Unit Data Models
+
+**Input**: Design documents from `/specs/037-flight-plan-models/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/api.py
+
+**Tests**: Included per constitution mandate (Test-First TDD) and spec SC-007 (comprehensive automated test coverage).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the `src/maverick/flight/` package skeleton and error hierarchy
+
+- [X] T001 Create src/maverick/flight/ package directory with __init__.py stub (empty __all__ list, `from __future__ import annotations`)
+- [X] T002 [P] Create FlightError hierarchy in src/maverick/exceptions/flight.py (FlightError, FlightPlanParseError, FlightPlanValidationError, FlightPlanNotFoundError, WorkUnitValidationError, WorkUnitDependencyError — all inheriting from MaverickError via FlightError). Follow the jj.py __init__ pattern: each error accepts `message: str` plus contextual keyword-only args (e.g., `path: Path | None = None`, `field: str | None = None`) stored as instance attributes. Re-export all from exceptions/__init__.py.
+- [X] T003 [P] Create error re-exports in src/maverick/flight/errors.py (import and re-export all errors from maverick.exceptions.flight)
+- [X] T004 [P] Create test package with shared fixtures in tests/unit/flight/__init__.py and tests/unit/flight/conftest.py (sample Flight Plan markdown string, sample Work Unit markdown string, factory helpers for model instances)
+
+---
+
+## Phase 2: Foundational (Shared Parser)
+
+**Purpose**: Core Markdown+YAML frontmatter parser used by ALL user stories — MUST complete before any story
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T005 Write tests for core parser functions in tests/unit/flight/test_parser.py: valid frontmatter extraction, missing delimiters error, invalid YAML error, checkbox parsing ([x]/[X]/[ ]), bullet list parsing, empty content, content with YAML-like syntax in body. Tests should FAIL before T006 implementation.
+- [X] T006 Implement core parser functions in src/maverick/flight/parser.py: parse_frontmatter(content) -> tuple[dict, str], parse_checkbox_list(content) -> list[tuple[bool, str]], parse_bullet_list(content) -> list[str]. Use manual `---` delimiter splitting with yaml.safe_load(). Raise FlightPlanParseError on malformed input.
+
+**Checkpoint**: Parser ready — user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 — Author a Flight Plan (Priority: P1) MVP
+
+**Goal**: Load Flight Plan Markdown files, validate structure, and provide completion introspection
+
+**Independent Test**: Create a sample Flight Plan Markdown file, load it, verify all fields accessible as structured data, check completion percentage
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T007 [P] [US1] Write FlightPlan model tests in tests/unit/flight/test_models.py: construction with all fields, frozen immutability, computed completion property (some checked, all checked, none checked, zero criteria → None percentage, absent Success Criteria section → 0/0 treated as None), Scope model with in_scope/out_of_scope/boundaries tuples, SuccessCriterion checked/unchecked states, to_dict() output, validation error on missing required fields (name, version, created, tags)
+- [X] T008 [P] [US1] Write FlightPlanFile loader tests in tests/unit/flight/test_loader.py: load() from valid file returns FlightPlan with correct fields, aload() async variant, FlightPlanNotFoundError on missing file, FlightPlanParseError on malformed frontmatter, FlightPlanValidationError on missing required fields, extra YAML fields ignored (forward compatibility), optional sections (context, constraints, notes) default gracefully
+
+### Implementation for User Story 1
+
+- [X] T009 [P] [US1] Implement FlightPlan, SuccessCriterion, CompletionStatus, and Scope frozen Pydantic models in src/maverick/flight/models.py (ConfigDict(frozen=True), field validators per data-model.md, completion computed property, to_dict() method). Include Field(description=...) on required fields per constitution VI.
+- [X] T010 [US1] Implement parse_flight_plan_sections() in src/maverick/flight/parser.py: extract ## Objective, ## Success Criteria (parse checkboxes), ## Scope (with ### In/### Out/### Boundaries subsections), ## Context, ## Constraints (parse bullets), ## Notes from Markdown body
+- [X] T011 [US1] Implement FlightPlanFile.load() and FlightPlanFile.aload() in src/maverick/flight/loader.py: read file, call parse_frontmatter, call parse_flight_plan_sections, construct FlightPlan model with source_path, handle FileNotFoundError → FlightPlanNotFoundError, handle ValidationError → FlightPlanValidationError. Async via asyncio.to_thread().
+
+**Checkpoint**: Flight Plan loading and introspection fully functional and tested
+
+---
+
+## Phase 4: User Story 2 — Define and Load Work Units (Priority: P1)
+
+**Goal**: Load Work Unit Markdown files, validate structure including kebab-case IDs, and link to Flight Plans
+
+**Independent Test**: Create sample Work Unit Markdown files, load them individually and from a directory, verify all fields accessible and linked to Flight Plan reference
+
+### Tests for User Story 2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T012 [P] [US2] Write WorkUnit model tests in tests/unit/flight/test_models.py: construction with all fields, frozen immutability, kebab-case ID validation (valid slugs pass, invalid formats reject), positive sequence validation, AcceptanceCriterion with and without trace_ref (SC-### format), FileScope with create/modify/protect tuples, optional parallel_group and depends_on defaults, to_dict() output
+- [X] T013 [P] [US2] Write WorkUnitFile loader tests in tests/unit/flight/test_loader.py: load() from valid file, aload() async variant, load_directory() discovers ###-slug.md files and returns sorted list, aload_directory() async variant, empty directory returns empty list, WorkUnitValidationError on invalid ID format, optional provider_hints section
+
+### Implementation for User Story 2
+
+- [X] T014 [P] [US2] Implement WorkUnit, AcceptanceCriterion, and FileScope frozen Pydantic models in src/maverick/flight/models.py (kebab-case regex validator for id field, positive int validator for sequence, tuple defaults for depends_on). Include Field(description=...) on required fields per constitution VI.
+- [X] T015 [US2] Implement parse_work_unit_sections() in src/maverick/flight/parser.py: extract ## Task, ## Acceptance Criteria (parse bullets with optional [SC-###] trace refs), ## File Scope (with ### Create/### Modify/### Protect subsections), ## Instructions, ## Verification (parse as command list), ## Provider Hints (optional)
+- [X] T016 [US2] Implement WorkUnitFile.load(), aload(), load_directory(), aload_directory() in src/maverick/flight/loader.py: file discovery via ###-slug.md glob pattern, parse frontmatter + sections, construct WorkUnit model with source_path, sort by sequence number. Async via asyncio.to_thread().
+
+**Checkpoint**: Work Unit loading and directory discovery fully functional and tested
+
+---
+
+## Phase 5: User Story 3 — Resolve Work Unit Dependencies and Ordering (Priority: P2)
+
+**Goal**: Topologically sort Work Units by dependencies, group parallel-eligible units into batches
+
+**Independent Test**: Create Work Units with various dependency graphs, resolve order, verify every unit appears after its dependencies and parallel groups are batched
+
+### Tests for User Story 3
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T017 [P] [US3] Write resolver tests in tests/unit/flight/test_resolver.py: linear chain ordering, diamond dependency, independent units in same batch, parallel_group batching, circular dependency raises WorkUnitDependencyError with cycle IDs, missing dependency raises WorkUnitDependencyError with missing ID, empty list returns empty batches, single unit returns single batch, ExecutionOrder and ExecutionBatch model construction
+
+### Implementation for User Story 3
+
+- [X] T018 [P] [US3] Implement ExecutionOrder and ExecutionBatch frozen Pydantic models in src/maverick/flight/models.py (ExecutionBatch with units tuple and optional parallel_group, ExecutionOrder with batches tuple)
+- [X] T019 [US3] Implement resolve_execution_order(units) -> ExecutionOrder in src/maverick/flight/resolver.py: build adjacency map from depends_on, validate all referenced IDs exist, DFS topological sort with cycle detection (adapted from PrerequisiteRegistry pattern in src/maverick/dsl/prerequisites/registry.py), group units by parallel_group within dependency tiers, raise WorkUnitDependencyError on cycles or missing deps
+
+**Checkpoint**: Dependency resolution and parallel batching fully functional and tested
+
+---
+
+## Phase 6: User Story 4 — Round-Trip Serialization (Priority: P2)
+
+**Goal**: Serialize FlightPlan and WorkUnit models back to Markdown+YAML format with round-trip fidelity
+
+**Independent Test**: Load a document, serialize it, reload the serialized output, verify identical structured data
+
+### Tests for User Story 4
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T020 [P] [US4] Write serializer and round-trip tests in tests/unit/flight/test_serializer.py: serialize_flight_plan() produces valid YAML frontmatter + Markdown sections, serialize_work_unit() produces valid YAML frontmatter + Markdown sections, round-trip fidelity for FlightPlan (load → serialize → reload → compare), round-trip fidelity for WorkUnit, FlightPlanFile.save/asave write correct content, WorkUnitFile.save/asave write correct content
+
+### Implementation for User Story 4
+
+- [X] T021 [P] [US4] Implement serialize_flight_plan() in src/maverick/flight/serializer.py: build YAML frontmatter dict from model fields, render Markdown sections (## Objective, ## Success Criteria with checkboxes, ## Scope with subsections, etc.), join with `---` delimiters
+- [X] T022 [P] [US4] Implement serialize_work_unit() in src/maverick/flight/serializer.py: build YAML frontmatter dict (work-unit, flight-plan, sequence, parallel-group, depends-on), render Markdown sections (## Task, ## Acceptance Criteria with trace refs, ## File Scope with subsections, etc.)
+- [X] T023 [US4] Implement FlightPlanFile.save/asave and WorkUnitFile.save/asave in src/maverick/flight/loader.py: call serialize function, write to path, async via asyncio.to_thread()
+
+**Checkpoint**: All models support round-trip Markdown+YAML serialization with fidelity
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finalize package exports, validate all checks pass, verify quickstart examples
+
+- [X] T024 Finalize src/maverick/flight/__init__.py with complete __all__ exports per contracts/api.py (all models, FlightPlanFile, WorkUnitFile, resolve_execution_order, serialize functions, parse_frontmatter, all error types)
+- [X] T025 Run make check (lint + typecheck + test) and fix any issues across all src/maverick/flight/ and tests/unit/flight/ files
+- [X] T026 Validate quickstart.md code examples against implemented API (verify imports, method signatures, and error types match)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup (T001-T004) — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Foundational (T005-T006)
+- **US2 (Phase 4)**: Depends on Foundational (T005-T006). Independent of US1 (models.py is additive, not conflicting)
+- **US3 (Phase 5)**: Depends on US2 (needs WorkUnit model from T014)
+- **US4 (Phase 6)**: Depends on US1 + US2 (needs both FlightPlan and WorkUnit models)
+- **Polish (Phase 7)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Foundational — no story dependencies
+- **US2 (P1)**: Can start after Foundational — independent of US1 (shares models.py file but different classes)
+- **US3 (P2)**: Depends on US2 (WorkUnit model + loader for test fixtures)
+- **US4 (P2)**: Depends on US1 + US2 (needs both model types for serialization)
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Models before parser integration
+- Parser integration before loader
+- Core implementation before integration tests pass
+
+### Parallel Opportunities
+
+- **Phase 1**: T002, T003, T004 can run in parallel (different files)
+- **Phase 2**: T005 (tests) then T006 (implementation) — TDD order, tests written first
+- **US1**: T007 + T008 in parallel (test files), then T009 (models), T010 (parser), T011 (loader)
+- **US2**: T012 + T013 in parallel (test files), then T014 (models), T015 (parser), T016 (loader)
+- **US3**: T017 + T018 in parallel (test + models), then T019 (resolver)
+- **US4**: T020 in parallel with T021 + T022, then T023 (loader save methods)
+- **Cross-story**: US1 and US2 can run in parallel after Foundational phase
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# TDD: Launch tests first (both test files in parallel):
+Task: "Write FlightPlan model tests in tests/unit/flight/test_models.py"
+Task: "Write FlightPlanFile loader tests in tests/unit/flight/test_loader.py"
+
+# Then implement (models first, no deps between them):
+Task: "Implement FlightPlan, SuccessCriterion, CompletionStatus, Scope models in src/maverick/flight/models.py"
+
+# Then sequential (parser integration depends on models, loader depends on both):
+Task: "Implement parse_flight_plan_sections() in src/maverick/flight/parser.py"
+Task: "Implement FlightPlanFile.load/aload in src/maverick/flight/loader.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T004)
+2. Complete Phase 2: Foundational parser (T005-T006)
+3. Complete Phase 3: User Story 1 — Flight Plan loading + introspection (T007-T011)
+4. **STOP and VALIDATE**: `make test-fast` — Flight Plan tests pass independently
+5. Deliver: Flight Plans can be loaded, validated, and queried for completion
+
+### Incremental Delivery
+
+1. Setup + Foundational → Parser ready
+2. Add US1 → Flight Plans loadable → **MVP!**
+3. Add US2 → Work Units loadable → Complete read-path
+4. Add US3 → Dependency resolution → Execution ordering
+5. Add US4 → Serialization → Full round-trip capability
+6. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: US1 (Flight Plan models + loader)
+   - Developer B: US2 (Work Unit models + loader)
+3. After US1 + US2 complete:
+   - Developer A: US4 (Serialization — needs both models)
+   - Developer B: US3 (Resolver — needs WorkUnit model)
+4. Polish phase together
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify tests fail before implementing (TDD)
+- Commit after each task or logical group
+- All models use `ConfigDict(frozen=True)` — mutations via `model_copy(update={...})`
+- Parser uses manual `---` splitting + PyYAML — no new dependencies
+- Resolver adapts DFS pattern from `src/maverick/dsl/prerequisites/registry.py`
+- Module size constraint: each file < 500 LOC per constitution

--- a/src/maverick/exceptions/__init__.py
+++ b/src/maverick/exceptions/__init__.py
@@ -40,6 +40,17 @@ from maverick.exceptions.beads import (
 # Configuration exceptions
 from maverick.exceptions.config import ConfigError
 
+# Flight plan and work unit exceptions
+from maverick.exceptions.flight import (
+    FlightError,
+    FlightPlanNotFoundError,
+    FlightPlanParseError,
+    FlightPlanValidationError,
+    WorkUnitDependencyError,
+    WorkUnitNotFoundError,
+    WorkUnitValidationError,
+)
+
 # Git-related exceptions
 from maverick.exceptions.git import (
     BranchExistsError,
@@ -183,4 +194,12 @@ __all__ = [
     "DuplicateStepNameError",
     "StagesNotFoundError",
     "WorkflowError",
+    # Flight
+    "FlightError",
+    "FlightPlanNotFoundError",
+    "FlightPlanParseError",
+    "FlightPlanValidationError",
+    "WorkUnitDependencyError",
+    "WorkUnitNotFoundError",
+    "WorkUnitValidationError",
 ]

--- a/src/maverick/exceptions/flight.py
+++ b/src/maverick/exceptions/flight.py
@@ -1,0 +1,150 @@
+"""Flight Plan and Work Unit exceptions.
+
+Exceptions for loading, parsing, and resolving flight plan documents
+and work unit dependency graphs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from maverick.exceptions.base import MaverickError
+
+
+class FlightError(MaverickError):
+    """Base exception for flight package operations.
+
+    Attributes:
+        message: Human-readable error message.
+    """
+
+
+class FlightPlanParseError(FlightError):
+    """YAML/Markdown parsing failure.
+
+    Attributes:
+        message: Human-readable error message.
+        path: Path to the file that failed to parse (if applicable).
+        field: Specific field or section that caused the parse error.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        path: Path | None = None,
+        field: str | None = None,
+    ) -> None:
+        self.path = path
+        self.field = field
+        super().__init__(message)
+
+
+class FlightPlanValidationError(FlightError):
+    """Model validation failure for Flight Plan documents.
+
+    Attributes:
+        message: Human-readable error message.
+        path: Path to the file that failed validation (if applicable).
+        field: Specific field that failed validation.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        path: Path | None = None,
+        field: str | None = None,
+    ) -> None:
+        self.path = path
+        self.field = field
+        super().__init__(message)
+
+
+class FlightPlanNotFoundError(FlightError):
+    """Flight Plan file not found.
+
+    Attributes:
+        message: Human-readable error message.
+        path: The path that was not found.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        path: Path | None = None,
+    ) -> None:
+        self.path = path
+        super().__init__(message)
+
+
+class WorkUnitNotFoundError(FlightError):
+    """Work Unit file not found.
+
+    Attributes:
+        message: Human-readable error message.
+        path: The path that was not found.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        path: Path | None = None,
+    ) -> None:
+        self.path = path
+        super().__init__(message)
+
+
+class WorkUnitValidationError(FlightError):
+    """Work Unit model validation failure.
+
+    Attributes:
+        message: Human-readable error message.
+        path: Path to the file that failed validation (if applicable).
+        field: Specific field that failed validation.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        path: Path | None = None,
+        field: str | None = None,
+    ) -> None:
+        self.path = path
+        self.field = field
+        super().__init__(message)
+
+
+class WorkUnitDependencyError(FlightError):
+    """Work Unit dependency resolution failure.
+
+    Attributes:
+        message: Human-readable error message.
+        cycle: List of Work Unit IDs forming a dependency cycle.
+        missing_id: The dependency ID that was not found.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        cycle: list[str] | None = None,
+        missing_id: str | None = None,
+    ) -> None:
+        self.cycle = cycle
+        self.missing_id = missing_id
+        super().__init__(message)
+
+
+__all__ = [
+    "FlightError",
+    "FlightPlanNotFoundError",
+    "FlightPlanParseError",
+    "FlightPlanValidationError",
+    "WorkUnitDependencyError",
+    "WorkUnitNotFoundError",
+    "WorkUnitValidationError",
+]

--- a/src/maverick/flight/__init__.py
+++ b/src/maverick/flight/__init__.py
@@ -1,0 +1,85 @@
+"""Flight Plan and Work Unit data models for Maverick.
+
+This package provides:
+- FlightPlan and WorkUnit frozen Pydantic models
+- Markdown+YAML frontmatter parsing
+- File loaders (FlightPlanFile, WorkUnitFile)
+- Dependency resolver (resolve_execution_order)
+- Round-trip serialization
+
+Public API::
+
+    from maverick.flight import (
+        FlightPlan, WorkUnit, FlightPlanFile, WorkUnitFile,
+        resolve_execution_order, serialize_flight_plan, serialize_work_unit,
+        FlightPlanNotFoundError, FlightPlanParseError, FlightPlanValidationError,
+    )
+"""
+
+from __future__ import annotations
+
+from maverick.flight.errors import (
+    FlightError,
+    FlightPlanNotFoundError,
+    FlightPlanParseError,
+    FlightPlanValidationError,
+    WorkUnitDependencyError,
+    WorkUnitNotFoundError,
+    WorkUnitValidationError,
+)
+from maverick.flight.loader import FlightPlanFile, WorkUnitFile
+from maverick.flight.models import (
+    AcceptanceCriterion,
+    CompletionStatus,
+    ExecutionBatch,
+    ExecutionOrder,
+    FileScope,
+    FlightPlan,
+    Scope,
+    SuccessCriterion,
+    WorkUnit,
+)
+from maverick.flight.parser import (
+    parse_bullet_list,
+    parse_checkbox_list,
+    parse_flight_plan_sections,
+    parse_frontmatter,
+    parse_work_unit_sections,
+)
+from maverick.flight.resolver import resolve_execution_order
+from maverick.flight.serializer import serialize_flight_plan, serialize_work_unit
+
+__all__: list[str] = [
+    # Errors
+    "FlightError",
+    "FlightPlanNotFoundError",
+    "FlightPlanParseError",
+    "FlightPlanValidationError",
+    "WorkUnitDependencyError",
+    "WorkUnitNotFoundError",
+    "WorkUnitValidationError",
+    # Models
+    "AcceptanceCriterion",
+    "CompletionStatus",
+    "ExecutionBatch",
+    "ExecutionOrder",
+    "FileScope",
+    "FlightPlan",
+    "Scope",
+    "SuccessCriterion",
+    "WorkUnit",
+    # Loaders
+    "FlightPlanFile",
+    "WorkUnitFile",
+    # Resolver
+    "resolve_execution_order",
+    # Serializers
+    "serialize_flight_plan",
+    "serialize_work_unit",
+    # Parser primitives
+    "parse_bullet_list",
+    "parse_checkbox_list",
+    "parse_flight_plan_sections",
+    "parse_frontmatter",
+    "parse_work_unit_sections",
+]

--- a/src/maverick/flight/errors.py
+++ b/src/maverick/flight/errors.py
@@ -1,0 +1,23 @@
+"""Flight package errors — re-exports from maverick.exceptions.flight."""
+
+from __future__ import annotations
+
+from maverick.exceptions.flight import (
+    FlightError,
+    FlightPlanNotFoundError,
+    FlightPlanParseError,
+    FlightPlanValidationError,
+    WorkUnitDependencyError,
+    WorkUnitNotFoundError,
+    WorkUnitValidationError,
+)
+
+__all__ = [
+    "FlightError",
+    "FlightPlanNotFoundError",
+    "FlightPlanParseError",
+    "FlightPlanValidationError",
+    "WorkUnitDependencyError",
+    "WorkUnitNotFoundError",
+    "WorkUnitValidationError",
+]

--- a/src/maverick/flight/loader.py
+++ b/src/maverick/flight/loader.py
@@ -1,0 +1,380 @@
+"""File loaders for Flight Plan and Work Unit documents.
+
+Provides synchronous and asynchronous loaders that read Markdown+YAML
+files from disk, parse them, and construct frozen Pydantic models.
+
+Public API:
+    FlightPlanFile.load(path) -> FlightPlan
+    FlightPlanFile.aload(path) -> Awaitable[FlightPlan]
+    WorkUnitFile.load(path) -> WorkUnit
+    WorkUnitFile.aload(path) -> Awaitable[WorkUnit]
+    WorkUnitFile.load_directory(directory) -> list[WorkUnit]
+    WorkUnitFile.aload_directory(directory) -> Awaitable[list[WorkUnit]]
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from maverick.flight.errors import (
+    FlightPlanNotFoundError,
+    FlightPlanParseError,
+    FlightPlanValidationError,
+    WorkUnitNotFoundError,
+    WorkUnitValidationError,
+)
+from maverick.flight.models import (
+    AcceptanceCriterion,
+    FileScope,
+    FlightPlan,
+    Scope,
+    SuccessCriterion,
+    WorkUnit,
+)
+from maverick.flight.parser import (
+    parse_flight_plan_sections,
+    parse_frontmatter,
+    parse_work_unit_sections,
+)
+from maverick.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Pattern for work unit files: ###-slug.md
+_WORK_UNIT_GLOB = "[0-9][0-9][0-9]-*.md"
+
+
+# ---------------------------------------------------------------------------
+# FlightPlanFile
+# ---------------------------------------------------------------------------
+
+
+class FlightPlanFile:
+    """Loader for Flight Plan Markdown+YAML files.
+
+    All methods are class methods; no instance state is maintained.
+    """
+
+    @classmethod
+    def load(cls, path: Path) -> FlightPlan:
+        """Load a FlightPlan from a Markdown file.
+
+        Args:
+            path: Path to the ``.md`` file.
+
+        Returns:
+            Parsed and validated FlightPlan model with source_path set.
+
+        Raises:
+            FlightPlanNotFoundError: When the file does not exist.
+            FlightPlanParseError: When the Markdown/YAML cannot be parsed,
+                or when the file cannot be read due to OS errors.
+            FlightPlanValidationError: When required fields are missing or
+                invalid.
+        """
+        logger.debug("loading_flight_plan", path=str(path))
+        try:
+            content = path.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise FlightPlanNotFoundError(
+                f"Flight plan file not found: {path}", path=path
+            ) from exc
+        except OSError as exc:
+            raise FlightPlanParseError(
+                f"Cannot read flight plan file {path}: {exc}",
+                path=path,
+            ) from exc
+
+        # parse_frontmatter raises FlightPlanParseError on invalid input
+        fm, body = parse_frontmatter(content)
+
+        # Pre-validate required frontmatter fields for clear error messages
+        required_keys = ("name", "version", "created")
+        for key in required_keys:
+            if key not in fm:
+                raise FlightPlanValidationError(
+                    f"Flight plan {path} is missing required frontmatter "
+                    f"field: {key!r}",
+                    path=path,
+                    field=key,
+                )
+
+        sections = parse_flight_plan_sections(body)
+
+        # Build nested model inputs
+        success_criteria = tuple(
+            SuccessCriterion(text=text, checked=checked)
+            for checked, text in sections["success_criteria"]
+        )
+        scope_data = sections["scope"]
+        scope = Scope(
+            in_scope=tuple(scope_data["in_scope"]),
+            out_of_scope=tuple(scope_data["out_of_scope"]),
+            boundaries=tuple(scope_data["boundaries"]),
+        )
+
+        try:
+            fp = FlightPlan(
+                name=fm.get("name", ""),
+                version=str(fm.get("version", "")),
+                created=fm.get("created"),  # type: ignore[arg-type]
+                tags=tuple(fm.get("tags") or []),
+                objective=sections["objective"],
+                success_criteria=success_criteria,
+                scope=scope,
+                context=sections["context"],
+                constraints=tuple(sections["constraints"]),
+                notes=sections["notes"],
+                source_path=path,
+            )
+        except ValidationError as exc:
+            raise FlightPlanValidationError(
+                f"Flight plan validation failed for {path}: {exc}",
+                path=path,
+            ) from exc
+
+        logger.debug("flight_plan_loaded", name=fp.name, path=str(path))
+        return fp
+
+    @classmethod
+    async def aload(cls, path: Path) -> FlightPlan:
+        """Asynchronously load a FlightPlan from a Markdown file.
+
+        Delegates to :meth:`load` via ``asyncio.to_thread`` to avoid
+        blocking the event loop.
+
+        Args:
+            path: Path to the ``.md`` file.
+
+        Returns:
+            Parsed and validated FlightPlan model.
+
+        Raises:
+            FlightPlanNotFoundError: When the file does not exist.
+            FlightPlanParseError: When the Markdown/YAML cannot be parsed.
+            FlightPlanValidationError: When required fields are missing or invalid.
+        """
+        return await asyncio.to_thread(cls.load, path)
+
+    @classmethod
+    def save(cls, plan: FlightPlan, path: Path) -> None:
+        """Save a FlightPlan to a Markdown file (synchronous).
+
+        Serializes the plan to YAML frontmatter + Markdown format and writes
+        it to the given path in UTF-8 encoding.
+
+        Args:
+            plan: FlightPlan model instance to serialize.
+            path: Destination file path. Will be created or overwritten.
+        """
+        from maverick.flight.serializer import serialize_flight_plan
+
+        content = serialize_flight_plan(plan)
+        path.write_text(content, encoding="utf-8")
+
+    @classmethod
+    async def asave(cls, plan: FlightPlan, path: Path) -> None:
+        """Save a FlightPlan to a Markdown file (asynchronous).
+
+        Delegates to :meth:`save` via ``asyncio.to_thread`` to avoid
+        blocking the event loop.
+
+        Args:
+            plan: FlightPlan model instance to serialize.
+            path: Destination file path. Will be created or overwritten.
+        """
+        await asyncio.to_thread(cls.save, plan, path)
+
+
+# ---------------------------------------------------------------------------
+# WorkUnitFile
+# ---------------------------------------------------------------------------
+
+
+class WorkUnitFile:
+    """Loader for Work Unit Markdown+YAML files.
+
+    All methods are class methods; no instance state is maintained.
+    """
+
+    @classmethod
+    def load(cls, path: Path) -> WorkUnit:
+        """Load a WorkUnit from a Markdown file.
+
+        Args:
+            path: Path to the ``.md`` file.
+
+        Returns:
+            Parsed and validated WorkUnit model with source_path set.
+
+        Raises:
+            WorkUnitNotFoundError: When the file does not exist.
+            WorkUnitValidationError: When required fields are missing or
+                invalid (including bad kebab-case ID), or when the file
+                cannot be read due to OS errors.
+        """
+        logger.debug("loading_work_unit", path=str(path))
+        try:
+            content = path.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise WorkUnitNotFoundError(
+                f"Work unit file not found: {path}", path=path
+            ) from exc
+        except OSError as exc:
+            raise WorkUnitValidationError(
+                f"Cannot read work unit file {path}: {exc}",
+                path=path,
+            ) from exc
+
+        # parse_frontmatter raises FlightPlanParseError on invalid input
+        fm, body = parse_frontmatter(content)
+
+        # Pre-validate required frontmatter fields for clear error messages
+        required_keys = ("work-unit", "flight-plan", "sequence")
+        for key in required_keys:
+            if key not in fm:
+                raise WorkUnitValidationError(
+                    f"Work unit {path} is missing required frontmatter field: {key!r}",
+                    path=path,
+                    field=key,
+                )
+
+        sections = parse_work_unit_sections(body)
+
+        # Build nested model inputs
+        acceptance_criteria = tuple(
+            AcceptanceCriterion(text=text, trace_ref=trace_ref)
+            for text, trace_ref in sections["acceptance_criteria"]
+        )
+
+        fs_data = sections["file_scope"]
+        file_scope = FileScope(
+            create=tuple(fs_data["create"]),
+            modify=tuple(fs_data["modify"]),
+            protect=tuple(fs_data["protect"]),
+        )
+
+        # Normalise depends-on: YAML may give None, a list, or be absent
+        raw_depends_on = fm.get("depends-on") or []
+        depends_on = tuple(str(d) for d in raw_depends_on)
+
+        try:
+            wu = WorkUnit(
+                id=fm.get("work-unit", ""),
+                flight_plan=str(fm.get("flight-plan", "")),
+                sequence=int(fm.get("sequence", 0)),
+                parallel_group=fm.get("parallel-group"),
+                depends_on=depends_on,
+                task=sections["task"],
+                acceptance_criteria=acceptance_criteria,
+                file_scope=file_scope,
+                instructions=sections["instructions"],
+                verification=tuple(sections["verification"]),
+                provider_hints=sections["provider_hints"],
+                source_path=path,
+            )
+        except ValidationError as exc:
+            raise WorkUnitValidationError(
+                f"Work unit validation failed for {path}: {exc}",
+                path=path,
+            ) from exc
+
+        logger.debug("work_unit_loaded", id=wu.id, path=str(path))
+        return wu
+
+    @classmethod
+    async def aload(cls, path: Path) -> WorkUnit:
+        """Asynchronously load a WorkUnit from a Markdown file.
+
+        Args:
+            path: Path to the ``.md`` file.
+
+        Returns:
+            Parsed and validated WorkUnit model.
+
+        Raises:
+            WorkUnitNotFoundError: When the file does not exist.
+            WorkUnitValidationError: When required fields are invalid.
+        """
+        return await asyncio.to_thread(cls.load, path)
+
+    @classmethod
+    def load_directory(cls, directory: Path) -> list[WorkUnit]:
+        """Load all Work Units from a directory.
+
+        Discovers files matching the ``###-slug.md`` pattern (three leading
+        digits followed by a hyphen and slug), loads each, and returns them
+        sorted by sequence number.
+
+        Args:
+            directory: Path to the directory containing work unit files.
+
+        Returns:
+            List of WorkUnit models sorted by sequence number (ascending).
+
+        Raises:
+            WorkUnitNotFoundError: If an individual file is missing while
+                being read (rare race condition).
+            WorkUnitValidationError: If any file fails validation.
+        """
+        logger.debug("loading_work_units_from_directory", directory=str(directory))
+        files = sorted(directory.glob(_WORK_UNIT_GLOB))
+        units = [cls.load(f) for f in files]
+        # Sort by sequence number (ascending)
+        units.sort(key=lambda u: u.sequence)
+        logger.debug(
+            "work_units_loaded_from_directory",
+            count=len(units),
+            directory=str(directory),
+        )
+        return units
+
+    @classmethod
+    async def aload_directory(cls, directory: Path) -> list[WorkUnit]:
+        """Asynchronously load all Work Units from a directory.
+
+        Args:
+            directory: Path to the directory containing work unit files.
+
+        Returns:
+            List of WorkUnit models sorted by sequence number (ascending).
+        """
+        return await asyncio.to_thread(cls.load_directory, directory)
+
+    @classmethod
+    def save(cls, unit: WorkUnit, path: Path) -> None:
+        """Save a WorkUnit to a Markdown file (synchronous).
+
+        Serializes the unit to YAML frontmatter + Markdown format and writes
+        it to the given path in UTF-8 encoding.
+
+        Args:
+            unit: WorkUnit model instance to serialize.
+            path: Destination file path. Will be created or overwritten.
+        """
+        from maverick.flight.serializer import serialize_work_unit
+
+        content = serialize_work_unit(unit)
+        path.write_text(content, encoding="utf-8")
+
+    @classmethod
+    async def asave(cls, unit: WorkUnit, path: Path) -> None:
+        """Save a WorkUnit to a Markdown file (asynchronous).
+
+        Delegates to :meth:`save` via ``asyncio.to_thread`` to avoid
+        blocking the event loop.
+
+        Args:
+            unit: WorkUnit model instance to serialize.
+            path: Destination file path. Will be created or overwritten.
+        """
+        await asyncio.to_thread(cls.save, unit, path)
+
+
+__all__ = [
+    "FlightPlanFile",
+    "WorkUnitFile",
+]

--- a/src/maverick/flight/models.py
+++ b/src/maverick/flight/models.py
@@ -1,0 +1,425 @@
+"""Frozen Pydantic models for Flight Plan and Work Unit documents.
+
+Provides the canonical data model for the maverick.flight package:
+- FlightPlan — master plan with objectives, success criteria, and scope
+- WorkUnit — individual unit of work linked to a flight plan
+
+All models use ConfigDict(frozen=True) to prevent accidental mutation.
+Use model_copy(update={...}) to create modified instances.
+
+Public API:
+    SuccessCriterion, CompletionStatus, Scope, FlightPlan
+    AcceptanceCriterion, FileScope, WorkUnit
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from maverick.logging import get_logger
+
+logger = get_logger(__name__)
+
+_KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+_TRACE_REF_RE = re.compile(r"^SC-\d+$")
+
+
+# ---------------------------------------------------------------------------
+# FlightPlan models
+# ---------------------------------------------------------------------------
+
+
+class SuccessCriterion(BaseModel):
+    """A single success criterion for a Flight Plan.
+
+    Attributes:
+        text: Non-empty criterion text.
+        checked: Whether this criterion is complete.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    text: str = Field(description="Criterion text")
+    checked: bool = Field(description="Whether this criterion is checked")
+
+    @field_validator("text")
+    @classmethod
+    def text_must_not_be_empty(cls, v: str) -> str:
+        """Reject empty text."""
+        if not v.strip():
+            raise ValueError("text must not be empty")
+        return v
+
+
+class CompletionStatus(BaseModel):
+    """Completion status derived from a FlightPlan's success criteria.
+
+    Attributes:
+        checked: Number of checked criteria.
+        total: Total number of criteria.
+        percentage: Checked/total*100, or None when total is zero.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    checked: int = Field(ge=0, description="Number of checked criteria")
+    total: int = Field(ge=0, description="Total number of criteria")
+    percentage: float | None = Field(
+        description="Completion percentage (None if no criteria)"
+    )
+
+    @field_validator("percentage")
+    @classmethod
+    def percentage_must_be_in_range(cls, v: float | None) -> float | None:
+        """Validate that percentage is between 0.0 and 100.0 when set."""
+        if v is not None and not (0.0 <= v <= 100.0):
+            raise ValueError(f"percentage must be between 0.0 and 100.0, got: {v}")
+        return v
+
+
+class Scope(BaseModel):
+    """Scope definition for a Flight Plan.
+
+    Attributes:
+        in_scope: Items explicitly in scope.
+        out_of_scope: Items explicitly out of scope.
+        boundaries: Boundary conditions that define the scope.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    in_scope: tuple[str, ...] = Field(description="Items in scope")
+    out_of_scope: tuple[str, ...] = Field(description="Items out of scope")
+    boundaries: tuple[str, ...] = Field(description="Scope boundaries")
+
+
+class FlightPlan(BaseModel):
+    """Master plan describing objectives, success criteria, and scope.
+
+    Attributes:
+        name: Non-empty plan identifier (from YAML frontmatter).
+        version: Non-empty version string (from YAML frontmatter).
+        created: Creation date (from YAML frontmatter ``created``).
+        tags: Classification tags (from YAML frontmatter ``tags``).
+        objective: High-level objective text (from ``## Objective``).
+        success_criteria: Measurable success criteria (from ``## Success Criteria``).
+        scope: In/out-of-scope and boundary definitions (from ``## Scope``).
+        context: Optional background context (from ``## Context``).
+        constraints: Optional constraints list (from ``## Constraints``).
+        notes: Optional additional notes (from ``## Notes``).
+        source_path: Path to the source ``.md`` file, set by the loader.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(description="Flight plan name")
+    version: str = Field(description="Version string")
+    created: date = Field(description="Creation date")
+    tags: tuple[str, ...] = Field(description="Classification tags")
+    objective: str = Field(description="Plan objective")
+    success_criteria: tuple[SuccessCriterion, ...] = Field(
+        description="Success criteria"
+    )
+    scope: Scope = Field(description="Scope definition")
+    context: str = Field(default="", description="Background context")
+    constraints: tuple[str, ...] = Field(default=(), description="Constraints")
+    notes: str = Field(default="", description="Additional notes")
+    source_path: Path | None = Field(default=None, description="Source file path")
+
+    @field_validator("name")
+    @classmethod
+    def name_must_not_be_empty(cls, v: str) -> str:
+        """Reject empty name."""
+        if not v.strip():
+            raise ValueError("name must not be empty")
+        return v
+
+    @field_validator("version")
+    @classmethod
+    def version_must_not_be_empty(cls, v: str) -> str:
+        """Reject empty version."""
+        if not v.strip():
+            raise ValueError("version must not be empty")
+        return v
+
+    @field_validator("objective")
+    @classmethod
+    def objective_must_not_be_empty(cls, v: str) -> str:
+        """Reject empty objective."""
+        if not v.strip():
+            raise ValueError("objective must not be empty")
+        return v
+
+    @property
+    def completion(self) -> CompletionStatus:
+        """Compute completion status from success criteria.
+
+        Returns:
+            CompletionStatus with checked count, total count, and percentage.
+            percentage is None when total == 0.
+        """
+        total = len(self.success_criteria)
+        checked = sum(1 for c in self.success_criteria if c.checked)
+        percentage: float | None = (checked / total * 100) if total > 0 else None
+        return CompletionStatus(checked=checked, total=total, percentage=percentage)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the model to a JSON-compatible dictionary.
+
+        Returns:
+            Dict with all fields serialised:
+            - date → ISO string
+            - tuple → list
+            - nested models → dict
+            - Path → string or None
+        """
+        return {
+            "name": self.name,
+            "version": self.version,
+            "created": self.created.isoformat(),
+            "tags": list(self.tags),
+            "objective": self.objective,
+            "success_criteria": [
+                {"text": sc.text, "checked": sc.checked} for sc in self.success_criteria
+            ],
+            "scope": {
+                "in_scope": list(self.scope.in_scope),
+                "out_of_scope": list(self.scope.out_of_scope),
+                "boundaries": list(self.scope.boundaries),
+            },
+            "context": self.context,
+            "constraints": list(self.constraints),
+            "notes": self.notes,
+            "source_path": str(self.source_path) if self.source_path else None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# WorkUnit models
+# ---------------------------------------------------------------------------
+
+
+class AcceptanceCriterion(BaseModel):
+    """A single acceptance criterion for a Work Unit.
+
+    Attributes:
+        text: Non-empty criterion text.
+        trace_ref: Optional ``SC-###`` reference to a FlightPlan SuccessCriterion.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    text: str = Field(description="Criterion text")
+    trace_ref: str | None = Field(
+        default=None, description="Optional SC-### trace reference"
+    )
+
+    @field_validator("text")
+    @classmethod
+    def text_must_not_be_empty(cls, v: str) -> str:
+        """Reject empty text."""
+        if not v.strip():
+            raise ValueError("text must not be empty")
+        return v
+
+    @field_validator("trace_ref")
+    @classmethod
+    def trace_ref_must_match_format(cls, v: str | None) -> str | None:
+        """Validate that trace_ref matches SC-\\d+ format when set."""
+        if v is not None and not _TRACE_REF_RE.match(v):
+            raise ValueError(f"trace_ref must match SC-\\d+ format, got: {v!r}")
+        return v
+
+
+class FileScope(BaseModel):
+    """File scope for a Work Unit — which files to create, modify, or protect.
+
+    Attributes:
+        create: Files to create.
+        modify: Files to modify.
+        protect: Files that must not be changed.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    create: tuple[str, ...] = Field(description="Files to create")
+    modify: tuple[str, ...] = Field(description="Files to modify")
+    protect: tuple[str, ...] = Field(description="Files to protect")
+
+
+class WorkUnit(BaseModel):
+    """A single unit of work linked to a Flight Plan.
+
+    Attributes:
+        id: Kebab-case work unit identifier.
+        flight_plan: Non-empty name of the parent FlightPlan.
+        sequence: Positive execution sequence number (>= 1).
+        parallel_group: Optional group label for parallel execution.
+        depends_on: IDs of work units that must complete first.
+        task: Task description text.
+        acceptance_criteria: Measurable acceptance criteria.
+        file_scope: Files to create, modify, and protect.
+        instructions: Implementation instructions.
+        verification: Verification command strings.
+        provider_hints: Optional hints for the implementation agent.
+        source_path: Path to the source ``.md`` file, set by the loader.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(description="Kebab-case work unit ID")
+    flight_plan: str = Field(description="Parent flight plan name")
+    sequence: int = Field(description="Positive execution sequence number")
+    parallel_group: str | None = Field(
+        default=None, description="Optional parallel execution group"
+    )
+    depends_on: tuple[str, ...] = Field(
+        default=(), description="IDs of prerequisite work units"
+    )
+    task: str = Field(description="Task description")
+    acceptance_criteria: tuple[AcceptanceCriterion, ...] = Field(
+        description="Acceptance criteria"
+    )
+    file_scope: FileScope = Field(description="File scope definition")
+    instructions: str = Field(description="Implementation instructions")
+    verification: tuple[str, ...] = Field(description="Verification commands")
+    provider_hints: str | None = Field(
+        default=None, description="Optional hints for the implementation agent"
+    )
+    source_path: Path | None = Field(default=None, description="Source file path")
+
+    @field_validator("id")
+    @classmethod
+    def id_must_be_kebab_case(cls, v: str) -> str:
+        """Validate that id matches kebab-case pattern."""
+        if not _KEBAB_RE.match(v):
+            raise ValueError(
+                f"id must match kebab-case pattern ^[a-z0-9]+(-[a-z0-9]+)*$, got: {v!r}"
+            )
+        return v
+
+    @field_validator("depends_on")
+    @classmethod
+    def depends_on_must_be_kebab_case(cls, v: tuple[str, ...]) -> tuple[str, ...]:
+        """Validate that each depends_on entry matches kebab-case pattern."""
+        for entry in v:
+            if not _KEBAB_RE.match(entry):
+                raise ValueError(
+                    f"depends_on entries must match kebab-case pattern "
+                    f"^[a-z0-9]+(-[a-z0-9]+)*$, got: {entry!r}"
+                )
+        return v
+
+    @field_validator("sequence")
+    @classmethod
+    def sequence_must_be_positive(cls, v: int) -> int:
+        """Validate that sequence is >= 1."""
+        if v < 1:
+            raise ValueError(f"sequence must be >= 1, got: {v}")
+        return v
+
+    @field_validator("flight_plan")
+    @classmethod
+    def flight_plan_must_not_be_empty(cls, v: str) -> str:
+        """Reject empty flight_plan."""
+        if not v.strip():
+            raise ValueError("flight_plan must not be empty")
+        return v
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the model to a JSON-compatible dictionary.
+
+        Returns:
+            Dict with all fields serialised:
+            - tuple → list
+            - nested models → dict
+            - Path → string or None
+        """
+        return {
+            "id": self.id,
+            "flight_plan": self.flight_plan,
+            "sequence": self.sequence,
+            "parallel_group": self.parallel_group,
+            "depends_on": list(self.depends_on),
+            "task": self.task,
+            "acceptance_criteria": [
+                {"text": ac.text, "trace_ref": ac.trace_ref}
+                for ac in self.acceptance_criteria
+            ],
+            "file_scope": {
+                "create": list(self.file_scope.create),
+                "modify": list(self.file_scope.modify),
+                "protect": list(self.file_scope.protect),
+            },
+            "instructions": self.instructions,
+            "verification": list(self.verification),
+            "provider_hints": self.provider_hints,
+            "source_path": str(self.source_path) if self.source_path else None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Resolver models
+# ---------------------------------------------------------------------------
+
+
+class ExecutionBatch(BaseModel):
+    """A batch of work units that can execute concurrently.
+
+    Units within a batch share the same dependency tier and optionally the
+    same ``parallel_group``. All units in a batch can start once the
+    preceding batch completes.
+
+    Attributes:
+        units: Work units that belong to this batch.
+        parallel_group: Shared parallel group ID, or ``None`` for ungrouped.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    units: tuple[WorkUnit, ...] = Field(description="Work units in this batch")
+    parallel_group: str | None = Field(
+        default=None, description="Shared parallel group ID"
+    )
+
+    @field_validator("units")
+    @classmethod
+    def units_must_not_be_empty(cls, v: tuple[WorkUnit, ...]) -> tuple[WorkUnit, ...]:
+        """Reject empty units tuple."""
+        if not v:
+            raise ValueError("units must not be empty")
+        return v
+
+
+class ExecutionOrder(BaseModel):
+    """Topologically sorted sequence of execution batches.
+
+    Produced by :func:`resolve_execution_order`. Each batch in ``batches``
+    must complete before the next batch begins. Units within a single batch
+    are safe to run concurrently.
+
+    Attributes:
+        batches: Ordered tuple of :class:`ExecutionBatch` instances.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    batches: tuple[ExecutionBatch, ...] = Field(description="Ordered execution batches")
+
+
+__all__ = [
+    "AcceptanceCriterion",
+    "CompletionStatus",
+    "ExecutionBatch",
+    "ExecutionOrder",
+    "FileScope",
+    "FlightPlan",
+    "Scope",
+    "SuccessCriterion",
+    "WorkUnit",
+]

--- a/src/maverick/flight/parser.py
+++ b/src/maverick/flight/parser.py
@@ -1,0 +1,342 @@
+"""Markdown + YAML frontmatter parser for flight plan documents.
+
+Provides low-level parsing primitives used by FlightPlanFile and WorkUnitFile
+loaders. All functions are pure (no I/O) for easy testing.
+
+Public API:
+    parse_frontmatter(content) -> tuple[dict, str]
+    parse_checkbox_list(content) -> list[tuple[bool, str]]
+    parse_bullet_list(content) -> list[str]
+    parse_flight_plan_sections(body) -> dict[str, Any]
+    parse_work_unit_sections(body) -> dict[str, Any]
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import yaml
+
+from maverick.flight.errors import FlightPlanParseError
+from maverick.logging import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Regex patterns
+# ---------------------------------------------------------------------------
+
+_CHECKBOX_RE = re.compile(r"^-\s+\[([xX ])\]\s+(.+)$")
+_BULLET_RE = re.compile(r"^-\s+(.+)$")
+_TRACE_REF_RE = re.compile(r"\[SC-(\d+)\]\s*$")
+
+
+# ---------------------------------------------------------------------------
+# Core primitives
+# ---------------------------------------------------------------------------
+
+
+def parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:
+    """Split a Markdown document into YAML frontmatter and body.
+
+    The document must begin with ``---\\n`` and contain a second ``---``
+    delimiter to close the frontmatter block.
+
+    Args:
+        content: Raw Markdown string with YAML frontmatter.
+
+    Returns:
+        A two-element tuple of (frontmatter_dict, markdown_body).
+
+    Raises:
+        FlightPlanParseError: If the ``---`` delimiters are missing or the
+            YAML inside the frontmatter block is invalid.
+    """
+    if not content.startswith("---"):
+        raise FlightPlanParseError(
+            "Document does not start with '---' frontmatter delimiter",
+            field="frontmatter",
+        )
+
+    # Split off the opening "---"
+    rest = content[3:]
+    # Match closing delimiter: "\n---" followed by newline or end-of-string.
+    # Using a regex avoids false positives from "---" inside YAML values.
+    _closing_re = re.search(r"\n---(\n|$)", rest)
+    if _closing_re is None:
+        raise FlightPlanParseError(
+            "Document is missing the closing '---' frontmatter delimiter",
+            field="frontmatter",
+        )
+
+    # Find the closing delimiter
+    close_idx = _closing_re.start()
+    yaml_block = rest[:close_idx]
+    # Body starts after the closing ---\n
+    body_start = close_idx + len("\n---")
+    # Skip the newline immediately after the closing ---
+    if body_start < len(rest) and rest[body_start] == "\n":
+        body_start += 1
+    body = rest[body_start:]
+
+    try:
+        fm: dict[str, Any] = yaml.safe_load(yaml_block) or {}
+    except yaml.YAMLError as exc:
+        raise FlightPlanParseError(
+            f"Invalid YAML in frontmatter block: {exc}",
+            field="frontmatter",
+        ) from exc
+
+    return fm, body
+
+
+def parse_checkbox_list(content: str) -> list[tuple[bool, str]]:
+    """Parse Markdown checkbox list items from *content*.
+
+    Recognises lines of the form ``- [x] text``, ``- [X] text``, and
+    ``- [ ] text``.  All other lines are ignored.
+
+    Args:
+        content: Block of Markdown text.
+
+    Returns:
+        List of ``(checked, text)`` tuples in document order.
+    """
+    results: list[tuple[bool, str]] = []
+    for line in content.splitlines():
+        m = _CHECKBOX_RE.match(line.rstrip())
+        if m:
+            marker, text = m.group(1), m.group(2).strip()
+            checked = marker.lower() == "x"
+            results.append((checked, text))
+    return results
+
+
+def parse_bullet_list(content: str) -> list[str]:
+    """Parse Markdown bullet list items from *content*.
+
+    Recognises lines of the form ``- text``.  All other lines are ignored.
+
+    Args:
+        content: Block of Markdown text.
+
+    Returns:
+        List of bullet text strings in document order.
+    """
+    results: list[str] = []
+    for line in content.splitlines():
+        m = _BULLET_RE.match(line.rstrip())
+        if m:
+            results.append(m.group(1).strip())
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Section splitting helpers
+# ---------------------------------------------------------------------------
+
+
+def _split_h2_sections(body: str) -> dict[str, str]:
+    """Split a Markdown body on ``## `` headings.
+
+    Args:
+        body: Markdown body text (without frontmatter).
+
+    Returns:
+        Dict mapping heading text (case-preserved) to section content (not
+        including the heading line itself).
+    """
+    sections: dict[str, str] = {}
+    current_key: str | None = None
+    current_lines: list[str] = []
+
+    for line in body.splitlines():
+        if line.startswith("## "):
+            if current_key is not None:
+                sections[current_key] = "\n".join(current_lines).strip()
+            current_key = line[3:].strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    if current_key is not None:
+        sections[current_key] = "\n".join(current_lines).strip()
+
+    return sections
+
+
+def _split_h3_sections(content: str) -> dict[str, str]:
+    """Split section content on ``### `` sub-headings.
+
+    Args:
+        content: Text content of an ``## `` section.
+
+    Returns:
+        Dict mapping sub-heading text (case-preserved) to sub-section content.
+    """
+    subsections: dict[str, str] = {}
+    current_key: str | None = None
+    current_lines: list[str] = []
+
+    for line in content.splitlines():
+        if line.startswith("### "):
+            if current_key is not None:
+                subsections[current_key] = "\n".join(current_lines).strip()
+            current_key = line[4:].strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    if current_key is not None:
+        subsections[current_key] = "\n".join(current_lines).strip()
+
+    return subsections
+
+
+# ---------------------------------------------------------------------------
+# Flight Plan section parser
+# ---------------------------------------------------------------------------
+
+
+def parse_flight_plan_sections(body: str) -> dict[str, Any]:
+    """Extract structured sections from a Flight Plan Markdown body.
+
+    Expected sections (case-sensitive heading names):
+    - ``## Objective`` — plain text
+    - ``## Success Criteria`` — checkbox list
+    - ``## Scope`` — has ``### In``, ``### Out``, ``### Boundaries`` sub-sections
+    - ``## Context`` — plain text (optional)
+    - ``## Constraints`` — bullet list (optional)
+    - ``## Notes`` — plain text (optional)
+
+    Args:
+        body: Markdown body text after frontmatter has been stripped.
+
+    Returns:
+        Dict with keys: ``objective``, ``success_criteria``, ``scope``,
+        ``context``, ``constraints``, ``notes``.  The ``scope`` value is
+        itself a dict with keys ``in_scope``, ``out_of_scope``,
+        ``boundaries``.
+    """
+    h2 = _split_h2_sections(body)
+
+    objective = h2.get("Objective", "").strip()
+    success_criteria = parse_checkbox_list(h2.get("Success Criteria", ""))
+
+    scope_content = h2.get("Scope", "")
+    h3_scope = _split_h3_sections(scope_content)
+    scope: dict[str, list[str]] = {
+        "in_scope": parse_bullet_list(h3_scope.get("In", "")),
+        "out_of_scope": parse_bullet_list(h3_scope.get("Out", "")),
+        "boundaries": parse_bullet_list(h3_scope.get("Boundaries", "")),
+    }
+
+    context = h2.get("Context", "").strip()
+    constraints = parse_bullet_list(h2.get("Constraints", ""))
+    notes = h2.get("Notes", "").strip()
+
+    return {
+        "objective": objective,
+        "success_criteria": success_criteria,
+        "scope": scope,
+        "context": context,
+        "constraints": constraints,
+        "notes": notes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Work Unit section parser
+# ---------------------------------------------------------------------------
+
+
+def _parse_acceptance_criteria_line(line: str) -> tuple[str, str | None] | None:
+    """Parse a single acceptance criterion bullet line.
+
+    Args:
+        line: A single line from the Acceptance Criteria section.
+
+    Returns:
+        ``(text, trace_ref)`` tuple, or ``None`` if line is not a bullet.
+        ``trace_ref`` is ``None`` when no ``[SC-###]`` suffix is present.
+    """
+    m = _BULLET_RE.match(line.rstrip())
+    if not m:
+        return None
+    raw_text = m.group(1).strip()
+    trace_m = _TRACE_REF_RE.search(raw_text)
+    if trace_m:
+        trace_ref: str | None = f"SC-{trace_m.group(1)}"
+        text = raw_text[: trace_m.start()].strip()
+    else:
+        trace_ref = None
+        text = raw_text
+    return text, trace_ref
+
+
+def parse_work_unit_sections(body: str) -> dict[str, Any]:
+    """Extract structured sections from a Work Unit Markdown body.
+
+    Expected sections:
+    - ``## Task`` — plain text
+    - ``## Acceptance Criteria`` — bullet list with optional ``[SC-###]`` refs
+    - ``## File Scope`` — has ``### Create``, ``### Modify``, ``### Protect``
+    - ``## Instructions`` — plain text
+    - ``## Verification`` — bullet list (command strings)
+    - ``## Provider Hints`` — plain text (optional)
+
+    Args:
+        body: Markdown body text after frontmatter has been stripped.
+
+    Returns:
+        Dict with keys: ``task``, ``acceptance_criteria``, ``file_scope``,
+        ``instructions``, ``verification``, ``provider_hints``.
+        ``acceptance_criteria`` is a list of ``(text, trace_ref | None)``.
+        ``file_scope`` is a dict with ``create``, ``modify``, ``protect``.
+    """
+    h2 = _split_h2_sections(body)
+
+    task = h2.get("Task", "").strip()
+
+    ac_content = h2.get("Acceptance Criteria", "")
+    acceptance_criteria: list[tuple[str, str | None]] = []
+    for line in ac_content.splitlines():
+        parsed = _parse_acceptance_criteria_line(line)
+        if parsed is not None:
+            acceptance_criteria.append(parsed)
+
+    file_scope_content = h2.get("File Scope", "")
+    h3_scope = _split_h3_sections(file_scope_content)
+    file_scope: dict[str, list[str]] = {
+        "create": parse_bullet_list(h3_scope.get("Create", "")),
+        "modify": parse_bullet_list(h3_scope.get("Modify", "")),
+        "protect": parse_bullet_list(h3_scope.get("Protect", "")),
+    }
+
+    instructions = h2.get("Instructions", "").strip()
+    verification = parse_bullet_list(h2.get("Verification", ""))
+
+    raw_hints = h2.get("Provider Hints", None)
+    provider_hints: str | None = raw_hints.strip() if raw_hints is not None else None
+    # Treat empty-string hints as None (section absent)
+    if provider_hints == "":
+        provider_hints = None
+
+    return {
+        "task": task,
+        "acceptance_criteria": acceptance_criteria,
+        "file_scope": file_scope,
+        "instructions": instructions,
+        "verification": verification,
+        "provider_hints": provider_hints,
+    }
+
+
+__all__ = [
+    "parse_frontmatter",
+    "parse_checkbox_list",
+    "parse_bullet_list",
+    "parse_flight_plan_sections",
+    "parse_work_unit_sections",
+]

--- a/src/maverick/flight/resolver.py
+++ b/src/maverick/flight/resolver.py
@@ -1,0 +1,153 @@
+"""Dependency resolver for Work Unit execution ordering.
+
+Provides :func:`resolve_execution_order` which accepts a list of
+:class:`~maverick.flight.models.WorkUnit` instances and returns an
+:class:`~maverick.flight.models.ExecutionOrder` describing topologically
+sorted :class:`~maverick.flight.models.ExecutionBatch` instances.
+
+Algorithm overview:
+
+1. Check for duplicate Work Unit IDs (raises
+   :class:`~maverick.flight.errors.WorkUnitDependencyError`).  Then build an
+   ID-to-unit lookup map and validate that all ``depends_on`` IDs reference
+   known units (raises :exc:`WorkUnitDependencyError` with ``missing_id`` set).
+2. DFS topological sort with explicit ``in_stack`` tracking for cycle
+   detection (raises :exc:`WorkUnitDependencyError` with ``cycle`` set).
+3. Compute the dependency *level* for each unit:
+   ``level = max(dep_levels) + 1``, or ``0`` when the unit has no deps.
+4. Group units by level into ordered tiers.
+5. Within each tier, further group by ``parallel_group``.  Units that share
+   the same non-``None`` ``parallel_group`` are placed in a single
+   :class:`ExecutionBatch` with that group label.  Units whose
+   ``parallel_group`` is ``None`` are collected into a single ungrouped
+   batch for their tier.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from maverick.flight.errors import WorkUnitDependencyError
+from maverick.flight.models import ExecutionBatch, ExecutionOrder, WorkUnit
+from maverick.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def resolve_execution_order(units: list[WorkUnit]) -> ExecutionOrder:
+    """Resolve dependency order using topological sort.
+
+    Groups units by ``parallel_group`` within each dependency tier so that
+    independent work can be executed concurrently.
+
+    Args:
+        units: List of :class:`WorkUnit` instances to order.
+
+    Returns:
+        :class:`ExecutionOrder` with topologically sorted
+        :class:`ExecutionBatch` instances.
+
+    Raises:
+        WorkUnitDependencyError: If a circular dependency is detected
+            (``cycle`` attribute holds the cycle IDs) or a referenced
+            dependency ID is not present in ``units`` (``missing_id``
+            attribute holds the unknown ID).
+    """
+    if not units:
+        logger.debug("resolve_execution_order.empty_input")
+        return ExecutionOrder(batches=())
+
+    # --- 1. Build lookup and validate deps -----------------------------------
+
+    # Check for duplicate IDs before building the map.
+    seen_ids: dict[str, int] = {}
+    for u in units:
+        seen_ids[u.id] = seen_ids.get(u.id, 0) + 1
+    duplicates = [uid for uid, count in seen_ids.items() if count > 1]
+    if duplicates:
+        raise WorkUnitDependencyError(
+            f"Duplicate work unit IDs: {', '.join(sorted(duplicates))}",
+        )
+
+    unit_map: dict[str, WorkUnit] = {u.id: u for u in units}
+
+    for unit in units:
+        for dep_id in unit.depends_on:
+            if dep_id not in unit_map:
+                raise WorkUnitDependencyError(
+                    f"Work unit '{unit.id}' depends on unknown unit '{dep_id}'",
+                    missing_id=dep_id,
+                )
+
+    # --- 2. DFS topological sort with cycle detection -----------------------
+
+    visited: set[str] = set()
+    in_stack: set[str] = set()
+    path: list[str] = []
+    topo_order: list[str] = []
+
+    def _visit(uid: str) -> None:
+        if uid in in_stack:
+            # Extract the exact cycle from the DFS path.
+            start = path.index(uid)
+            cycle = path[start:] + [uid]
+            raise WorkUnitDependencyError(
+                f"Circular dependency detected involving '{uid}': {' -> '.join(cycle)}",
+                cycle=cycle,
+            )
+        if uid in visited:
+            return
+
+        in_stack.add(uid)
+        path.append(uid)
+        for dep_id in unit_map[uid].depends_on:
+            _visit(dep_id)
+        path.pop()
+        in_stack.remove(uid)
+        visited.add(uid)
+        topo_order.append(uid)
+
+    for uid in unit_map:
+        _visit(uid)
+
+    logger.debug(
+        "resolve_execution_order.topo_order",
+        order=topo_order,
+    )
+
+    # --- 3. Assign dependency levels ----------------------------------------
+
+    levels: dict[str, int] = {}
+    for uid in topo_order:  # topo_order is deps-before-dependents
+        deps = unit_map[uid].depends_on
+        if deps:
+            levels[uid] = max(levels[dep] for dep in deps) + 1
+        else:
+            levels[uid] = 0
+
+    # --- 4. Group by level into tiers ----------------------------------------
+
+    level_groups: dict[int, list[WorkUnit]] = defaultdict(list)
+    for uid in topo_order:
+        level_groups[levels[uid]].append(unit_map[uid])
+
+    # --- 5. Within each tier, group by parallel_group ------------------------
+
+    batches: list[ExecutionBatch] = []
+    for level in sorted(level_groups):
+        tier_units = level_groups[level]
+
+        # Collect ungrouped units first; then each distinct parallel_group.
+        pg_groups: dict[str | None, list[WorkUnit]] = defaultdict(list)
+        for u in tier_units:
+            pg_groups[u.parallel_group].append(u)
+
+        for pg, pg_units in pg_groups.items():
+            batches.append(ExecutionBatch(units=tuple(pg_units), parallel_group=pg))
+
+    logger.debug(
+        "resolve_execution_order.batches_built",
+        batch_count=len(batches),
+    )
+
+    return ExecutionOrder(batches=tuple(batches))

--- a/src/maverick/flight/serializer.py
+++ b/src/maverick/flight/serializer.py
@@ -1,0 +1,230 @@
+"""Round-trip serializers for Flight Plan and Work Unit documents.
+
+Converts in-memory Pydantic models back to the Markdown+YAML frontmatter
+format that can be reloaded by FlightPlanFile and WorkUnitFile loaders.
+
+Public API:
+    serialize_flight_plan(plan) -> str
+    serialize_work_unit(unit) -> str
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+from maverick.flight.models import FlightPlan, WorkUnit
+
+# ---------------------------------------------------------------------------
+# FlightPlan serializer
+# ---------------------------------------------------------------------------
+
+
+def serialize_flight_plan(plan: FlightPlan) -> str:
+    """Serialize a FlightPlan model to Markdown+YAML string.
+
+    The output can be reloaded via FlightPlanFile.load() with identical data.
+
+    Args:
+        plan: FlightPlan model instance.
+
+    Returns:
+        Markdown+YAML string with YAML frontmatter and Markdown sections.
+        The document structure is:
+        - YAML frontmatter (name, version, created, tags)
+        - ## Objective
+        - ## Success Criteria (checkbox list)
+        - ## Scope (### In / ### Out / ### Boundaries sub-sections)
+        - ## Context (omitted when empty)
+        - ## Constraints (omitted when empty)
+        - ## Notes (omitted when empty)
+    """
+    lines: list[str] = []
+
+    # --- Frontmatter ---
+    frontmatter: dict[str, Any] = {
+        "name": plan.name,
+        "version": plan.version,
+        "created": plan.created.isoformat(),
+        "tags": list(plan.tags),
+    }
+    fm_yaml = yaml.dump(
+        frontmatter,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )
+    lines.append("---")
+    lines.append(fm_yaml.rstrip())
+    lines.append("---")
+    lines.append("")
+
+    # --- Objective ---
+    lines.append("## Objective")
+    lines.append("")
+    lines.append(plan.objective)
+    lines.append("")
+
+    # --- Success Criteria ---
+    lines.append("## Success Criteria")
+    lines.append("")
+    for criterion in plan.success_criteria:
+        marker = "x" if criterion.checked else " "
+        lines.append(f"- [{marker}] {criterion.text}")
+    lines.append("")
+
+    # --- Scope ---
+    lines.append("## Scope")
+    lines.append("")
+    lines.append("### In")
+    lines.append("")
+    for item in plan.scope.in_scope:
+        lines.append(f"- {item}")
+    lines.append("")
+    lines.append("### Out")
+    lines.append("")
+    for item in plan.scope.out_of_scope:
+        lines.append(f"- {item}")
+    lines.append("")
+    lines.append("### Boundaries")
+    lines.append("")
+    for item in plan.scope.boundaries:
+        lines.append(f"- {item}")
+    lines.append("")
+
+    # --- Context (optional) ---
+    if plan.context:
+        lines.append("## Context")
+        lines.append("")
+        lines.append(plan.context)
+        lines.append("")
+
+    # --- Constraints (optional) ---
+    if plan.constraints:
+        lines.append("## Constraints")
+        lines.append("")
+        for constraint in plan.constraints:
+            lines.append(f"- {constraint}")
+        lines.append("")
+
+    # --- Notes (optional) ---
+    if plan.notes:
+        lines.append("## Notes")
+        lines.append("")
+        lines.append(plan.notes)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# WorkUnit serializer
+# ---------------------------------------------------------------------------
+
+
+def serialize_work_unit(unit: WorkUnit) -> str:
+    """Serialize a WorkUnit model to Markdown+YAML string.
+
+    The output can be reloaded via WorkUnitFile.load() with identical data.
+
+    Args:
+        unit: WorkUnit model instance.
+
+    Returns:
+        Markdown+YAML string with YAML frontmatter and Markdown sections.
+        The document structure is:
+        - YAML frontmatter (work-unit, flight-plan, sequence, depends-on,
+          and optionally parallel-group)
+        - ## Task
+        - ## Acceptance Criteria (bullet list with optional [SC-###] refs)
+        - ## File Scope (### Create / ### Modify / ### Protect sub-sections)
+        - ## Instructions
+        - ## Verification (bullet list)
+        - ## Provider Hints (omitted when None)
+    """
+    lines: list[str] = []
+
+    # --- Frontmatter ---
+    frontmatter: dict[str, Any] = {
+        "work-unit": unit.id,
+        "flight-plan": unit.flight_plan,
+        "sequence": unit.sequence,
+        "depends-on": list(unit.depends_on),
+    }
+    if unit.parallel_group is not None:
+        frontmatter["parallel-group"] = unit.parallel_group
+
+    fm_yaml = yaml.dump(
+        frontmatter,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )
+    lines.append("---")
+    lines.append(fm_yaml.rstrip())
+    lines.append("---")
+    lines.append("")
+
+    # --- Task ---
+    lines.append("## Task")
+    lines.append("")
+    lines.append(unit.task)
+    lines.append("")
+
+    # --- Acceptance Criteria ---
+    lines.append("## Acceptance Criteria")
+    lines.append("")
+    for ac in unit.acceptance_criteria:
+        if ac.trace_ref:
+            lines.append(f"- {ac.text} [{ac.trace_ref}]")
+        else:
+            lines.append(f"- {ac.text}")
+    lines.append("")
+
+    # --- File Scope ---
+    lines.append("## File Scope")
+    lines.append("")
+    lines.append("### Create")
+    lines.append("")
+    for item in unit.file_scope.create:
+        lines.append(f"- {item}")
+    lines.append("")
+    lines.append("### Modify")
+    lines.append("")
+    for item in unit.file_scope.modify:
+        lines.append(f"- {item}")
+    lines.append("")
+    lines.append("### Protect")
+    lines.append("")
+    for item in unit.file_scope.protect:
+        lines.append(f"- {item}")
+    lines.append("")
+
+    # --- Instructions ---
+    lines.append("## Instructions")
+    lines.append("")
+    lines.append(unit.instructions)
+    lines.append("")
+
+    # --- Verification ---
+    lines.append("## Verification")
+    lines.append("")
+    for cmd in unit.verification:
+        lines.append(f"- {cmd}")
+    lines.append("")
+
+    # --- Provider Hints (optional) ---
+    if unit.provider_hints:
+        lines.append("## Provider Hints")
+        lines.append("")
+        lines.append(unit.provider_hints)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+__all__ = [
+    "serialize_flight_plan",
+    "serialize_work_unit",
+]

--- a/tests/unit/flight/__init__.py
+++ b/tests/unit/flight/__init__.py
@@ -1,0 +1,3 @@
+"""Unit tests for the maverick.flight package."""
+
+from __future__ import annotations

--- a/tests/unit/flight/conftest.py
+++ b/tests/unit/flight/conftest.py
@@ -1,0 +1,168 @@
+"""Shared fixtures for maverick.flight unit tests."""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Sample Markdown strings
+# ---------------------------------------------------------------------------
+
+SAMPLE_FLIGHT_PLAN_MD = """\
+---
+name: setup-authentication
+version: "1.0"
+created: 2026-02-27
+tags:
+  - auth
+  - security
+---
+
+## Objective
+
+Implement user authentication with JWT tokens.
+
+## Success Criteria
+
+- [x] Users can register with email and password
+- [ ] Users can log in and receive a JWT
+- [ ] Protected routes reject unauthenticated requests
+
+## Scope
+
+### In
+
+- Registration endpoint
+- Login endpoint
+- JWT middleware
+
+### Out
+
+- OAuth providers
+- Password reset flow
+
+### Boundaries
+
+- JWT tokens expire after 24 hours
+
+## Context
+
+Building on the existing Express.js API framework.
+
+## Constraints
+
+- Must use bcrypt for password hashing
+- Token secret from environment variable
+
+## Notes
+
+Consider adding refresh tokens in a follow-up.
+"""
+
+SAMPLE_WORK_UNIT_MD = """\
+---
+work-unit: setup-database
+flight-plan: setup-authentication
+sequence: 1
+depends-on: []
+---
+
+## Task
+
+Create the users table and database connection module.
+
+## Acceptance Criteria
+
+- Database connection pool is configured [SC-001]
+- Users table has email, password_hash, created_at columns
+
+## File Scope
+
+### Create
+
+- src/db/connection.py
+- src/db/models/user.py
+
+### Modify
+
+- src/config.py
+
+### Protect
+
+- src/main.py
+
+## Instructions
+
+Use SQLAlchemy with async support. Follow existing patterns in the project.
+
+## Verification
+
+- make test-fast
+- make lint
+- make typecheck
+"""
+
+SAMPLE_WORK_UNIT_MD_WITH_PARALLEL = """\
+---
+work-unit: add-login-endpoint
+flight-plan: setup-authentication
+sequence: 2
+parallel-group: endpoints
+depends-on:
+  - setup-database
+---
+
+## Task
+
+Implement the login endpoint.
+
+## Acceptance Criteria
+
+- POST /login accepts email and password
+- Returns JWT on success [SC-002]
+
+## File Scope
+
+### Create
+
+- src/api/login.py
+
+### Modify
+
+- src/api/__init__.py
+
+### Protect
+
+- src/db/connection.py
+
+## Instructions
+
+Use the database connection from setup-database work unit.
+
+## Verification
+
+- make test-fast
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_flight_plan_md() -> str:
+    """Return a sample Flight Plan Markdown string."""
+    return SAMPLE_FLIGHT_PLAN_MD
+
+
+@pytest.fixture
+def sample_work_unit_md() -> str:
+    """Return a sample Work Unit Markdown string."""
+    return SAMPLE_WORK_UNIT_MD
+
+
+@pytest.fixture
+def sample_work_unit_md_with_parallel() -> str:
+    """Return a sample Work Unit with parallel-group and depends-on."""
+    return SAMPLE_WORK_UNIT_MD_WITH_PARALLEL

--- a/tests/unit/flight/test_loader.py
+++ b/tests/unit/flight/test_loader.py
@@ -1,0 +1,662 @@
+"""Tests for maverick.flight.loader module.
+
+T008: FlightPlanFile loader tests.
+T013: WorkUnitFile loader tests.
+
+Tests written before implementation (TDD). All tests must fail until
+loaders are implemented.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from tests.unit.flight.conftest import (
+    SAMPLE_FLIGHT_PLAN_MD,
+    SAMPLE_WORK_UNIT_MD,
+    SAMPLE_WORK_UNIT_MD_WITH_PARALLEL,
+)
+
+# ===========================================================================
+# T008: FlightPlanFile loader tests
+# ===========================================================================
+
+
+class TestFlightPlanFileLoad:
+    """Tests for FlightPlanFile.load()."""
+
+    def test_load_valid_file_returns_flight_plan(self, tmp_path: Path) -> None:
+        """load() from a valid file returns a FlightPlan with correct fields."""
+        from maverick.flight.loader import FlightPlanFile
+        from maverick.flight.models import FlightPlan
+
+        fp_file = tmp_path / "flight-plan.md"
+        fp_file.write_text(SAMPLE_FLIGHT_PLAN_MD)
+
+        fp = FlightPlanFile.load(fp_file)
+
+        assert isinstance(fp, FlightPlan)
+        assert fp.name == "setup-authentication"
+        assert fp.version == "1.0"
+        assert fp.created == date(2026, 2, 27)
+        assert "auth" in fp.tags
+        assert "security" in fp.tags
+
+    def test_load_sets_source_path(self, tmp_path: Path) -> None:
+        """load() sets source_path on the returned FlightPlan."""
+        from maverick.flight.loader import FlightPlanFile
+
+        fp_file = tmp_path / "flight-plan.md"
+        fp_file.write_text(SAMPLE_FLIGHT_PLAN_MD)
+
+        fp = FlightPlanFile.load(fp_file)
+        assert fp.source_path == fp_file
+
+    def test_load_objective_field(self, tmp_path: Path) -> None:
+        """load() correctly populates the objective field."""
+        from maverick.flight.loader import FlightPlanFile
+
+        fp_file = tmp_path / "plan.md"
+        fp_file.write_text(SAMPLE_FLIGHT_PLAN_MD)
+
+        fp = FlightPlanFile.load(fp_file)
+        assert "JWT tokens" in fp.objective
+
+    def test_load_success_criteria(self, tmp_path: Path) -> None:
+        """load() populates success_criteria with correct checked states."""
+        from maverick.flight.loader import FlightPlanFile
+
+        fp_file = tmp_path / "plan.md"
+        fp_file.write_text(SAMPLE_FLIGHT_PLAN_MD)
+
+        fp = FlightPlanFile.load(fp_file)
+        assert len(fp.success_criteria) == 3
+        assert fp.success_criteria[0].checked is True
+        assert fp.success_criteria[1].checked is False
+
+    def test_load_scope_in_scope(self, tmp_path: Path) -> None:
+        """load() populates scope.in_scope from the ### In subsection."""
+        from maverick.flight.loader import FlightPlanFile
+
+        fp_file = tmp_path / "plan.md"
+        fp_file.write_text(SAMPLE_FLIGHT_PLAN_MD)
+
+        fp = FlightPlanFile.load(fp_file)
+        assert "Registration endpoint" in fp.scope.in_scope
+
+    def test_load_optional_context(self, tmp_path: Path) -> None:
+        """load() populates optional context field."""
+        from maverick.flight.loader import FlightPlanFile
+
+        fp_file = tmp_path / "plan.md"
+        fp_file.write_text(SAMPLE_FLIGHT_PLAN_MD)
+
+        fp = FlightPlanFile.load(fp_file)
+        assert "Express.js" in fp.context
+
+    def test_load_optional_constraints(self, tmp_path: Path) -> None:
+        """load() populates optional constraints field."""
+        from maverick.flight.loader import FlightPlanFile
+
+        fp_file = tmp_path / "plan.md"
+        fp_file.write_text(SAMPLE_FLIGHT_PLAN_MD)
+
+        fp = FlightPlanFile.load(fp_file)
+        assert len(fp.constraints) == 2
+
+    def test_load_optional_notes(self, tmp_path: Path) -> None:
+        """load() populates optional notes field."""
+        from maverick.flight.loader import FlightPlanFile
+
+        fp_file = tmp_path / "plan.md"
+        fp_file.write_text(SAMPLE_FLIGHT_PLAN_MD)
+
+        fp = FlightPlanFile.load(fp_file)
+        assert "refresh tokens" in fp.notes
+
+    def test_load_missing_file_raises_not_found(self, tmp_path: Path) -> None:
+        """load() on a missing file raises FlightPlanNotFoundError with path."""
+        from maverick.flight.errors import FlightPlanNotFoundError
+        from maverick.flight.loader import FlightPlanFile
+
+        missing = tmp_path / "nonexistent.md"
+        with pytest.raises(FlightPlanNotFoundError) as exc_info:
+            FlightPlanFile.load(missing)
+        assert exc_info.value.path == missing
+
+    def test_load_oserror_raises_parse_error(self, tmp_path: Path) -> None:
+        """load() wraps non-FileNotFoundError OSError in FlightPlanParseError."""
+        from maverick.flight.errors import FlightPlanParseError
+        from maverick.flight.loader import FlightPlanFile
+
+        # Use a directory path — reading it as text raises IsADirectoryError
+        dir_path = tmp_path / "a-directory"
+        dir_path.mkdir()
+
+        with pytest.raises(FlightPlanParseError) as exc_info:
+            FlightPlanFile.load(dir_path)
+        assert exc_info.value.path == dir_path
+
+    def test_load_missing_frontmatter_name_raises_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """load() raises FlightPlanValidationError when 'name' is absent."""
+        from maverick.flight.errors import FlightPlanValidationError
+        from maverick.flight.loader import FlightPlanFile
+
+        content = (
+            "---\n"
+            "version: '1.0'\n"
+            "created: 2026-01-01\n"
+            "tags:\n  - test\n"
+            "---\n\n## Objective\n\nDo something.\n\n"
+            "## Success Criteria\n\n- [x] Done\n\n"
+            "## Scope\n\n### In\n\n- item\n\n### Out\n\n### Boundaries\n"
+        )
+        fp_file = tmp_path / "no-name.md"
+        fp_file.write_text(content)
+
+        with pytest.raises(FlightPlanValidationError) as exc_info:
+            FlightPlanFile.load(fp_file)
+        assert exc_info.value.field == "name"
+        assert exc_info.value.path == fp_file
+
+    def test_load_missing_frontmatter_version_raises_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """load() raises FlightPlanValidationError when 'version' is absent."""
+        from maverick.flight.errors import FlightPlanValidationError
+        from maverick.flight.loader import FlightPlanFile
+
+        content = (
+            "---\n"
+            "name: my-plan\n"
+            "created: 2026-01-01\n"
+            "tags:\n  - test\n"
+            "---\n\n## Objective\n\nDo something.\n\n"
+            "## Success Criteria\n\n- [x] Done\n\n"
+            "## Scope\n\n### In\n\n- item\n\n### Out\n\n### Boundaries\n"
+        )
+        fp_file = tmp_path / "no-version.md"
+        fp_file.write_text(content)
+
+        with pytest.raises(FlightPlanValidationError) as exc_info:
+            FlightPlanFile.load(fp_file)
+        assert exc_info.value.field == "version"
+        assert exc_info.value.path == fp_file
+
+    def test_load_missing_frontmatter_created_raises_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """load() raises FlightPlanValidationError when 'created' is absent."""
+        from maverick.flight.errors import FlightPlanValidationError
+        from maverick.flight.loader import FlightPlanFile
+
+        content = (
+            "---\n"
+            "name: my-plan\n"
+            "version: '1.0'\n"
+            "tags:\n  - test\n"
+            "---\n\n## Objective\n\nDo something.\n\n"
+            "## Success Criteria\n\n- [x] Done\n\n"
+            "## Scope\n\n### In\n\n- item\n\n### Out\n\n### Boundaries\n"
+        )
+        fp_file = tmp_path / "no-created.md"
+        fp_file.write_text(content)
+
+        with pytest.raises(FlightPlanValidationError) as exc_info:
+            FlightPlanFile.load(fp_file)
+        assert exc_info.value.field == "created"
+        assert exc_info.value.path == fp_file
+
+    def test_load_malformed_frontmatter_raises_parse_error(
+        self, tmp_path: Path
+    ) -> None:
+        """load() on content without --- delimiters raises FlightPlanParseError."""
+        from maverick.flight.errors import FlightPlanParseError
+        from maverick.flight.loader import FlightPlanFile
+
+        bad_file = tmp_path / "bad.md"
+        bad_file.write_text("name: my-plan\nversion: 1.0\n\n## Objective\n\nSomething.")
+
+        with pytest.raises(FlightPlanParseError):
+            FlightPlanFile.load(bad_file)
+
+    def test_load_missing_required_fields_raises_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """load() on YAML missing required fields raises FlightPlanValidationError."""
+        from maverick.flight.errors import FlightPlanValidationError
+        from maverick.flight.loader import FlightPlanFile
+
+        incomplete = tmp_path / "incomplete.md"
+        # Valid YAML but missing 'name', 'version', etc.
+        incomplete.write_text(
+            "---\ntags:\n  - test\n---\n\n## Objective\n\nSomething.\n\n"
+            "## Success Criteria\n\n## Scope\n\n### In\n\n### Out\n\n### Boundaries\n"
+        )
+        with pytest.raises(FlightPlanValidationError) as exc_info:
+            FlightPlanFile.load(incomplete)
+        assert exc_info.value.path == incomplete
+
+    def test_load_extra_yaml_fields_ignored(self, tmp_path: Path) -> None:
+        """load() ignores extra YAML frontmatter fields (forward compatibility)."""
+        from maverick.flight.loader import FlightPlanFile
+
+        extra_fields = SAMPLE_FLIGHT_PLAN_MD.replace(
+            "---\n\n## Objective",
+            "future-field: some-value\n---\n\n## Objective",
+        )
+        fp_file = tmp_path / "plan.md"
+        fp_file.write_text(extra_fields)
+
+        # Should not raise
+        fp = FlightPlanFile.load(fp_file)
+        assert fp.name == "setup-authentication"
+
+    def test_load_optional_sections_absent_defaults(self, tmp_path: Path) -> None:
+        """load() uses empty defaults when optional sections are absent."""
+        from maverick.flight.loader import FlightPlanFile
+
+        minimal = (
+            "---\n"
+            "name: minimal-plan\n"
+            "version: '1.0'\n"
+            "created: 2026-01-01\n"
+            "tags:\n"
+            "  - test\n"
+            "---\n\n"
+            "## Objective\n\nDo something.\n\n"
+            "## Success Criteria\n\n- [x] Done\n\n"
+            "## Scope\n\n### In\n\n- item\n\n### Out\n\n### Boundaries\n\n"
+        )
+        fp_file = tmp_path / "minimal.md"
+        fp_file.write_text(minimal)
+
+        fp = FlightPlanFile.load(fp_file)
+        assert fp.context == ""
+        assert fp.constraints == ()
+        assert fp.notes == ""
+
+    def test_load_absent_success_criteria_section(self, tmp_path: Path) -> None:
+        """Absent Success Criteria gives empty tuple and None pct."""
+        from maverick.flight.loader import FlightPlanFile
+
+        no_sc = (
+            "---\n"
+            "name: no-sc-plan\n"
+            "version: '1.0'\n"
+            "created: 2026-01-01\n"
+            "tags:\n"
+            "  - test\n"
+            "---\n\n"
+            "## Objective\n\nDo something.\n\n"
+            "## Scope\n\n### In\n\n- item\n\n### Out\n\n### Boundaries\n\n"
+        )
+        fp_file = tmp_path / "no-sc.md"
+        fp_file.write_text(no_sc)
+
+        fp = FlightPlanFile.load(fp_file)
+        assert fp.success_criteria == ()
+        assert fp.completion.percentage is None
+
+
+class TestFlightPlanFileAload:
+    """Tests for FlightPlanFile.aload()."""
+
+    async def test_aload_valid_file(self, tmp_path: Path) -> None:
+        """aload() returns FlightPlan asynchronously."""
+        from maverick.flight.loader import FlightPlanFile
+        from maverick.flight.models import FlightPlan
+
+        fp_file = tmp_path / "plan.md"
+        fp_file.write_text(SAMPLE_FLIGHT_PLAN_MD)
+
+        fp = await FlightPlanFile.aload(fp_file)
+        assert isinstance(fp, FlightPlan)
+        assert fp.name == "setup-authentication"
+
+    async def test_aload_missing_file_raises(self, tmp_path: Path) -> None:
+        """aload() on missing file raises FlightPlanNotFoundError with path."""
+        from maverick.flight.errors import FlightPlanNotFoundError
+        from maverick.flight.loader import FlightPlanFile
+
+        missing = tmp_path / "nonexistent.md"
+        with pytest.raises(FlightPlanNotFoundError) as exc_info:
+            await FlightPlanFile.aload(missing)
+        assert exc_info.value.path == missing
+
+
+# ===========================================================================
+# T013: WorkUnitFile loader tests
+# ===========================================================================
+
+
+class TestWorkUnitFileLoad:
+    """Tests for WorkUnitFile.load()."""
+
+    def test_load_valid_file_returns_work_unit(self, tmp_path: Path) -> None:
+        """load() from a valid file returns a WorkUnit with correct fields."""
+        from maverick.flight.loader import WorkUnitFile
+        from maverick.flight.models import WorkUnit
+
+        wu_file = tmp_path / "001-setup-database.md"
+        wu_file.write_text(SAMPLE_WORK_UNIT_MD)
+
+        wu = WorkUnitFile.load(wu_file)
+
+        assert isinstance(wu, WorkUnit)
+        assert wu.id == "setup-database"
+        assert wu.flight_plan == "setup-authentication"
+        assert wu.sequence == 1
+
+    def test_load_sets_source_path(self, tmp_path: Path) -> None:
+        """load() sets source_path on the returned WorkUnit."""
+        from maverick.flight.loader import WorkUnitFile
+
+        wu_file = tmp_path / "001-setup-database.md"
+        wu_file.write_text(SAMPLE_WORK_UNIT_MD)
+
+        wu = WorkUnitFile.load(wu_file)
+        assert wu.source_path == wu_file
+
+    def test_load_acceptance_criteria(self, tmp_path: Path) -> None:
+        """load() populates acceptance_criteria with trace refs."""
+        from maverick.flight.loader import WorkUnitFile
+
+        wu_file = tmp_path / "001-setup-database.md"
+        wu_file.write_text(SAMPLE_WORK_UNIT_MD)
+
+        wu = WorkUnitFile.load(wu_file)
+        assert len(wu.acceptance_criteria) == 2
+        assert wu.acceptance_criteria[0].trace_ref == "SC-001"
+        assert wu.acceptance_criteria[1].trace_ref is None
+
+    def test_load_file_scope(self, tmp_path: Path) -> None:
+        """load() populates file_scope sections."""
+        from maverick.flight.loader import WorkUnitFile
+
+        wu_file = tmp_path / "001-setup-database.md"
+        wu_file.write_text(SAMPLE_WORK_UNIT_MD)
+
+        wu = WorkUnitFile.load(wu_file)
+        assert "src/db/connection.py" in wu.file_scope.create
+        assert "src/config.py" in wu.file_scope.modify
+        assert "src/main.py" in wu.file_scope.protect
+
+    def test_load_verification_commands(self, tmp_path: Path) -> None:
+        """load() populates verification command list."""
+        from maverick.flight.loader import WorkUnitFile
+
+        wu_file = tmp_path / "001-setup-database.md"
+        wu_file.write_text(SAMPLE_WORK_UNIT_MD)
+
+        wu = WorkUnitFile.load(wu_file)
+        assert "make test-fast" in wu.verification
+
+    def test_load_depends_on_empty_list(self, tmp_path: Path) -> None:
+        """load() populates depends_on as empty tuple when YAML has []."""
+        from maverick.flight.loader import WorkUnitFile
+
+        wu_file = tmp_path / "001-setup-database.md"
+        wu_file.write_text(SAMPLE_WORK_UNIT_MD)
+
+        wu = WorkUnitFile.load(wu_file)
+        assert wu.depends_on == ()
+
+    def test_load_with_parallel_group_and_depends_on(self, tmp_path: Path) -> None:
+        """load() correctly handles parallel-group and depends-on fields."""
+        from maverick.flight.loader import WorkUnitFile
+
+        wu_file = tmp_path / "002-add-login-endpoint.md"
+        wu_file.write_text(SAMPLE_WORK_UNIT_MD_WITH_PARALLEL)
+
+        wu = WorkUnitFile.load(wu_file)
+        assert wu.parallel_group == "endpoints"
+        assert "setup-database" in wu.depends_on
+
+    def test_load_missing_file_raises_not_found(self, tmp_path: Path) -> None:
+        """load() on missing file raises WorkUnitNotFoundError with path."""
+        from maverick.flight.errors import WorkUnitNotFoundError
+        from maverick.flight.loader import WorkUnitFile
+
+        missing = tmp_path / "nonexistent.md"
+        with pytest.raises(WorkUnitNotFoundError) as exc_info:
+            WorkUnitFile.load(missing)
+        assert exc_info.value.path == missing
+
+    def test_load_oserror_raises_validation_error(self, tmp_path: Path) -> None:
+        """load() wraps non-FileNotFoundError OSError in WorkUnitValidationError."""
+        from maverick.flight.errors import WorkUnitValidationError
+        from maverick.flight.loader import WorkUnitFile
+
+        dir_path = tmp_path / "a-directory"
+        dir_path.mkdir()
+
+        with pytest.raises(WorkUnitValidationError) as exc_info:
+            WorkUnitFile.load(dir_path)
+        assert exc_info.value.path == dir_path
+
+    def test_load_missing_frontmatter_work_unit_raises_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """load() raises WorkUnitValidationError when 'work-unit' is absent."""
+        from maverick.flight.errors import WorkUnitValidationError
+        from maverick.flight.loader import WorkUnitFile
+
+        content = (
+            "---\n"
+            "flight-plan: my-plan\n"
+            "sequence: 1\n"
+            "depends-on: []\n"
+            "---\n\n## Task\n\nDo something.\n\n"
+            "## Acceptance Criteria\n\n- Something done\n\n"
+            "## File Scope\n\n### Create\n\n### Modify\n\n### Protect\n\n"
+            "## Instructions\n\nDo it.\n\n## Verification\n\n- make test\n"
+        )
+        wu_file = tmp_path / "001-no-id.md"
+        wu_file.write_text(content)
+
+        with pytest.raises(WorkUnitValidationError) as exc_info:
+            WorkUnitFile.load(wu_file)
+        assert exc_info.value.field == "work-unit"
+        assert exc_info.value.path == wu_file
+
+    def test_load_missing_frontmatter_flight_plan_raises_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """load() raises WorkUnitValidationError when 'flight-plan' is absent."""
+        from maverick.flight.errors import WorkUnitValidationError
+        from maverick.flight.loader import WorkUnitFile
+
+        content = (
+            "---\n"
+            "work-unit: my-unit\n"
+            "sequence: 1\n"
+            "depends-on: []\n"
+            "---\n\n## Task\n\nDo something.\n\n"
+            "## Acceptance Criteria\n\n- Something done\n\n"
+            "## File Scope\n\n### Create\n\n### Modify\n\n### Protect\n\n"
+            "## Instructions\n\nDo it.\n\n## Verification\n\n- make test\n"
+        )
+        wu_file = tmp_path / "001-no-plan.md"
+        wu_file.write_text(content)
+
+        with pytest.raises(WorkUnitValidationError) as exc_info:
+            WorkUnitFile.load(wu_file)
+        assert exc_info.value.field == "flight-plan"
+        assert exc_info.value.path == wu_file
+
+    def test_load_missing_frontmatter_sequence_raises_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """load() raises WorkUnitValidationError when 'sequence' is absent."""
+        from maverick.flight.errors import WorkUnitValidationError
+        from maverick.flight.loader import WorkUnitFile
+
+        content = (
+            "---\n"
+            "work-unit: my-unit\n"
+            "flight-plan: my-plan\n"
+            "depends-on: []\n"
+            "---\n\n## Task\n\nDo something.\n\n"
+            "## Acceptance Criteria\n\n- Something done\n\n"
+            "## File Scope\n\n### Create\n\n### Modify\n\n### Protect\n\n"
+            "## Instructions\n\nDo it.\n\n## Verification\n\n- make test\n"
+        )
+        wu_file = tmp_path / "001-no-seq.md"
+        wu_file.write_text(content)
+
+        with pytest.raises(WorkUnitValidationError) as exc_info:
+            WorkUnitFile.load(wu_file)
+        assert exc_info.value.field == "sequence"
+        assert exc_info.value.path == wu_file
+
+    def test_load_invalid_id_raises_validation_error(self, tmp_path: Path) -> None:
+        """Invalid kebab-case ID raises WorkUnitValidationError."""
+        from maverick.flight.errors import WorkUnitValidationError
+        from maverick.flight.loader import WorkUnitFile
+
+        bad_content = SAMPLE_WORK_UNIT_MD.replace(
+            "work-unit: setup-database", "work-unit: SetupDatabase"
+        )
+        wu_file = tmp_path / "001-bad-id.md"
+        wu_file.write_text(bad_content)
+
+        with pytest.raises(WorkUnitValidationError) as exc_info:
+            WorkUnitFile.load(wu_file)
+        assert exc_info.value.path == wu_file
+
+    def test_load_provider_hints_absent_is_none(self, tmp_path: Path) -> None:
+        """load() sets provider_hints to None when section is absent."""
+        from maverick.flight.loader import WorkUnitFile
+
+        wu_file = tmp_path / "001-setup-database.md"
+        wu_file.write_text(SAMPLE_WORK_UNIT_MD)
+
+        wu = WorkUnitFile.load(wu_file)
+        assert wu.provider_hints is None
+
+    def test_load_provider_hints_present(self, tmp_path: Path) -> None:
+        """load() populates provider_hints when section is present."""
+        from maverick.flight.loader import WorkUnitFile
+
+        content_with_hints = (
+            SAMPLE_WORK_UNIT_MD + "\n## Provider Hints\n\nUse the fast path.\n"
+        )
+        wu_file = tmp_path / "001-hints.md"
+        wu_file.write_text(content_with_hints)
+
+        wu = WorkUnitFile.load(wu_file)
+        assert wu.provider_hints is not None
+        assert "fast path" in wu.provider_hints
+
+
+class TestWorkUnitFileAload:
+    """Tests for WorkUnitFile.aload()."""
+
+    async def test_aload_valid_file(self, tmp_path: Path) -> None:
+        """aload() returns WorkUnit asynchronously."""
+        from maverick.flight.loader import WorkUnitFile
+        from maverick.flight.models import WorkUnit
+
+        wu_file = tmp_path / "001-setup-database.md"
+        wu_file.write_text(SAMPLE_WORK_UNIT_MD)
+
+        wu = await WorkUnitFile.aload(wu_file)
+        assert isinstance(wu, WorkUnit)
+        assert wu.id == "setup-database"
+
+    async def test_aload_missing_file_raises(self, tmp_path: Path) -> None:
+        """aload() on missing file raises WorkUnitNotFoundError with path."""
+        from maverick.flight.errors import WorkUnitNotFoundError
+        from maverick.flight.loader import WorkUnitFile
+
+        missing = tmp_path / "nonexistent.md"
+        with pytest.raises(WorkUnitNotFoundError) as exc_info:
+            await WorkUnitFile.aload(missing)
+        assert exc_info.value.path == missing
+
+
+class TestWorkUnitFileLoadDirectory:
+    """Tests for WorkUnitFile.load_directory()."""
+
+    def test_load_directory_discovers_files(self, tmp_path: Path) -> None:
+        """load_directory() discovers ###-slug.md files and returns WorkUnits."""
+        from maverick.flight.loader import WorkUnitFile
+
+        (tmp_path / "001-setup-database.md").write_text(SAMPLE_WORK_UNIT_MD)
+        (tmp_path / "002-add-login-endpoint.md").write_text(
+            SAMPLE_WORK_UNIT_MD_WITH_PARALLEL
+        )
+
+        units = WorkUnitFile.load_directory(tmp_path)
+        assert len(units) == 2
+
+    def test_load_directory_sorted_by_sequence(self, tmp_path: Path) -> None:
+        """load_directory() returns units sorted by sequence number."""
+        from maverick.flight.loader import WorkUnitFile
+
+        # Write in reverse order on disk
+        (tmp_path / "002-add-login-endpoint.md").write_text(
+            SAMPLE_WORK_UNIT_MD_WITH_PARALLEL
+        )
+        (tmp_path / "001-setup-database.md").write_text(SAMPLE_WORK_UNIT_MD)
+
+        units = WorkUnitFile.load_directory(tmp_path)
+        assert units[0].sequence == 1
+        assert units[1].sequence == 2
+
+    def test_load_directory_empty_returns_empty_list(self, tmp_path: Path) -> None:
+        """load_directory() on an empty directory returns empty list."""
+        from maverick.flight.loader import WorkUnitFile
+
+        units = WorkUnitFile.load_directory(tmp_path)
+        assert units == []
+
+    def test_load_directory_ignores_non_matching_files(self, tmp_path: Path) -> None:
+        """load_directory() ignores files not matching ###-slug.md pattern."""
+        from maverick.flight.loader import WorkUnitFile
+
+        (tmp_path / "001-setup-database.md").write_text(SAMPLE_WORK_UNIT_MD)
+        (tmp_path / "README.md").write_text("# This should be ignored\n")
+        (tmp_path / "notes.txt").write_text("ignored\n")
+
+        units = WorkUnitFile.load_directory(tmp_path)
+        assert len(units) == 1
+
+    def test_load_directory_returns_list_of_work_units(self, tmp_path: Path) -> None:
+        """load_directory() returns a list of WorkUnit instances."""
+        from maverick.flight.loader import WorkUnitFile
+        from maverick.flight.models import WorkUnit
+
+        (tmp_path / "001-setup-database.md").write_text(SAMPLE_WORK_UNIT_MD)
+
+        units = WorkUnitFile.load_directory(tmp_path)
+        assert all(isinstance(u, WorkUnit) for u in units)
+
+
+class TestWorkUnitFileAloadDirectory:
+    """Tests for WorkUnitFile.aload_directory()."""
+
+    async def test_aload_directory_valid(self, tmp_path: Path) -> None:
+        """aload_directory() returns list of WorkUnits asynchronously."""
+        from maverick.flight.loader import WorkUnitFile
+
+        (tmp_path / "001-setup-database.md").write_text(SAMPLE_WORK_UNIT_MD)
+
+        units = await WorkUnitFile.aload_directory(tmp_path)
+        assert len(units) == 1
+        assert units[0].id == "setup-database"
+
+    async def test_aload_directory_empty_returns_empty_list(
+        self, tmp_path: Path
+    ) -> None:
+        """aload_directory() on empty directory returns empty list."""
+        from maverick.flight.loader import WorkUnitFile
+
+        units = await WorkUnitFile.aload_directory(tmp_path)
+        assert units == []

--- a/tests/unit/flight/test_models.py
+++ b/tests/unit/flight/test_models.py
@@ -1,0 +1,889 @@
+"""Tests for maverick.flight.models module.
+
+T007: FlightPlan, SuccessCriterion, CompletionStatus, Scope model tests.
+T012: WorkUnit, AcceptanceCriterion, FileScope model tests.
+
+Tests are written before implementation (TDD) and must fail until models
+are implemented.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from maverick.flight.models import FlightPlan, WorkUnit
+
+# ===========================================================================
+# T007: FlightPlan model tests
+# ===========================================================================
+
+
+class TestSuccessCriterion:
+    """Tests for SuccessCriterion model."""
+
+    def test_checked_criterion(self) -> None:
+        """SuccessCriterion with checked=True is created correctly."""
+        from maverick.flight.models import SuccessCriterion
+
+        sc = SuccessCriterion(text="Users can register", checked=True)
+        assert sc.text == "Users can register"
+        assert sc.checked is True
+
+    def test_unchecked_criterion(self) -> None:
+        """SuccessCriterion with checked=False is created correctly."""
+        from maverick.flight.models import SuccessCriterion
+
+        sc = SuccessCriterion(text="Users can log in", checked=False)
+        assert sc.checked is False
+
+    def test_frozen_immutability(self) -> None:
+        """SuccessCriterion is frozen — mutation raises an error."""
+        from maverick.flight.models import SuccessCriterion
+
+        sc = SuccessCriterion(text="item", checked=False)
+        with pytest.raises((TypeError, ValidationError)):
+            sc.checked = True  # type: ignore[misc]
+
+    def test_empty_text_raises(self) -> None:
+        """Empty text raises ValidationError."""
+        from maverick.flight.models import SuccessCriterion
+
+        with pytest.raises(ValidationError):
+            SuccessCriterion(text="", checked=False)
+
+
+class TestCompletionStatus:
+    """Tests for CompletionStatus model."""
+
+    def test_some_checked(self) -> None:
+        """CompletionStatus with some checked items has correct percentage."""
+        from maverick.flight.models import CompletionStatus
+
+        cs = CompletionStatus(checked=1, total=3, percentage=33.333333333333336)
+        assert cs.checked == 1
+        assert cs.total == 3
+        assert cs.percentage is not None
+        assert abs(cs.percentage - 33.33) < 1.0
+
+    def test_all_checked_percentage_100(self) -> None:
+        """CompletionStatus with all checked has percentage=100.0."""
+        from maverick.flight.models import CompletionStatus
+
+        cs = CompletionStatus(checked=3, total=3, percentage=100.0)
+        assert cs.percentage == 100.0
+
+    def test_none_checked_percentage_0(self) -> None:
+        """CompletionStatus with none checked has percentage=0.0."""
+        from maverick.flight.models import CompletionStatus
+
+        cs = CompletionStatus(checked=0, total=3, percentage=0.0)
+        assert cs.percentage == 0.0
+
+    def test_zero_total_percentage_none(self) -> None:
+        """CompletionStatus with zero total has percentage=None."""
+        from maverick.flight.models import CompletionStatus
+
+        cs = CompletionStatus(checked=0, total=0, percentage=None)
+        assert cs.percentage is None
+
+    def test_frozen_immutability(self) -> None:
+        """CompletionStatus is frozen."""
+        from maverick.flight.models import CompletionStatus
+
+        cs = CompletionStatus(checked=1, total=2, percentage=50.0)
+        with pytest.raises((TypeError, ValidationError)):
+            cs.checked = 2  # type: ignore[misc]
+
+
+class TestScope:
+    """Tests for Scope model."""
+
+    def test_all_subsections(self) -> None:
+        """Scope with all subsections populated."""
+        from maverick.flight.models import Scope
+
+        scope = Scope(
+            in_scope=("Registration endpoint", "Login endpoint"),
+            out_of_scope=("OAuth providers",),
+            boundaries=("JWT tokens expire after 24 hours",),
+        )
+        assert "Registration endpoint" in scope.in_scope
+        assert "OAuth providers" in scope.out_of_scope
+        assert len(scope.boundaries) == 1
+
+    def test_empty_subsections(self) -> None:
+        """Scope with empty subsections is valid."""
+        from maverick.flight.models import Scope
+
+        scope = Scope(in_scope=(), out_of_scope=(), boundaries=())
+        assert scope.in_scope == ()
+        assert scope.out_of_scope == ()
+
+    def test_frozen_immutability(self) -> None:
+        """Scope is frozen."""
+        from maverick.flight.models import Scope
+
+        scope = Scope(in_scope=("item",), out_of_scope=(), boundaries=())
+        with pytest.raises((TypeError, ValidationError)):
+            scope.in_scope = ("other",)  # type: ignore[misc]
+
+    def test_in_scope_is_tuple(self) -> None:
+        """in_scope is a tuple even when constructed with a list."""
+        from maverick.flight.models import Scope
+
+        scope = Scope(in_scope=["a", "b"], out_of_scope=[], boundaries=[])  # type: ignore[arg-type]
+        assert isinstance(scope.in_scope, tuple)
+
+
+class TestFlightPlan:
+    """Tests for FlightPlan model."""
+
+    def _make_flight_plan(self) -> FlightPlan:
+        """Build a valid FlightPlan from sample data."""
+        from maverick.flight.models import FlightPlan, Scope, SuccessCriterion
+
+        return FlightPlan(
+            name="setup-authentication",
+            version="1.0",
+            created=date(2026, 2, 27),
+            tags=("auth", "security"),
+            objective="Implement user authentication with JWT tokens.",
+            success_criteria=(
+                SuccessCriterion(
+                    text="Users can register with email and password", checked=True
+                ),
+                SuccessCriterion(
+                    text="Users can log in and receive a JWT", checked=False
+                ),
+                SuccessCriterion(
+                    text="Protected routes reject unauthenticated requests",
+                    checked=False,
+                ),
+            ),
+            scope=Scope(
+                in_scope=("Registration endpoint", "Login endpoint", "JWT middleware"),
+                out_of_scope=("OAuth providers", "Password reset flow"),
+                boundaries=("JWT tokens expire after 24 hours",),
+            ),
+            context="Building on the existing Express.js API framework.",
+            constraints=(
+                "Must use bcrypt for password hashing",
+                "Token secret from environment variable",
+            ),
+            notes="Consider adding refresh tokens in a follow-up.",
+        )
+
+    def test_construction_all_fields(self) -> None:
+        """FlightPlan can be constructed with all fields."""
+        fp = self._make_flight_plan()
+        from maverick.flight.models import FlightPlan
+
+        assert isinstance(fp, FlightPlan)
+
+    def test_required_fields_accessible(self) -> None:
+        """All required fields are accessible on the model."""
+        fp = self._make_flight_plan()
+
+        assert fp.name == "setup-authentication"
+        assert fp.version == "1.0"
+        assert fp.created == date(2026, 2, 27)
+        assert "auth" in fp.tags
+
+    def test_frozen_immutability(self) -> None:
+        """FlightPlan is frozen — mutation raises an error."""
+        fp = self._make_flight_plan()
+        with pytest.raises((TypeError, ValidationError)):
+            fp.name = "changed"  # type: ignore[misc]
+
+    def test_completion_some_checked(self) -> None:
+        """completion property returns correct status when some criteria checked."""
+        fp = self._make_flight_plan()
+
+        status = fp.completion
+        assert status.checked == 1
+        assert status.total == 3
+        assert status.percentage is not None
+        assert abs(status.percentage - 33.333) < 0.5
+
+    def test_completion_all_checked(self) -> None:
+        """completion returns 100% when all criteria checked."""
+        from maverick.flight.models import FlightPlan, Scope, SuccessCriterion
+
+        fp = FlightPlan(
+            name="plan",
+            version="1.0",
+            created=date(2026, 1, 1),
+            tags=("test",),
+            objective="Do something",
+            success_criteria=(
+                SuccessCriterion(text="A", checked=True),
+                SuccessCriterion(text="B", checked=True),
+            ),
+            scope=Scope(in_scope=(), out_of_scope=(), boundaries=()),
+        )
+        assert fp.completion.percentage == 100.0
+
+    def test_completion_none_checked(self) -> None:
+        """completion returns 0% when no criteria checked."""
+        from maverick.flight.models import FlightPlan, Scope, SuccessCriterion
+
+        fp = FlightPlan(
+            name="plan",
+            version="1.0",
+            created=date(2026, 1, 1),
+            tags=("test",),
+            objective="Do something",
+            success_criteria=(
+                SuccessCriterion(text="A", checked=False),
+                SuccessCriterion(text="B", checked=False),
+            ),
+            scope=Scope(in_scope=(), out_of_scope=(), boundaries=()),
+        )
+        assert fp.completion.percentage == 0.0
+
+    def test_completion_zero_criteria_percentage_none(self) -> None:
+        """completion returns percentage=None when there are zero criteria."""
+        from maverick.flight.models import FlightPlan, Scope
+
+        fp = FlightPlan(
+            name="plan",
+            version="1.0",
+            created=date(2026, 1, 1),
+            tags=("test",),
+            objective="Do something",
+            success_criteria=(),
+            scope=Scope(in_scope=(), out_of_scope=(), boundaries=()),
+        )
+        status = fp.completion
+        assert status.total == 0
+        assert status.checked == 0
+        assert status.percentage is None
+
+    def test_optional_fields_have_defaults(self) -> None:
+        """Optional fields (context, constraints, notes) have sensible defaults."""
+        from maverick.flight.models import FlightPlan, Scope
+
+        fp = FlightPlan(
+            name="plan",
+            version="1.0",
+            created=date(2026, 1, 1),
+            tags=(),
+            objective="Something",
+            success_criteria=(),
+            scope=Scope(in_scope=(), out_of_scope=(), boundaries=()),
+        )
+        assert fp.context == ""
+        assert fp.constraints == ()
+        assert fp.notes == ""
+        assert fp.source_path is None
+
+    def test_validation_error_missing_name(self) -> None:
+        """Missing required field 'name' raises ValidationError."""
+        from maverick.flight.models import FlightPlan, Scope
+
+        with pytest.raises(ValidationError):
+            FlightPlan(  # type: ignore[call-arg]
+                version="1.0",
+                created=date(2026, 1, 1),
+                tags=("test",),
+                objective="Something",
+                success_criteria=(),
+                scope=Scope(in_scope=(), out_of_scope=(), boundaries=()),
+            )
+
+    def test_validation_error_empty_name(self) -> None:
+        """Empty 'name' raises ValidationError."""
+        from maverick.flight.models import FlightPlan, Scope
+
+        with pytest.raises(ValidationError):
+            FlightPlan(
+                name="",
+                version="1.0",
+                created=date(2026, 1, 1),
+                tags=(),
+                objective="Something",
+                success_criteria=(),
+                scope=Scope(in_scope=(), out_of_scope=(), boundaries=()),
+            )
+
+    def test_validation_error_missing_version(self) -> None:
+        """Missing 'version' raises ValidationError."""
+        from maverick.flight.models import FlightPlan, Scope
+
+        with pytest.raises(ValidationError):
+            FlightPlan(  # type: ignore[call-arg]
+                name="plan",
+                created=date(2026, 1, 1),
+                tags=(),
+                objective="Something",
+                success_criteria=(),
+                scope=Scope(in_scope=(), out_of_scope=(), boundaries=()),
+            )
+
+    def test_validation_error_missing_objective(self) -> None:
+        """Missing 'objective' raises ValidationError."""
+        from maverick.flight.models import FlightPlan, Scope
+
+        with pytest.raises(ValidationError):
+            FlightPlan(  # type: ignore[call-arg]
+                name="plan",
+                version="1.0",
+                created=date(2026, 1, 1),
+                tags=(),
+                success_criteria=(),
+                scope=Scope(in_scope=(), out_of_scope=(), boundaries=()),
+            )
+
+    def test_to_dict_has_expected_keys(self) -> None:
+        """to_dict() output contains all expected keys."""
+        fp = self._make_flight_plan()
+        d = fp.to_dict()
+        assert "name" in d
+        assert "version" in d
+        assert "created" in d
+        assert "tags" in d
+        assert "objective" in d
+        assert "success_criteria" in d
+        assert "scope" in d
+        assert "context" in d
+        assert "constraints" in d
+        assert "notes" in d
+
+    def test_to_dict_date_is_iso_string(self) -> None:
+        """to_dict() serializes date as ISO-format string."""
+        fp = self._make_flight_plan()
+        d = fp.to_dict()
+        assert isinstance(d["created"], str)
+        assert d["created"] == "2026-02-27"
+
+    def test_to_dict_tuples_as_lists(self) -> None:
+        """to_dict() converts tuple fields to lists."""
+        fp = self._make_flight_plan()
+        d = fp.to_dict()
+        assert isinstance(d["tags"], list)
+        assert isinstance(d["constraints"], list)
+        assert isinstance(d["success_criteria"], list)
+
+    def test_to_dict_nested_models_as_dicts(self) -> None:
+        """to_dict() converts nested models to dicts."""
+        fp = self._make_flight_plan()
+        d = fp.to_dict()
+        assert isinstance(d["scope"], dict)
+        assert isinstance(d["success_criteria"][0], dict)
+
+    def test_tags_is_tuple(self) -> None:
+        """tags field is stored as a tuple."""
+        fp = self._make_flight_plan()
+        assert isinstance(fp.tags, tuple)
+
+    def test_source_path_defaults_to_none(self) -> None:
+        """source_path defaults to None."""
+        fp = self._make_flight_plan()
+        assert fp.source_path is None
+
+
+# ===========================================================================
+# T012: WorkUnit model tests
+# ===========================================================================
+
+
+class TestAcceptanceCriterion:
+    """Tests for AcceptanceCriterion model."""
+
+    def test_without_trace_ref(self) -> None:
+        """AcceptanceCriterion without trace_ref has trace_ref=None."""
+        from maverick.flight.models import AcceptanceCriterion
+
+        ac = AcceptanceCriterion(
+            text="Users table has email, password_hash columns", trace_ref=None
+        )
+        assert ac.text == "Users table has email, password_hash columns"
+        assert ac.trace_ref is None
+
+    def test_with_trace_ref(self) -> None:
+        """AcceptanceCriterion with SC-### trace_ref is stored correctly."""
+        from maverick.flight.models import AcceptanceCriterion
+
+        ac = AcceptanceCriterion(
+            text="Database connection pool is configured", trace_ref="SC-001"
+        )
+        assert ac.trace_ref == "SC-001"
+
+    def test_frozen_immutability(self) -> None:
+        """AcceptanceCriterion is frozen."""
+        from maverick.flight.models import AcceptanceCriterion
+
+        ac = AcceptanceCriterion(text="item", trace_ref=None)
+        with pytest.raises((TypeError, ValidationError)):
+            ac.text = "changed"  # type: ignore[misc]
+
+    def test_empty_text_raises(self) -> None:
+        """Empty text raises ValidationError."""
+        from maverick.flight.models import AcceptanceCriterion
+
+        with pytest.raises(ValidationError):
+            AcceptanceCriterion(text="", trace_ref=None)
+
+
+class TestFileScope:
+    """Tests for FileScope model."""
+
+    def test_all_sections(self) -> None:
+        """FileScope with all sections populated."""
+        from maverick.flight.models import FileScope
+
+        fs = FileScope(
+            create=("src/db/connection.py", "src/db/models/user.py"),
+            modify=("src/config.py",),
+            protect=("src/main.py",),
+        )
+        assert "src/db/connection.py" in fs.create
+        assert "src/config.py" in fs.modify
+        assert "src/main.py" in fs.protect
+
+    def test_empty_sections(self) -> None:
+        """FileScope with all empty sections is valid."""
+        from maverick.flight.models import FileScope
+
+        fs = FileScope(create=(), modify=(), protect=())
+        assert fs.create == ()
+
+    def test_frozen_immutability(self) -> None:
+        """FileScope is frozen."""
+        from maverick.flight.models import FileScope
+
+        fs = FileScope(create=("file.py",), modify=(), protect=())
+        with pytest.raises((TypeError, ValidationError)):
+            fs.create = ("other.py",)  # type: ignore[misc]
+
+    def test_create_is_tuple(self) -> None:
+        """create field is a tuple."""
+        from maverick.flight.models import FileScope
+
+        fs = FileScope(create=["a.py"], modify=[], protect=[])  # type: ignore[arg-type]
+        assert isinstance(fs.create, tuple)
+
+
+class TestWorkUnit:
+    """Tests for WorkUnit model."""
+
+    def _make_work_unit(self, **overrides: object) -> WorkUnit:
+        """Build a valid WorkUnit from sample data."""
+        from maverick.flight.models import AcceptanceCriterion, FileScope, WorkUnit
+
+        defaults: dict[str, object] = {
+            "id": "setup-database",
+            "flight_plan": "setup-authentication",
+            "sequence": 1,
+            "parallel_group": None,
+            "depends_on": (),
+            "task": "Create the users table and database connection module.",
+            "acceptance_criteria": (
+                AcceptanceCriterion(
+                    text="Database connection pool is configured", trace_ref="SC-001"
+                ),
+                AcceptanceCriterion(
+                    text="Users table has email, password_hash, created_at columns",
+                    trace_ref=None,
+                ),
+            ),
+            "file_scope": FileScope(
+                create=("src/db/connection.py", "src/db/models/user.py"),
+                modify=("src/config.py",),
+                protect=("src/main.py",),
+            ),
+            "instructions": "Use SQLAlchemy with async support.",
+            "verification": ("make test-fast", "make lint", "make typecheck"),
+            "provider_hints": None,
+        }
+        defaults.update(overrides)
+        return WorkUnit(**defaults)  # type: ignore[arg-type]
+
+    def test_construction_all_fields(self) -> None:
+        """WorkUnit can be constructed with all fields."""
+        from maverick.flight.models import WorkUnit
+
+        wu = self._make_work_unit()
+        assert isinstance(wu, WorkUnit)
+
+    def test_required_fields_accessible(self) -> None:
+        """All required fields are accessible."""
+        wu = self._make_work_unit()
+        assert wu.id == "setup-database"
+        assert wu.flight_plan == "setup-authentication"
+        assert wu.sequence == 1
+
+    def test_frozen_immutability(self) -> None:
+        """WorkUnit is frozen — mutation raises."""
+        wu = self._make_work_unit()
+        with pytest.raises((TypeError, ValidationError)):
+            wu.sequence = 2  # type: ignore[misc]
+
+    # --- ID validation ---
+
+    def test_valid_kebab_case_id(self) -> None:
+        """Simple kebab-case ID passes validation."""
+        wu = self._make_work_unit(id="setup-database")
+        assert wu.id == "setup-database"
+
+    def test_valid_kebab_case_id_with_numbers(self) -> None:
+        """Kebab-case ID with numbers passes."""
+        wu = self._make_work_unit(id="step-1-create")
+        assert wu.id == "step-1-create"
+
+    def test_invalid_id_uppercase_raises(self) -> None:
+        """PascalCase ID raises ValidationError."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(id="SetupDatabase")
+
+    def test_invalid_id_underscores_raises(self) -> None:
+        """Underscore-separated ID raises ValidationError."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(id="setup_database")
+
+    def test_invalid_id_double_hyphens_raises(self) -> None:
+        """Double-hyphen ID raises ValidationError."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(id="setup--database")
+
+    def test_invalid_id_leading_hyphen_raises(self) -> None:
+        """Leading hyphen in ID raises ValidationError."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(id="-setup-database")
+
+    def test_invalid_id_trailing_hyphen_raises(self) -> None:
+        """Trailing hyphen in ID raises ValidationError."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(id="setup-database-")
+
+    # --- sequence validation ---
+
+    def test_sequence_1_is_valid(self) -> None:
+        """sequence=1 is valid."""
+        wu = self._make_work_unit(sequence=1)
+        assert wu.sequence == 1
+
+    def test_sequence_0_raises(self) -> None:
+        """sequence=0 raises ValidationError."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(sequence=0)
+
+    def test_sequence_negative_raises(self) -> None:
+        """Negative sequence raises ValidationError."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(sequence=-1)
+
+    # --- optional field defaults ---
+
+    def test_depends_on_defaults_to_empty_tuple(self) -> None:
+        """depends_on defaults to empty tuple."""
+        from maverick.flight.models import AcceptanceCriterion, FileScope, WorkUnit
+
+        wu = WorkUnit(
+            id="simple-task",
+            flight_plan="my-plan",
+            sequence=1,
+            task="Do it",
+            acceptance_criteria=(AcceptanceCriterion(text="Done", trace_ref=None),),
+            file_scope=FileScope(create=(), modify=(), protect=()),
+            instructions="Just do it.",
+            verification=("make test",),
+        )
+        assert wu.depends_on == ()
+
+    def test_parallel_group_defaults_to_none(self) -> None:
+        """parallel_group defaults to None."""
+        from maverick.flight.models import AcceptanceCriterion, FileScope, WorkUnit
+
+        wu = WorkUnit(
+            id="simple-task",
+            flight_plan="my-plan",
+            sequence=1,
+            task="Do it",
+            acceptance_criteria=(AcceptanceCriterion(text="Done", trace_ref=None),),
+            file_scope=FileScope(create=(), modify=(), protect=()),
+            instructions="Just do it.",
+            verification=("make test",),
+        )
+        assert wu.parallel_group is None
+
+    def test_provider_hints_defaults_to_none(self) -> None:
+        """provider_hints defaults to None."""
+        wu = self._make_work_unit()
+        assert wu.provider_hints is None
+
+    def test_source_path_defaults_to_none(self) -> None:
+        """source_path defaults to None."""
+        wu = self._make_work_unit()
+        assert wu.source_path is None
+
+    # --- parallel_group with depends_on ---
+
+    def test_work_unit_with_parallel_group(self) -> None:
+        """WorkUnit with parallel_group and depends_on is valid."""
+        wu = self._make_work_unit(
+            id="add-login-endpoint",
+            sequence=2,
+            parallel_group="endpoints",
+            depends_on=("setup-database",),
+        )
+        assert wu.parallel_group == "endpoints"
+        assert "setup-database" in wu.depends_on
+
+    # --- to_dict ---
+
+    def test_to_dict_has_expected_keys(self) -> None:
+        """to_dict() output has all expected keys."""
+        wu = self._make_work_unit()
+        d = wu.to_dict()
+        assert "id" in d
+        assert "flight_plan" in d
+        assert "sequence" in d
+        assert "parallel_group" in d
+        assert "depends_on" in d
+        assert "task" in d
+        assert "acceptance_criteria" in d
+        assert "file_scope" in d
+        assert "instructions" in d
+        assert "verification" in d
+        assert "provider_hints" in d
+
+    def test_to_dict_tuples_as_lists(self) -> None:
+        """to_dict() converts tuple fields to lists."""
+        wu = self._make_work_unit()
+        d = wu.to_dict()
+        assert isinstance(d["depends_on"], list)
+        assert isinstance(d["verification"], list)
+        assert isinstance(d["acceptance_criteria"], list)
+
+    def test_to_dict_nested_models_as_dicts(self) -> None:
+        """to_dict() converts nested models to dicts."""
+        wu = self._make_work_unit()
+        d = wu.to_dict()
+        assert isinstance(d["file_scope"], dict)
+        assert isinstance(d["acceptance_criteria"][0], dict)
+
+    def test_flight_plan_empty_raises(self) -> None:
+        """Empty flight_plan raises ValidationError."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(flight_plan="")
+
+    def test_depends_on_is_tuple(self) -> None:
+        """depends_on is stored as a tuple."""
+        wu = self._make_work_unit(depends_on=["a", "b"])
+        assert isinstance(wu.depends_on, tuple)
+
+    # --- depends_on kebab-case validation (SPEC-1) ---
+
+    def test_depends_on_valid_kebab_case(self) -> None:
+        """depends_on with valid kebab-case entries passes validation."""
+        wu = self._make_work_unit(depends_on=("setup-database", "create-schema"))
+        assert wu.depends_on == ("setup-database", "create-schema")
+
+    def test_depends_on_uppercase_raises(self) -> None:
+        """depends_on entry with uppercase raises ValidationError."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(depends_on=("SetupDatabase",))
+
+    def test_depends_on_underscores_raises(self) -> None:
+        """depends_on entry with underscores raises ValidationError."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(depends_on=("setup_database",))
+
+    def test_depends_on_leading_hyphen_raises(self) -> None:
+        """depends_on entry with leading hyphen raises ValidationError."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(depends_on=("-setup",))
+
+    def test_depends_on_empty_string_raises(self) -> None:
+        """depends_on entry that is empty string raises ValidationError."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(depends_on=("",))
+
+    def test_depends_on_mixed_valid_invalid_raises(self) -> None:
+        """depends_on with one invalid entry among valid ones raises."""
+        with pytest.raises(ValidationError):
+            self._make_work_unit(depends_on=("valid-id", "Invalid_Id"))
+
+
+# ===========================================================================
+# SPEC-2: AcceptanceCriterion.trace_ref validation tests
+# ===========================================================================
+
+
+class TestAcceptanceCriterionTraceRef:
+    """Tests for trace_ref SC-\\d+ format validation."""
+
+    def test_valid_trace_ref_sc001(self) -> None:
+        """SC-001 is a valid trace_ref."""
+        from maverick.flight.models import AcceptanceCriterion
+
+        ac = AcceptanceCriterion(text="criterion", trace_ref="SC-001")
+        assert ac.trace_ref == "SC-001"
+
+    def test_valid_trace_ref_sc99(self) -> None:
+        """SC-99 is a valid trace_ref."""
+        from maverick.flight.models import AcceptanceCriterion
+
+        ac = AcceptanceCriterion(text="criterion", trace_ref="SC-99")
+        assert ac.trace_ref == "SC-99"
+
+    def test_none_trace_ref_is_valid(self) -> None:
+        """None trace_ref is valid (optional field)."""
+        from maverick.flight.models import AcceptanceCriterion
+
+        ac = AcceptanceCriterion(text="criterion", trace_ref=None)
+        assert ac.trace_ref is None
+
+    def test_invalid_trace_ref_wrong_prefix(self) -> None:
+        """trace_ref with wrong prefix raises ValidationError."""
+        from maverick.flight.models import AcceptanceCriterion
+
+        with pytest.raises(ValidationError):
+            AcceptanceCriterion(text="criterion", trace_ref="XX-001")
+
+    def test_invalid_trace_ref_no_digits(self) -> None:
+        """trace_ref without digits raises ValidationError."""
+        from maverick.flight.models import AcceptanceCriterion
+
+        with pytest.raises(ValidationError):
+            AcceptanceCriterion(text="criterion", trace_ref="SC-")
+
+    def test_invalid_trace_ref_lowercase(self) -> None:
+        """trace_ref with lowercase 'sc' raises ValidationError."""
+        from maverick.flight.models import AcceptanceCriterion
+
+        with pytest.raises(ValidationError):
+            AcceptanceCriterion(text="criterion", trace_ref="sc-001")
+
+    def test_invalid_trace_ref_no_hyphen(self) -> None:
+        """trace_ref without hyphen raises ValidationError."""
+        from maverick.flight.models import AcceptanceCriterion
+
+        with pytest.raises(ValidationError):
+            AcceptanceCriterion(text="criterion", trace_ref="SC001")
+
+    def test_invalid_trace_ref_trailing_text(self) -> None:
+        """trace_ref with trailing text raises ValidationError."""
+        from maverick.flight.models import AcceptanceCriterion
+
+        with pytest.raises(ValidationError):
+            AcceptanceCriterion(text="criterion", trace_ref="SC-001-extra")
+
+
+# ===========================================================================
+# SPEC-3 & SPEC-4: CompletionStatus validation tests
+# ===========================================================================
+
+
+class TestCompletionStatusValidation:
+    """Tests for CompletionStatus checked/total >= 0 and percentage range."""
+
+    def test_negative_checked_raises(self) -> None:
+        """Negative checked raises ValidationError."""
+        from maverick.flight.models import CompletionStatus
+
+        with pytest.raises(ValidationError):
+            CompletionStatus(checked=-1, total=3, percentage=0.0)
+
+    def test_negative_total_raises(self) -> None:
+        """Negative total raises ValidationError."""
+        from maverick.flight.models import CompletionStatus
+
+        with pytest.raises(ValidationError):
+            CompletionStatus(checked=0, total=-1, percentage=0.0)
+
+    def test_zero_checked_and_total_valid(self) -> None:
+        """Zero checked and total are valid."""
+        from maverick.flight.models import CompletionStatus
+
+        cs = CompletionStatus(checked=0, total=0, percentage=None)
+        assert cs.checked == 0
+        assert cs.total == 0
+
+    def test_percentage_negative_raises(self) -> None:
+        """Negative percentage raises ValidationError."""
+        from maverick.flight.models import CompletionStatus
+
+        with pytest.raises(ValidationError):
+            CompletionStatus(checked=0, total=3, percentage=-1.0)
+
+    def test_percentage_above_100_raises(self) -> None:
+        """Percentage above 100.0 raises ValidationError."""
+        from maverick.flight.models import CompletionStatus
+
+        with pytest.raises(ValidationError):
+            CompletionStatus(checked=3, total=3, percentage=100.1)
+
+    def test_percentage_exactly_0_valid(self) -> None:
+        """Percentage of exactly 0.0 is valid."""
+        from maverick.flight.models import CompletionStatus
+
+        cs = CompletionStatus(checked=0, total=3, percentage=0.0)
+        assert cs.percentage == 0.0
+
+    def test_percentage_exactly_100_valid(self) -> None:
+        """Percentage of exactly 100.0 is valid."""
+        from maverick.flight.models import CompletionStatus
+
+        cs = CompletionStatus(checked=3, total=3, percentage=100.0)
+        assert cs.percentage == 100.0
+
+    def test_percentage_none_valid(self) -> None:
+        """Percentage of None is valid."""
+        from maverick.flight.models import CompletionStatus
+
+        cs = CompletionStatus(checked=0, total=0, percentage=None)
+        assert cs.percentage is None
+
+
+# ===========================================================================
+# SPEC-5: ExecutionBatch.units non-empty validation tests
+# ===========================================================================
+
+
+class TestExecutionBatchValidation:
+    """Tests for ExecutionBatch.units non-empty validation."""
+
+    def _make_work_unit(self) -> WorkUnit:
+        """Build a minimal valid WorkUnit for batch testing."""
+        from maverick.flight.models import AcceptanceCriterion, FileScope, WorkUnit
+
+        return WorkUnit(
+            id="test-unit",
+            flight_plan="test-plan",
+            sequence=1,
+            task="Test task",
+            acceptance_criteria=(AcceptanceCriterion(text="Done", trace_ref=None),),
+            file_scope=FileScope(create=(), modify=(), protect=()),
+            instructions="Do it.",
+            verification=("make test",),
+        )
+
+    def test_empty_units_raises(self) -> None:
+        """Empty units tuple raises ValidationError."""
+        from maverick.flight.models import ExecutionBatch
+
+        with pytest.raises(ValidationError):
+            ExecutionBatch(units=())
+
+    def test_single_unit_valid(self) -> None:
+        """Single unit in batch is valid."""
+        from maverick.flight.models import ExecutionBatch
+
+        wu = self._make_work_unit()
+        batch = ExecutionBatch(units=(wu,))
+        assert len(batch.units) == 1
+
+    def test_multiple_units_valid(self) -> None:
+        """Multiple units in batch is valid."""
+        from maverick.flight.models import ExecutionBatch
+
+        wu = self._make_work_unit()
+        batch = ExecutionBatch(units=(wu, wu))
+        assert len(batch.units) == 2

--- a/tests/unit/flight/test_parser.py
+++ b/tests/unit/flight/test_parser.py
@@ -1,0 +1,441 @@
+"""Tests for maverick.flight.parser module.
+
+T005: Write tests for core parser functions.
+Tests must FAIL before T006 implementation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from maverick.flight.errors import FlightPlanParseError
+
+# ---------------------------------------------------------------------------
+# T005: parse_frontmatter tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseFrontmatter:
+    """Tests for parse_frontmatter()."""
+
+    def test_valid_frontmatter_returns_dict_and_body(self) -> None:
+        """Valid frontmatter is parsed into a dict, body is the rest."""
+        from maverick.flight.parser import parse_frontmatter
+
+        content = "---\nname: my-plan\nversion: '1.0'\n---\n\n## Objective\n\nHello.\n"
+        fm, body = parse_frontmatter(content)
+        assert fm == {"name": "my-plan", "version": "1.0"}
+        assert "## Objective" in body
+
+    def test_frontmatter_with_list_fields(self) -> None:
+        """Frontmatter with list-valued fields is parsed correctly."""
+        from maverick.flight.parser import parse_frontmatter
+
+        content = "---\ntags:\n  - auth\n  - security\n---\n\nBody here.\n"
+        fm, body = parse_frontmatter(content)
+        assert fm["tags"] == ["auth", "security"]
+        assert "Body here." in body
+
+    def test_missing_opening_delimiter_raises(self) -> None:
+        """Content without opening --- raises FlightPlanParseError."""
+        from maverick.flight.parser import parse_frontmatter
+
+        content = "name: my-plan\nversion: '1.0'\n---\n\n## Objective\n"
+        with pytest.raises(FlightPlanParseError):
+            parse_frontmatter(content)
+
+    def test_missing_closing_delimiter_raises(self) -> None:
+        """Content with opening --- but no closing --- raises FlightPlanParseError."""
+        from maverick.flight.parser import parse_frontmatter
+
+        content = "---\nname: my-plan\nversion: '1.0'\n\n## Objective\n"
+        with pytest.raises(FlightPlanParseError):
+            parse_frontmatter(content)
+
+    def test_empty_content_raises(self) -> None:
+        """Empty content (no delimiters) raises FlightPlanParseError."""
+        from maverick.flight.parser import parse_frontmatter
+
+        with pytest.raises(FlightPlanParseError):
+            parse_frontmatter("")
+
+    def test_invalid_yaml_raises(self) -> None:
+        """Invalid YAML inside frontmatter block raises FlightPlanParseError."""
+        from maverick.flight.parser import parse_frontmatter
+
+        content = "---\nname: [unclosed bracket\n---\n\n## Body\n"
+        with pytest.raises(FlightPlanParseError):
+            parse_frontmatter(content)
+
+    def test_body_content_with_yaml_like_syntax(self) -> None:
+        """Body can contain YAML-like text without interfering with frontmatter."""
+        from maverick.flight.parser import parse_frontmatter
+
+        content = (
+            "---\nname: my-plan\n---\n\n## Section\n\nkey: value\nlist:\n  - item\n"
+        )
+        fm, body = parse_frontmatter(content)
+        assert fm == {"name": "my-plan"}
+        assert "key: value" in body
+
+    def test_empty_frontmatter_block_returns_empty_dict(self) -> None:
+        """Empty frontmatter block returns empty dict."""
+        from maverick.flight.parser import parse_frontmatter
+
+        content = "---\n---\n\nBody content here.\n"
+        fm, body = parse_frontmatter(content)
+        assert fm == {}
+        assert "Body content here." in body
+
+    def test_body_stripped_of_leading_whitespace(self) -> None:
+        """The body is returned with leading blank lines stripped."""
+        from maverick.flight.parser import parse_frontmatter
+
+        content = "---\nname: x\n---\n\n\n## Objective\n"
+        _, body = parse_frontmatter(content)
+        # Body should not be empty
+        assert "## Objective" in body
+
+    def test_yaml_value_containing_triple_dash_not_treated_as_delimiter(self) -> None:
+        """YAML value with '---' is not the closing delimiter."""
+        from maverick.flight.parser import parse_frontmatter
+
+        content = (
+            "---\nname: my-plan\nseparator: '---'\n---\n\n## Objective\n\nHello.\n"
+        )
+        fm, body = parse_frontmatter(content)
+        assert fm["name"] == "my-plan"
+        assert fm["separator"] == "---"
+        assert "## Objective" in body
+
+    def test_returns_tuple(self) -> None:
+        """Return type is a two-element tuple."""
+        from maverick.flight.parser import parse_frontmatter
+
+        content = "---\nname: test\n---\n\nBody.\n"
+        result = parse_frontmatter(content)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# T005: parse_checkbox_list tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseCheckboxList:
+    """Tests for parse_checkbox_list()."""
+
+    def test_lowercase_x_is_checked(self) -> None:
+        """[x] items are parsed as checked=True."""
+        from maverick.flight.parser import parse_checkbox_list
+
+        content = "- [x] First item\n"
+        result = parse_checkbox_list(content)
+        assert result == [(True, "First item")]
+
+    def test_uppercase_x_is_checked(self) -> None:
+        """[X] items are parsed as checked=True."""
+        from maverick.flight.parser import parse_checkbox_list
+
+        content = "- [X] Second item\n"
+        result = parse_checkbox_list(content)
+        assert result == [(True, "Second item")]
+
+    def test_space_is_unchecked(self) -> None:
+        """[ ] items are parsed as checked=False."""
+        from maverick.flight.parser import parse_checkbox_list
+
+        content = "- [ ] Third item\n"
+        result = parse_checkbox_list(content)
+        assert result == [(False, "Third item")]
+
+    def test_mixed_checked_and_unchecked(self) -> None:
+        """Mixed checked/unchecked items are all parsed correctly."""
+        from maverick.flight.parser import parse_checkbox_list
+
+        content = (
+            "- [x] Users can register with email and password\n"
+            "- [ ] Users can log in and receive a JWT\n"
+            "- [ ] Protected routes reject unauthenticated requests\n"
+        )
+        result = parse_checkbox_list(content)
+        assert result == [
+            (True, "Users can register with email and password"),
+            (False, "Users can log in and receive a JWT"),
+            (False, "Protected routes reject unauthenticated requests"),
+        ]
+
+    def test_empty_content_returns_empty_list(self) -> None:
+        """Empty string returns empty list."""
+        from maverick.flight.parser import parse_checkbox_list
+
+        result = parse_checkbox_list("")
+        assert result == []
+
+    def test_whitespace_only_returns_empty_list(self) -> None:
+        """Whitespace-only string returns empty list."""
+        from maverick.flight.parser import parse_checkbox_list
+
+        result = parse_checkbox_list("   \n  \n")
+        assert result == []
+
+    def test_content_with_yaml_like_lines_ignored(self) -> None:
+        """Non-checkbox lines (e.g. YAML-like) are ignored."""
+        from maverick.flight.parser import parse_checkbox_list
+
+        content = "key: value\n- [x] Real item\nname: foo\n"
+        result = parse_checkbox_list(content)
+        assert result == [(True, "Real item")]
+
+    def test_text_is_stripped(self) -> None:
+        """Item text is stripped of surrounding whitespace."""
+        from maverick.flight.parser import parse_checkbox_list
+
+        content = "- [x]   Item with extra spaces   \n"
+        result = parse_checkbox_list(content)
+        assert result == [(True, "Item with extra spaces")]
+
+    def test_returns_list_of_tuples(self) -> None:
+        """Return type is list of (bool, str) tuples."""
+        from maverick.flight.parser import parse_checkbox_list
+
+        content = "- [x] Item\n"
+        result = parse_checkbox_list(content)
+        assert isinstance(result, list)
+        assert isinstance(result[0], tuple)
+        checked, text = result[0]
+        assert isinstance(checked, bool)
+        assert isinstance(text, str)
+
+
+# ---------------------------------------------------------------------------
+# T005: parse_bullet_list tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseBulletList:
+    """Tests for parse_bullet_list()."""
+
+    def test_single_bullet(self) -> None:
+        """Single bullet line is parsed into a list with one element."""
+        from maverick.flight.parser import parse_bullet_list
+
+        content = "- Registration endpoint\n"
+        result = parse_bullet_list(content)
+        assert result == ["Registration endpoint"]
+
+    def test_multiple_bullets(self) -> None:
+        """Multiple bullet lines are all parsed."""
+        from maverick.flight.parser import parse_bullet_list
+
+        content = "- Registration endpoint\n- Login endpoint\n- JWT middleware\n"
+        result = parse_bullet_list(content)
+        assert result == ["Registration endpoint", "Login endpoint", "JWT middleware"]
+
+    def test_empty_content_returns_empty_list(self) -> None:
+        """Empty content returns empty list."""
+        from maverick.flight.parser import parse_bullet_list
+
+        result = parse_bullet_list("")
+        assert result == []
+
+    def test_whitespace_only_returns_empty_list(self) -> None:
+        """Whitespace-only content returns empty list."""
+        from maverick.flight.parser import parse_bullet_list
+
+        result = parse_bullet_list("  \n  \n")
+        assert result == []
+
+    def test_text_is_stripped(self) -> None:
+        """Bullet text is stripped of surrounding whitespace."""
+        from maverick.flight.parser import parse_bullet_list
+
+        content = "-   Extra spaces around text   \n"
+        result = parse_bullet_list(content)
+        assert result == ["Extra spaces around text"]
+
+    def test_non_bullet_lines_ignored(self) -> None:
+        """Non-bullet lines are ignored."""
+        from maverick.flight.parser import parse_bullet_list
+
+        content = "Some plain text\n- Bullet item\nAnother plain line\n"
+        result = parse_bullet_list(content)
+        assert result == ["Bullet item"]
+
+    def test_returns_list_of_strings(self) -> None:
+        """Return type is list of strings."""
+        from maverick.flight.parser import parse_bullet_list
+
+        content = "- item\n"
+        result = parse_bullet_list(content)
+        assert isinstance(result, list)
+        assert all(isinstance(x, str) for x in result)
+
+
+# ---------------------------------------------------------------------------
+# T005: parse_flight_plan_sections tests (integration with sample data)
+# ---------------------------------------------------------------------------
+
+
+class TestParseFlightPlanSections:
+    """Tests for parse_flight_plan_sections()."""
+
+    def test_objective_extracted(self, sample_flight_plan_md: str) -> None:
+        """## Objective section is extracted as plain text."""
+        from maverick.flight.parser import parse_flight_plan_sections, parse_frontmatter
+
+        _, body = parse_frontmatter(sample_flight_plan_md)
+        sections = parse_flight_plan_sections(body)
+        assert "JWT tokens" in sections["objective"]
+
+    def test_success_criteria_extracted(self, sample_flight_plan_md: str) -> None:
+        """## Success Criteria is a list of (checked, text) tuples."""
+        from maverick.flight.parser import parse_flight_plan_sections, parse_frontmatter
+
+        _, body = parse_frontmatter(sample_flight_plan_md)
+        sections = parse_flight_plan_sections(body)
+        criteria = sections["success_criteria"]
+        assert len(criteria) == 3
+        assert criteria[0][0] is True  # [x]
+        assert criteria[1][0] is False  # [ ]
+        assert criteria[2][0] is False  # [ ]
+
+    def test_scope_in_scope_extracted(self, sample_flight_plan_md: str) -> None:
+        """## Scope ### In subsection is extracted."""
+        from maverick.flight.parser import parse_flight_plan_sections, parse_frontmatter
+
+        _, body = parse_frontmatter(sample_flight_plan_md)
+        sections = parse_flight_plan_sections(body)
+        assert "Registration endpoint" in sections["scope"]["in_scope"]
+
+    def test_scope_out_of_scope_extracted(self, sample_flight_plan_md: str) -> None:
+        """## Scope ### Out subsection is extracted."""
+        from maverick.flight.parser import parse_flight_plan_sections, parse_frontmatter
+
+        _, body = parse_frontmatter(sample_flight_plan_md)
+        sections = parse_flight_plan_sections(body)
+        assert "OAuth providers" in sections["scope"]["out_of_scope"]
+
+    def test_scope_boundaries_extracted(self, sample_flight_plan_md: str) -> None:
+        """## Scope ### Boundaries subsection is extracted."""
+        from maverick.flight.parser import parse_flight_plan_sections, parse_frontmatter
+
+        _, body = parse_frontmatter(sample_flight_plan_md)
+        sections = parse_flight_plan_sections(body)
+        assert len(sections["scope"]["boundaries"]) >= 1
+
+    def test_context_extracted(self, sample_flight_plan_md: str) -> None:
+        """## Context section is extracted as plain text."""
+        from maverick.flight.parser import parse_flight_plan_sections, parse_frontmatter
+
+        _, body = parse_frontmatter(sample_flight_plan_md)
+        sections = parse_flight_plan_sections(body)
+        assert "Express.js" in sections["context"]
+
+    def test_constraints_extracted(self, sample_flight_plan_md: str) -> None:
+        """## Constraints section is extracted as bullet list."""
+        from maverick.flight.parser import parse_flight_plan_sections, parse_frontmatter
+
+        _, body = parse_frontmatter(sample_flight_plan_md)
+        sections = parse_flight_plan_sections(body)
+        assert len(sections["constraints"]) == 2
+
+    def test_notes_extracted(self, sample_flight_plan_md: str) -> None:
+        """## Notes section is extracted as plain text."""
+        from maverick.flight.parser import parse_flight_plan_sections, parse_frontmatter
+
+        _, body = parse_frontmatter(sample_flight_plan_md)
+        sections = parse_flight_plan_sections(body)
+        assert "refresh tokens" in sections["notes"]
+
+    def test_missing_optional_sections_default(self) -> None:
+        """Missing optional sections (context, constraints, notes) are empty."""
+        from maverick.flight.parser import parse_flight_plan_sections
+
+        body = (
+            "## Objective\n\nDo something.\n\n"
+            "## Success Criteria\n\n- [x] Done\n\n"
+            "## Scope\n\n### In\n\n- item\n\n### Out\n\n### Boundaries\n\n"
+        )
+        sections = parse_flight_plan_sections(body)
+        assert sections["context"] == ""
+        assert sections["constraints"] == []
+        assert sections["notes"] == ""
+
+
+# ---------------------------------------------------------------------------
+# T005: parse_work_unit_sections tests (integration with sample data)
+# ---------------------------------------------------------------------------
+
+
+class TestParseWorkUnitSections:
+    """Tests for parse_work_unit_sections()."""
+
+    def test_task_extracted(self, sample_work_unit_md: str) -> None:
+        """## Task section is extracted as plain text."""
+        from maverick.flight.parser import parse_frontmatter, parse_work_unit_sections
+
+        _, body = parse_frontmatter(sample_work_unit_md)
+        sections = parse_work_unit_sections(body)
+        assert "users table" in sections["task"]
+
+    def test_acceptance_criteria_with_trace_ref(self, sample_work_unit_md: str) -> None:
+        """Acceptance criteria with [SC-###] trace refs are parsed."""
+        from maverick.flight.parser import parse_frontmatter, parse_work_unit_sections
+
+        _, body = parse_frontmatter(sample_work_unit_md)
+        sections = parse_work_unit_sections(body)
+        criteria = sections["acceptance_criteria"]
+        # First criterion has SC-001 trace ref
+        assert any(ref == "SC-001" for _, ref in criteria)
+        # Second criterion has no trace ref
+        assert any(ref is None for _, ref in criteria)
+
+    def test_file_scope_create_extracted(self, sample_work_unit_md: str) -> None:
+        """## File Scope ### Create subsection is extracted."""
+        from maverick.flight.parser import parse_frontmatter, parse_work_unit_sections
+
+        _, body = parse_frontmatter(sample_work_unit_md)
+        sections = parse_work_unit_sections(body)
+        assert "src/db/connection.py" in sections["file_scope"]["create"]
+
+    def test_file_scope_modify_extracted(self, sample_work_unit_md: str) -> None:
+        """## File Scope ### Modify subsection is extracted."""
+        from maverick.flight.parser import parse_frontmatter, parse_work_unit_sections
+
+        _, body = parse_frontmatter(sample_work_unit_md)
+        sections = parse_work_unit_sections(body)
+        assert "src/config.py" in sections["file_scope"]["modify"]
+
+    def test_file_scope_protect_extracted(self, sample_work_unit_md: str) -> None:
+        """## File Scope ### Protect subsection is extracted."""
+        from maverick.flight.parser import parse_frontmatter, parse_work_unit_sections
+
+        _, body = parse_frontmatter(sample_work_unit_md)
+        sections = parse_work_unit_sections(body)
+        assert "src/main.py" in sections["file_scope"]["protect"]
+
+    def test_instructions_extracted(self, sample_work_unit_md: str) -> None:
+        """## Instructions section is extracted as plain text."""
+        from maverick.flight.parser import parse_frontmatter, parse_work_unit_sections
+
+        _, body = parse_frontmatter(sample_work_unit_md)
+        sections = parse_work_unit_sections(body)
+        assert "SQLAlchemy" in sections["instructions"]
+
+    def test_verification_extracted(self, sample_work_unit_md: str) -> None:
+        """## Verification section is extracted as list of command strings."""
+        from maverick.flight.parser import parse_frontmatter, parse_work_unit_sections
+
+        _, body = parse_frontmatter(sample_work_unit_md)
+        sections = parse_work_unit_sections(body)
+        assert "make test-fast" in sections["verification"]
+
+    def test_provider_hints_missing_is_none(self, sample_work_unit_md: str) -> None:
+        """Missing ## Provider Hints section returns None."""
+        from maverick.flight.parser import parse_frontmatter, parse_work_unit_sections
+
+        _, body = parse_frontmatter(sample_work_unit_md)
+        sections = parse_work_unit_sections(body)
+        assert sections["provider_hints"] is None

--- a/tests/unit/flight/test_resolver.py
+++ b/tests/unit/flight/test_resolver.py
@@ -1,0 +1,440 @@
+"""Tests for resolve_execution_order() and related models (US3).
+
+Tests cover:
+- ExecutionBatch and ExecutionOrder model construction
+- Linear chain dependency resolution
+- Diamond dependency resolution
+- Independent units batched together
+- parallel_group batching within tiers
+- Duplicate work unit ID detection (WorkUnitDependencyError)
+- Circular dependency detection (WorkUnitDependencyError with deterministic cycle)
+- Missing dependency detection (WorkUnitDependencyError with missing_id)
+- Empty list returns empty batches
+- Single unit returns single batch
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from maverick.flight.errors import WorkUnitDependencyError
+from maverick.flight.models import (
+    AcceptanceCriterion,
+    ExecutionBatch,
+    ExecutionOrder,
+    FileScope,
+    WorkUnit,
+)
+from maverick.flight.resolver import resolve_execution_order
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_work_unit(
+    uid: str,
+    *,
+    sequence: int = 1,
+    depends_on: tuple[str, ...] = (),
+    parallel_group: str | None = None,
+) -> WorkUnit:
+    """Create a minimal WorkUnit for testing."""
+    return WorkUnit(
+        id=uid,
+        flight_plan="test-plan",
+        sequence=sequence,
+        parallel_group=parallel_group,
+        depends_on=depends_on,
+        task=f"Task for {uid}",
+        acceptance_criteria=(AcceptanceCriterion(text="Done"),),
+        file_scope=FileScope(create=(), modify=(), protect=()),
+        instructions="Do the work.",
+        verification=("make test-fast",),
+    )
+
+
+def _batch_unit_ids(batch: ExecutionBatch) -> frozenset[str]:
+    """Return the set of unit IDs in a batch."""
+    return frozenset(u.id for u in batch.units)
+
+
+# ---------------------------------------------------------------------------
+# Model construction tests (T017 item 9 and 10)
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionBatchConstruction:
+    """ExecutionBatch frozen model construction and field access."""
+
+    def test_construction_with_units_and_no_group(self) -> None:
+        u = _make_work_unit("alpha")
+        batch = ExecutionBatch(units=(u,), parallel_group=None)
+        assert batch.units == (u,)
+        assert batch.parallel_group is None
+
+    def test_construction_with_parallel_group(self) -> None:
+        u = _make_work_unit("beta")
+        batch = ExecutionBatch(units=(u,), parallel_group="group-a")
+        assert batch.parallel_group == "group-a"
+
+    def test_parallel_group_defaults_to_none(self) -> None:
+        u = _make_work_unit("gamma")
+        batch = ExecutionBatch(units=(u,))
+        assert batch.parallel_group is None
+
+    def test_frozen_immutability(self) -> None:
+        u = _make_work_unit("delta")
+        batch = ExecutionBatch(units=(u,))
+        with pytest.raises(Exception):
+            batch.parallel_group = "mutated"  # type: ignore[misc]
+
+    def test_units_is_tuple(self) -> None:
+        u1 = _make_work_unit("e1")
+        u2 = _make_work_unit("e2")
+        batch = ExecutionBatch(units=(u1, u2))
+        assert isinstance(batch.units, tuple)
+        assert len(batch.units) == 2
+
+
+class TestExecutionOrderConstruction:
+    """ExecutionOrder frozen model construction and field access."""
+
+    def test_construction_with_empty_batches(self) -> None:
+        order = ExecutionOrder(batches=())
+        assert order.batches == ()
+
+    def test_construction_with_batches(self) -> None:
+        u = _make_work_unit("alpha")
+        batch = ExecutionBatch(units=(u,))
+        order = ExecutionOrder(batches=(batch,))
+        assert len(order.batches) == 1
+        assert order.batches[0] is batch
+
+    def test_frozen_immutability(self) -> None:
+        order = ExecutionOrder(batches=())
+        with pytest.raises(Exception):
+            order.batches = ()  # type: ignore[misc]
+
+    def test_batches_is_tuple(self) -> None:
+        u = _make_work_unit("alpha")
+        batch = ExecutionBatch(units=(u,))
+        order = ExecutionOrder(batches=(batch,))
+        assert isinstance(order.batches, tuple)
+
+
+# ---------------------------------------------------------------------------
+# Empty and single unit edge cases (T017 items 7 and 8)
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases: empty list and single unit."""
+
+    def test_empty_list_returns_empty_batches(self) -> None:
+        order = resolve_execution_order([])
+        assert isinstance(order, ExecutionOrder)
+        assert order.batches == ()
+
+    def test_single_unit_returns_single_batch(self) -> None:
+        u = _make_work_unit("solo")
+        order = resolve_execution_order([u])
+        assert len(order.batches) == 1
+        assert _batch_unit_ids(order.batches[0]) == {"solo"}
+
+
+# ---------------------------------------------------------------------------
+# Linear chain ordering (T017 item 1)
+# ---------------------------------------------------------------------------
+
+
+class TestLinearChain:
+    """A → B → C must resolve A first, then B, then C (separate batches)."""
+
+    def test_linear_chain_three_units(self) -> None:
+        a = _make_work_unit("unit-a", sequence=1)
+        b = _make_work_unit("unit-b", sequence=2, depends_on=("unit-a",))
+        c = _make_work_unit("unit-c", sequence=3, depends_on=("unit-b",))
+
+        order = resolve_execution_order([a, b, c])
+
+        assert len(order.batches) == 3
+        all_ids = [_batch_unit_ids(batch) for batch in order.batches]
+        assert all_ids[0] == {"unit-a"}
+        assert all_ids[1] == {"unit-b"}
+        assert all_ids[2] == {"unit-c"}
+
+    def test_linear_chain_input_order_irrelevant(self) -> None:
+        """Reversed input order should produce same dependency-ordered output."""
+        a = _make_work_unit("unit-a", sequence=1)
+        b = _make_work_unit("unit-b", sequence=2, depends_on=("unit-a",))
+        c = _make_work_unit("unit-c", sequence=3, depends_on=("unit-b",))
+
+        order_forward = resolve_execution_order([a, b, c])
+        order_reversed = resolve_execution_order([c, b, a])
+
+        ids_forward = [_batch_unit_ids(batch) for batch in order_forward.batches]
+        ids_reversed = [_batch_unit_ids(batch) for batch in order_reversed.batches]
+        assert ids_forward == ids_reversed
+
+
+# ---------------------------------------------------------------------------
+# Diamond dependency (T017 item 2)
+# ---------------------------------------------------------------------------
+
+
+class TestDiamondDependency:
+    """A → B, A → C, B → D, C → D: A first, B+C can be concurrent, D last."""
+
+    def test_diamond_dependency_ordering(self) -> None:
+        a = _make_work_unit("unit-a", sequence=1)
+        b = _make_work_unit("unit-b", sequence=2, depends_on=("unit-a",))
+        c = _make_work_unit("unit-c", sequence=3, depends_on=("unit-a",))
+        d = _make_work_unit("unit-d", sequence=4, depends_on=("unit-b", "unit-c"))
+
+        order = resolve_execution_order([a, b, c, d])
+
+        # A must be first
+        assert _batch_unit_ids(order.batches[0]) == {"unit-a"}
+
+        # D must be last
+        assert _batch_unit_ids(order.batches[-1]) == {"unit-d"}
+
+        # B and C appear before D and after A
+        middle_ids: set[str] = set()
+        for batch in order.batches[1:-1]:
+            middle_ids |= _batch_unit_ids(batch)
+        assert middle_ids == {"unit-b", "unit-c"}
+
+    def test_diamond_d_in_own_batch(self) -> None:
+        """D must be in its own batch since it depends on B and C."""
+        a = _make_work_unit("unit-a", sequence=1)
+        b = _make_work_unit("unit-b", sequence=2, depends_on=("unit-a",))
+        c = _make_work_unit("unit-c", sequence=3, depends_on=("unit-a",))
+        d = _make_work_unit("unit-d", sequence=4, depends_on=("unit-b", "unit-c"))
+
+        order = resolve_execution_order([a, b, c, d])
+
+        last_batch = order.batches[-1]
+        assert _batch_unit_ids(last_batch) == {"unit-d"}
+
+
+# ---------------------------------------------------------------------------
+# Independent units in same batch (T017 item 3)
+# ---------------------------------------------------------------------------
+
+
+class TestIndependentUnits:
+    """Units with no dependencies should be grouped together in one batch."""
+
+    def test_three_independent_units_same_batch(self) -> None:
+        x = _make_work_unit("unit-x", sequence=1)
+        y = _make_work_unit("unit-y", sequence=2)
+        z = _make_work_unit("unit-z", sequence=3)
+
+        order = resolve_execution_order([x, y, z])
+
+        # All three have no deps, so they should all be at level 0
+        # They may be in individual batches (None parallel_group) or merged —
+        # but collectively they should all appear in the same dependency tier.
+        all_ids = set()
+        for batch in order.batches:
+            all_ids |= _batch_unit_ids(batch)
+        assert all_ids == {"unit-x", "unit-y", "unit-z"}
+
+        # All should appear before any dependents (trivially satisfied here)
+
+    def test_independent_units_all_in_level_zero(self) -> None:
+        """All independent units should be in the same dependency tier (level 0)."""
+        x = _make_work_unit("unit-x", sequence=1)
+        y = _make_work_unit("unit-y", sequence=2)
+        dep = _make_work_unit("unit-dep", sequence=3, depends_on=("unit-x",))
+
+        order = resolve_execution_order([x, y, dep])
+
+        # unit-dep must come after unit-x; unit-y is independent
+        all_ids_before_dep: set[str] = set()
+        dep_batch_index = next(
+            i
+            for i, batch in enumerate(order.batches)
+            if "unit-dep" in _batch_unit_ids(batch)
+        )
+        for batch in order.batches[:dep_batch_index]:
+            all_ids_before_dep |= _batch_unit_ids(batch)
+
+        assert "unit-x" in all_ids_before_dep
+
+
+# ---------------------------------------------------------------------------
+# parallel_group batching (T017 item 4)
+# ---------------------------------------------------------------------------
+
+
+class TestParallelGroupBatching:
+    """Units with the same parallel_group in the same dependency tier → one batch."""
+
+    def test_same_group_same_tier_in_one_batch(self) -> None:
+        x = _make_work_unit("unit-x", sequence=1, parallel_group="grp-a")
+        y = _make_work_unit("unit-y", sequence=2, parallel_group="grp-a")
+
+        order = resolve_execution_order([x, y])
+
+        # Both should be in a single batch with parallel_group="grp-a"
+        assert len(order.batches) == 1
+        batch = order.batches[0]
+        assert batch.parallel_group == "grp-a"
+        assert _batch_unit_ids(batch) == {"unit-x", "unit-y"}
+
+    def test_different_groups_different_batches(self) -> None:
+        x = _make_work_unit("unit-x", sequence=1, parallel_group="grp-a")
+        y = _make_work_unit("unit-y", sequence=2, parallel_group="grp-b")
+
+        order = resolve_execution_order([x, y])
+
+        # Different groups → separate batches (even at same tier)
+        assert len(order.batches) == 2
+        groups = {batch.parallel_group for batch in order.batches}
+        assert groups == {"grp-a", "grp-b"}
+
+    def test_group_only_in_same_tier(self) -> None:
+        """Units with same parallel_group but different tiers are NOT merged."""
+        a = _make_work_unit("unit-a", sequence=1, parallel_group="grp")
+        b = _make_work_unit(
+            "unit-b", sequence=2, depends_on=("unit-a",), parallel_group="grp"
+        )
+
+        order = resolve_execution_order([a, b])
+
+        # They are in different tiers, so they get separate batches
+        assert len(order.batches) == 2
+
+    def test_no_group_units_get_none_parallel_group(self) -> None:
+        u = _make_work_unit("unit-a", sequence=1)
+
+        order = resolve_execution_order([u])
+
+        assert order.batches[0].parallel_group is None
+
+    def test_mixed_group_and_no_group_in_same_tier(self) -> None:
+        """Group units and ungrouped units at same tier produce separate batches."""
+        x = _make_work_unit("unit-x", sequence=1, parallel_group="grp-a")
+        y = _make_work_unit("unit-y", sequence=2, parallel_group="grp-a")
+        z = _make_work_unit("unit-z", sequence=3)  # no parallel_group
+
+        order = resolve_execution_order([x, y, z])
+
+        group_a_batch = next(b for b in order.batches if b.parallel_group == "grp-a")
+        assert _batch_unit_ids(group_a_batch) == {"unit-x", "unit-y"}
+
+
+# ---------------------------------------------------------------------------
+# Error cases (T017 items 5 and 6)
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateWorkUnitIds:
+    """Duplicate work unit IDs raise WorkUnitDependencyError."""
+
+    def test_duplicate_id_raises(self) -> None:
+        a1 = _make_work_unit("unit-a", sequence=1)
+        a2 = _make_work_unit("unit-a", sequence=2)
+        with pytest.raises(WorkUnitDependencyError, match="Duplicate work unit IDs"):
+            resolve_execution_order([a1, a2])
+
+    def test_duplicate_id_message_contains_id(self) -> None:
+        a1 = _make_work_unit("unit-a", sequence=1)
+        a2 = _make_work_unit("unit-a", sequence=2)
+        with pytest.raises(WorkUnitDependencyError) as exc_info:
+            resolve_execution_order([a1, a2])
+        assert "unit-a" in str(exc_info.value)
+
+    def test_multiple_duplicate_ids_all_reported(self) -> None:
+        a1 = _make_work_unit("unit-a", sequence=1)
+        a2 = _make_work_unit("unit-a", sequence=2)
+        b1 = _make_work_unit("unit-b", sequence=3)
+        b2 = _make_work_unit("unit-b", sequence=4)
+        with pytest.raises(WorkUnitDependencyError) as exc_info:
+            resolve_execution_order([a1, a2, b1, b2])
+        msg = str(exc_info.value)
+        assert "unit-a" in msg
+        assert "unit-b" in msg
+
+    def test_duplicate_has_no_cycle_or_missing_id(self) -> None:
+        a1 = _make_work_unit("unit-a", sequence=1)
+        a2 = _make_work_unit("unit-a", sequence=2)
+        with pytest.raises(WorkUnitDependencyError) as exc_info:
+            resolve_execution_order([a1, a2])
+        assert exc_info.value.cycle is None
+        assert exc_info.value.missing_id is None
+
+
+class TestCircularDependency:
+    """Circular dependencies raise WorkUnitDependencyError with cycle attribute."""
+
+    def test_self_dependency_raises(self) -> None:
+        a = _make_work_unit("unit-a", depends_on=("unit-a",))
+        with pytest.raises(WorkUnitDependencyError) as exc_info:
+            resolve_execution_order([a])
+        assert exc_info.value.cycle == ["unit-a", "unit-a"]
+
+    def test_two_unit_cycle_raises(self) -> None:
+        a = _make_work_unit("unit-a", depends_on=("unit-b",))
+        b = _make_work_unit("unit-b", depends_on=("unit-a",))
+        with pytest.raises(WorkUnitDependencyError) as exc_info:
+            resolve_execution_order([a, b])
+        err = exc_info.value
+        assert err.cycle is not None
+        # The cycle path must be deterministic: a -> b -> a
+        assert err.cycle == ["unit-a", "unit-b", "unit-a"]
+
+    def test_three_unit_cycle_raises(self) -> None:
+        a = _make_work_unit("unit-a", depends_on=("unit-c",))
+        b = _make_work_unit("unit-b", depends_on=("unit-a",))
+        c = _make_work_unit("unit-c", depends_on=("unit-b",))
+        with pytest.raises(WorkUnitDependencyError) as exc_info:
+            resolve_execution_order([a, b, c])
+        err = exc_info.value
+        assert err.cycle is not None
+        # Deterministic path: a -> c -> b -> a
+        assert err.cycle == ["unit-a", "unit-c", "unit-b", "unit-a"]
+
+    def test_cycle_starts_and_ends_with_same_node(self) -> None:
+        """The cycle list starts and ends with the same node ID."""
+        a = _make_work_unit("unit-a", depends_on=("unit-b",))
+        b = _make_work_unit("unit-b", depends_on=("unit-a",))
+        with pytest.raises(WorkUnitDependencyError) as exc_info:
+            resolve_execution_order([a, b])
+        cycle = exc_info.value.cycle
+        assert cycle is not None
+        assert cycle[0] == cycle[-1]
+
+    def test_cycle_missing_id_is_none(self) -> None:
+        """Cycle errors should not set missing_id."""
+        a = _make_work_unit("unit-a", depends_on=("unit-a",))
+        with pytest.raises(WorkUnitDependencyError) as exc_info:
+            resolve_execution_order([a])
+        assert exc_info.value.missing_id is None
+
+
+class TestMissingDependency:
+    """Missing dep IDs raise WorkUnitDependencyError."""
+
+    def test_unknown_dep_raises(self) -> None:
+        a = _make_work_unit("unit-a", depends_on=("nonexistent",))
+        with pytest.raises(WorkUnitDependencyError) as exc_info:
+            resolve_execution_order([a])
+        err = exc_info.value
+        assert err.missing_id == "nonexistent"
+
+    def test_cycle_is_none_for_missing_dep(self) -> None:
+        """Missing-dep errors should not set cycle."""
+        a = _make_work_unit("unit-a", depends_on=("ghost",))
+        with pytest.raises(WorkUnitDependencyError) as exc_info:
+            resolve_execution_order([a])
+        assert exc_info.value.cycle is None
+
+    def test_missing_dep_error_message_mentions_id(self) -> None:
+        a = _make_work_unit("unit-a", depends_on=("ghost-unit",))
+        with pytest.raises(WorkUnitDependencyError) as exc_info:
+            resolve_execution_order([a])
+        assert "ghost-unit" in str(exc_info.value)

--- a/tests/unit/flight/test_serializer.py
+++ b/tests/unit/flight/test_serializer.py
@@ -1,0 +1,698 @@
+"""Tests for maverick.flight.serializer round-trip serialization.
+
+Covers:
+- serialize_flight_plan() produces valid YAML frontmatter + Markdown sections
+- serialize_work_unit() produces valid YAML frontmatter + Markdown sections
+- Round-trip fidelity for FlightPlan: load → serialize → reload → compare
+- Round-trip fidelity for WorkUnit: same
+- FlightPlanFile.save(plan, path) writes correct content to file
+- FlightPlanFile.asave(plan, path) async variant
+- WorkUnitFile.save(unit, path) writes correct content to file
+- WorkUnitFile.asave(unit, path) async variant
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from maverick.flight.loader import FlightPlanFile, WorkUnitFile
+from maverick.flight.models import FlightPlan, WorkUnit
+from maverick.flight.serializer import serialize_flight_plan, serialize_work_unit
+from tests.unit.flight.conftest import (
+    SAMPLE_FLIGHT_PLAN_MD,
+    SAMPLE_WORK_UNIT_MD,
+    SAMPLE_WORK_UNIT_MD_WITH_PARALLEL,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_flight_plan_from_string(content: str, tmp_path: Path) -> FlightPlan:
+    """Write content to a temp file and load via FlightPlanFile."""
+    p = tmp_path / "flight-plan.md"
+    p.write_text(content, encoding="utf-8")
+    return FlightPlanFile.load(p)
+
+
+def _load_work_unit_from_string(
+    content: str, tmp_path: Path, name: str = "001-unit.md"
+) -> WorkUnit:
+    """Write content to a temp file and load via WorkUnitFile."""
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return WorkUnitFile.load(p)
+
+
+# ---------------------------------------------------------------------------
+# serialize_flight_plan() — output format tests
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeFlightPlan:
+    """Tests for serialize_flight_plan() output format."""
+
+    def test_produces_string(self, tmp_path: Path) -> None:
+        """serialize_flight_plan returns a string."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        assert isinstance(result, str)
+
+    def test_starts_with_frontmatter_delimiter(self, tmp_path: Path) -> None:
+        """Output must start with --- frontmatter opener."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        assert result.startswith("---\n")
+
+    def test_frontmatter_contains_name(self, tmp_path: Path) -> None:
+        """Frontmatter must contain the plan name."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        # Extract frontmatter block
+        parts = result.split("---\n", 2)
+        fm = yaml.safe_load(parts[1])
+        assert fm["name"] == "setup-authentication"
+
+    def test_frontmatter_contains_version(self, tmp_path: Path) -> None:
+        """Frontmatter must contain the version."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        parts = result.split("---\n", 2)
+        fm = yaml.safe_load(parts[1])
+        assert str(fm["version"]) == "1.0"
+
+    def test_frontmatter_contains_created_date(self, tmp_path: Path) -> None:
+        """Frontmatter must contain the created date as ISO string."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        parts = result.split("---\n", 2)
+        fm = yaml.safe_load(parts[1])
+        # YAML may parse it as date or string — either is acceptable
+        assert str(fm["created"]) == "2026-02-27"
+
+    def test_frontmatter_contains_tags(self, tmp_path: Path) -> None:
+        """Frontmatter must contain the tags list."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        parts = result.split("---\n", 2)
+        fm = yaml.safe_load(parts[1])
+        assert fm["tags"] == ["auth", "security"]
+
+    def test_contains_objective_section(self, tmp_path: Path) -> None:
+        """Output must contain ## Objective section."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        assert "## Objective" in result
+        assert "Implement user authentication with JWT tokens." in result
+
+    def test_contains_success_criteria_section(self, tmp_path: Path) -> None:
+        """Output must contain ## Success Criteria section with checkbox items."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        assert "## Success Criteria" in result
+        assert "- [x] Users can register with email and password" in result
+        assert "- [ ] Users can log in and receive a JWT" in result
+        assert "- [ ] Protected routes reject unauthenticated requests" in result
+
+    def test_contains_scope_section(self, tmp_path: Path) -> None:
+        """Output must contain ## Scope section with In/Out/Boundaries sub-sections."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        assert "## Scope" in result
+        assert "### In" in result
+        assert "### Out" in result
+        assert "### Boundaries" in result
+        assert "- Registration endpoint" in result
+        assert "- OAuth providers" in result
+        assert "- JWT tokens expire after 24 hours" in result
+
+    def test_contains_context_section_when_non_empty(self, tmp_path: Path) -> None:
+        """Output must contain ## Context section when plan.context is non-empty."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        assert "## Context" in result
+        assert "Building on the existing Express.js API framework." in result
+
+    def test_omits_context_section_when_empty(self, tmp_path: Path) -> None:
+        """## Context section must be omitted when plan.context is empty."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        # Build plan without context
+        plan_no_ctx = plan.model_copy(update={"context": "", "source_path": None})
+        result = serialize_flight_plan(plan_no_ctx)
+        assert "## Context" not in result
+
+    def test_contains_constraints_when_non_empty(self, tmp_path: Path) -> None:
+        """Output must contain ## Constraints section when constraints is non-empty."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        assert "## Constraints" in result
+        assert "- Must use bcrypt for password hashing" in result
+
+    def test_omits_constraints_when_empty(self, tmp_path: Path) -> None:
+        """## Constraints section must be omitted when constraints is empty."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        plan_no_c = plan.model_copy(update={"constraints": (), "source_path": None})
+        result = serialize_flight_plan(plan_no_c)
+        assert "## Constraints" not in result
+
+    def test_contains_notes_when_non_empty(self, tmp_path: Path) -> None:
+        """Output must contain ## Notes section when notes is non-empty."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        assert "## Notes" in result
+        assert "Consider adding refresh tokens in a follow-up." in result
+
+    def test_omits_notes_when_empty(self, tmp_path: Path) -> None:
+        """## Notes section must be omitted when notes is empty."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        plan_no_n = plan.model_copy(update={"notes": "", "source_path": None})
+        result = serialize_flight_plan(plan_no_n)
+        assert "## Notes" not in result
+
+    def test_checked_criteria_format(self, tmp_path: Path) -> None:
+        """Checked criteria use - [x] marker."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        assert "- [x] Users can register with email and password" in result
+
+    def test_unchecked_criteria_format(self, tmp_path: Path) -> None:
+        """Unchecked criteria use - [ ] marker."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        result = serialize_flight_plan(plan)
+        assert "- [ ] Users can log in and receive a JWT" in result
+
+
+# ---------------------------------------------------------------------------
+# serialize_work_unit() — output format tests
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeWorkUnit:
+    """Tests for serialize_work_unit() output format."""
+
+    def test_produces_string(self, tmp_path: Path) -> None:
+        """serialize_work_unit returns a string."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        assert isinstance(result, str)
+
+    def test_starts_with_frontmatter_delimiter(self, tmp_path: Path) -> None:
+        """Output must start with --- frontmatter opener."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        assert result.startswith("---\n")
+
+    def test_frontmatter_contains_work_unit_id(self, tmp_path: Path) -> None:
+        """Frontmatter must contain work-unit id."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        parts = result.split("---\n", 2)
+        fm = yaml.safe_load(parts[1])
+        assert fm["work-unit"] == "setup-database"
+
+    def test_frontmatter_contains_flight_plan(self, tmp_path: Path) -> None:
+        """Frontmatter must contain flight-plan."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        parts = result.split("---\n", 2)
+        fm = yaml.safe_load(parts[1])
+        assert fm["flight-plan"] == "setup-authentication"
+
+    def test_frontmatter_contains_sequence(self, tmp_path: Path) -> None:
+        """Frontmatter must contain sequence number."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        parts = result.split("---\n", 2)
+        fm = yaml.safe_load(parts[1])
+        assert fm["sequence"] == 1
+
+    def test_frontmatter_contains_depends_on(self, tmp_path: Path) -> None:
+        """Frontmatter must contain depends-on list."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        parts = result.split("---\n", 2)
+        fm = yaml.safe_load(parts[1])
+        assert fm["depends-on"] == []
+
+    def test_frontmatter_contains_parallel_group_when_set(self, tmp_path: Path) -> None:
+        """Frontmatter must contain parallel-group when non-None."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD_WITH_PARALLEL, tmp_path)
+        result = serialize_work_unit(unit)
+        parts = result.split("---\n", 2)
+        fm = yaml.safe_load(parts[1])
+        assert fm["parallel-group"] == "endpoints"
+
+    def test_frontmatter_omits_parallel_group_when_none(self, tmp_path: Path) -> None:
+        """Frontmatter must not contain parallel-group when None."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        parts = result.split("---\n", 2)
+        fm = yaml.safe_load(parts[1])
+        assert "parallel-group" not in fm
+
+    def test_contains_task_section(self, tmp_path: Path) -> None:
+        """Output must contain ## Task section."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        assert "## Task" in result
+        assert "Create the users table and database connection module." in result
+
+    def test_contains_acceptance_criteria_section(self, tmp_path: Path) -> None:
+        """Output must contain ## Acceptance Criteria section."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        assert "## Acceptance Criteria" in result
+        assert "- Database connection pool is configured [SC-001]" in result
+        assert "- Users table has email, password_hash, created_at columns" in result
+
+    def test_acceptance_criteria_with_trace_ref(self, tmp_path: Path) -> None:
+        """Acceptance criteria with trace_ref include [SC-###] suffix."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        assert "[SC-001]" in result
+
+    def test_acceptance_criteria_without_trace_ref(self, tmp_path: Path) -> None:
+        """Acceptance criteria without trace_ref have no [SC-###] suffix."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        # Second criterion has no trace ref
+        assert "- Users table has email, password_hash, created_at columns\n" in result
+
+    def test_contains_file_scope_section(self, tmp_path: Path) -> None:
+        """Output must contain ## File Scope section with sub-sections."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        assert "## File Scope" in result
+        assert "### Create" in result
+        assert "### Modify" in result
+        assert "### Protect" in result
+        assert "- src/db/connection.py" in result
+        assert "- src/config.py" in result
+        assert "- src/main.py" in result
+
+    def test_contains_instructions_section(self, tmp_path: Path) -> None:
+        """Output must contain ## Instructions section."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        assert "## Instructions" in result
+        assert "Use SQLAlchemy with async support." in result
+
+    def test_contains_verification_section(self, tmp_path: Path) -> None:
+        """Output must contain ## Verification section."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        result = serialize_work_unit(unit)
+        assert "## Verification" in result
+        assert "- make test-fast" in result
+        assert "- make lint" in result
+
+    def test_omits_provider_hints_when_none(self, tmp_path: Path) -> None:
+        """## Provider Hints section must be omitted when provider_hints is None."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        assert unit.provider_hints is None
+        result = serialize_work_unit(unit)
+        assert "## Provider Hints" not in result
+
+    def test_contains_provider_hints_when_set(self, tmp_path: Path) -> None:
+        """Provider Hints section must be present when provider_hints is non-empty."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        unit_with_hints = unit.model_copy(
+            update={
+                "provider_hints": "Prefer async SQLAlchemy patterns.",
+                "source_path": None,
+            }
+        )
+        result = serialize_work_unit(unit_with_hints)
+        assert "## Provider Hints" in result
+        assert "Prefer async SQLAlchemy patterns." in result
+
+    def test_depends_on_with_values(self, tmp_path: Path) -> None:
+        """Frontmatter depends-on must list dependency IDs."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD_WITH_PARALLEL, tmp_path)
+        result = serialize_work_unit(unit)
+        parts = result.split("---\n", 2)
+        fm = yaml.safe_load(parts[1])
+        assert fm["depends-on"] == ["setup-database"]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip fidelity — FlightPlan
+# ---------------------------------------------------------------------------
+
+
+class TestFlightPlanRoundTrip:
+    """Round-trip fidelity: load → serialize → write → reload → compare."""
+
+    @staticmethod
+    def _round_trip(tmp_path: Path, markdown: str) -> tuple[FlightPlan, FlightPlan]:
+        """Load a flight plan, serialize it, write to a new file, and reload.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+            markdown: Raw Markdown+frontmatter content.
+
+        Returns:
+            Tuple of (original, reloaded) FlightPlan models.
+        """
+        original_path = tmp_path / "original.md"
+        original_path.write_text(markdown, encoding="utf-8")
+        original = FlightPlanFile.load(original_path)
+
+        content = serialize_flight_plan(original)
+        serialized_path = tmp_path / "serialized.md"
+        serialized_path.write_text(content, encoding="utf-8")
+        reloaded = FlightPlanFile.load(serialized_path)
+
+        return original, reloaded
+
+    def test_round_trip_name(self, tmp_path: Path) -> None:
+        """name must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_FLIGHT_PLAN_MD)
+        assert reloaded.name == original.name
+
+    def test_round_trip_version(self, tmp_path: Path) -> None:
+        """version must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_FLIGHT_PLAN_MD)
+        assert reloaded.version == original.version
+
+    def test_round_trip_created(self, tmp_path: Path) -> None:
+        """created date must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_FLIGHT_PLAN_MD)
+        assert reloaded.created == original.created
+
+    def test_round_trip_tags(self, tmp_path: Path) -> None:
+        """tags must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_FLIGHT_PLAN_MD)
+        assert reloaded.tags == original.tags
+
+    def test_round_trip_objective(self, tmp_path: Path) -> None:
+        """objective must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_FLIGHT_PLAN_MD)
+        assert reloaded.objective == original.objective
+
+    def test_round_trip_success_criteria_count(self, tmp_path: Path) -> None:
+        """Number of success criteria must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_FLIGHT_PLAN_MD)
+        assert len(reloaded.success_criteria) == len(original.success_criteria)
+
+    def test_round_trip_success_criteria_text(self, tmp_path: Path) -> None:
+        """Success criteria text must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_FLIGHT_PLAN_MD)
+        for orig, rt in zip(
+            original.success_criteria, reloaded.success_criteria, strict=True
+        ):
+            assert rt.text == orig.text
+            assert rt.checked == orig.checked
+
+    def test_round_trip_scope(self, tmp_path: Path) -> None:
+        """Scope in/out/boundaries must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_FLIGHT_PLAN_MD)
+        assert reloaded.scope.in_scope == original.scope.in_scope
+        assert reloaded.scope.out_of_scope == original.scope.out_of_scope
+        assert reloaded.scope.boundaries == original.scope.boundaries
+
+    def test_round_trip_context(self, tmp_path: Path) -> None:
+        """context must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_FLIGHT_PLAN_MD)
+        assert reloaded.context == original.context
+
+    def test_round_trip_constraints(self, tmp_path: Path) -> None:
+        """constraints must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_FLIGHT_PLAN_MD)
+        assert reloaded.constraints == original.constraints
+
+    def test_round_trip_notes(self, tmp_path: Path) -> None:
+        """notes must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_FLIGHT_PLAN_MD)
+        assert reloaded.notes == original.notes
+
+
+# ---------------------------------------------------------------------------
+# Round-trip fidelity — WorkUnit
+# ---------------------------------------------------------------------------
+
+
+class TestWorkUnitRoundTrip:
+    """Round-trip fidelity: load → serialize → write → reload → compare."""
+
+    @staticmethod
+    def _round_trip(
+        tmp_path: Path,
+        markdown: str,
+        *,
+        original_name: str = "001-setup-database.md",
+        serialized_name: str = "001-serialized.md",
+    ) -> tuple[WorkUnit, WorkUnit]:
+        """Load a work unit, serialize it, write to a new file, and reload.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+            markdown: Raw Markdown+frontmatter content.
+            original_name: Filename for the original file.
+            serialized_name: Filename for the serialized file.
+
+        Returns:
+            Tuple of (original, reloaded) WorkUnit models.
+        """
+        original_path = tmp_path / original_name
+        original_path.write_text(markdown, encoding="utf-8")
+        original = WorkUnitFile.load(original_path)
+
+        content = serialize_work_unit(original)
+        serialized_path = tmp_path / serialized_name
+        serialized_path.write_text(content, encoding="utf-8")
+        reloaded = WorkUnitFile.load(serialized_path)
+
+        return original, reloaded
+
+    def test_round_trip_id(self, tmp_path: Path) -> None:
+        """id must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_WORK_UNIT_MD)
+        assert reloaded.id == original.id
+
+    def test_round_trip_flight_plan(self, tmp_path: Path) -> None:
+        """flight_plan must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_WORK_UNIT_MD)
+        assert reloaded.flight_plan == original.flight_plan
+
+    def test_round_trip_sequence(self, tmp_path: Path) -> None:
+        """sequence must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_WORK_UNIT_MD)
+        assert reloaded.sequence == original.sequence
+
+    def test_round_trip_depends_on(self, tmp_path: Path) -> None:
+        """depends_on must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_WORK_UNIT_MD)
+        assert reloaded.depends_on == original.depends_on
+
+    def test_round_trip_task(self, tmp_path: Path) -> None:
+        """task must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_WORK_UNIT_MD)
+        assert reloaded.task == original.task
+
+    def test_round_trip_acceptance_criteria(self, tmp_path: Path) -> None:
+        """acceptance_criteria must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_WORK_UNIT_MD)
+        assert len(reloaded.acceptance_criteria) == len(original.acceptance_criteria)
+        for orig, rt in zip(
+            original.acceptance_criteria, reloaded.acceptance_criteria, strict=True
+        ):
+            assert rt.text == orig.text
+            assert rt.trace_ref == orig.trace_ref
+
+    def test_round_trip_file_scope(self, tmp_path: Path) -> None:
+        """file_scope must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_WORK_UNIT_MD)
+        assert reloaded.file_scope.create == original.file_scope.create
+        assert reloaded.file_scope.modify == original.file_scope.modify
+        assert reloaded.file_scope.protect == original.file_scope.protect
+
+    def test_round_trip_instructions(self, tmp_path: Path) -> None:
+        """instructions must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_WORK_UNIT_MD)
+        assert reloaded.instructions == original.instructions
+
+    def test_round_trip_verification(self, tmp_path: Path) -> None:
+        """verification must survive round-trip."""
+        original, reloaded = self._round_trip(tmp_path, SAMPLE_WORK_UNIT_MD)
+        assert reloaded.verification == original.verification
+
+    def test_round_trip_parallel_group(self, tmp_path: Path) -> None:
+        """parallel_group must survive round-trip."""
+        original, reloaded = self._round_trip(
+            tmp_path,
+            SAMPLE_WORK_UNIT_MD_WITH_PARALLEL,
+            original_name="002-add-login-endpoint.md",
+            serialized_name="002-serialized.md",
+        )
+        assert reloaded.parallel_group == original.parallel_group
+
+    def test_round_trip_depends_on_with_values(self, tmp_path: Path) -> None:
+        """depends_on with values must survive round-trip."""
+        original, reloaded = self._round_trip(
+            tmp_path,
+            SAMPLE_WORK_UNIT_MD_WITH_PARALLEL,
+            original_name="002-add-login-endpoint.md",
+            serialized_name="002-serialized.md",
+        )
+        assert reloaded.depends_on == original.depends_on
+
+    def test_round_trip_provider_hints(self, tmp_path: Path) -> None:
+        """provider_hints must survive round-trip when set."""
+        original_path = tmp_path / "001-setup-database.md"
+        original_path.write_text(SAMPLE_WORK_UNIT_MD, encoding="utf-8")
+        unit = WorkUnitFile.load(original_path)
+        unit_with_hints = unit.model_copy(
+            update={"provider_hints": "Use connection pooling.", "source_path": None}
+        )
+
+        content = serialize_work_unit(unit_with_hints)
+        serialized_path = tmp_path / "001-serialized.md"
+        serialized_path.write_text(content, encoding="utf-8")
+        reloaded = WorkUnitFile.load(serialized_path)
+
+        assert reloaded.provider_hints == unit_with_hints.provider_hints
+
+
+# ---------------------------------------------------------------------------
+# FlightPlanFile.save / asave
+# ---------------------------------------------------------------------------
+
+
+class TestFlightPlanFileSave:
+    """Tests for FlightPlanFile.save() and FlightPlanFile.asave()."""
+
+    def test_save_creates_file(self, tmp_path: Path) -> None:
+        """save() must create the file at the given path."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        out_path = tmp_path / "output.md"
+        FlightPlanFile.save(plan, out_path)
+        assert out_path.exists()
+
+    def test_save_writes_correct_content(self, tmp_path: Path) -> None:
+        """save() must write content that can be reloaded."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        out_path = tmp_path / "output.md"
+        FlightPlanFile.save(plan, out_path)
+        plan2 = FlightPlanFile.load(out_path)
+        assert plan2.name == plan.name
+        assert plan2.objective == plan.objective
+
+    def test_save_utf8_encoding(self, tmp_path: Path) -> None:
+        """save() must write in UTF-8 encoding."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        out_path = tmp_path / "output.md"
+        FlightPlanFile.save(plan, out_path)
+        # Read raw bytes to verify UTF-8
+        content = out_path.read_bytes()
+        # Should be valid UTF-8
+        content.decode("utf-8")
+
+    def test_save_overwrites_existing_file(self, tmp_path: Path) -> None:
+        """save() must overwrite an existing file at the path."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        out_path = tmp_path / "output.md"
+        out_path.write_text("old content", encoding="utf-8")
+        FlightPlanFile.save(plan, out_path)
+        content = out_path.read_text(encoding="utf-8")
+        assert "old content" not in content
+        assert "---" in content
+
+    async def test_asave_creates_file(self, tmp_path: Path) -> None:
+        """asave() must create the file at the given path."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        out_path = tmp_path / "async_output.md"
+        await FlightPlanFile.asave(plan, out_path)
+        assert out_path.exists()
+
+    async def test_asave_writes_correct_content(self, tmp_path: Path) -> None:
+        """asave() must write content that can be reloaded."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        out_path = tmp_path / "async_output.md"
+        await FlightPlanFile.asave(plan, out_path)
+        plan2 = FlightPlanFile.load(out_path)
+        assert plan2.name == plan.name
+        assert plan2.objective == plan.objective
+
+    async def test_asave_matches_save_output(self, tmp_path: Path) -> None:
+        """asave() must produce identical content to save()."""
+        plan = _load_flight_plan_from_string(SAMPLE_FLIGHT_PLAN_MD, tmp_path)
+        sync_path = tmp_path / "sync_output.md"
+        async_path = tmp_path / "async_output.md"
+        FlightPlanFile.save(plan, sync_path)
+        await FlightPlanFile.asave(plan, async_path)
+        sync_content = sync_path.read_text(encoding="utf-8")
+        async_content = async_path.read_text(encoding="utf-8")
+        assert sync_content == async_content
+
+
+# ---------------------------------------------------------------------------
+# WorkUnitFile.save / asave
+# ---------------------------------------------------------------------------
+
+
+class TestWorkUnitFileSave:
+    """Tests for WorkUnitFile.save() and WorkUnitFile.asave()."""
+
+    def test_save_creates_file(self, tmp_path: Path) -> None:
+        """save() must create the file at the given path."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        out_path = tmp_path / "output.md"
+        WorkUnitFile.save(unit, out_path)
+        assert out_path.exists()
+
+    def test_save_writes_correct_content(self, tmp_path: Path) -> None:
+        """save() must write content that can be reloaded."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        out_path = tmp_path / "001-output.md"
+        WorkUnitFile.save(unit, out_path)
+        unit2 = WorkUnitFile.load(out_path)
+        assert unit2.id == unit.id
+        assert unit2.task == unit.task
+
+    def test_save_utf8_encoding(self, tmp_path: Path) -> None:
+        """save() must write in UTF-8 encoding."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        out_path = tmp_path / "output.md"
+        WorkUnitFile.save(unit, out_path)
+        content = out_path.read_bytes()
+        content.decode("utf-8")
+
+    def test_save_overwrites_existing_file(self, tmp_path: Path) -> None:
+        """save() must overwrite an existing file at the path."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        out_path = tmp_path / "output.md"
+        out_path.write_text("old content", encoding="utf-8")
+        WorkUnitFile.save(unit, out_path)
+        content = out_path.read_text(encoding="utf-8")
+        assert "old content" not in content
+        assert "---" in content
+
+    async def test_asave_creates_file(self, tmp_path: Path) -> None:
+        """asave() must create the file at the given path."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        out_path = tmp_path / "async_output.md"
+        await WorkUnitFile.asave(unit, out_path)
+        assert out_path.exists()
+
+    async def test_asave_writes_correct_content(self, tmp_path: Path) -> None:
+        """asave() must write content that can be reloaded."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        out_path = tmp_path / "001-async-output.md"
+        await WorkUnitFile.asave(unit, out_path)
+        unit2 = WorkUnitFile.load(out_path)
+        assert unit2.id == unit.id
+        assert unit2.task == unit.task
+
+    async def test_asave_matches_save_output(self, tmp_path: Path) -> None:
+        """asave() must produce identical content to save()."""
+        unit = _load_work_unit_from_string(SAMPLE_WORK_UNIT_MD, tmp_path)
+        sync_path = tmp_path / "sync_output.md"
+        async_path = tmp_path / "async_output.md"
+        WorkUnitFile.save(unit, sync_path)
+        await WorkUnitFile.asave(unit, async_path)
+        sync_content = sync_path.read_text(encoding="utf-8")
+        async_content = async_path.read_text(encoding="utf-8")
+        assert sync_content == async_content


### PR DESCRIPTION
## Summary

- Adds `maverick.flight` package with frozen Pydantic models for **Flight Plans** and **Work Units**, including Markdown+YAML frontmatter round-trip parsing and serialization
- Implements topological dependency resolution with deterministic cycle detection for work unit execution ordering
- Introduces `FlightError` exception hierarchy under `MaverickError` with specific error types (`FlightPlanNotFoundError`, `WorkUnitNotFoundError`, `FlightPlanParseError`, `FlightPlanValidationError`, `WorkUnitValidationError`, `WorkUnitDependencyError`)
- 281 unit tests covering models, parser, loader, resolver, and serializer

## New Modules

| Module | Purpose |
|--------|---------|
| `flight/models.py` | Frozen Pydantic models (`FlightPlan`, `WorkUnit`, `AcceptanceCriterion`, etc.) with field validators |
| `flight/parser.py` | Markdown+YAML frontmatter parsing, section splitting, bullet/checkbox extraction |
| `flight/loader.py` | `FlightPlanFile` / `WorkUnitFile` loaders with sync+async variants and directory loading |
| `flight/resolver.py` | Topological sort with DFS-based cycle detection for work unit dependencies |
| `flight/serializer.py` | Markdown serialization with round-trip fidelity |
| `flight/errors.py` | Re-exports from `exceptions/flight.py` for convenience |
| `exceptions/flight.py` | `FlightError` hierarchy under `MaverickError` |

## Tech Debt Issues Created

- #71 — `__all__` annotation style inconsistency across flight submodules
- #72 — `source_path` included in `to_dict()` but absent from serialization format
- #73 — Contract `api.py` `__all__` missing exported parser functions

## Test plan

- [x] 281 unit tests pass (`make test-fast`)
- [x] Lint clean (`make lint`)
- [x] Type check clean (`make typecheck`)
- [x] Full `make check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)