### PR TITLE
feat(burr): Phase 1 — port plan workflow behind MAVERICK_USE_BURR

### DIFF
--- a/src/maverick/burr/hooks.py
+++ b/src/maverick/burr/hooks.py
@@ -4,8 +4,11 @@
 ``ApplicationBuilder().with_hooks(hook)``. It converts every action's
 ``pre_run_step`` / ``post_run_step`` into a :class:`StepStarted` /
 :class:`StepCompleted` push onto an ``asyncio.Queue`` shared with the
-driver. After the terminal action's ``post_run_step``, the hook enqueues
-a ``None`` sentinel to signal end-of-stream.
+driver. The hook enqueues a ``None`` end-of-stream sentinel after the
+terminal action's ``post_run_step`` *or* after any action that raised
+(an uncaught exception in a non-terminal action ends the run too, and
+without the sentinel the driver's consumer loop would hang waiting on
+the queue).
 
 Async hooks are required: Burr's sync ``PreRunStepHook`` /
 ``PostRunStepHook`` base classes call hook methods synchronously, so
@@ -98,5 +101,5 @@ class ProgressEventHook(PreRunStepHookAsync, PostRunStepHookAsync):
                 error=str(exception) if exception else None,
             )
         )
-        if name in self._terminal:
+        if name in self._terminal or exception is not None:
             await self._queue.put(None)

--- a/src/maverick/workflows/generate_flight_plan/actions.py
+++ b/src/maverick/workflows/generate_flight_plan/actions.py
@@ -1,0 +1,399 @@
+"""Burr actions for the ``generate_flight_plan`` workflow.
+
+Each ``@action`` is a small async function that:
+
+1. Reads what it needs from ``State`` (or its bound dependencies).
+2. Calls into the :class:`~maverick.squadron.plan.PlanSquadron` (or an
+   on-demand briefing agent built from it) — the substrate-clean
+   agent layer.
+3. Writes results back to ``State`` and emits any per-agent progress
+   events to a bound ``asyncio.Queue``.
+
+The graph that wires these together lives in ``burr_graph.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from burr.core import State, action
+
+from maverick.events import AgentCompleted, AgentStarted, ProgressEvent, StepOutput
+from maverick.payloads import (
+    SUPERVISOR_TOOL_PAYLOAD_MODELS,
+    SubmitFlightPlanPayload,
+    SupervisorInboxPayload,
+    dump_supervisor_payload,
+)
+
+if TYPE_CHECKING:
+    from maverick.squadron.plan import PlanSquadron
+
+
+__all__ = [
+    "BRIEFING_CONFIG",
+    "PARALLEL_BRIEFING_AGENTS",
+    "contrarian_briefing",
+    "generate_plan",
+    "init_state",
+    "parallel_briefings",
+    "synthesize_briefing",
+    "validate_plan",
+    "write_plan",
+]
+
+_SOURCE = "plan-burr"
+
+
+#: ``(agent_name, display_label, mcp_tool, role_key)`` tuples — same
+#: layout as the xoscar ``PLAN_BRIEFING_CONFIG`` so per-role configuration
+#: stays portable across the two drivers.
+BRIEFING_CONFIG: tuple[tuple[str, str, str, str], ...] = (
+    ("scopist", "Scopist", "submit_scope", "scope"),
+    ("codebase_analyst", "Codebase Analyst", "submit_analysis", "analysis"),
+    ("criteria_writer", "Criteria Writer", "submit_criteria", "criteria"),
+    ("contrarian", "Contrarian", "submit_challenge", "challenge"),
+)
+
+#: Agent names that run during the first (parallel) briefing phase.
+PARALLEL_BRIEFING_AGENTS: tuple[str, ...] = (
+    "scopist",
+    "codebase_analyst",
+    "criteria_writer",
+)
+
+# Lookup helpers — derived once from BRIEFING_CONFIG so callers don't
+# have to walk the tuple themselves.
+_LABEL_FOR: dict[str, str] = {n: lbl for n, lbl, _t, _r in BRIEFING_CONFIG}
+_TOOL_FOR: dict[str, str] = {n: tool for n, _lbl, tool, _r in BRIEFING_CONFIG}
+_ROLE_FOR: dict[str, str] = {n: role for n, _lbl, _t, role in BRIEFING_CONFIG}
+
+
+def _schema_for(agent_name: str) -> Any:
+    tool = _TOOL_FOR[agent_name]
+    schema = SUPERVISOR_TOOL_PAYLOAD_MODELS.get(tool)
+    if schema is None:
+        raise RuntimeError(f"No payload schema registered for tool {tool!r}")
+    return schema
+
+
+async def _run_one_briefing(
+    *,
+    agent_name: str,
+    prompt: str,
+    squadron: PlanSquadron,
+    events: asyncio.Queue[ProgressEvent | None],
+    provider_label: str,
+) -> tuple[str, dict[str, Any]]:
+    """Build a briefing agent, run it, emit AgentStarted/AgentCompleted.
+
+    Returns ``(role_key, payload_dict)``. The action wrappers stash the
+    result on ``State["briefs"]`` keyed by role.
+    """
+    schema = _schema_for(agent_name)
+    label = _LABEL_FOR[agent_name]
+    agent = squadron.build_briefing_agent(agent_name=agent_name, result_model=schema)
+
+    await events.put(AgentStarted(step_name="briefing", agent_name=label, provider=provider_label))
+    t0 = time.monotonic()
+    payload = await agent.brief(prompt)
+    await events.put(
+        AgentCompleted(
+            step_name="briefing",
+            agent_name=label,
+            duration_seconds=time.monotonic() - t0,
+        )
+    )
+    if not isinstance(payload, SupervisorInboxPayload):
+        raise TypeError(
+            f"briefing agent {agent_name!r} returned {type(payload).__name__}, "
+            f"expected a SupervisorInboxPayload subclass"
+        )
+    return _ROLE_FOR[agent_name], dump_supervisor_payload(payload)
+
+
+# ---------------------------------------------------------------------------
+# Actions
+# ---------------------------------------------------------------------------
+
+
+@action(reads=[], writes=["briefs", "briefing_markdown", "flight_plan"])
+async def init_state(state: State) -> tuple[dict[str, Any], State]:
+    """Seed scratch slots used by downstream actions."""
+    return {}, state.update(briefs={}, briefing_markdown="", flight_plan=None)
+
+
+@action(reads=["prd_content", "provider_labels"], writes=["briefs"])
+async def parallel_briefings(
+    state: State,
+    *,
+    squadron: PlanSquadron,
+    events: asyncio.Queue[ProgressEvent | None],
+    max_concurrent: int,
+) -> tuple[dict[str, Any], State]:
+    """Run scopist + codebase_analyst + criteria_writer in parallel.
+
+    Concurrency capped by ``max_concurrent`` (default 3 — matches the
+    legacy ``parallel.max_briefing_agents`` setting). Each sub-task
+    builds its own briefing agent via the squadron, so the per-task
+    HTTP session/token state is isolated.
+    """
+    from maverick.agents.preflight_briefing.prompts import (
+        build_preflight_briefing_prompt,
+    )
+
+    prompt = build_preflight_briefing_prompt(state["prd_content"])
+    provider_labels: dict[str, str] = state["provider_labels"]
+    sem = asyncio.Semaphore(max(1, max_concurrent))
+
+    async def _bounded(name: str) -> tuple[str, dict[str, Any]]:
+        async with sem:
+            return await _run_one_briefing(
+                agent_name=name,
+                prompt=prompt,
+                squadron=squadron,
+                events=events,
+                provider_label=provider_labels.get(_LABEL_FOR[name], ""),
+            )
+
+    results = await asyncio.gather(*(_bounded(n) for n in PARALLEL_BRIEFING_AGENTS))
+    briefs = dict(state["briefs"])
+    for role_key, payload_dict in results:
+        briefs[role_key] = payload_dict
+    return {"briefs_collected": list(briefs)}, state.update(briefs=briefs)
+
+
+@action(reads=["prd_content", "briefs", "provider_labels"], writes=["briefs"])
+async def contrarian_briefing(
+    state: State,
+    *,
+    squadron: PlanSquadron,
+    events: asyncio.Queue[ProgressEvent | None],
+) -> tuple[dict[str, Any], State]:
+    """Run the contrarian after the parallel briefings are in.
+
+    Sequential by design — the contrarian's prompt incorporates the
+    three earlier briefs and acts as a critique pass over them.
+    """
+    briefs = state["briefs"]
+    scope_json = json.dumps(briefs.get("scope") or {}, indent=2)
+    analysis_json = json.dumps(briefs.get("analysis") or {}, indent=2)
+    criteria_json = json.dumps(briefs.get("criteria") or {}, indent=2)
+    prompt = (
+        f"## PRD Content\n\n{state['prd_content']}\n\n"
+        f"## Scopist Analysis\n\n```json\n{scope_json}\n```\n\n"
+        f"## Codebase Analysis\n\n```json\n{analysis_json}\n```\n\n"
+        f"## Success Criteria\n\n```json\n{criteria_json}\n```\n\n"
+        f"Challenge these analyses. Identify risks, blind spots, "
+        f"and missing considerations."
+    )
+
+    role_key, payload_dict = await _run_one_briefing(
+        agent_name="contrarian",
+        prompt=prompt,
+        squadron=squadron,
+        events=events,
+        provider_label=state["provider_labels"].get("Contrarian", ""),
+    )
+    new_briefs = dict(briefs)
+    new_briefs[role_key] = payload_dict
+    return {"contrarian_done": True}, state.update(briefs=new_briefs)
+
+
+@action(reads=["plan_name", "briefs"], writes=["briefing_markdown"])
+async def synthesize_briefing(state: State) -> tuple[dict[str, Any], State]:
+    """Render the four briefs into a single markdown block."""
+    from maverick.preflight_briefing.serializer import serialize_briefs_to_markdown
+
+    briefs = state["briefs"]
+    md = serialize_briefs_to_markdown(
+        state["plan_name"],
+        scope=briefs.get("scope"),
+        analysis=briefs.get("analysis"),
+        criteria=briefs.get("criteria"),
+        challenge=briefs.get("challenge"),
+    )
+    return {"briefing_markdown_length": len(md)}, state.update(briefing_markdown=md)
+
+
+@action(
+    reads=["prd_content", "briefing_markdown"],
+    writes=["flight_plan"],
+)
+async def generate_plan(
+    state: State,
+    *,
+    squadron: PlanSquadron,
+    events: asyncio.Queue[ProgressEvent | None],
+) -> tuple[dict[str, Any], State]:
+    """Hand the briefing to the generator agent."""
+    await events.put(
+        StepOutput(
+            step_name="plan",
+            message="Sending briefing to flight-plan generator",
+            display_label="",
+            level="info",
+            source=_SOURCE,
+            metadata=None,
+        )
+    )
+    parts = [f"## PRD Content\n\n{state['prd_content']}"]
+    if state["briefing_markdown"]:
+        parts.append(f"## Pre-Flight Briefing\n\n{state['briefing_markdown']}")
+    prompt = "\n\n".join(parts)
+    payload = await squadron.generator.generate(prompt)
+    plan_dict = dump_supervisor_payload(payload)
+    sc_count = len(payload.success_criteria)
+    await events.put(
+        StepOutput(
+            step_name="plan",
+            message=f"Flight plan generated ({sc_count} success criteria); validating",
+            display_label="",
+            level="success",
+            source=_SOURCE,
+            metadata={"success_criteria_count": sc_count},
+        )
+    )
+    return {"success_criteria_count": sc_count}, state.update(flight_plan=plan_dict)
+
+
+@action(reads=["plan_name", "prd_content", "flight_plan"], writes=["validation_passed"])
+async def validate_plan(
+    state: State,
+    *,
+    events: asyncio.Queue[ProgressEvent | None],
+) -> tuple[dict[str, Any], State]:
+    """Validate the generated plan via the existing V1-V9 file validators.
+
+    Renders the plan to markdown into a tmp file, runs the existing
+    :func:`maverick.flight.validator.validate_flight_plan_file` over it,
+    surfaces any issues as warnings. Same shape as
+    :class:`maverick.actors.xoscar.plan_validator.PlanValidatorActor`,
+    just inlined here so we don't depend on a deterministic actor.
+    """
+    import tempfile
+
+    from maverick.flight.validator import validate_flight_plan_file
+    from maverick.workflows.generate_flight_plan.markdown import (
+        render_flight_plan_markdown,
+    )
+
+    flight_plan_dict = state["flight_plan"]
+    if flight_plan_dict is None:
+        raise RuntimeError("validate_plan ran with no flight plan in state")
+
+    passed = True
+    warnings: tuple[str, ...] = ()
+    try:
+        flight_plan = SubmitFlightPlanPayload.model_validate(flight_plan_dict)
+        plan_name = str(flight_plan.name or state["plan_name"] or "plan")
+        markdown = render_flight_plan_markdown(
+            plan_name=plan_name,
+            prd_content=state["prd_content"],
+            flight_plan=flight_plan,
+        )
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write(markdown)
+            tmp_path = Path(tmp.name)
+        try:
+            issues = validate_flight_plan_file(tmp_path)
+            warnings = tuple(f"{issue.location}: {issue.message}" for issue in issues)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+    except Exception as exc:  # noqa: BLE001 — preserve legacy lenient behaviour
+        passed = False
+        warnings = (str(exc),)
+
+    if passed and warnings:
+        await events.put(
+            StepOutput(
+                step_name="plan",
+                message=f"Validation warnings ({len(warnings)}); continuing to write",
+                display_label="",
+                level="warning",
+                source=_SOURCE,
+                metadata={"warning_count": len(warnings)},
+            )
+        )
+    elif passed:
+        await events.put(
+            StepOutput(
+                step_name="plan",
+                message="Validation passed",
+                display_label="",
+                level="success",
+                source=_SOURCE,
+                metadata=None,
+            )
+        )
+    else:
+        await events.put(
+            StepOutput(
+                step_name="plan",
+                message=f"Validation errored: {warnings[0]}",
+                display_label="",
+                level="error",
+                source=_SOURCE,
+                metadata=None,
+            )
+        )
+    return {"validation_passed": passed}, state.update(validation_passed=passed)
+
+
+@action(
+    reads=["plan_name", "prd_content", "flight_plan", "briefing_markdown"],
+    writes=["flight_plan_path", "briefing_path"],
+)
+async def write_plan(
+    state: State,
+    *,
+    output_dir: str,
+    events: asyncio.Queue[ProgressEvent | None],
+) -> tuple[dict[str, Any], State]:
+    """Render markdown + write the plan + (optional) briefing to disk."""
+    from maverick.workflows.generate_flight_plan.markdown import (
+        render_flight_plan_markdown,
+    )
+
+    flight_plan_dict = state["flight_plan"]
+    if flight_plan_dict is None:
+        raise RuntimeError("write_plan ran with no flight plan in state")
+
+    flight_plan = SubmitFlightPlanPayload.model_validate(flight_plan_dict)
+    flight_plan_md = render_flight_plan_markdown(
+        plan_name=state["plan_name"],
+        prd_content=state["prd_content"],
+        flight_plan=flight_plan,
+    )
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    flight_plan_path = out_dir / "flight-plan.md"
+    flight_plan_path.write_text(flight_plan_md, encoding="utf-8")
+
+    briefing_path: str | None = None
+    if state["briefing_markdown"]:
+        briefing_file = out_dir / "preflight-briefing.md"
+        briefing_file.write_text(state["briefing_markdown"], encoding="utf-8")
+        briefing_path = str(briefing_file)
+
+    sc_count = len(flight_plan.success_criteria)
+    await events.put(
+        StepOutput(
+            step_name="plan",
+            message=f"Flight plan written ({sc_count} success criteria)",
+            display_label="",
+            level="success",
+            source=_SOURCE,
+            metadata={"success_criteria_count": sc_count},
+        )
+    )
+    return {"flight_plan_path": str(flight_plan_path)}, state.update(
+        flight_plan_path=str(flight_plan_path),
+        briefing_path=briefing_path,
+    )

--- a/src/maverick/workflows/generate_flight_plan/burr_graph.py
+++ b/src/maverick/workflows/generate_flight_plan/burr_graph.py
@@ -1,0 +1,159 @@
+"""Burr ``Application`` factory for the ``generate_flight_plan`` workflow.
+
+Wires the ``@action`` functions in :mod:`actions` into a state machine
+that mirrors the legacy ``PlanSupervisor`` shape:
+
+    init_state
+      → parallel_briefings (3 in parallel: scopist/analyst/criteria)
+      → contrarian_briefing
+      → synthesize_briefing
+      → generate_plan
+      → validate_plan
+      → write_plan
+      → done
+
+When ``skip_briefing=True`` the briefing actions are routed around:
+``init_state → generate_plan``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from burr.core import ApplicationBuilder, action
+
+from maverick.burr import ProgressEventHook
+from maverick.types import StepType
+from maverick.workflows.generate_flight_plan import actions as plan_actions
+
+if TYPE_CHECKING:
+    from maverick.events import ProgressEvent
+    from maverick.squadron.plan import PlanSquadron
+
+
+__all__ = ["build_plan_application", "PLAN_ACTION_LABELS", "PLAN_TERMINAL_ACTIONS"]
+
+
+PLAN_ACTION_LABELS: dict[str, str] = {
+    "init_state": "Init",
+    "parallel_briefings": "Briefing (parallel)",
+    "contrarian_briefing": "Contrarian briefing",
+    "synthesize_briefing": "Synthesizing briefing",
+    "generate_plan": "Generating flight plan",
+    "validate_plan": "Validating",
+    "write_plan": "Writing flight plan",
+    "done": "Done",
+}
+
+PLAN_TERMINAL_ACTIONS: tuple[str, ...] = ("done",)
+
+
+@action(reads=[], writes=[])
+async def _done(state: Any) -> tuple[dict[str, Any], Any]:
+    """No-op terminal action — provides a natural ``halt_after`` target."""
+    return {"final": True}, state
+
+
+def build_plan_application(
+    *,
+    squadron: PlanSquadron,
+    event_queue: asyncio.Queue[ProgressEvent | None],
+    prd_content: str,
+    plan_name: str,
+    output_dir: str,
+    skip_briefing: bool,
+    provider_labels: dict[str, str] | None = None,
+    max_briefing_agents: int = 3,
+) -> Any:
+    """Build the ``Application`` for one plan-generation run.
+
+    Args:
+        squadron: Open :class:`PlanSquadron` — owns the agents the
+            actions invoke via ``squadron.generator`` /
+            ``squadron.build_briefing_agent``.
+        event_queue: Shared queue the actions + hook push
+            :class:`ProgressEvent` instances into. The
+            :class:`~maverick.burr.BurrWorkflowDriver` drains this.
+        prd_content / plan_name / output_dir: Workflow inputs, seeded
+            into ``State`` so actions can read them.
+        skip_briefing: When ``True``, skip the four briefing actions
+            and jump straight to ``generate_plan``.
+        provider_labels: Optional ``label → "provider/model"`` map for
+            emitted ``AgentStarted`` events. Defaults to empty.
+        max_briefing_agents: Concurrency cap inside
+            ``parallel_briefings``. Default 3 matches the legacy
+            ``parallel.max_briefing_agents`` setting.
+
+    Returns:
+        A built :class:`burr.core.Application`. Caller passes it (plus
+        the same ``event_queue``) to
+        :class:`maverick.burr.BurrWorkflowDriver` to drive the run.
+    """
+    hook = ProgressEventHook(
+        event_queue,
+        terminal_actions=PLAN_TERMINAL_ACTIONS,
+        action_labels=PLAN_ACTION_LABELS,
+        step_type=StepType.AGENT,
+    )
+
+    builder: Any = (
+        ApplicationBuilder()
+        .with_actions(
+            init_state=plan_actions.init_state,
+            parallel_briefings=plan_actions.parallel_briefings.bind(
+                squadron=squadron,
+                events=event_queue,
+                max_concurrent=max_briefing_agents,
+            ),
+            contrarian_briefing=plan_actions.contrarian_briefing.bind(
+                squadron=squadron,
+                events=event_queue,
+            ),
+            synthesize_briefing=plan_actions.synthesize_briefing,
+            generate_plan=plan_actions.generate_plan.bind(
+                squadron=squadron,
+                events=event_queue,
+            ),
+            validate_plan=plan_actions.validate_plan.bind(events=event_queue),
+            write_plan=plan_actions.write_plan.bind(
+                output_dir=output_dir,
+                events=event_queue,
+            ),
+            done=_done,
+        )
+        .with_state(
+            prd_content=prd_content,
+            plan_name=plan_name,
+            provider_labels=dict(provider_labels or {}),
+            briefs={},
+            briefing_markdown="",
+            flight_plan=None,
+            flight_plan_path=None,
+            briefing_path=None,
+            validation_passed=True,
+            skip_briefing=skip_briefing,
+        )
+        .with_hooks(hook)
+        .with_entrypoint("init_state")
+    )
+
+    if skip_briefing:
+        builder = builder.with_transitions(
+            ("init_state", "generate_plan"),
+            ("generate_plan", "validate_plan"),
+            ("validate_plan", "write_plan"),
+            ("write_plan", "done"),
+        )
+    else:
+        builder = builder.with_transitions(
+            ("init_state", "parallel_briefings"),
+            ("parallel_briefings", "contrarian_briefing"),
+            ("contrarian_briefing", "synthesize_briefing"),
+            ("synthesize_briefing", "generate_plan"),
+            ("generate_plan", "validate_plan"),
+            ("validate_plan", "write_plan"),
+            ("write_plan", "done"),
+        )
+
+    return builder.build()

--- a/src/maverick/workflows/generate_flight_plan/workflow.py
+++ b/src/maverick/workflows/generate_flight_plan/workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,20 @@ from maverick.workflows.generate_flight_plan.models import (
 )
 
 logger = get_logger(__name__)
+
+
+def _use_burr_for(workflow_key: str) -> bool:
+    """Return True when ``MAVERICK_USE_BURR`` opts this workflow into the Burr driver.
+
+    The env var accepts a comma-separated list of workflow keys, matching
+    the planned roll-out shape (``MAVERICK_USE_BURR=plan,refuel,fly``).
+    Whitespace + empty entries are tolerated. Unset / empty → xoscar.
+    """
+    raw = os.environ.get("MAVERICK_USE_BURR", "")
+    if not raw:
+        return False
+    parts = {p.strip().lower() for p in raw.split(",") if p.strip()}
+    return workflow_key.lower() in parts
 
 
 def _build_generate_prompt(
@@ -189,16 +204,27 @@ class GenerateFlightPlanWorkflow(PythonWorkflow):
         await self.emit_step_completed(READ_PRD, output={"prd_size": prd_size})
 
         # ------------------------------------------------------------------
-        # Steps 2-5: xoscar supervisor handles briefing, generation,
-        # validation, and writing via supervisor-driven message routing.
+        # Steps 2-5: briefing, generation, validation, and writing.
+        # xoscar is the default driver; ``MAVERICK_USE_BURR=plan`` opts
+        # this workflow into the Burr-backed driver. Both drivers expose
+        # the same return-dict contract.
         # ------------------------------------------------------------------
-        result = await self._generate_with_xoscar(
-            prd_content=prd_content,
-            name=name,
-            plan_dir=plan_dir,
-            skip_briefing=skip_briefing,
-            cwd=cwd_input,
-        )
+        if _use_burr_for("plan"):
+            result = await self._generate_with_burr(
+                prd_content=prd_content,
+                name=name,
+                plan_dir=plan_dir,
+                skip_briefing=skip_briefing,
+                cwd=cwd_input,
+            )
+        else:
+            result = await self._generate_with_xoscar(
+                prd_content=prd_content,
+                name=name,
+                plan_dir=plan_dir,
+                skip_briefing=skip_briefing,
+                cwd=cwd_input,
+            )
         return GenerateFlightPlanResult(
             flight_plan_path=result.get("flight_plan_path", str(target_file)),
             name=name,
@@ -316,3 +342,92 @@ class GenerateFlightPlanWorkflow(PythonWorkflow):
         )
 
         return result
+
+    async def _generate_with_burr(
+        self,
+        *,
+        prd_content: str,
+        name: str,
+        plan_dir: Path,
+        skip_briefing: bool,
+        cwd: str,
+    ) -> dict[str, Any]:
+        """Generate the flight plan via the Burr-backed driver.
+
+        Opt-in path behind ``MAVERICK_USE_BURR=plan``. Same return-dict
+        contract as :meth:`_generate_with_xoscar`. The squadron, agents,
+        provider labels, and step configs are sourced exactly as in the
+        xoscar path; only the orchestration substrate differs.
+        """
+        import asyncio
+
+        from maverick.burr import BurrWorkflowDriver
+        from maverick.events import ProgressEvent
+        from maverick.squadron.plan import PlanSquadron
+        from maverick.types import StepType as _StepType
+        from maverick.workflows.fly_beads.workflow import _cost_sink_for_cwd
+        from maverick.workflows.generate_flight_plan.burr_graph import (
+            PLAN_TERMINAL_ACTIONS,
+            build_plan_application,
+        )
+
+        provider_labels: dict[str, str] = {}
+        if not skip_briefing:
+            for step_name, agent_name, label in (
+                ("briefing_scopist", "scopist", "Scopist"),
+                ("briefing_codebase_analyst", "codebase_analyst", "Codebase Analyst"),
+                ("briefing_criteria_writer", "criteria_writer", "Criteria Writer"),
+                ("briefing_contrarian", "contrarian", "Contrarian"),
+            ):
+                config = self.resolve_step_config(
+                    step_name, _StepType.PYTHON, agent_name=agent_name
+                )
+                provider_labels[label] = self._resolve_display_label_for_config(config)
+
+        cost_sink = _cost_sink_for_cwd(Path(cwd))
+        async with PlanSquadron(
+            cwd=Path(cwd), config=self._config, cost_sink=cost_sink
+        ) as squadron:
+            event_queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+            app = build_plan_application(
+                squadron=squadron,
+                event_queue=event_queue,
+                prd_content=prd_content,
+                plan_name=name,
+                output_dir=str(plan_dir),
+                skip_briefing=skip_briefing,
+                provider_labels=provider_labels,
+                max_briefing_agents=self._config.parallel.max_briefing_agents,
+            )
+            driver = BurrWorkflowDriver(
+                app,
+                halt_after=PLAN_TERMINAL_ACTIONS,
+                event_queue=event_queue,
+            )
+            async for evt in driver.events():
+                await self._event_queue.put(evt)
+            _, _result, state = driver.result
+
+        flight_plan_path = state.get("flight_plan_path")
+        if not flight_plan_path:
+            raise WorkflowError(
+                "Burr plan workflow exited without producing a flight plan path",
+                workflow_name="generate-flight-plan",
+            )
+
+        flight_plan_dict = state.get("flight_plan") or {}
+        sc_count = len(flight_plan_dict.get("success_criteria") or ())
+
+        await self.emit_output(
+            GENERATE,
+            f"Generated {sc_count} success criteria",
+            level="success",
+        )
+
+        return {
+            "success": True,
+            "flight_plan_path": flight_plan_path,
+            "briefing_path": state.get("briefing_path"),
+            "success_criteria_count": sc_count,
+            "validation_passed": bool(state.get("validation_passed", True)),
+        }

--- a/tests/unit/workflows/generate_flight_plan/test_burr_graph.py
+++ b/tests/unit/workflows/generate_flight_plan/test_burr_graph.py
@@ -1,0 +1,347 @@
+"""Unit tests for the Burr-mode plan generation graph.
+
+Covers the same supervisor-orchestration surface that
+``test_workflow.py::TestGenerateFlightPlanWorkflowHappyPath`` covers for
+the xoscar driver, but at the Burr ``Application`` level — no actor
+shells, no xoscar pool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from maverick.burr import BurrWorkflowDriver
+from maverick.events import (
+    AgentCompleted,
+    AgentStarted,
+    ProgressEvent,
+    StepCompleted,
+    StepOutput,
+    StepStarted,
+)
+from maverick.payloads import (
+    FlightPlanSuccessCriterionPayload,
+    SubmitAnalysisPayload,
+    SubmitChallengePayload,
+    SubmitCriteriaPayload,
+    SubmitFlightPlanPayload,
+    SubmitScopePayload,
+)
+from maverick.workflows.generate_flight_plan.burr_graph import (
+    PLAN_TERMINAL_ACTIONS,
+    build_plan_application,
+)
+from tests.unit.agents.airframe_stubs import StubBriefingAgent, StubGeneratorAgent
+
+# ---------------------------------------------------------------------------
+# Stub squadron — keeps the Burr graph 100% offline
+# ---------------------------------------------------------------------------
+
+
+_BRIEF_PAYLOADS: dict[str, Any] = {
+    "scopist": SubmitScopePayload(
+        in_scope=("src/foo.py",),
+        out_scope=(),
+        boundaries=(),
+        summary="stub scope",
+    ),
+    "codebase_analyst": SubmitAnalysisPayload(
+        modules=("src/foo",),
+        patterns=(),
+        dependencies=(),
+        complexity_assessment="stub analysis",
+    ),
+    "criteria_writer": SubmitCriteriaPayload(
+        criteria=("ship the thing",),
+        test_scenarios=(),
+        objective_draft="stub draft",
+        measurability_notes="stub notes",
+    ),
+    "contrarian": SubmitChallengePayload(
+        risks=("hubris",),
+        blind_spots=(),
+        open_questions=(),
+        consensus_points=(),
+    ),
+}
+
+
+def _make_flight_plan_payload(
+    name: str = "test-plan",
+    sc_count: int = 2,
+) -> SubmitFlightPlanPayload:
+    return SubmitFlightPlanPayload(
+        name=name,
+        version="1",
+        objective="Build a test CLI tool",
+        success_criteria=tuple(
+            FlightPlanSuccessCriterionPayload(description=f"sc-{i}") for i in range(sc_count)
+        ),
+        in_scope=("src/foo.py",),
+        out_of_scope=(),
+        boundaries=(),
+        context="stub context",
+        constraints=(),
+        notes="",
+    )
+
+
+class StubPlanSquadron:
+    """Mimics :class:`PlanSquadron`'s interface for Burr-mode tests.
+
+    Holds one :class:`StubGeneratorAgent` and one fresh
+    :class:`StubBriefingAgent` per ``build_briefing_agent`` call. Both
+    stubs derive from :mod:`tests.unit.agents.airframe_stubs` and pop
+    their canned payloads on each invocation.
+    """
+
+    def __init__(
+        self,
+        *,
+        flight_plan: SubmitFlightPlanPayload | None = None,
+        briefing_payloads: dict[str, Any] | None = None,
+    ) -> None:
+        self.generator = StubGeneratorAgent(
+            generate_payloads=[flight_plan or _make_flight_plan_payload()],
+        )
+        # Canned per-agent payloads — callers can override one or all.
+        self._briefing_payloads = dict(briefing_payloads or _BRIEF_PAYLOADS)
+        self.built_briefings: list[StubBriefingAgent] = []
+
+    def build_briefing_agent(self, *, agent_name: str, result_model: Any) -> StubBriefingAgent:
+        payload = self._briefing_payloads.get(agent_name)
+        if payload is None:
+            raise AssertionError(f"no stub briefing payload registered for agent {agent_name!r}")
+        stub = StubBriefingAgent(
+            agent_name=agent_name,
+            result_model=result_model,
+            brief_payloads=[payload],
+        )
+        self.built_briefings.append(stub)
+        return stub
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _collect(driver: BurrWorkflowDriver) -> list[ProgressEvent]:
+    events: list[ProgressEvent] = []
+    async for evt in driver.events():
+        events.append(evt)
+    return events
+
+
+def _by_action(events: list[ProgressEvent]) -> list[str]:
+    """Action sequence as derived from emitted ``StepStarted`` events."""
+    return [e.step_name for e in events if isinstance(e, StepStarted)]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBurrPlanGraphHappyPath:
+    async def test_full_pipeline_executes_all_actions(self, tmp_path: Path) -> None:
+        """Briefing → contrarian → generate → validate → write → done."""
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        squadron = StubPlanSquadron()
+        app = build_plan_application(
+            squadron=squadron,
+            event_queue=queue,
+            prd_content="# stub PRD\n\nbuild a thing",
+            plan_name="test-plan",
+            output_dir=str(tmp_path / "test-plan"),
+            skip_briefing=False,
+            provider_labels={"Scopist": "claude/x"},
+            max_briefing_agents=3,
+        )
+        driver = BurrWorkflowDriver(app, halt_after=PLAN_TERMINAL_ACTIONS, event_queue=queue)
+        events = await _collect(driver)
+
+        action_sequence = _by_action(events)
+        assert action_sequence == [
+            "init_state",
+            "parallel_briefings",
+            "contrarian_briefing",
+            "synthesize_briefing",
+            "generate_plan",
+            "validate_plan",
+            "write_plan",
+            "done",
+        ]
+
+        # Every step ended successfully.
+        for name in action_sequence:
+            completed = [e for e in events if isinstance(e, StepCompleted) and e.step_name == name]
+            assert len(completed) == 1
+            assert completed[0].success is True, f"action {name} not successful"
+
+        _, _, state = driver.result
+        assert state["flight_plan"] is not None
+        assert state["flight_plan_path"].endswith("flight-plan.md")
+        assert state["briefing_path"].endswith("preflight-briefing.md")
+        assert state["validation_passed"] is True
+
+        # Files actually landed on disk.
+        assert Path(state["flight_plan_path"]).exists()
+        assert Path(state["briefing_path"]).exists()
+
+    async def test_emits_agent_started_completed_per_briefing(self, tmp_path: Path) -> None:
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        squadron = StubPlanSquadron()
+        app = build_plan_application(
+            squadron=squadron,
+            event_queue=queue,
+            prd_content="x",
+            plan_name="test-plan",
+            output_dir=str(tmp_path / "test-plan"),
+            skip_briefing=False,
+        )
+        driver = BurrWorkflowDriver(app, halt_after=PLAN_TERMINAL_ACTIONS, event_queue=queue)
+        events = await _collect(driver)
+
+        agent_names_started = sorted(e.agent_name for e in events if isinstance(e, AgentStarted))
+        assert agent_names_started == [
+            "Codebase Analyst",
+            "Contrarian",
+            "Criteria Writer",
+            "Scopist",
+        ]
+        agent_names_completed = sorted(
+            e.agent_name for e in events if isinstance(e, AgentCompleted)
+        )
+        assert agent_names_completed == agent_names_started
+
+        # Provider label propagates onto the Scopist AgentStarted (only one
+        # we set in this test).
+        scopist_started = [
+            e for e in events if isinstance(e, AgentStarted) and e.agent_name == "Scopist"
+        ]
+        assert len(scopist_started) == 1
+
+    async def test_step_output_events_carry_success_metadata(self, tmp_path: Path) -> None:
+        """``generate_plan`` + ``write_plan`` surface success_criteria_count."""
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        squadron = StubPlanSquadron(flight_plan=_make_flight_plan_payload(sc_count=3))
+        app = build_plan_application(
+            squadron=squadron,
+            event_queue=queue,
+            prd_content="x",
+            plan_name="test-plan",
+            output_dir=str(tmp_path / "test-plan"),
+            skip_briefing=False,
+        )
+        driver = BurrWorkflowDriver(app, halt_after=PLAN_TERMINAL_ACTIONS, event_queue=queue)
+        events = await _collect(driver)
+
+        outputs = [e for e in events if isinstance(e, StepOutput)]
+        sc_outputs = [
+            o for o in outputs if o.metadata and o.metadata.get("success_criteria_count") == 3
+        ]
+        # Two StepOutput events should mention sc_count=3 — one from
+        # generate_plan ("generated"), one from write_plan ("written").
+        assert len(sc_outputs) >= 2
+
+
+class TestBurrPlanGraphSkipBriefing:
+    async def test_skip_briefing_routes_around_briefing_actions(self, tmp_path: Path) -> None:
+        """When ``skip_briefing=True``, init_state → generate_plan directly."""
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        squadron = StubPlanSquadron()
+        app = build_plan_application(
+            squadron=squadron,
+            event_queue=queue,
+            prd_content="x",
+            plan_name="test-plan",
+            output_dir=str(tmp_path / "test-plan"),
+            skip_briefing=True,
+        )
+        driver = BurrWorkflowDriver(app, halt_after=PLAN_TERMINAL_ACTIONS, event_queue=queue)
+        events = await _collect(driver)
+
+        action_sequence = _by_action(events)
+        assert action_sequence == [
+            "init_state",
+            "generate_plan",
+            "validate_plan",
+            "write_plan",
+            "done",
+        ]
+
+        # No briefing agents should have been built.
+        assert squadron.built_briefings == []
+
+        _, _, state = driver.result
+        assert state["briefing_path"] is None  # only set when briefing ran
+        assert state["flight_plan_path"] is not None
+
+
+class TestBurrDispatch:
+    """Verify ``MAVERICK_USE_BURR`` env var routes ``_run`` correctly."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("", False),
+            ("   ", False),
+            ("plan", True),
+            ("PLAN", True),
+            ("refuel,fly", False),
+            ("refuel,plan,fly", True),
+            ("plan ,refuel", True),
+            ("other", False),
+        ],
+    )
+    def test_use_burr_for_parses_env_var(
+        self, raw: str, expected: bool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from maverick.workflows.generate_flight_plan.workflow import _use_burr_for
+
+        monkeypatch.setenv("MAVERICK_USE_BURR", raw)
+        assert _use_burr_for("plan") is expected
+
+    def test_use_burr_for_no_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from maverick.workflows.generate_flight_plan.workflow import _use_burr_for
+
+        monkeypatch.delenv("MAVERICK_USE_BURR", raising=False)
+        assert _use_burr_for("plan") is False
+
+
+class TestBurrPlanGraphErrors:
+    async def test_generator_failure_propagates(self, tmp_path: Path) -> None:
+        """A failure in the generator agent surfaces via driver.result."""
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        squadron = StubPlanSquadron()
+        squadron.generator.raise_error = RuntimeError("stub generator boom")  # type: ignore[attr-defined]
+
+        app = build_plan_application(
+            squadron=squadron,
+            event_queue=queue,
+            prd_content="x",
+            plan_name="test-plan",
+            output_dir=str(tmp_path / "test-plan"),
+            skip_briefing=True,
+        )
+        driver = BurrWorkflowDriver(app, halt_after=PLAN_TERMINAL_ACTIONS, event_queue=queue)
+
+        events: list[ProgressEvent] = []
+        with pytest.raises(RuntimeError, match="stub generator boom"):
+            async for evt in driver.events():
+                events.append(evt)
+            _ = driver.result
+
+        # generate_plan must have started but its StepCompleted should be
+        # marked success=False.
+        completed = [
+            e for e in events if isinstance(e, StepCompleted) and e.step_name == "generate_plan"
+        ]
+        assert len(completed) == 1
+        assert completed[0].success is False
+        assert "stub generator boom" in (completed[0].error or "")


### PR DESCRIPTION
## Summary

Second slice of the xoscar → Apache Burr migration. Lands the first workflow on the Burr substrate. **xoscar stays the default**; opt-in via `MAVERICK_USE_BURR=plan`. Same input/output contract, same provider labels emitted, same files written.

Builds on Phase 0 (#116) which scaffolded `src/maverick/burr/{driver,hooks}.py`.

## What lands

- **`actions.py`** — 7 `@action` async functions covering the legacy `PlanSupervisor` state machine:
  - `init_state` → `parallel_briefings` (3 in parallel with `asyncio.Semaphore` cap) → `contrarian_briefing` → `synthesize_briefing` → `generate_plan` → `validate_plan` (inlines the V1-V9 file check that `PlanValidatorActor` runs) → `write_plan`.
- **`burr_graph.py`** — `build_plan_application(squadron, event_queue, **inputs)` factory. Two transition shapes: full briefing flow, or `skip_briefing` → `init_state → generate_plan` shortcut. `done` is the terminal `halt_after` target.
- **`workflow.py`** — `_use_burr_for(workflow_key)` env-var helper + `_generate_with_burr` sibling to `_generate_with_xoscar`. `_run` dispatches between them.
- **`src/maverick/burr/hooks.py`** — small fix carried over from Phase 0: `ProgressEventHook` now enqueues the end-of-stream sentinel when *any* action raises, not only on terminal-action completion. Without it, a non-terminal exception leaves the driver's consumer loop hanging on an empty queue.
- **`test_burr_graph.py`** — 14 tests via `StubPlanSquadron` (a thin container around existing airframe stubs):
  - Full pipeline happy path
  - Agent event emission per briefing
  - Skip-briefing routing
  - Exception propagation
  - 9 parametrized dispatch checks for `MAVERICK_USE_BURR`

## Test plan

- [x] `make ci` — 3526 tests pass (3512 prior + 14 new), mypy + ruff + format clean.
- [x] Spot-checked imports + small smoke runs locally.
- [ ] Manual end-to-end smoke against the sample project under `MAVERICK_USE_BURR=plan` (deferred to after Phase 2 lands; needs LLM creds).

## What's not in this PR

- No xoscar deletions. `PlanSupervisor`, `BriefingActor`, `GeneratorActor`, `PlanValidatorActor`, `PlanWriterActor` all remain — they're the default path. Phase 4 strips them once all three workflows have migrated.
- Phase 2 (`RefuelSupervisor` → Burr) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)