### PR TITLE
feat(burr): Phase 0 — scaffold burr driver + hook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "airframe-agents[all]>=0.9.0rc1,<0.10",
     "anyio>=4.0,<5",
     "atomicwrites>=1.4,<2",
+    "burr>=0.40,<0.41",
     "click>=8.1.0,<9",
     "detect-secrets>=1.4,<2",
     "gitpython>=3.1,<4",

--- a/src/maverick/burr/__init__.py
+++ b/src/maverick/burr/__init__.py
@@ -1,0 +1,24 @@
+"""Apache Burr orchestration substrate for maverick workflows.
+
+This package supplies the shared building blocks that per-workflow Burr
+applications use to surface progress and run end-to-end:
+
+* :class:`BurrWorkflowDriver` — drives an ``Application.arun()`` and
+  yields :class:`maverick.events.ProgressEvent` instances from a queue
+  the actions emit into.
+* :class:`ProgressEventHook` — Burr lifecycle hook that translates
+  ``pre_run_step`` / ``post_run_step`` into ``StepStarted`` /
+  ``StepCompleted`` and signals end-of-stream when a terminal action
+  completes.
+
+Per-workflow graphs live next to the workflow they implement
+(``src/maverick/workflows/<name>/burr_graph.py``). This module only
+holds the cross-cutting plumbing.
+"""
+
+from __future__ import annotations
+
+from maverick.burr.driver import BurrWorkflowDriver
+from maverick.burr.hooks import ProgressEventHook
+
+__all__ = ["BurrWorkflowDriver", "ProgressEventHook"]

--- a/src/maverick/burr/driver.py
+++ b/src/maverick/burr/driver.py
@@ -1,0 +1,124 @@
+"""Burr ``Application`` driver — wraps ``arun()`` into an event stream.
+
+The driver follows the producer/consumer pattern verified in the Phase 0
+spikes:
+
+* ``Application.arun()`` runs as a background ``asyncio.Task``.
+* Actions and a :class:`~maverick.burr.hooks.ProgressEventHook` push
+  :class:`maverick.events.ProgressEvent` instances into an
+  ``asyncio.Queue``; the hook enqueues a ``None`` sentinel after the
+  terminal action's ``post_run_step`` to signal end-of-stream.
+* :meth:`BurrWorkflowDriver.events` drains the queue, yielding each
+  event to the consumer in real time (Spike 3 measured sub-millisecond
+  emit→consume lag).
+* After the consumer finishes iterating, ``result`` exposes the tuple
+  returned by ``Application.arun()`` for downstream use.
+
+This is the airframe-side analogue of the xoscar supervisor's
+``@xo.generator run()`` drain (see
+:meth:`maverick.workflows.base.PythonWorkflow._drain_xoscar_supervisor`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Sequence
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from burr.core import Application
+
+    from maverick.events import ProgressEvent
+
+__all__ = ["BurrWorkflowDriver"]
+
+
+class BurrWorkflowDriver:
+    """Run a Burr ``Application`` and stream its ProgressEvents.
+
+    Usage::
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        app = build_plan_application(squadron, queue)
+        driver = BurrWorkflowDriver(
+            app, halt_after=["write_plan"], event_queue=queue,
+        )
+        async for event in driver.events():
+            ...
+        last_action, result, state = driver.result
+
+    Args:
+        app: A built :class:`burr.core.Application`.
+        halt_after: Action names that, when completed, terminate the
+            run. Forwarded to ``app.arun(halt_after=...)``.
+        event_queue: The same queue the application's hook and actions
+            push :class:`ProgressEvent` instances into. The driver
+            drains it until it receives a ``None`` sentinel.
+    """
+
+    def __init__(
+        self,
+        app: Application,
+        *,
+        halt_after: Sequence[str],
+        event_queue: asyncio.Queue[ProgressEvent | None],
+    ) -> None:
+        if not halt_after:
+            raise ValueError("halt_after must name at least one terminal action")
+        self._app = app
+        self._halt_after = list(halt_after)
+        self._queue = event_queue
+        self._result: tuple[Any, Any, Any] | None = None
+        self._exception: BaseException | None = None
+
+    async def events(self) -> AsyncIterator[ProgressEvent]:
+        """Drive the application and yield emitted events.
+
+        The application task runs concurrently with this iterator. When
+        a terminal action completes, the hook enqueues ``None``; the
+        iterator returns and the application task is awaited so any
+        exception surfaces to :attr:`result`. Cancelling the wrapping
+        task propagates through Burr cleanly (Spike 4).
+
+        On natural exit (sentinel received) we *do not* cancel the
+        application task — cancelling races with Burr's in-flight
+        exception propagation and replaces the underlying error with
+        ``CancelledError``. We only cancel when the consumer bails out
+        without draining (consumer-side break, exception, GeneratorExit).
+        """
+        app_task: asyncio.Task[tuple[Any, Any, Any]] = asyncio.create_task(
+            self._app.arun(halt_after=self._halt_after)
+        )
+        saw_sentinel = False
+        try:
+            while True:
+                evt = await self._queue.get()
+                if evt is None:
+                    saw_sentinel = True
+                    break
+                yield evt
+        finally:
+            if not saw_sentinel and not app_task.done():
+                app_task.cancel()
+            try:
+                self._result = await app_task
+            except BaseException as exc:  # noqa: BLE001
+                self._exception = exc
+
+    @property
+    def result(self) -> tuple[Any, Any, Any]:
+        """The ``(last_action, result, state)`` tuple ``app.arun()`` returned.
+
+        Raises:
+            BaseException: If the application task raised. The original
+                exception is re-raised here (including
+                ``asyncio.CancelledError`` on cancelled runs).
+            RuntimeError: If ``events()`` hasn't been drained yet.
+        """
+        if self._exception is not None:
+            raise self._exception
+        if self._result is None:
+            raise RuntimeError(
+                "BurrWorkflowDriver.events() must be drained before reading .result"
+            )
+        return self._result

--- a/src/maverick/burr/hooks.py
+++ b/src/maverick/burr/hooks.py
@@ -1,0 +1,102 @@
+"""Burr lifecycle hooks that translate to maverick :mod:`events`.
+
+:class:`ProgressEventHook` is wired into a Burr ``Application`` via
+``ApplicationBuilder().with_hooks(hook)``. It converts every action's
+``pre_run_step`` / ``post_run_step`` into a :class:`StepStarted` /
+:class:`StepCompleted` push onto an ``asyncio.Queue`` shared with the
+driver. After the terminal action's ``post_run_step``, the hook enqueues
+a ``None`` sentinel to signal end-of-stream.
+
+Async hooks are required: Burr's sync ``PreRunStepHook`` /
+``PostRunStepHook`` base classes call hook methods synchronously, so
+``async def`` methods on the sync bases silently produce un-awaited
+coroutine warnings. Inherit from the ``*Async`` variants instead.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any
+
+from burr.lifecycle import PostRunStepHookAsync, PreRunStepHookAsync
+
+from maverick.events import ProgressEvent, StepCompleted, StepStarted
+from maverick.types import StepType
+
+if TYPE_CHECKING:
+    import asyncio
+
+    from burr.core import State
+
+__all__ = ["ProgressEventHook"]
+
+
+class ProgressEventHook(PreRunStepHookAsync, PostRunStepHookAsync):
+    """Emit :class:`StepStarted` / :class:`StepCompleted` per Burr action.
+
+    Args:
+        queue: The shared event queue the driver drains. The hook puts
+            :class:`ProgressEvent` instances here; it also enqueues
+            ``None`` after the terminal action so the driver knows to
+            stop.
+        terminal_actions: Action names that signal end-of-stream. Match
+            the ``halt_after`` set on the driver.
+        action_labels: Optional human-readable label per action name
+            (e.g. ``{"select_next_bead": "Picking next bead"}``). Falls
+            back to the action name itself.
+        step_type: Default :class:`StepType` for emitted events. The
+            existing CLI Rich progress renderer keys off this for
+            display styling.
+    """
+
+    def __init__(
+        self,
+        queue: asyncio.Queue[ProgressEvent | None],
+        *,
+        terminal_actions: Sequence[str],
+        action_labels: Mapping[str, str] | None = None,
+        step_type: StepType = StepType.AGENT,
+    ) -> None:
+        if not terminal_actions:
+            raise ValueError("terminal_actions must name at least one action")
+        self._queue = queue
+        self._terminal = frozenset(terminal_actions)
+        self._labels = dict(action_labels or {})
+        self._step_type = step_type
+        self._start_times: dict[str, float] = {}
+
+    async def pre_run_step(self, *, action: Any, state: State, **_kw: Any) -> None:
+        name = action.name
+        self._start_times[name] = time.monotonic()
+        await self._queue.put(
+            StepStarted(
+                step_name=name,
+                step_type=self._step_type,
+                display_label=self._labels.get(name, name),
+            )
+        )
+
+    async def post_run_step(
+        self,
+        *,
+        action: Any,
+        state: State,
+        result: Any,
+        exception: BaseException | None,
+        **_kw: Any,
+    ) -> None:
+        name = action.name
+        start = self._start_times.pop(name, time.monotonic())
+        duration_ms = int((time.monotonic() - start) * 1000)
+        await self._queue.put(
+            StepCompleted(
+                step_name=name,
+                step_type=self._step_type,
+                success=exception is None,
+                duration_ms=duration_ms,
+                error=str(exception) if exception else None,
+            )
+        )
+        if name in self._terminal:
+            await self._queue.put(None)

--- a/tests/unit/burr/test_scaffolding.py
+++ b/tests/unit/burr/test_scaffolding.py
@@ -1,0 +1,161 @@
+"""Unit tests for ``maverick.burr`` scaffolding.
+
+Phase 0 scaffolding tests only — verify the driver + hook integrate
+correctly against a trivial Burr graph that has no LLM, no squadron,
+no maverick-internal coupling. Per-workflow application tests live next
+to their workflow under ``tests/unit/workflows/<name>/test_burr_*.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from burr.core import ApplicationBuilder, State, action
+
+from maverick.burr import BurrWorkflowDriver, ProgressEventHook
+from maverick.events import ProgressEvent, StepCompleted, StepStarted
+from maverick.types import StepType
+
+
+@action(reads=[], writes=["counter"])
+async def _start(state: State) -> tuple[dict[str, Any], State]:
+    return {"counter": 0}, state.update(counter=0)
+
+
+@action(reads=["counter"], writes=["counter"])
+async def _bump(state: State) -> tuple[dict[str, Any], State]:
+    new_counter = state["counter"] + 1
+    return {"counter": new_counter}, state.update(counter=new_counter)
+
+
+@action(reads=["counter"], writes=[])
+async def _finish(state: State) -> tuple[dict[str, Any], State]:
+    return {"counter": state["counter"]}, state
+
+
+@action(reads=[], writes=[])
+async def _boom(state: State) -> tuple[dict[str, Any], State]:
+    raise RuntimeError("intentional test failure")
+
+
+def _build_happy_app(
+    queue: asyncio.Queue[ProgressEvent | None],
+) -> Any:
+    """Three-action graph: start → bump → finish."""
+    hook = ProgressEventHook(
+        queue,
+        terminal_actions=["finish"],
+        action_labels={"start": "Init", "bump": "Bump", "finish": "Done"},
+    )
+    return (
+        ApplicationBuilder()
+        .with_actions(start=_start, bump=_bump, finish=_finish)
+        .with_transitions(("start", "bump"), ("bump", "finish"))
+        .with_entrypoint("start")
+        .with_state(counter=0)
+        .with_hooks(hook)
+        .build()
+    )
+
+
+class TestProgressEventHook:
+    async def test_emits_step_started_then_completed_per_action(self) -> None:
+        """Each action produces a paired StepStarted + StepCompleted event."""
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        app = _build_happy_app(queue)
+        driver = BurrWorkflowDriver(app, halt_after=["finish"], event_queue=queue)
+
+        events: list[ProgressEvent] = []
+        async for evt in driver.events():
+            events.append(evt)
+
+        # Three actions → 6 events (StepStarted + StepCompleted each)
+        assert len(events) == 6
+        for i, action_name in enumerate(("start", "bump", "finish")):
+            started = events[2 * i]
+            completed = events[2 * i + 1]
+            assert isinstance(started, StepStarted)
+            assert started.step_name == action_name
+            assert started.step_type == StepType.AGENT
+            assert isinstance(completed, StepCompleted)
+            assert completed.step_name == action_name
+            assert completed.success is True
+            assert completed.error is None
+            assert completed.duration_ms >= 0
+
+    async def test_display_label_overrides_action_name(self) -> None:
+        """``action_labels`` mapping populates ``StepStarted.display_label``."""
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        app = _build_happy_app(queue)
+        driver = BurrWorkflowDriver(app, halt_after=["finish"], event_queue=queue)
+
+        labels = [
+            evt.display_label async for evt in driver.events() if isinstance(evt, StepStarted)
+        ]
+        assert labels == ["Init", "Bump", "Done"]
+
+    async def test_post_run_step_records_exception(self) -> None:
+        """A raised action emits StepCompleted(success=False, error=<msg>)."""
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        hook = ProgressEventHook(queue, terminal_actions=["boom"])
+        app = (
+            ApplicationBuilder()
+            .with_actions(start=_start, boom=_boom)
+            .with_transitions(("start", "boom"))
+            .with_entrypoint("start")
+            .with_state(counter=0)
+            .with_hooks(hook)
+            .build()
+        )
+        driver = BurrWorkflowDriver(app, halt_after=["boom"], event_queue=queue)
+
+        events: list[ProgressEvent] = []
+        with pytest.raises(RuntimeError, match="intentional test failure"):
+            async for evt in driver.events():
+                events.append(evt)
+            # Result access re-raises the underlying RuntimeError.
+            _ = driver.result
+
+        boom_completed = [
+            e for e in events if isinstance(e, StepCompleted) and e.step_name == "boom"
+        ]
+        assert len(boom_completed) == 1
+        assert boom_completed[0].success is False
+        assert "intentional test failure" in (boom_completed[0].error or "")
+
+    async def test_rejects_empty_terminal_actions(self) -> None:
+        """``terminal_actions`` must not be empty (no end-of-stream signal)."""
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with pytest.raises(ValueError, match="terminal_actions"):
+            ProgressEventHook(queue, terminal_actions=[])
+
+
+class TestBurrWorkflowDriver:
+    async def test_result_exposes_app_arun_return(self) -> None:
+        """After draining, ``driver.result`` returns Burr's tuple."""
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        app = _build_happy_app(queue)
+        driver = BurrWorkflowDriver(app, halt_after=["finish"], event_queue=queue)
+
+        async for _ in driver.events():
+            pass
+
+        last_action, _result, state = driver.result
+        assert last_action.name == "finish"
+        assert state["counter"] == 1
+
+    async def test_result_before_drain_raises(self) -> None:
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        app = _build_happy_app(queue)
+        driver = BurrWorkflowDriver(app, halt_after=["finish"], event_queue=queue)
+
+        with pytest.raises(RuntimeError, match="must be drained"):
+            _ = driver.result
+
+    async def test_rejects_empty_halt_after(self) -> None:
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        app = _build_happy_app(queue)
+        with pytest.raises(ValueError, match="halt_after"):
+            BurrWorkflowDriver(app, halt_after=[], event_queue=queue)

--- a/uv.lock
+++ b/uv.lock
@@ -350,6 +350,15 @@ wheels = [
 ]
 
 [[package]]
+name = "burr"
+version = "0.40.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/9c/f978b798a82eb2592c12be7ef24eb41851be33edd68395d283201719f8bf/burr-0.40.2.tar.gz", hash = "sha256:275f3e26a3deede8126c57f78e1e6a0d9940b0c89c0b8ae78ce97a3ae1e2c2a6", size = 25533834, upload-time = "2025-05-28T05:55:30.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/93/b678ae49ff67fbb2f6fdd21ca4c0ff455857ae58dc180860cc4407c2ae5e/burr-0.40.2-py3-none-any.whl", hash = "sha256:b8e790cdba5ffc61270db2ef2324d828de1a4d56d06f732d7d496d7cb053d0c7", size = 5809991, upload-time = "2025-05-28T05:55:21.387Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1261,6 +1270,7 @@ dependencies = [
     { name = "airframe-agents", extra = ["all"] },
     { name = "anyio" },
     { name = "atomicwrites" },
+    { name = "burr" },
     { name = "click" },
     { name = "detect-secrets" },
     { name = "gitpython" },
@@ -1314,6 +1324,7 @@ requires-dist = [
     { name = "airframe-agents", extras = ["all"], specifier = ">=0.9.0rc1,<0.10" },
     { name = "anyio", specifier = ">=4.0,<5" },
     { name = "atomicwrites", specifier = ">=1.4,<2" },
+    { name = "burr", specifier = ">=0.40,<0.41" },
     { name = "click", specifier = ">=8.1.0,<9" },
     { name = "detect-secrets", specifier = ">=1.4,<2" },
     { name = "gitpython", specifier = ">=3.1,<4" },


### PR DESCRIPTION
## Summary

First slice of the xoscar → Apache Burr migration (plan in `docs/BURR.md`, planning doc in this session at `/home/vscode/.claude/plans/validated-wandering-tome.md`). Phase 0 lands the cross-cutting building blocks every workflow-specific Burr graph will use. **No behavior change yet** — xoscar is still the only orchestrator in production.

## What lands

- `src/maverick/burr/driver.py` — `BurrWorkflowDriver` wraps `Application.arun()` as a background task and yields `ProgressEvent`s from a shared `asyncio.Queue`. Drives terminate naturally on a `None` sentinel; consumer-side bailouts cancel the app task cleanly.
- `src/maverick/burr/hooks.py` — `ProgressEventHook` translates Burr's per-action `pre_run_step` / `post_run_step` lifecycle into `StepStarted` / `StepCompleted`. Records duration, surfaces action exceptions via `StepCompleted.error`, enqueues the end-of-stream sentinel after the terminal action.
- `tests/unit/burr/test_scaffolding.py` — 7 tests covering happy path, label override, exception emission, sentinel routing, and driver result/error semantics.
- `pyproject.toml` — adds `burr>=0.40,<0.41` runtime dep.

## Pre-flight spikes (not committed; ran in `/tmp/burr_spikes/`)

All four green:

1. **Async + hooks + cancellation.** Async actions work; hooks fire pre/post in correct order; `post_run_step` fires with `exception=` set even on raise; `CancelledError` propagates cleanly. *Catch:* hooks must inherit `PreRunStepHookAsync` / `PostRunStepHookAsync` — sync variants silently swallow `async def`.
2. **`bind()` with mutable squadron + state re-eval.** `bind(squadron=obj)` holds a live reference; `state["current_tier"]` is re-read each invocation; per-tier dispatch lands on the right agent. Tier escalation pattern viable for fly.
3. **Streaming events.** Producer/consumer with `asyncio.Queue` produces sub-millisecond emit→consume lag. Rich progress display will keep updating in real time.
4. **Cancellation + graceful stop.** `CancelledError` propagates from mid-action `await`; module-level flag + router action exits cleanly; fresh apps run after cancelled ones.

## Test plan

- [x] `make ci` — 3512 tests pass (3505 prior + 7 new scaffolding tests), mypy + ruff + format clean.
- [ ] Phase 1 (next PR) will exercise the driver + hook end-to-end against the plan workflow behind a `MAVERICK_USE_BURR=plan` feature flag.

## What's not in this PR

- No workflow ports. Phases 1–3 each get their own PR (`PlanSupervisor` → `RefuelSupervisor` → `FlySupervisor`).
- No xoscar deletions. Phase 4 strips `src/maverick/actors/xoscar/` once all three workflows have migrated.
- No Burr persister adoption. Existing `CheckpointStore` semantics are preserved across the migration; persister is a follow-up if its time-travel UI proves useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)