### PR TITLE
feat(burr): port spec-check Rust rules into the fly action

### DIFF
--- a/src/maverick/workflows/fly_beads/_spec_check.py
+++ b/src/maverick/workflows/fly_beads/_spec_check.py
@@ -1,0 +1,189 @@
+"""Pure-Python spec-compliance grep checks for the fly workflow.
+
+Ports the rule engine from the pre-migration ``SpecCheckActor`` into a
+substrate-independent helper that the Burr ``spec_check`` action can
+call directly. No xoscar, no actor shell — just :mod:`subprocess` calls
+to ``git diff`` and ``grep``.
+
+Rust is the only project type with rules today (matches the legacy
+behaviour). Other project types return ``passed=True`` with no findings.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+
+# (grep_pattern, description, severity) — Rust-specific anti-patterns.
+# Patterns are passed to ``grep -F`` (fixed string) so no regex escapes
+# are needed; ``.`` is literal, ``(`` is literal. The pre-migration
+# ``SpecCheckActor`` shipped escapes (``r"\.unwrap()"``) but combined
+# them with ``grep -F``, which never matched — fixed here.
+RUST_CHECKS: list[tuple[str, str, str]] = [
+    (
+        ".unwrap()",
+        "unwrap() in runtime code — use Result propagation with .context() instead",
+        "critical",
+    ),
+    (
+        ".expect(",
+        "unchecked expect() in runtime code — use fallible error handling instead",
+        "critical",
+    ),
+    (
+        "std::process::Command",
+        "blocking std::process::Command in async code — use tokio::process::Command",
+        "critical",
+    ),
+]
+
+
+@dataclass(frozen=True, slots=True)
+class SpecCheckResult:
+    """One pass through the spec-compliance rules.
+
+    Attributes:
+        passed: ``True`` when no critical findings landed.
+        details: Short human-readable summary.
+        findings: Per-finding strings formatted as
+            ``"file:line: <description> — `<code>`"``.
+    """
+
+    passed: bool
+    details: str
+    findings: tuple[str, ...] = ()
+
+
+def run_spec_check(*, cwd: str, project_type: str = "rust") -> SpecCheckResult:
+    """Run the spec-compliance grep checks against changed files.
+
+    Args:
+        cwd: Workspace directory; ``git diff HEAD`` is run here.
+        project_type: ``"rust"`` enables :data:`RUST_CHECKS`; anything
+            else returns a no-op pass.
+    """
+    if not cwd:
+        return SpecCheckResult(passed=True, details="no cwd — skipped")
+
+    changed = _get_changed_files(cwd)
+    if not changed:
+        return SpecCheckResult(passed=True, details="no changed files")
+
+    checks = RUST_CHECKS if project_type == "rust" else []
+    if not checks:
+        return SpecCheckResult(passed=True, details=f"no checks for project type {project_type!r}")
+
+    source_files = _filter_source_files(changed, project_type=project_type)
+    if not source_files:
+        return SpecCheckResult(passed=True, details="only test files changed")
+
+    findings_raw: list[dict[str, str]] = []
+    for pattern, description, severity in checks:
+        for file_path, line_num, line_text in _grep_files(cwd, pattern, source_files):
+            findings_raw.append(
+                {
+                    "file": file_path,
+                    "line": line_num,
+                    "description": description,
+                    "severity": severity,
+                    "text": line_text.strip()[:200],
+                }
+            )
+
+    critical = [f for f in findings_raw if f["severity"] == "critical"]
+    passed = not critical
+    details = (
+        f"{len(critical)} critical, {len(findings_raw) - len(critical)} warnings"
+        if findings_raw
+        else "all checks passed"
+    )
+    formatted = tuple(
+        f"{f['file']}:{f['line']}: {f['description']} — `{f['text']}`" for f in findings_raw
+    )
+    return SpecCheckResult(passed=passed, details=details, findings=formatted)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _get_changed_files(cwd: str) -> list[str]:
+    """Return paths the working copy has changed since ``HEAD``."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "HEAD", "--name-only", "--diff-filter=ACMR"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=10,
+            start_new_session=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return [f.strip() for f in result.stdout.strip().split("\n") if f.strip()]
+    except Exception:  # noqa: BLE001 — git can fail many ways; treat as "no diff"
+        pass
+    return []
+
+
+def _filter_source_files(files: list[str], *, project_type: str) -> list[str]:
+    """Keep only source files for ``project_type``; drop tests."""
+    out: list[str] = []
+    for f in files:
+        if "/tests/" in f or f.startswith("tests/"):
+            continue
+        if f.endswith("_test.rs") or f.endswith("_tests.rs"):
+            continue
+        if (project_type == "rust" and f.endswith(".rs")) or (
+            project_type == "python" and f.endswith(".py")
+        ):
+            out.append(f)
+    return out
+
+
+def _grep_files(cwd: str, pattern: str, files: list[str]) -> list[tuple[str, str, str]]:
+    """Run ``grep -nF pattern <files>`` under ``cwd``.
+
+    Returns ``(file_path, line_num, line_text)`` triples, with lines
+    that look like test scaffolding filtered out.
+    """
+    hits: list[tuple[str, str, str]] = []
+    try:
+        # ``-H`` forces ``grep`` to prefix the filename even when only
+        # one file is passed — otherwise the parser below sees
+        # ``"line:content"`` and skips it because there's no
+        # ``file:line:content`` split.
+        cmd = ["grep", "-H", "-n", "-F", pattern, *files]
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=10,
+            start_new_session=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.strip().split("\n"):
+                if not line:
+                    continue
+                parts = line.split(":", 2)
+                if len(parts) >= 3:
+                    file_path, line_num, line_text = parts[0], parts[1], parts[2]
+                    if _is_test_context(line_text):
+                        continue
+                    hits.append((file_path, line_num, line_text))
+    except Exception:  # noqa: BLE001 — grep can fail many ways
+        pass
+    return hits
+
+
+def _is_test_context(line_text: str) -> bool:
+    """Heuristic: skip lines that obviously live in test scaffolding."""
+    text = line_text.strip()
+    if text.startswith("//"):
+        return True
+    if "#[test]" in text or "#[cfg(test)]" in text:
+        return True
+    return "assert!" in text or "assert_eq!" in text

--- a/src/maverick/workflows/fly_beads/actions.py
+++ b/src/maverick/workflows/fly_beads/actions.py
@@ -19,12 +19,13 @@ follow-up; tracked in the repo as TODO items):
 * **Human-bead creation** — the commit's ``Tag: needs-human-review``
   trailer still lands, but no companion assumption bead is created
   on ``bd``.
-* **Spec check** — currently a no-op (Rust-specific grep rules not
-  ported).
 * **Watch mode** — the loop terminates on bead-empty rather than
   polling.
 
-Graceful stop is preserved.
+Graceful stop is preserved. The Rust spec-check rules
+(``.unwrap()`` / ``.expect()`` / ``std::process::Command`` in async
+contexts) are now active again via
+:mod:`maverick.workflows.fly_beads._spec_check`.
 """
 
 from __future__ import annotations
@@ -474,27 +475,73 @@ async def ac_check(
     return {"passed": True}, state.update(ac_passed=True)
 
 
-@action(reads=["current_bead_id"], writes=["spec_passed"])
+@action(reads=["current_bead_id"], writes=["spec_passed", "bead_aborted"])
 async def spec_check(
     state: State,
     *,
+    squadron: FlySquadron,
     events: asyncio.Queue[ProgressEvent | None],
+    cwd: str,
+    project_type: str = "rust",
 ) -> tuple[dict[str, Any], State]:
-    """Spec-compliance check — Phase 3 no-op.
+    """Run the grep-based spec-compliance checks.
 
-    The pre-migration spec checker ran Rust-specific grep rules
-    against changed files. Porting the rule engine + changed-files
-    discovery is queued behind the rest of the post-migration gaps;
-    for now this action emits a noop StepOutput so the gap is obvious
-    in the logs.
+    Rust-specific rules: ``.unwrap()`` / ``.expect()`` in runtime code,
+    ``std::process::Command`` in async paths. Other project types are
+    a no-op pass.
+
+    Mirrors the legacy ``SpecCheckActor`` fix-loop: on findings, ask
+    the implementer to fix them and re-run, up to
+    ``MAX_SPEC_FIX_ATTEMPTS`` rounds. Abandon the bead on exhaustion.
     """
-    await _put_output(
-        events,
-        "spec",
-        "Spec check skipped (Phase 3 no-op)",
-        level="info",
-    )
-    return {"passed": True, "phase_3_noop": True}, state.update(spec_passed=True)
+    from maverick.workflows.fly_beads._spec_check import run_spec_check
+
+    bead_id = state["current_bead_id"]
+
+    for attempt in range(MAX_SPEC_FIX_ATTEMPTS + 1):
+        result = run_spec_check(cwd=cwd, project_type=project_type)
+        if result.passed:
+            if attempt > 0 or result.findings:
+                # Surface the recovery for the live progress feed.
+                await _put_output(
+                    events,
+                    "spec",
+                    f"Spec check passed: {result.details}",
+                    level="success",
+                )
+            return {"passed": True, "attempts": attempt + 1}, state.update(spec_passed=True)
+
+        summary = "; ".join(result.findings) or result.details
+        if attempt >= MAX_SPEC_FIX_ATTEMPTS:
+            await _put_output(
+                events,
+                "spec",
+                f"Spec fix attempts exhausted: {summary}",
+                level="error",
+                metadata={"findings_count": len(result.findings)},
+            )
+            return {"passed": False}, state.update(spec_passed=False, bead_aborted=True)
+
+        await _put_output(
+            events,
+            "spec",
+            f"Spec failed ({attempt + 1}/{MAX_SPEC_FIX_ATTEMPTS}); requesting fix",
+            level="warning",
+            metadata={"findings_count": len(result.findings)},
+        )
+        ok = await _run_fix(
+            squadron=squadron,
+            events=events,
+            bead_id=bead_id,
+            phase="spec",
+            round_n=attempt + 1,
+            failure_message=summary,
+        )
+        if not ok:
+            return {"passed": False, "fix_failed": True}, state.update(
+                spec_passed=False, bead_aborted=True
+            )
+    return {"passed": False}, state.update(spec_passed=False, bead_aborted=True)
 
 
 @action(

--- a/src/maverick/workflows/fly_beads/burr_graph.py
+++ b/src/maverick/workflows/fly_beads/burr_graph.py
@@ -76,6 +76,7 @@ def build_fly_application(
     max_beads: int = 0,
     completed_bead_ids: tuple[str, ...] = (),
     validation_commands: dict[str, tuple[str, ...]] | None = None,
+    project_type: str = "rust",
 ) -> Any:
     """Build the ``Application`` for one fly run."""
     hook = ProgressEventHook(
@@ -104,7 +105,12 @@ def build_fly_application(
                 validation_commands=validation_commands,
             ),
             ac_check=fly_actions.ac_check.bind(squadron=squadron, events=event_queue, cwd=cwd),
-            spec_check=fly_actions.spec_check.bind(events=event_queue),
+            spec_check=fly_actions.spec_check.bind(
+                squadron=squadron,
+                events=event_queue,
+                cwd=cwd,
+                project_type=project_type,
+            ),
             review=fly_actions.review.bind(squadron=squadron, events=event_queue),
             commit=fly_actions.commit.bind(cwd=cwd, events=event_queue),
             abandon_bead=fly_actions.abandon_bead.bind(events=event_queue),

--- a/src/maverick/workflows/fly_beads/workflow.py
+++ b/src/maverick/workflows/fly_beads/workflow.py
@@ -468,6 +468,7 @@ async def _run_fly_with_burr_impl(
             max_beads=max_beads,
             completed_bead_ids=completed_bead_ids,
             validation_commands=None,
+            project_type=getattr(workflow._config, "project_type", "rust") or "rust",
         )
         driver = BurrWorkflowDriver(
             app,

--- a/tests/unit/workflows/fly_beads/test_spec_check.py
+++ b/tests/unit/workflows/fly_beads/test_spec_check.py
@@ -1,0 +1,154 @@
+"""Unit tests for the spec-compliance grep checks.
+
+Exercises :mod:`maverick.workflows.fly_beads._spec_check` directly,
+without the action/Burr wrapper. The action's behaviour is covered by
+``test_burr_graph.py``'s happy-path test.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from maverick.workflows.fly_beads._spec_check import (
+    RUST_CHECKS,
+    SpecCheckResult,
+    _filter_source_files,
+    _is_test_context,
+    run_spec_check,
+)
+
+
+def _init_git_repo(path: Path) -> None:
+    """Initialise a git repo + commit a baseline so ``git diff HEAD`` works."""
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=path, check=True)
+    # Empty commit so HEAD exists.
+    (path / "baseline.txt").write_text("baseline\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "baseline"], cwd=path, check=True)
+
+
+class TestFilterSourceFiles:
+    def test_rust_keeps_rs_drops_tests(self) -> None:
+        files = [
+            "src/foo.rs",
+            "tests/test_foo.rs",
+            "src/foo_test.rs",
+            "src/foo_tests.rs",
+            "src/sub/tests/helper.rs",
+            "README.md",
+        ]
+        assert _filter_source_files(files, project_type="rust") == ["src/foo.rs"]
+
+    def test_python_keeps_py_only(self) -> None:
+        files = ["src/foo.py", "src/foo.rs", "tests/test_foo.py"]
+        assert _filter_source_files(files, project_type="python") == ["src/foo.py"]
+
+    def test_unknown_project_type_keeps_nothing(self) -> None:
+        assert _filter_source_files(["src/foo.go"], project_type="go") == []
+
+
+class TestIsTestContext:
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "// this is a comment",
+            "    // commented unwrap()",
+            "#[test]",
+            "    #[cfg(test)]",
+            "assert!(x.unwrap() > 0);",
+            "assert_eq!(a.unwrap(), b);",
+        ],
+    )
+    def test_classifies_as_test(self, line: str) -> None:
+        assert _is_test_context(line) is True
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "let x = foo.unwrap();",
+            '    return result.expect("oops");',
+            'tokio::process::Command::new("ls")',
+        ],
+    )
+    def test_runtime_code_is_not_test(self, line: str) -> None:
+        assert _is_test_context(line) is False
+
+
+class TestRunSpecCheck:
+    def test_no_cwd_returns_skipped_pass(self) -> None:
+        result = run_spec_check(cwd="", project_type="rust")
+        assert isinstance(result, SpecCheckResult)
+        assert result.passed is True
+        assert "skipped" in result.details
+
+    def test_no_git_repo_returns_no_changes_pass(self, tmp_path: Path) -> None:
+        result = run_spec_check(cwd=str(tmp_path), project_type="rust")
+        assert result.passed is True
+        assert result.findings == ()
+
+    def test_non_rust_project_type_returns_noop(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        (tmp_path / "foo.go").write_text("package main\n")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        result = run_spec_check(cwd=str(tmp_path), project_type="go")
+        assert result.passed is True
+        assert "no checks for" in result.details
+
+    def test_clean_rust_file_passes(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "foo.rs").write_text(
+            "pub fn ok() -> Result<i32, Box<dyn std::error::Error>> {\n    Ok(42)\n}\n"
+        )
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        result = run_spec_check(cwd=str(tmp_path), project_type="rust")
+        assert result.passed is True
+        assert result.findings == ()
+
+    def test_unwrap_in_runtime_code_is_critical(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "foo.rs").write_text(
+            "pub fn bad() -> i32 {\n    let x: Result<i32, ()> = Ok(1);\n    x.unwrap()\n}\n"
+        )
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        result = run_spec_check(cwd=str(tmp_path), project_type="rust")
+        assert result.passed is False
+        assert any("unwrap" in f for f in result.findings)
+        assert "critical" in result.details
+
+    def test_test_file_findings_are_ignored(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "foo_test.rs").write_text("fn t() { let x: Result<i32,()> = Ok(1); x.unwrap(); }\n")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        result = run_spec_check(cwd=str(tmp_path), project_type="rust")
+        assert result.passed is True
+        assert result.findings == ()
+
+    def test_assert_lines_are_ignored(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        src = tmp_path / "src"
+        src.mkdir()
+        # Source file (not a test file) but the unwrap is inside an
+        # assert!() invocation — the heuristic skips it.
+        (src / "foo.rs").write_text("fn check() { assert!(some_result().unwrap()); }\n")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        result = run_spec_check(cwd=str(tmp_path), project_type="rust")
+        assert result.passed is True
+
+
+def test_rust_checks_constant_shape() -> None:
+    """RUST_CHECKS must stay shaped as ``(pattern, description, severity)``."""
+    for pattern, description, severity in RUST_CHECKS:
+        assert isinstance(pattern, str) and pattern
+        assert isinstance(description, str) and description
+        assert severity in {"critical", "major", "minor"}


### PR DESCRIPTION
## Summary

First of the post-migration gap PRs. Re-enables the Rust-specific spec-compliance grep checks (``.unwrap()``, ``.expect()``, ``std::process::Command`` in async contexts) inside the Burr ``spec_check`` action. The Phase 3 no-op short-cut is gone — bad patterns now block the bead and trigger the fix loop bounded by ``MAX_SPEC_FIX_ATTEMPTS=2`` (same budget the pre-migration supervisor used).

## What lands

- **`src/maverick/workflows/fly_beads/_spec_check.py`** — pure-Python helper: `RUST_CHECKS`, `run_spec_check`, plus the supporting primitives (`_get_changed_files`, `_filter_source_files`, `_grep_files`, `_is_test_context`). No xoscar, no actor shell — just subprocess calls.
- **`actions.py`** — `spec_check` now drives the helper through the same fix-loop shape as `gate`/`ac_check`/`review`.
- **`burr_graph.py`** + **`workflow.py`** — thread `project_type` through; defaults to `"rust"`, comes from `self._config.project_type`.
- **`test_spec_check.py`** — 20 tests covering filter rules, the test-context heuristic, no-cwd / no-git / non-rust paths, clean Rust source, unwrap detection, `_test.rs` exclusion, and the `assert!()` heuristic.

## Drive-by fix in the original

The pre-migration `RUST_CHECKS` used regex-escaped patterns (`r"\.unwrap()"`) but passed them to `grep -F` (fixed-string mode), so the escape was matched literally and the rules **never fired** on real Rust source. Patterns rewritten as plain strings; added `grep -H` so single-file invocations emit a filename prefix the parser can split on. This was a latent bug in xoscar's `SpecCheckActor` going back to its introduction.

## Test plan

- [x] `make ci` — 3353 tests pass (3333 prior + 20 new). mypy + ruff + format clean.
- [ ] Manual smoke: a fly run against a Rust project with intentional `.unwrap()` in non-test code should now flag + fix; previously skipped.

## What's not in this PR

Other gaps from the migration are still queued — refuel cache write-back, fly tier escalation, aggregate review, etc. One PR per gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)