### PR TITLE
feat(burr): merge fix-round work_units back into the outline

### DIFF
--- a/src/maverick/workflows/refuel_maverick/actions.py
+++ b/src/maverick/workflows/refuel_maverick/actions.py
@@ -17,10 +17,10 @@ follow-up):
   driver does not write cache files**. Re-running a Burr-mode refuel
   starts from scratch; rerun on xoscar to re-populate caches.
 * Quota error special-handling: treated like any other failure for now.
-* Fix-round merge: only merges ``details`` from the fix payload, not
-  ``work_units``. The xoscar supervisor merges both (handles the case
-  where the fixer splits an overloaded unit). Restoring outline-merge
-  on fix is queued behind the rest of Phase 2's simplifications.
+* Fix-round merge: merges both ``details`` and ``work_units`` from
+  the fix payload (handles the case where the fixer splits an
+  overloaded unit). New ``work_units`` returned by the fixer are
+  appended to the outline; existing ones are replaced by id.
 
 Default driver remains xoscar; opt in via ``MAVERICK_USE_BURR=refuel``.
 """
@@ -531,8 +531,8 @@ async def validate(
 
 
 @action(
-    reads=["specs", "validation_warnings", "fix_rounds"],
-    writes=["accumulated_details", "fix_rounds"],
+    reads=["specs", "validation_warnings", "fix_rounds", "outline", "accumulated_details"],
+    writes=["accumulated_details", "outline", "fix_rounds"],
 )
 async def request_fix(
     state: State,
@@ -540,7 +540,15 @@ async def request_fix(
     squadron: RefuelSquadron,
     events: asyncio.Queue[ProgressEvent | None],
 ) -> tuple[dict[str, Any], State]:
-    """One round of decomposer fix dispatch — merges deltas into details."""
+    """One round of decomposer fix dispatch.
+
+    Merges both ``details`` (refined acceptance criteria / verification
+    steps) and ``work_units`` (outline-level changes — e.g. when the
+    fixer splits an overloaded unit) from the returned ``SubmitFixPayload``
+    into State. Matches the pre-migration supervisor's behaviour; without
+    the outline merge, splits introduced by the fixer would be silently
+    dropped.
+    """
     new_fix_rounds = state["fix_rounds"] + 1
     await _put_output(
         events,
@@ -573,9 +581,10 @@ async def request_fix(
         )
     payload_dict = dump_supervisor_payload(payload)
     fix_details = payload_dict.get("details", []) or []
+    fix_work_units = payload_dict.get("work_units", []) or []
 
-    # Merge fix deltas into accumulated_details (replace by unit_id where
-    # the fixer sent a new version; append where it's new).
+    # Merge fix deltas into accumulated_details (replace by unit_id
+    # where the fixer sent a new version; append where it's new).
     accumulated = list(state["accumulated_details"])
     by_id = {d.get("id") or d.get("unit_id"): i for i, d in enumerate(accumulated)}
     for d in fix_details:
@@ -588,8 +597,38 @@ async def request_fix(
             accumulated.append(d)
             by_id[uid] = len(accumulated) - 1
 
-    return {"fix_rounds": new_fix_rounds}, state.update(
+    # Merge work_units deltas back into the outline. Handles the case
+    # where the fixer adds a new unit (splitting an overloaded one).
+    # Existing units with the same id are replaced; new ids are
+    # appended. Outline-only fields (id, task, sequence, depends_on,
+    # file_scope, complexity) are taken verbatim from the fix payload.
+    outline_dict = dict(state["outline"] or {})
+    outline_units = list(outline_dict.get("work_units", []))
+    outline_by_id = {u.get("id"): i for i, u in enumerate(outline_units)}
+    new_units = 0
+    for wu in fix_work_units:
+        uid = wu.get("id")
+        if uid is None:
+            continue
+        if uid in outline_by_id:
+            outline_units[outline_by_id[uid]] = wu
+        else:
+            outline_units.append(wu)
+            outline_by_id[uid] = len(outline_units) - 1
+            new_units += 1
+    outline_dict["work_units"] = outline_units
+
+    if new_units:
+        await _put_output(
+            events,
+            "decompose",
+            f"Fix introduced {new_units} new work unit(s)",
+            metadata={"new_unit_count": new_units},
+        )
+
+    return {"fix_rounds": new_fix_rounds, "new_units": new_units}, state.update(
         accumulated_details=accumulated,
+        outline=outline_dict,
         fix_rounds=new_fix_rounds,
     )
 

--- a/tests/unit/workflows/refuel_maverick/test_burr_graph.py
+++ b/tests/unit/workflows/refuel_maverick/test_burr_graph.py
@@ -449,3 +449,105 @@ class TestRefuelBurrGraphValidationLoop:
         assert action_sequence.count("validate") >= 2
         _, _, state = driver.result
         assert state["fix_rounds"] >= 1
+
+    async def test_fix_round_merges_new_work_units_into_outline(self, tmp_path: Path) -> None:
+        """``SubmitFixPayload.work_units`` deltas are merged into the outline.
+
+        Models the "fixer splits an overloaded unit" path: the outline
+        starts with one unit, the fix returns a second unit + a
+        replacement detail for both. After ``request_fix``, the outline
+        should contain both units so downstream actions see the split.
+        """
+        outline = _make_outline(unit_ids=("u-1",))
+        empty_details = SubmitDetailsPayload(
+            details=(
+                WorkUnitDetailPayload(
+                    id="u-1",
+                    instructions="todo",
+                    acceptance_criteria=(AcceptanceCriterionPayload(text="todo ac"),),
+                    verification=("pytest -k todo",),
+                    test_specification="",
+                ),
+            )
+        )
+        # Fix splits u-1 → u-1-a + u-1-b (new work_units appear).
+        new_unit_a = WorkUnitOutlinePayload(
+            id="u-1-a",
+            task="half a",
+            sequence=2,
+            depends_on=(),
+            file_scope=FileScopePayload(),
+            complexity="simple",
+        )
+        new_unit_b = WorkUnitOutlinePayload(
+            id="u-1-b",
+            task="half b",
+            sequence=3,
+            depends_on=(),
+            file_scope=FileScopePayload(),
+            complexity="simple",
+        )
+        fix_payload = SubmitFixPayload(
+            work_units=(new_unit_a, new_unit_b),
+            details=(
+                WorkUnitDetailPayload(
+                    id="u-1-a",
+                    instructions="done a",
+                    acceptance_criteria=(
+                        AcceptanceCriterionPayload(text="ac-a", trace_ref="SC-1"),
+                    ),
+                    verification=("pytest",),
+                    test_specification="",
+                ),
+                WorkUnitDetailPayload(
+                    id="u-1-b",
+                    instructions="done b",
+                    acceptance_criteria=(
+                        AcceptanceCriterionPayload(text="ac-b", trace_ref="SC-1"),
+                    ),
+                    verification=("pytest",),
+                    test_specification="",
+                ),
+            ),
+        )
+
+        squadron = StubRefuelSquadron(
+            outline_payload=outline,
+            detail_payloads=[empty_details],
+            fix_payloads=[fix_payload],
+        )
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.create_beads",
+                new=AsyncMock(return_value=_make_bead_result()),
+            ),
+            patch(
+                "maverick.library.actions.beads.wire_dependencies",
+                new=AsyncMock(return_value=_make_wire_result()),
+            ),
+        ):
+            app = build_refuel_application(
+                squadron=squadron,
+                event_queue=queue,
+                raw_content="x",
+                briefing_prompt="x",
+                codebase_context=_empty_codebase_context(),
+                open_bead_context=None,
+                runway_context_text=None,
+                plan_name="p",
+                plan_objective="o",
+                cwd=str(tmp_path),
+                skip_briefing=True,
+                success_criteria_count=1,
+                expected_sc_refs=("SC-1",),
+            )
+            driver = BurrWorkflowDriver(app, halt_after=REFUEL_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        _, _, state = driver.result
+        outline_ids = sorted(u["id"] for u in state["outline"]["work_units"])
+        assert outline_ids == ["u-1", "u-1-a", "u-1-b"], (
+            f"fix-round work_units not merged into outline: {outline_ids}"
+        )


### PR DESCRIPTION
## Summary

Restore the fix-round outline-merge that the pre-migration supervisor had — refuel's ``request_fix`` action handled the ``details`` portion of ``SubmitFixPayload`` but ignored the ``work_units`` portion. Any new unit the fixer introduced (e.g. when splitting an overloaded one) was silently dropped, so downstream actions never saw the split.

## What changed

- ``request_fix`` now merges both halves of the fix payload:
  - ``details`` → ``accumulated_details`` (replace-by-id-or-append). Unchanged.
  - ``work_units`` → ``state["outline"]`` (same shape). **New.**
- Surfaces a ``"Fix introduced N new work unit(s)"`` ``StepOutput`` when new units land, so the live feed shows the topology change.
- Action ``reads`` extended with ``outline`` and ``accumulated_details``; ``writes`` adds ``outline``.

## Test plan

- [x] New ``test_fix_round_merges_new_work_units_into_outline`` — outline starts with `u-1`, fix payload returns `u-1-a` + `u-1-b`, after the action the outline has all three.
- [x] Existing ``test_fix_loop_runs_when_validation_fails_then_passes`` still passes.
- [x] ``make ci`` — 3354 tests pass, mypy + ruff + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)