### PR TITLE
ci: skip test-reporter on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,12 @@ jobs:
         continue-on-error: true
 
       - name: Test Report
+        # Skip on dependabot PRs — the bot's GITHUB_TOKEN is restricted
+        # to read-only by GitHub for security, so dorny/test-reporter's
+        # check-creation call returns HTTP 403 and the action errors out
+        # even though tests passed. Human PRs still get the rich report.
         uses: dorny/test-reporter@v1
-        if: always()
+        if: always() && github.actor != 'dependabot[bot]'
         with:
           name: Test Results (Python ${{ matrix.python-version }})
           path: "results.xml"


### PR DESCRIPTION
## Summary

Every dependabot PR right now is showing red despite all tests passing. Root cause: `dorny/test-reporter@v1` calls the GitHub check-runs API to publish a per-test report, but **dependabot-triggered runs get a read-only `GITHUB_TOKEN`** (GitHub security default) and that API call returns `HTTP 403 - Resource not accessible by integration`. The step errors out, the job fails, the PR shows red — even though `make ci-coverage` reported 3498 passed earlier in the same job.

Fix: gate the Test Report step on `github.actor != 'dependabot[bot]'`. Human PRs keep the rich report (they still have the right token scopes); dependabot PRs get a clean green check that reflects the actual CI result.

## Test plan

- [ ] This PR is human-authored, so CI here should run the test-reporter step as today (no regression for human PRs).
- [ ] After merge, one of the existing dependabot PRs (e.g. #101 actions/checkout) gets re-run and shows green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)