### PR TITLE
docs: OpenCode → OpenAI Agents SDK + LiteLLM + Burr migration plan

### DIFF
--- a/docs/BURR.md
+++ b/docs/BURR.md
@@ -1,184 +1,326 @@
-# Burr as a potential xoscar replacement
+# OpenCode → OpenAI Agents SDK + LiteLLM + Burr migration
 
-Captured from a research thread. Not a decision — a starting point.
+**Status:** Plan. Phase 0 spike pending (see
+[migration-phase-0-spike.md](./migration-phase-0-spike.md)); phases 1–3
+contingent on Phase 0 outcome.
 
-## Why we looked
+## Why migrate
 
-xoscar gives us actor RPC, supervisor lifecycle, and `@xo.generator`
-event streaming, but we're not using its distributed/multi-process
-features (`n_process=0`, all coroutines on one loop). The framework's
-ceremony — `__pre_destroy__`, `@xo.no_lock`, `xo.wait_for` vs
-`asyncio.wait_for` — is bigger than what we get back. Question: would a
-lighter framework simplify things, or should we drop framework support
-entirely?
+The current substrate works but carries real cost:
 
-Frameworks surveyed: LangGraph, PyFlue, Prefect/ControlFlow,
-Temporal/Restate/DBOS, pydantic-graph, Burr.
+- **OpenCode HTTP runtime** (~2400 LOC in `runtime/opencode/`) wraps an
+  external subprocess we spawn and manage. Four documented operational
+  landmines (silent crash loops on bad modelID, HTTP-200 empty-body
+  silent failures, Claude `StructuredOutput` envelope wrapping, silent
+  upstream retry storms — see issue #95).
+- **xoscar** ceremony (`@xo.no_lock`, `__pre_destroy__`, `xo.wait_for`
+  vs `asyncio.wait_for`, `@xo.generator` semantics) is bigger than what
+  we get back — we run `n_process=0` and never use the
+  distributed/multi-process features.
+- Together: substantial maintenance surface for capabilities we mostly
+  don't use, and a subprocess dependency in the critical path.
 
-## Why Burr made the shortlist
+## Decision
 
-[Apache Burr](https://github.com/apache/burr/) (formerly DAGWorks-Inc)
-is explicitly positioned as the lighter alternative to LangGraph:
-"while langgraph took a heavier-handed pregel-based approach... Burr
-aims towards simplification." It's a state-machine library, not an LLM
-framework — no LangChain dependency tree, model-agnostic. Apache
-incubation as of 2026.
+Migrate to a fully in-process Python stack:
 
-### Maverick → Burr mapping
+- **Slot A (multi-provider routing):** [LiteLLM] — in-process library
+  only; first-class `github_copilot/*` provider via OAuth device flow.
+- **Slot B (structured output):** [OpenAI Agents SDK] — first-class
+  `output_type=PydanticModel` at the agent level.
+- **Slot C (agent loop + tools):** OpenAI Agents SDK — tools, agent loop,
+  `as_tool()` for subagent delegation matching Maverick's `Task` pattern.
+- **Slot D (workflow orchestration):** [Apache Burr] — state-machine
+  library replacing xoscar's actor/supervisor pattern.
+- **Slot E (per-workflow lifecycle):** Maverick's existing `Squadron`
+  classes (merged in [#94]) — survive unchanged.
+- **Slot F (domain API):** Maverick's existing `Agent` base class
+  (merged in [#94]) — survives, internals rewritten.
+
+## Target architecture
+
+```
+fly CLI command
+   │
+   ▼
+Burr Application                    ← workflow state machine (replaces xoscar)
+   │ actions reference bound agents
+   ▼
+Maverick Squadron                   ← per-workflow lifecycle (already in main)
+   │
+   ▼
+Maverick Agent classes              ← domain API (already in main from PR #94)
+   │
+   ▼
+OpenAI Agents SDK Agent             ← LLM loop + tools + structured output
+   │
+   ▼
+LiteLLM                             ← provider routing (Copilot OAuth + others)
+   │
+   ▼
+github_copilot / openai / openrouter / ...
+```
+
+Six layers, same count as today, but **no subprocess we manage**, no
+HTTP plumbing between us and the LLM, all four landmines collapsed,
+and the xoscar ceremony goes away. Responsibilities are clean:
+
+- Burr owns workflow state machines (bead loops, fix cycles, commit phase).
+- OpenAI Agents SDK owns one-LLM-call's worth of orchestration (tool
+  use loop within a single `agent.run_async()`).
+- Maverick owns the seam between them and the domain semantics.
+
+## Phased plan
+
+The phasing unit is **layers, not roles** — each phase swaps one
+substitution independently with a clear back-out path.
+
+### Phase 0 — End-to-end spike (1–2 days)
+
+Prove the bottom-of-stack works for Maverick's hardest case before
+committing. Full details in
+[migration-phase-0-spike.md](./migration-phase-0-spike.md).
+
+**Decision gate:** if any required validation fails, abort the
+migration and revisit. If only cost-telemetry fails, proceed but accept
+we wire cost tracking ourselves.
+
+### Phase 1 — Replace OpenCode runtime (3–4 weeks)
+
+Swap out the bottom two layers (OpenCode HTTP + subprocess) while
+keeping xoscar at the top.
+
+**The big win.** ~2400 LOC of `runtime/opencode/` plus the four
+landmines die.
+
+Sub-phases:
+
+- **1a — `MaverickCascadingModel` (~200 LOC).** Implements OpenAI Agents
+  SDK's `Model` interface; internally walks our tier bindings, calls
+  `LitellmModel` for each, raises on terminal failure. Same algorithm
+  as today's `cascade_send` in `runtime/opencode/tiers.py`, different
+  transport.
+- **1b — Rewrite `Agent.__init__`, `_send_structured`, `_send_text`** to
+  build/call an underlying OpenAI Agents SDK `Agent`. Replace
+  `_ensure_session` / `_build_client` with "construct on demand" — no
+  session lifecycle.
+- **1c — Wire tools.** Per-role tool lists (briefing = Read/Glob/Grep,
+  implementer = full kit). Python implementations live in
+  `library/actions/` and reuse `CommandRunner` for Bash.
+- **1d — Strip `Squadron._build_agents`.** No more
+  `spawn_opencode_server`; just construct `MaverickCascadingModel`
+  instances. Drop the `validate_model_id` startup pass (cascade handles
+  bad modelIDs naturally).
+- **1e — Per-role migration behind a runtime flag.**
+  `MaverickConfig.runtime: Literal["opencode", "openai_agents"]`. Start
+  with briefing (lowest risk), then reviewer, decomposer, generator,
+  implementer (hardest).
+
+**End state of Phase 1:** xoscar still drives the workflow. OpenCode
+HTTP runtime is gone. All landmines collapsed. ~2400 LOC deleted,
+~500 LOC added (cascading model + tool implementations + new Agent
+backend).
+
+**Back-out path:** flip the runtime flag back to `"opencode"` per
+workflow. OpenCode runtime stays in-tree until Phase 3.
+
+### Phase 2 — Replace xoscar with Burr (2–3 weeks)
+
+Swap the workflow-orchestration layer. Pre-condition: Phase 1 stable in
+production for ≥1 week.
+
+Why this order: xoscar isn't load-bearing for correctness. Doing the
+substrate swap second means we're never debugging "is this a Burr
+problem or an OpenAI-Agents-SDK problem?" — Phase 1 is proven by the
+time we touch the supervisor.
+
+Sub-phases:
+
+- **2a — `fly_supervisor` → Burr `Application`** with explicit actions:
+  `select_bead`, `implement`, `gate`, `review_correctness`,
+  `review_completeness`, `fix`, `commit`. Squadron-bound agents reach
+  actions via `action.bind(coder=squadron.coder)`.
+- **2b — Hooks for progress events.** Replace `@xo.generator run()`
+  yielding `ProgressEvent`s with Burr `Hook`s on `pre_run_step` /
+  `post_run_step`. The Rich CLI consumer doesn't change.
+- **2c — Two-stage Ctrl-C.** Custom hook setting a "stop after current
+  step" flag. Validate at Phase 2 kickoff (BURR.md historically flagged
+  as unknown).
+- **2d — Bead loop as a cycle.** "Peek next ready bead → implement-or-
+  exit" becomes a branching action returning `next_bead → implement` or
+  `done → exit`.
+- **2e — Remaining supervisors.** Refuel, plan, land — same pattern.
+- **2f — Drop xoscar.** Remove the pool, drop `xoscar` from dependencies.
+
+**End state of Phase 2:** Burr drives all workflows. xoscar is gone.
+~600 LOC of supervisor ceremony deleted; Burr Applications add ~400 LOC
+of declarative wiring.
+
+**Back-out path:** keep xoscar supervisors during 2a–2e, runtime-flag
+them off when Burr equivalent is ready. Last step is removal.
+
+### Phase 3 — Cleanup (1 week)
+
+- `rm -rf src/maverick/runtime/opencode/`.
+- Drop the `opencode` binary dependency from CLAUDE.md and devcontainer.
+- Update CLAUDE.md: remove the four landmines (or move them to a
+  historical-context section), document the new stack.
+- Close issue #95 — silent-retry-storm landmine ceases to exist.
+- Tests guide for mocking at the Maverick `Agent` boundary
+  (TestModel/FunctionModel equivalents).
+
+## Risks specific to this stack
+
+1. **Cascade is still DIY.** Neither OpenAI Agents SDK nor LiteLLM gives
+   us tier-cascade across `(provider, model)` bindings out of the box.
+   `MaverickCascadingModel` is ~200 LOC in Phase 1a. The SDK gives
+   per-agent model selection; per-call fallback is our concern.
+
+2. **Two "Agent" concepts.** OpenAI Agents SDK has `agents.Agent`;
+   Maverick has `maverick.agents.Agent`. Use `from agents import Agent
+   as _AgentSDK` at internal boundaries to keep call sites unambiguous.
+
+3. **Tool-implementation parity.** OpenCode bundles polished
+   Read/Glob/Grep/Edit/Write/Bash/Task tools. We write Python
+   implementations of each in Phase 1c. Bash is essentially free (use
+   `CommandRunner`); Read/Write are trivial; Edit, Glob, Grep, Task
+   need ~100–200 LOC each. Total ~500–800 LOC of tool code, but it's
+   *our* code we can debug.
+
+4. **Burr maturity.** Less battle-tested than LangGraph.
+   Streaming-async historically had open issues; verify current state
+   at Phase 2 kickoff. If Burr disappoints, the fallback is plain
+   `asyncio.TaskGroup` orchestration (which is what xoscar effectively
+   is anyway minus the ceremony). Phase 1's gains stand independent of
+   Burr's fate.
+
+5. **Test mockability across the stack.** Design the Maverick `Agent`
+   layer's public surface so tests mock there, not at OpenAI Agents SDK
+   or LiteLLM. Existing tests in `tests/unit/agents/` (added in PR #94)
+   are the template — they should survive Phase 1 substantially
+   unchanged.
+
+## Why this beats the alternatives surveyed
+
+| Option | Verdict |
+|---|---|
+| Stay on OpenCode | Landmines 1–4 unaddressed, subprocess pain, 2400 LOC carried |
+| PydanticAI + LiteLLM | Reasonable; LiteLLM shim is community (22★) — load-bearing single-maintainer risk |
+| OpenAI Agents SDK + LiteLLM (no Burr) | Reasonable; xoscar ceremony stays |
+| **OpenAI Agents SDK + LiteLLM + Burr** | **First-party LiteLLM bridge + clean workflow layer + biggest delta from current pain** |
+| Vendor Agent SDKs (Claude / Codex) | Subscription bundles inaccessible, paradigms divergent, role-locks |
+| Instructor + LiteLLM + custom loop | Most code we own; viable backup if Phase 0 finds OpenAI Agents SDK issues |
+
+The decisive points: OpenAI Agents SDK has a **first-party** LiteLLM
+bridge (vs PydanticAI's community shim), first-class `output_type=`
+Pydantic returns, `as_tool()` for `Task` subagent delegation, and Burr
+delivers clean workflow ergonomics without the xoscar overhead.
+
+## OpenAI Agents SDK — what we use
+
+- **`agents.Agent`** with `model=`, `tools=`, `output_type=`.
+- **`agents.extensions.models.litellm_model.LitellmModel`** — wraps a
+  LiteLLM model id (`"github_copilot/claude-sonnet-4.6"`).
+- **`agent.run_async(prompt)`** — returns `RunResult` with typed
+  `final_output` matching `output_type`.
+- **`sub_agent.as_tool(name=, description=)`** — exposes a sub-agent as
+  a callable tool. Direct map for Maverick's current `Task` subagent
+  pattern (parallel briefings, parallel decompose-detail workers).
+- **Per-agent model assignment** — each `Agent` instance has its own
+  `model=`. Different agents in one workflow run on different
+  (provider, model) bindings cleanly.
+- **`tool_use_behavior`** — `"run_llm_again"` (default) for normal tool
+  loops; `"stop_on_first_tool"` / `StopAtTools` for short-circuit
+  patterns when needed.
+
+Known issues to watch:
+
+- Structured outputs + tools combined have provider-specific
+  compatibility gaps (e.g., Gemini issue #1575). Verify for our primary
+  bindings (Claude / GPT codex on github-copilot) in Phase 0.
+- Mixing "Responses" and "Chat Completions" API shapes in one workflow
+  isn't recommended; stick to one shape per workflow.
+
+## Burr — what we use (and don't)
+
+### What we use
+
+- **`Application`** with explicit actions and transitions — replaces the
+  xoscar supervisor pattern.
+- **`bind()`** for injecting Squadron-owned agent instances into actions.
+  Class-based actions don't support `bind()`; we keep actions as
+  functions.
+- **`Hook`s** on `pre_run_step` / `post_run_step` — replace
+  `ProgressEvent` yields for Rich Live console.
+- **Built-in `Persister`** + time-travel UI — replaces bespoke
+  bead-by-bead checkpointing.
+
+### What we don't use
+
+- **Streaming actions.** Our actors are single-shot `_send_structured`
+  calls returning typed payloads. Burr's streaming primitives are for
+  chatbot-style UIs.
+- **`MapActions` / `MapStates`.** Our "stream beads as they become
+  ready" pattern fits a *cycle* with a "next bead?" branching action
+  better than `MapActions`'s eager materialization.
+
+### Burr-specific concerns to validate
+
+1. **Async hard rule.** One blocking call freezes the whole
+   `Application`. We're already async-first (Guardrail #1), but anything
+   that sneaks in (`subprocess.run`, sync GitPython call) becomes a real
+   bug, not a slow path.
+2. **State is the contract.** Per-actor session IDs and OpenCode clients
+   were runtime artifacts that should NOT live in `State` (they'd
+   serialize into checkpoints meaninglessly). Use `bind()` for transient
+   handles, `State` for workflow data. (This is moot after Phase 1
+   eliminates sessions, but the principle still applies to other
+   runtime handles.)
+3. **`bind()` is functional-API only.** Class-based actions can't use
+   `bind()`. Keep actions as functions or pass dependencies via
+   `__init__`.
+
+## Maverick → Burr mapping (preserved from original research)
 
 | Maverick today                                 | Burr equivalent                              |
 | ---------------------------------------------- | -------------------------------------------- |
 | `fly`: implement → gate → review → fix → commit | `Application` with cycle (`fix → review`)    |
-| Briefing/decompose fan-out                     | `MapStates` / `MapActions` (sub-applications) |
+| Briefing/decompose fan-out                     | OpenAI Agents SDK `as_tool()` sub-agents OR Burr branching actions (TBD) |
 | `ProgressEvent` to Rich CLI                    | `Hook`s on `pre_run_step` / `post_run_step` |
-| Per-actor OpenCode session                     | Bound dependency (not in `State`)            |
+| Per-actor OpenCode session                     | Gone after Phase 1 (no sessions)             |
 | Bead-by-bead checkpointing                     | Built-in `Persister` + time-travel UI        |
 | `@xo.generator`, `__pre_destroy__`, `@xo.no_lock` | Gone — actions are async functions       |
 
-### Things we don't actually need from Burr
+## Actor liveness translates cleanly
 
-- **Streaming actions.** Our actors are single-shot
-  `_send_structured` calls returning typed payloads
-  (`implementer.py:104`, `reviewer.py:122`). The SSE machinery in
-  `runtime/opencode/client.py` is internal error detection, not token
-  streaming to the supervisor. Burr's streaming primitives are for
-  chatbot-style UIs and don't help us.
-- **Hooks fit our needs better than streaming** for the Rich Live
-  console — we already emit phase-boundary events, not deltas.
-
-## Key concerns before adopting
-
-1. **"Async all the way down" is a hard rule.** One blocking call
-   freezes the whole `Application`. We're already async-first
-   (Guardrail #1), but anything that sneaks in (`subprocess.run`, sync
-   GitPython call) becomes a real bug, not a slow path. Burr enforces
-   what CLAUDE.md already requires.
-2. **`MapActions` materializes eagerly.** Our "stream beads as they
-   become ready" pattern doesn't fit `MapActions` — it fits a *cycle*
-   with a "next bead?" branching action. Still natural, not a 1:1 swap.
-3. **State is the contract.** Burr wants a single `State` object
-   flowing between actions. Per-actor session IDs and OpenCode clients
-   are runtime artifacts that should NOT live in `State` (they'd get
-   serialized into checkpoints meaninglessly). Use `bind()` for
-   transient handles, `State` for workflow data.
-4. **Maturity.** Less battle-tested than LangGraph. Streaming-async had
-   open issues last year — verify current status before relying on it.
-5. **`bind()` is functional API only.** Class-based actions don't
-   support `bind()`. Either keep actions as functions or hand
-   dependencies via `__init__`.
-
-## The actor liveness pattern translates cleanly
-
-Confirmed from code:
-
-- Same `ImplementerActor` instance handles `send_implement` and
-  `send_fix` (`fly_supervisor.py:709,717,1177`). The persistent OpenCode
-  session is what carries context from implement → fix.
-- Same applies to reviewers: one `new_bead`, then potentially many
-  `send_review` rounds.
-- `_rotate_session()` only fires inside `new_bead()` — between beads,
-  not between fix rounds (`implementer.py:97`, `reviewer.py:111`).
-
-In Burr, this becomes structural: the same `bind()`-ed agent instance
-appears in both `implement` and `fix` actions. Continuity is right
-there in the wiring, not buried in actor reference identity.
-
-## The decoupled win: extract Agent classes regardless
-
-The actor abstraction today does two unrelated jobs:
-
-1. **RPC/lifecycle plumbing** — xoscar mailbox, `__post_create__`,
-   `@xo.no_lock`.
-2. **LLM session management + domain methods** — `_send_structured`,
-   `_rotate_session`, prompt assembly, cascade across provider tiers.
-
-Splitting them gives a clean three-layer stack:
-
-```
-Burr actions (or whatever)  ── calls ──>  Maverick Agents  ── calls ──>  OpenCode HTTP
-   (workflow)                              (domain API)                  (transport)
-```
-
-This refactor is independently valuable — even if we don't adopt Burr,
-the agent classes:
-
-- Encapsulate OpenCode behind a domain API (`coder.implement(bead)` not
-  `client.send_structured(prompt, schema=...)`).
-- Make LLM calls testable without spinning up xoscar.
-- Give a clear owner for the bead-boundary `new_bead()` rotation.
-- Centralize cost tracking, cascade logic, error classification.
-- Survive substrate churn — we already migrated ACP+MCP → OpenCode HTTP
-  once (`1bc06ae`); next migration only touches `Agent.__init__`.
-
-## Squadron: the other layer
-
-Above `Agent`, a `Squadron` (per-workflow subclass: `FlySquadron`,
-`RefuelSquadron`, `PlanSquadron`) owns:
-
-- OpenCode server lifecycle (replaces xoscar pool's `with_opencode=True`)
-- Model validation at startup (the async-dispatch + bad-modelID landmine,
-  collapsed to one place)
-- Agent factory + registry
-- Bead-boundary session rotation across all agents
-
-Then Burr binding becomes one step:
-
-```python
-async with FlySquadron(config) as squadron:
-    app = (
-        ApplicationBuilder()
-        .with_actions(
-            implement=implement.bind(coder=squadron.coder),
-            fix=fix.bind(coder=squadron.coder),                        # SAME instance
-            review_correctness=review.bind(rev=squadron.correctness_reviewer),
-            review_completeness=review.bind(rev=squadron.completeness_reviewer),
-        )
-        .build()
-    )
-    await app.arun(...)
-```
-
-## Recommended order of operations
-
-1. **Extract `Agent` classes from `OpenCodeAgentMixin`.** Actors become
-   thin shells holding an `Agent` instance and forwarding calls. Zero
-   behavior change, fully backward compatible.
-2. **Add `Squadron`.** Initially constructed by the xoscar pool (or
-   workflow), but owns server + agents.
-3. **Now decide about Burr.** With steps 1–2 done, the actor layer is
-   mostly RPC plumbing around stateless calls — and we can see clearly
-   whether it's worth swapping to Burr, dropping to plain
-   `asyncio.TaskGroup`, or keeping xoscar.
-
-Steps 1 and 2 are net wins regardless. Step 3 is informed by what the
-code actually looks like, not speculation.
-
-## Concerns specific to a Burr migration (revisit if/when we get there)
-
-- **`fly`'s outer bead loop** — Burr models cycles natively, but the
-  "peek next ready bead, exit when none" pattern needs a branching
-  action that returns either `next_bead → implement` or `done → exit`.
-  Sketch this on real code before committing.
-- **Two-stage Ctrl-C** — today fly catches SIGINT to set a graceful-stop
-  flag. Burr's `Application.run()` doesn't natively expose a "stop after
-  current step" hook. Probably solvable with a custom `Hook`, but
-  verify.
-- **The `new_implementer` recovery path** at `fly_supervisor.py:1163` —
-  rebuilds the actor on hard failure. In a Squadron world this becomes
-  `squadron.replace_coder()`; in a Burr world it's a transition into a
-  recovery branch. Either works.
-- **Concurrent workflows** — multiple Burr `Application`s can coexist on
-  one process; multiple Squadrons each own one OpenCode server on a
-  free port. No conflict.
+Today, the same `ImplementerActor` instance handles `send_implement`
+and `send_fix`; the persistent OpenCode session carries context from
+implement → fix. After Phase 1, sessions don't exist — context comes
+from `message_history` passed to `agent.run_async()`. The continuity
+becomes structural in the Burr wiring: the same `bind()`-ed agent
+appears in both `implement` and `fix` actions, with prior turns passed
+in explicitly. Continuity is right there in the wiring, not buried in
+actor reference identity.
 
 ## Sources
 
-- [Apache Burr](https://github.com/apache/burr/)
-- [Why Burr](https://burr.dagworks.io/getting_started/why-burr/)
-- [Burr parallelism (MapActions/MapStates)](https://burr.dagworks.io/concepts/parallelism/)
-- [Burr streaming actions](https://burr.dagworks.io/concepts/streaming-actions/)
-- [Burr sync vs async](https://burr.dagworks.io/concepts/sync-vs-async/)
-- [Burr actions / `bind()`](https://burr.dagworks.io/concepts/actions/)
-- [pydantic-graph](https://ai.pydantic.dev/api/pydantic_graph/graph/) — runner-up; pure state machine library, no LLM coupling
+- [OpenAI Agents SDK]
+- [OpenAI Agents SDK — LiteLLM extension reference](https://openai.github.io/openai-agents-python/ref/extensions/litellm/)
+- [OpenAI Agents SDK — Agents (output_type, handoffs, tools)](https://openai.github.io/openai-agents-python/agents/)
+- [LiteLLM]
+- [LiteLLM — GitHub Copilot provider](https://docs.litellm.ai/docs/providers/github_copilot)
+- [LiteLLM Router](https://docs.litellm.ai/docs/routing)
+- [Apache Burr]
+- [Burr — Why Burr](https://burr.dagworks.io/getting_started/why-burr/)
+- [Burr — sync vs async](https://burr.dagworks.io/concepts/sync-vs-async/)
+- [Burr — actions / `bind()`](https://burr.dagworks.io/concepts/actions/)
+- [Issue #95 — silent retry storm landmine](https://github.com/get2knowio/maverick/issues/95)
+- [PR #94 — Squadron + Agent extraction](https://github.com/get2knowio/maverick/pull/94)
+- [pydantic-graph](https://ai.pydantic.dev/api/pydantic_graph/graph/) — Burr runner-up; pure state machine library, no LLM coupling
 - [LangGraph complexity critique](https://www.ema.ai/additional-blogs/addition-blogs/langgraph-alternatives-to-consider)
 - [Durable execution: Temporal/Restate/DBOS](https://devstarsj.github.io/2026/04/03/durable-execution-temporal-restate-dbos-distributed-workflows-2026/) — overkill for an interactive CLI
+
+[LiteLLM]: https://docs.litellm.ai/
+[OpenAI Agents SDK]: https://openai.github.io/openai-agents-python/
+[Apache Burr]: https://github.com/apache/burr/
+[#94]: https://github.com/get2knowio/maverick/pull/94

--- a/docs/migration-phase-0-spike.md
+++ b/docs/migration-phase-0-spike.md
@@ -1,0 +1,424 @@
+# Phase 0 Spike — OpenAI Agents SDK + LiteLLM end-to-end
+
+**Parent doc:** [BURR.md](./BURR.md). This spike is the decision gate for
+phases 1–3 of that migration.
+
+**Goal:** prove the bottom-of-stack works for Maverick's hardest case
+(one implementer bead) before committing to the migration. Surface any
+blocker now while the spike is throwaway code, not Phase 1 production
+code.
+
+**Effort target:** 1–2 days, single-developer.
+
+**Status:** Not yet started.
+
+## What the spike is
+
+A standalone Python script — outside `src/maverick/`, owned by the
+spike author — that picks one ready bead from a known sample project,
+runs it end-to-end through OpenAI Agents SDK + LiteLLM, and emits a
+report covering five validations. The script does NOT integrate with
+the existing Maverick runtime; it stands alone.
+
+```
+scripts/spike-openai-agents-sdk-litellm.py
+```
+
+## Prerequisites
+
+1. `pip install "openai-agents[litellm]"` in a scratch venv (NOT
+   `uv sync` against the main project — keep the spike isolated).
+2. A `github-copilot` OAuth completed and credentials available. Either:
+   - Reuse the existing `~/.local/share/opencode/auth.json` if the
+     OAuth flow can extract them (verify in the OAuth validation below), or
+   - Run LiteLLM's first-use OAuth device flow, which writes to
+     `~/.config/litellm/github_copilot/`.
+3. The sample project at `/workspaces/sample-maverick-project` already
+   initialized with a refueled plan and at least one ready bead. (We
+   have this from the e2e run that produced PR #94's validation —
+   beads `sample-maverick-project-37n.3` and `37n.4` remain open.)
+4. `git config user.name` / `user.email` set in the sample project
+   (required for the eventual commit verification).
+
+## Script outline
+
+```python
+# scripts/spike-openai-agents-sdk-litellm.py
+"""Phase 0 spike — proves the post-migration bottom layers work end-to-end."""
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+from agents import Agent, Runner
+from agents.extensions.models.litellm_model import LitellmModel
+
+from maverick.payloads import SubmitImplementationPayload  # reuse the real payload schema
+from maverick.runners.command import CommandRunner          # reuse the existing Bash wrapper
+
+# ── Tools (minimum viable; not production-grade) ─────────────────────
+
+def read_tool(path: str) -> str:
+    """Read a file, return its content."""
+    return Path(path).read_text(encoding="utf-8")
+
+def write_tool(path: str, content: str) -> str:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return f"wrote {len(content)} bytes to {path}"
+
+def edit_tool(path: str, old: str, new: str) -> str:
+    """Replace exactly one occurrence of `old` with `new` in `path`."""
+    content = Path(path).read_text(encoding="utf-8")
+    if content.count(old) != 1:
+        raise ValueError(f"edit_tool: old-string must appear exactly once (found {content.count(old)})")
+    Path(path).write_text(content.replace(old, new), encoding="utf-8")
+    return f"edited {path}"
+
+def glob_tool(pattern: str, cwd: str = ".") -> list[str]:
+    """Find files matching a glob under cwd."""
+    return [str(p) for p in Path(cwd).rglob(pattern) if p.is_file()][:200]
+
+def grep_tool(pattern: str, cwd: str = ".", glob: str = "*") -> list[str]:
+    """Recursive ripgrep-style search."""
+    import re
+    rx = re.compile(pattern)
+    hits = []
+    for f in Path(cwd).rglob(glob):
+        if not f.is_file():
+            continue
+        try:
+            for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+                if rx.search(line):
+                    hits.append(f"{f}:{i}:{line}")
+                    if len(hits) >= 200:
+                        return hits
+        except (UnicodeDecodeError, PermissionError):
+            continue
+    return hits
+
+async def bash_tool(command: str, cwd: str = ".") -> dict:
+    """Run a shell command via the existing CommandRunner."""
+    runner = CommandRunner()
+    result = await runner.run(command, cwd=cwd, timeout=120)
+    return {"stdout": result.stdout, "stderr": result.stderr, "exit_code": result.returncode}
+
+
+# ── Spike configuration ──────────────────────────────────────────────
+
+SAMPLE_PROJECT = Path("/workspaces/sample-maverick-project")
+TARGET_BEAD_ID = "sample-maverick-project-37n.3"  # rendering bead (ready, non-trivial)
+
+PRIMARY_MODEL = "github_copilot/gpt-5.3-codex"   # what we expect to use post-migration
+FALLBACK_MODEL = "openai/gpt-5.3-codex"           # for cascade simulation in validation 3
+
+
+# ── Validation 1: Copilot OAuth device flow ──────────────────────────
+
+async def validation_1_oauth() -> dict:
+    """First-use OAuth device flow completes; subsequent calls use cached creds."""
+    model = LitellmModel(PRIMARY_MODEL)
+    # Trivial agent with no tools — just verifies the auth path works.
+    agent = Agent(name="oauth-probe", model=model)
+    t0 = time.monotonic()
+    result = await Runner.run(agent, "Reply with the single word: ready.")
+    return {
+        "passed": "ready" in result.final_output.lower(),
+        "elapsed_s": time.monotonic() - t0,
+        "output_sample": result.final_output[:80],
+    }
+
+
+# ── Validation 2: structured output via output_type ──────────────────
+
+async def validation_2_structured_output() -> dict:
+    """Agent returns a typed Pydantic payload first-try, no retry loop."""
+    bead_prompt = _build_bead_prompt(TARGET_BEAD_ID)
+    agent = Agent(
+        name="implementer-spike",
+        model=LitellmModel(PRIMARY_MODEL),
+        output_type=SubmitImplementationPayload,  # ← the real Maverick payload
+        instructions="You are an implementer. Use the tools provided to read the bead, "
+                     "explore the repo, make changes, and return a SubmitImplementationPayload.",
+        tools=[read_tool, glob_tool, grep_tool, edit_tool, write_tool, bash_tool],
+    )
+    t0 = time.monotonic()
+    result = await Runner.run(agent, bead_prompt)
+    payload = result.final_output
+    return {
+        "passed": isinstance(payload, SubmitImplementationPayload),
+        "elapsed_s": time.monotonic() - t0,
+        "summary": payload.summary[:200] if payload else None,
+        "files_modified": getattr(payload, "files_modified", None),
+    }
+
+
+# ── Validation 3: structured output + tool calling combined ──────────
+
+# Implicit in validation_2 — the implementer agent uses tools AND returns
+# a typed payload. If validation 2 passes for `github_copilot/claude-sonnet-4.6`
+# and `github_copilot/gpt-5.3-codex` both, validation 3 is covered.
+# Run validation_2 twice with different PRIMARY_MODEL values to cover this.
+
+
+# ── Validation 4: prompt-cache hit on repeated invocation ────────────
+
+async def validation_4_prompt_cache() -> dict:
+    """Two consecutive runs with shared context → second run shows cache hit."""
+    base_messages = _build_seeded_context(TARGET_BEAD_ID)  # ~10k tokens
+    agent = Agent(
+        name="cache-probe",
+        model=LitellmModel(PRIMARY_MODEL),
+        instructions="Briefly acknowledge the context, do not call tools.",
+    )
+    # First call — populates cache.
+    r1 = await Runner.run(agent, base_messages + [{"role": "user", "content": "Run 1: acknowledge."}])
+    # Second call — same prefix, should be a cache read.
+    r2 = await Runner.run(agent, base_messages + [{"role": "user", "content": "Run 2: acknowledge."}])
+    # Inspect usage fields. LiteLLM normalizes usage on `response.usage`; cache fields
+    # depend on provider — `prompt_tokens_details.cached_tokens` for OpenAI,
+    # `cache_read_input_tokens` for Anthropic-via-Copilot.
+    return {
+        "run1_input_tokens": _extract_input_tokens(r1),
+        "run2_input_tokens": _extract_input_tokens(r2),
+        "run1_cached": _extract_cached_tokens(r1),
+        "run2_cached": _extract_cached_tokens(r2),
+        "passed": _extract_cached_tokens(r2) > 0,  # second run must hit cache
+    }
+
+
+# ── Validation 5: cost telemetry surface ─────────────────────────────
+
+async def validation_5_cost_telemetry() -> dict:
+    """`agent.cost`-shaped fields are reachable from the result."""
+    agent = Agent(name="cost-probe", model=LitellmModel(PRIMARY_MODEL))
+    result = await Runner.run(agent, "Reply with: cost-probe-ok.")
+    # The interesting question is whether we can fish out:
+    #   provider_id, model_id, input_tokens, output_tokens,
+    #   cache_read_tokens, cache_write_tokens, cost_usd
+    # from `result.usage` / `result.raw_responses` / LiteLLM's hidden_params.
+    return {
+        "passed": True,
+        "usage_keys": _enumerate_usage(result),
+        "cost_usd_path": _find_cost_usd_path(result),
+        "notes": "see report; cost telemetry parity is informational, not a blocker",
+    }
+
+
+# ── Orchestration ────────────────────────────────────────────────────
+
+async def main() -> None:
+    print("Phase 0 spike — OpenAI Agents SDK + LiteLLM + Copilot")
+    print(f"Sample project: {SAMPLE_PROJECT}")
+    print(f"Target bead: {TARGET_BEAD_ID}")
+    print(f"Primary model: {PRIMARY_MODEL}")
+    print()
+
+    results = {}
+    for name, fn in (
+        ("v1_oauth", validation_1_oauth),
+        ("v2_structured_output", validation_2_structured_output),
+        ("v4_prompt_cache", validation_4_prompt_cache),
+        ("v5_cost_telemetry", validation_5_cost_telemetry),
+    ):
+        print(f"running {name}...")
+        try:
+            results[name] = await fn()
+            print(f"  {'PASS' if results[name]['passed'] else 'FAIL'}: "
+                  f"{results[name].get('elapsed_s', '?'):.1f}s" if 'elapsed_s' in results[name]
+                  else f"  {'PASS' if results[name]['passed'] else 'FAIL'}")
+        except Exception as exc:
+            results[name] = {"passed": False, "error": str(exc)}
+            print(f"  FAIL: {exc}")
+
+    # Validation 3: re-run v2 with the second model.
+    global PRIMARY_MODEL
+    PRIMARY_MODEL = "github_copilot/claude-sonnet-4.6"
+    print(f"\nrunning v3_structured_output_claude (model={PRIMARY_MODEL})...")
+    try:
+        results["v3_structured_output_claude"] = await validation_2_structured_output()
+    except Exception as exc:
+        results["v3_structured_output_claude"] = {"passed": False, "error": str(exc)}
+
+    _write_report(results)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Helper functions (`_build_bead_prompt`, `_build_seeded_context`,
+`_extract_input_tokens`, `_extract_cached_tokens`, `_enumerate_usage`,
+`_find_cost_usd_path`, `_write_report`) are simple shims around the
+sample project's bead reader and the OpenAI Agents SDK `RunResult` /
+LiteLLM response shapes — flesh out during the spike.
+
+## The five validations
+
+### V1 — Copilot OAuth device flow works in our dev environment
+
+**Why it matters:** the whole migration assumes we can reach
+`github_copilot/*` from in-process Python in our containerized dev
+setup. If LiteLLM's OAuth flow can't complete (e.g., device-flow URL
+unreachable from inside the container), the primary subscription route
+fails and we need a different strategy.
+
+**Pass criteria:**
+- A single `Runner.run(agent, ...)` against `LitellmModel("github_copilot/<model>")`
+  returns a valid response.
+- Subsequent runs reuse cached creds without re-prompting.
+
+**Fail modes:**
+- OAuth flow demands a browser interaction unavailable in the container
+  → document the workaround (forward port, paste device code) and
+  proceed.
+- LiteLLM cannot find the existing OpenCode-auth creds → run the OAuth
+  flow fresh; acceptable cost.
+- Auth completes but the call returns 401 → Copilot OAuth scope mismatch;
+  investigate before proceeding.
+
+### V2 — Structured output via `output_type=SubmitImplementationPayload`
+
+**Why it matters:** typed Pydantic payloads are non-negotiable for
+Maverick. Every agent role today returns a `Submit*Payload` validated
+by OpenCode's `format=json_schema`. If the OpenAI Agents SDK can't
+deliver this first-try with a tool-using agent, the whole migration
+loses its core property.
+
+**Pass criteria:**
+- `result.final_output` is an instance of `SubmitImplementationPayload`.
+- No retry loop fires (success on first attempt).
+- The payload is non-trivial (non-empty `files_modified`, non-empty
+  `summary`).
+
+**Fail modes:**
+- The model returns text instead of a structured payload → check that
+  `output_type=` was honored; verify provider support for structured
+  output via LiteLLM (the [Gemini issue](https://github.com/openai/openai-agents-python/issues/1575)
+  was Gemini-specific but verify for our bindings).
+- The payload validates but is empty / hallucinated → tooling problem,
+  not framework problem; tune prompts.
+- The payload fails Pydantic validation → may be intermittent; capture
+  the raw output and assess.
+
+### V3 — Structured output + tools combined for both primary bindings
+
+**Why it matters:** the known compatibility gap is specifically
+"structured output + tool calling together." Our two front-of-line
+bindings are `github_copilot/gpt-5.3-codex` (implement) and
+`github_copilot/claude-sonnet-4.6` (decompose/generate). Both must work.
+
+**Pass criteria:**
+- V2 passes for `github_copilot/gpt-5.3-codex`.
+- V2 passes for `github_copilot/claude-sonnet-4.6`.
+
+**Fail modes:**
+- One of the two fails → fall back to its corresponding `openai/*`
+  binding for the role; acceptable but reduces subscription leverage.
+- Both fail → serious problem; consider Instructor + LiteLLM + custom
+  loop as the Stack 2 fallback (see [BURR.md](./BURR.md) alternatives).
+
+### V4 — Anthropic / OpenAI prompt cache engages across runs
+
+**Why it matters:** Maverick's decomposer relies on warm cache across
+the outline → detail handoff. Implementer's fix loop relies on warm
+cache across review → fix turns. A 10–30k token seeded context that
+*doesn't* cache costs 4–10× more per call.
+
+**Pass criteria:**
+- Second run's usage shows `cached_tokens > 0` (OpenAI) or
+  `cache_read_input_tokens > 0` (Anthropic-via-Copilot).
+- The cached fraction is meaningful (>50% of the prefix).
+
+**Fail modes (and what each means):**
+- **Cache works transparently** → great, no wiring needed beyond
+  `message_history`. Migration is clean.
+- **Cache works but needs explicit markers** → small wiring effort in
+  the Maverick `Agent` layer to add `cache_control` markers around
+  seeded context. Tractable; add to Phase 1 scope.
+- **Cache doesn't engage at all** → reroute cache-sensitive paths
+  (decomposer, implementer fix loop) to `openai/gpt-5.x` in
+  `DEFAULT_TIERS`. Copilot stays as primary for non-cache-sensitive
+  roles. Document as a Phase 1 constraint.
+
+### V5 — Cost-telemetry surface
+
+**Why it matters:** today's `agent.cost` structured log row carries
+`provider_id`, `model_id`, `input_tokens`, `output_tokens`,
+`cache_read_tokens`, `cache_write_tokens`, `cost_usd`. Maverick's
+runway store records this per bead for cost forecasting.
+
+**Pass criteria:** all seven fields are reachable from `result.usage` /
+LiteLLM's `_hidden_params["response_cost"]` or equivalent.
+
+**Fail modes:**
+- All fields reachable → no work needed.
+- Token counts but no `cost_usd` → we maintain our own cost table
+  per `(provider, model)` and compute it ourselves. Annoying, not
+  blocking.
+- Token counts missing → unlikely; if it happens, fall back to
+  consulting raw responses; flag as a Phase 1 concern.
+
+This is the only validation whose failure is **non-blocking**. We can
+proceed without cost telemetry parity if necessary.
+
+## Decision gate
+
+After all five validations:
+
+| V1 | V2 | V3 | V4 | V5 | Decision |
+|---|---|---|---|---|---|
+| pass | pass | pass | pass | pass | **Proceed to Phase 1** as planned |
+| pass | pass | pass | pass | fail | **Proceed to Phase 1**, wire cost telemetry ourselves |
+| pass | pass | pass | partial | * | **Proceed to Phase 1**, document cache constraints in `DEFAULT_TIERS` |
+| pass | pass | partial | * | * | **Proceed to Phase 1** with reduced Copilot leverage for one binding |
+| pass | pass | fail | * | * | **Reconsider** — Stack 2 (Instructor + LiteLLM + custom loop) fallback |
+| pass | fail | * | * | * | **Abort migration as planned** — typed-output guarantee is non-negotiable; re-evaluate |
+| fail | * | * | * | * | **Abort migration as planned** — primary subscription path unavailable; re-evaluate |
+
+The "reconsider" path doesn't mean stay on OpenCode — it means revisit
+the framework choice with V3 evidence in hand.
+
+## Deliverables
+
+1. `scripts/spike-openai-agents-sdk-litellm.py` — the spike script
+   (~300 LOC including helpers).
+2. `docs/migration-phase-0-report.md` — a one-page report covering:
+   - Each validation's pass/fail with timing and notes.
+   - The raw OAuth credential location (so Phase 1 knows where to read).
+   - The exact LiteLLM model strings that worked / failed.
+   - Cache field paths for the providers tested.
+   - Cost telemetry field paths.
+   - Any gotchas worth flagging to Phase 1.
+3. A go / no-go recommendation against the decision-gate table.
+
+The script and report live in-repo so Phase 1 can build on them.
+
+## Out of scope for Phase 0
+
+- Burr is NOT involved. Phase 0 validates Slots A–C only.
+- Tool implementations are MVP — production-grade Read/Write/Edit/Glob/
+  Grep/Bash/Task come in Phase 1c.
+- Subagent / `as_tool()` patterns are NOT validated here. The
+  implementer doesn't spawn subagents for a single bead; that's a
+  decomposer / fanout concern handled separately in Phase 1.
+- `MaverickCascadingModel` (~200 LOC tier-cascade wrapper) is NOT
+  validated here. We test the primary binding only. The cascade is
+  algorithmically identical to today's `cascade_send` and is built in
+  Phase 1a.
+- No integration with the existing Maverick runtime. The spike is
+  throwaway.
+
+## Pre-commit checklist for the spike author
+
+Before declaring Phase 0 done:
+
+- [ ] Spike script runs successfully against `sample-maverick-project`.
+- [ ] All five validations executed (report includes results for each).
+- [ ] OAuth credential path documented.
+- [ ] Cache field paths documented per provider.
+- [ ] Decision recorded against the decision-gate table.
+- [ ] Report committed to `docs/migration-phase-0-report.md`.
+- [ ] Findings shared with the team before Phase 1 kickoff.


### PR DESCRIPTION
## Summary

- **Rewrites `docs/BURR.md`** from the original "is Burr a reasonable xoscar replacement?" research note into a full plan for migrating the LLM substrate from OpenCode HTTP runtime to OpenAI Agents SDK + LiteLLM + Burr, in three phases. Original Burr-specific research is preserved in dedicated sections.
- **Adds `docs/migration-phase-0-spike.md`** — a concrete spike with a ~300 LOC standalone script outline, five named validations, and a decision-gate matrix tying outcomes to migration verdicts. Phase 0 is the gate for Phase 1.

## What the plan proposes

A staged, layer-by-layer swap (not role-by-role) of the LLM substrate:

```
Phase 0  Spike (1–2 days)        End-to-end validation on one bead; go/no-go
Phase 1  Replace OpenCode (3–4w) ~2400 LOC of runtime/opencode/ deleted; landmines 1–4 die
Phase 2  Replace xoscar (2–3w)   Burr Applications drive workflows
Phase 3  Cleanup (1 week)        Drop opencode binary dep + xoscar dep
```

Each phase has a documented back-out path. Phase 1 is the biggest win and is independent of Phase 2 — if Burr disappoints, Phase 1's wins stand.

## Why this stack

- **LiteLLM** (in-process library) — first-class `github_copilot/*` provider via OAuth device flow → Copilot Pro subscription path survives the migration.
- **OpenAI Agents SDK** — **first-party** LiteLLM bridge (vs PydanticAI's community shim), first-class `output_type=PydanticModel`, `as_tool()` for Maverick's `Task` subagent pattern.
- **Burr** — clean workflow state-machine ergonomics without xoscar's ceremony. Already analyzed as a fit in the prior research.
- **Maverick `Squadron` + `Agent`** classes (merged in #94) — survive unchanged at the seam between Burr and the SDK.

Full alternatives table including PydanticAI, smolagents, vendor Agent SDKs, LangChain/LangGraph, Instructor + custom loop, and others is in BURR.md.

## What's NOT in this PR

This PR is documentation only. No code changes, no spike script implementation. Phase 0 is the next step and is scoped at 1–2 days; expect a follow-up PR with `scripts/spike-openai-agents-sdk-litellm.py` and the report once executed.

## Test plan

- [x] BURR.md renders correctly in GitHub markdown.
- [x] migration-phase-0-spike.md renders correctly in GitHub markdown.
- [x] Cross-references between the two docs resolve.
- [ ] Reviewer can read both docs end-to-end and answer: (a) what's the target architecture? (b) what's the migration order? (c) what does Phase 0 prove and what does each failure mode mean?

## Related

- Closes nothing directly.
- Sets up future work to close #95 (silent retry storm landmine) by deleting the OpenCode runtime in Phase 3.
- Builds on the Squadron + Agent extraction merged in #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)