### PR TITLE
feat(burr): create assumption-review bead on review exhaustion (#111)

### DIFF
--- a/src/maverick/workflows/fly_beads/actions.py
+++ b/src/maverick/workflows/fly_beads/actions.py
@@ -57,6 +57,7 @@ __all__ = [
     "abandon_bead",
     "ac_check",
     "commit",
+    "create_human_bead",
     "gate",
     "implement",
     "init_state",
@@ -546,7 +547,7 @@ async def spec_check(
 
 @action(
     reads=["current_bead", "current_bead_id"],
-    writes=["approved", "review_rounds", "needs_human_review"],
+    writes=["approved", "review_rounds", "needs_human_review", "last_review_findings"],
 )
 async def review(
     state: State,
@@ -556,13 +557,19 @@ async def review(
 ) -> tuple[dict[str, Any], State]:
     """Per-bead review: correctness + completeness reviewers in parallel.
 
-    Fix-loop up to ``MAX_REVIEW_ROUNDS``.
+    Fix-loop up to ``MAX_REVIEW_ROUNDS``. Persists the last cycle's
+    findings into ``state["last_review_findings"]`` so the downstream
+    ``create_human_bead`` action can include them in the assumption
+    bead's description.
     """
     bead = state["current_bead"]
     bead_id = state["current_bead_id"]
     if bead is None:
         return {"approved": False}, state.update(
-            approved=False, review_rounds=0, needs_human_review=True
+            approved=False,
+            review_rounds=0,
+            needs_human_review=True,
+            last_review_findings=[],
         )
 
     correctness = squadron.correctness_reviewer_for(DEFAULT_TIER)
@@ -605,6 +612,7 @@ async def review(
                     approved=False,
                     review_rounds=rounds_with_findings,
                     needs_human_review=True,
+                    last_review_findings=[f"Review crashed: {exc}"],
                 )
             duration = time.monotonic() - t0
         await events.put(
@@ -625,10 +633,13 @@ async def review(
         approved = all(_payload_approved(p) for p in results)
         if approved:
             return {"approved": True, "rounds": rounds_with_findings}, state.update(
-                approved=True, review_rounds=rounds_with_findings
+                approved=True,
+                review_rounds=rounds_with_findings,
+                last_review_findings=[],
             )
 
         rounds_with_findings += 1
+        round_findings = _findings_list(results)
         if round_n >= MAX_REVIEW_ROUNDS:
             await _put_output(
                 events,
@@ -640,27 +651,31 @@ async def review(
                 approved=False,
                 review_rounds=rounds_with_findings,
                 needs_human_review=True,
+                last_review_findings=round_findings,
             )
 
         # Re-prompt the implementer to address review feedback.
-        findings_text = _format_findings(results)
         ok = await _run_fix(
             squadron=squadron,
             events=events,
             bead_id=bead_id,
             phase="review",
             round_n=round_n,
-            failure_message=findings_text,
+            failure_message="\n".join(round_findings) or "(no specific findings)",
         )
         if not ok:
             return {"approved": False, "rounds": rounds_with_findings}, state.update(
                 approved=False,
                 review_rounds=rounds_with_findings,
                 needs_human_review=True,
+                last_review_findings=round_findings,
             )
 
     return {"approved": False, "rounds": rounds_with_findings}, state.update(
-        approved=False, review_rounds=rounds_with_findings, needs_human_review=True
+        approved=False,
+        review_rounds=rounds_with_findings,
+        needs_human_review=True,
+        last_review_findings=[],
     )
 
 
@@ -681,19 +696,123 @@ def _payload_approved(payload: Any) -> bool:
     return not findings
 
 
-def _format_findings(payloads: list[Any] | tuple[Any, ...]) -> str:
+def _findings_list(payloads: list[Any] | tuple[Any, ...]) -> list[str]:
+    """Flatten reviewer findings into ``"<severity>: <issue>"`` lines.
+
+    The current ``ReviewFindingPayload`` schema uses ``issue`` (not the
+    legacy ``description``); both are checked for forward/back-compat
+    with stubs that still ship the older shape.
+    """
     parts: list[str] = []
     for p in payloads:
         findings = getattr(p, "findings", None) or (
             p.get("findings", []) if isinstance(p, dict) else []
         )
         for f in findings:
-            text = getattr(f, "description", None) or (
-                f.get("description") if isinstance(f, dict) else None
+            severity = getattr(f, "severity", None) or (
+                f.get("severity") if isinstance(f, dict) else None
             )
-            if text:
-                parts.append(text)
-    return "\n".join(parts) if parts else "(no specific findings provided)"
+            issue = (
+                getattr(f, "issue", None)
+                or getattr(f, "description", None)
+                or (f.get("issue") if isinstance(f, dict) else None)
+                or (f.get("description") if isinstance(f, dict) else None)
+            )
+            if not issue:
+                continue
+            parts.append(f"{severity}: {issue}" if severity else issue)
+    return parts
+
+
+@action(
+    reads=["current_bead", "current_bead_id", "review_rounds", "last_review_findings"],
+    writes=["human_bead_id"],
+)
+async def create_human_bead(
+    state: State,
+    *,
+    cwd: str,
+    epic_id: str,
+    flight_plan_name: str,
+    events: asyncio.Queue[ProgressEvent | None],
+) -> tuple[dict[str, Any], State]:
+    """Create an assumption-review bead on ``bd`` for human triage.
+
+    Runs when ``needs_human_review`` is true (review rounds exhausted
+    or a fix request failed). Mirrors the pre-migration
+    ``FlySupervisor._create_human_bead``: ``TASK``/``REVIEW``
+    bead assigned to ``human`` with labels
+    ``["assumption-review", "needs-human-review"]`` and a metadata
+    state payload tying it back to the source bead. Failure here is
+    non-fatal — we emit a warning and continue to commit so the
+    commit's ``Tag: needs-human-review`` trailer still lands.
+    """
+    from maverick.beads.client import BeadClient
+    from maverick.beads.models import BeadCategory, BeadDefinition, BeadType
+
+    bead = state["current_bead"] or {}
+    bead_id = state["current_bead_id"]
+    bead_title = bead.get("title", bead_id) or bead_id
+    findings: list[str] = list(state.get("last_review_findings") or ())
+    findings_text = "\n".join(f"- {f}" for f in findings) if findings else "None"
+    reason = (
+        f"Review rounds exhausted ({state.get('review_rounds', 0)} of "
+        f"{MAX_REVIEW_ROUNDS}) without approval."
+    )
+
+    review_def = BeadDefinition(
+        title=f"Review: {bead_title[:150]}",
+        bead_type=BeadType.TASK,
+        priority=1,
+        category=BeadCategory.REVIEW,
+        description=f"## Escalation Reason\n\n{reason}\n\n## Findings\n\n{findings_text}",
+        assignee="human",
+        labels=["assumption-review", "needs-human-review"],
+    )
+
+    client = BeadClient(cwd=Path(cwd))
+    try:
+        created = await client.create_bead(
+            review_def,
+            parent_id=epic_id or None,
+        )
+    except Exception as exc:  # noqa: BLE001 — non-fatal; commit still tags the trailer
+        await _put_output(
+            events,
+            "fly",
+            f"Failed to create assumption bead for {bead_id}: {exc}",
+            level="warning",
+        )
+        return {"created": False, "error": str(exc)}, state.update(human_bead_id="")
+
+    try:
+        await client.set_state(
+            created.bd_id,
+            {
+                "source_bead": bead_id,
+                "escalation_type": "fix_exhaustion",
+                "flight_plan": flight_plan_name,
+            },
+            reason=f"Escalated from {bead_id}",
+        )
+    except Exception as exc:  # noqa: BLE001 — non-fatal
+        await _put_output(
+            events,
+            "fly",
+            f"Failed to set state on assumption bead {created.bd_id}: {exc}",
+            level="warning",
+        )
+
+    await _put_output(
+        events,
+        "fly",
+        f"Created human review bead {created.bd_id} for {bead_id}",
+        level="warning",
+        metadata={"human_bead_id": created.bd_id, "source_bead": bead_id},
+    )
+    return {"created": True, "human_bead_id": created.bd_id}, state.update(
+        human_bead_id=created.bd_id
+    )
 
 
 @action(

--- a/src/maverick/workflows/fly_beads/burr_graph.py
+++ b/src/maverick/workflows/fly_beads/burr_graph.py
@@ -52,6 +52,7 @@ FLY_ACTION_LABELS: dict[str, str] = {
     "ac_check": "AC check",
     "spec_check": "Spec check",
     "review": "Reviewing",
+    "create_human_bead": "Creating human review bead",
     "commit": "Committing",
     "abandon_bead": "Abandoning bead",
     "record_outcome": "Recording outcome",
@@ -77,6 +78,7 @@ def build_fly_application(
     completed_bead_ids: tuple[str, ...] = (),
     validation_commands: dict[str, tuple[str, ...]] | None = None,
     project_type: str = "rust",
+    flight_plan_name: str = "",
 ) -> Any:
     """Build the ``Application`` for one fly run."""
     hook = ProgressEventHook(
@@ -112,6 +114,12 @@ def build_fly_application(
                 project_type=project_type,
             ),
             review=fly_actions.review.bind(squadron=squadron, events=event_queue),
+            create_human_bead=fly_actions.create_human_bead.bind(
+                cwd=cwd,
+                epic_id=epic_id,
+                flight_plan_name=flight_plan_name,
+                events=event_queue,
+            ),
             commit=fly_actions.commit.bind(cwd=cwd, events=event_queue),
             abandon_bead=fly_actions.abandon_bead.bind(events=event_queue),
             record_outcome=fly_actions.record_outcome,
@@ -143,6 +151,8 @@ def build_fly_application(
             spec_passed=False,
             approved=False,
             commit_ok=False,
+            last_review_findings=[],
+            human_bead_id="",
         )
         .with_hooks(hook)
         .with_entrypoint("init_state")
@@ -165,10 +175,13 @@ def build_fly_application(
             ("ac_check", "spec_check"),
             ("spec_check", "abandon_bead", expr("not spec_passed")),
             ("spec_check", "review"),
-            # Review always proceeds to commit; commit may tag
-            # the bead as needs-human-review (the review_rounds-exceeded
-            # path) rather than abandoning the work-in-progress.
+            # Review either approves → commit, or escalates to
+            # create_human_bead → commit. The bead's work still lands
+            # in either case (commit applies the needs-human-review
+            # trailer when the assumption bead is created).
+            ("review", "create_human_bead", expr("needs_human_review")),
             ("review", "commit"),
+            ("create_human_bead", "commit"),
             ("commit", "record_outcome"),
             ("abandon_bead", "record_outcome"),
             # Cycle back into the loop.

--- a/src/maverick/workflows/fly_beads/workflow.py
+++ b/src/maverick/workflows/fly_beads/workflow.py
@@ -184,6 +184,7 @@ class FlyBeadsWorkflow(PythonWorkflow):
 
         run_id = ""
         run_dir: Path | None = None
+        flight_plan_name: str = ""
         if epic_id:
             run_meta = find_run_for_epic(epic_id, base=cwd)
             if run_meta:
@@ -191,6 +192,7 @@ class FlyBeadsWorkflow(PythonWorkflow):
                 run_dir = cwd / ".maverick" / "runs" / run_id
                 run_meta.status = "flying"
                 write_metadata(run_dir, run_meta)
+                flight_plan_name = run_meta.plan_name or ""
 
         if not run_id:
             run_id = uuid.uuid4().hex[:8]
@@ -352,6 +354,7 @@ class FlyBeadsWorkflow(PythonWorkflow):
             cwd=cwd,
             max_beads=max_beads,
             completed_bead_ids=completed_bead_ids,
+            flight_plan_name=flight_plan_name,
         )
         beads_succeeded = int(burr_result.get("beads_completed", 0))
         beads_failed = int(burr_result.get("beads_failed", 0))
@@ -400,6 +403,7 @@ class FlyBeadsWorkflow(PythonWorkflow):
         cwd: Path,
         max_beads: int = MAX_BEADS,
         completed_bead_ids: set[str] | None = None,
+        flight_plan_name: str = "",
     ) -> dict[str, Any]:
         """Run the fly bead loop via the Burr-backed driver.
 
@@ -412,6 +416,7 @@ class FlyBeadsWorkflow(PythonWorkflow):
             cwd=cwd,
             max_beads=max_beads,
             completed_bead_ids=tuple(completed_bead_ids or ()),
+            flight_plan_name=flight_plan_name,
         )
 
 
@@ -441,6 +446,7 @@ async def _run_fly_with_burr_impl(
     cwd: Path,
     max_beads: int,
     completed_bead_ids: tuple[str, ...],
+    flight_plan_name: str = "",
 ) -> dict[str, Any]:
     """Drive the fly Burr application; return the same shape as xoscar.
 
@@ -469,6 +475,7 @@ async def _run_fly_with_burr_impl(
             completed_bead_ids=completed_bead_ids,
             validation_commands=None,
             project_type=getattr(workflow._config, "project_type", "rust") or "rust",
+            flight_plan_name=flight_plan_name,
         )
         driver = BurrWorkflowDriver(
             app,

--- a/tests/unit/workflows/fly_beads/test_burr_graph.py
+++ b/tests/unit/workflows/fly_beads/test_burr_graph.py
@@ -372,6 +372,206 @@ class TestFlyBurrReviewLoop:
         assert state["succeeded_count"] == 1
 
 
+class TestFlyBurrHumanBeadCreation:
+    async def test_review_exhaustion_creates_human_bead(self, tmp_path: Path) -> None:
+        """3 review rounds with findings → create_human_bead → commit (with tag)."""
+        from maverick.beads.models import BeadCategory, BeadDefinition, BeadType
+        from maverick.workflows.fly_beads.graceful_stop import reset_graceful_stop
+
+        reset_graceful_stop()
+
+        # All 3 review rounds return findings (correctness is unhappy).
+        correctness = StubReviewerAgent(
+            review_kind="correctness",
+            review_payloads=[
+                SubmitReviewPayload(
+                    approved=False,
+                    findings=(ReviewFindingPayload(severity="major", issue=f"finding round {n}"),),
+                )
+                for n in range(1, 4)
+            ],
+        )
+        completeness = StubReviewerAgent(
+            review_kind="completeness",
+            review_payloads=[SubmitReviewPayload(approved=True, findings=()) for _ in range(3)],
+        )
+        squadron = StubFlySquadron(
+            correctness=correctness,
+            completeness=completeness,
+            coder=StubCodingAgent(
+                implement_payloads=[SubmitImplementationPayload(summary="i1")],
+                fix_payloads=[SubmitFixResultPayload(summary="f") for _ in range(5)],
+            ),
+        )
+
+        captured_create_args: dict[str, Any] = {}
+        captured_set_state_args: dict[str, Any] = {}
+
+        async def _fake_create_bead(
+            self: Any, definition: Any, parent_id: str | None = None
+        ) -> Any:
+            captured_create_args["definition"] = definition
+            captured_create_args["parent_id"] = parent_id
+            assert isinstance(definition, BeadDefinition)
+            return type(
+                "CreatedBead",
+                (),
+                {"bd_id": "human-bead-1", "definition": definition},
+            )()
+
+        async def _fake_set_state(
+            self: Any,
+            bd_id: str,
+            state_dict: dict[str, Any],
+            *,
+            reason: str = "",
+        ) -> None:
+            captured_set_state_args["bd_id"] = bd_id
+            captured_set_state_args["state"] = dict(state_dict)
+            captured_set_state_args["reason"] = reason
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.select_next_bead",
+                new=AsyncMock(side_effect=[_bead("b-1"), _NO_MORE]),
+            ),
+            patch(
+                "maverick.library.actions.validation.run_independent_gate",
+                new=AsyncMock(return_value=_gate_passed()),
+            ),
+            patch(
+                "maverick.library.actions.jj.jj_commit_bead",
+                new=AsyncMock(return_value={"change_id": "c", "success": True}),
+            ),
+            patch(
+                "maverick.library.actions.beads.mark_bead_complete",
+                new=AsyncMock(
+                    return_value=MarkBeadCompleteResult(success=True, bead_id="b-1", error=None)
+                ),
+            ),
+            patch(
+                "maverick.beads.client.BeadClient.create_bead",
+                new=_fake_create_bead,
+            ),
+            patch(
+                "maverick.beads.client.BeadClient.set_state",
+                new=_fake_set_state,
+            ),
+        ):
+            app = build_fly_application(
+                squadron=squadron,  # type: ignore[arg-type]
+                event_queue=queue,
+                epic_id="e-1",
+                cwd=str(tmp_path),
+                max_beads=10,
+                flight_plan_name="my-plan",
+            )
+            driver = BurrWorkflowDriver(app, halt_after=FLY_TERMINAL_ACTIONS, event_queue=queue)
+            events = await _collect(driver)
+
+        action_sequence = _action_sequence(events)
+        # The escalation transition fires after review.
+        assert "create_human_bead" in action_sequence
+        assert action_sequence.index("create_human_bead") < action_sequence.index("commit")
+
+        _, _, state = driver.result
+        assert state["needs_human_review"] is True
+        assert state["human_bead_id"] == "human-bead-1"
+        # The bead-events row carries the tag for the CLI summary.
+        bead_event = state["bead_events"][0]
+        assert bead_event["tag"] == "needs-human-review"
+
+        # Created with the right shape.
+        defn: BeadDefinition = captured_create_args["definition"]
+        assert defn.bead_type == BeadType.TASK
+        assert defn.category == BeadCategory.REVIEW
+        assert defn.assignee == "human"
+        assert "assumption-review" in defn.labels
+        assert "needs-human-review" in defn.labels
+        assert captured_create_args["parent_id"] == "e-1"
+
+        # Findings get inlined into the description, and the state-set
+        # call ties the new bead back to the source.
+        assert "finding round 3" in defn.description
+        assert captured_set_state_args["bd_id"] == "human-bead-1"
+        assert captured_set_state_args["state"]["source_bead"] == "b-1"
+        assert captured_set_state_args["state"]["flight_plan"] == "my-plan"
+
+    async def test_create_human_bead_failure_does_not_block_commit(self, tmp_path: Path) -> None:
+        """If ``bd create`` raises, we still commit (with the tag)."""
+        from maverick.workflows.fly_beads.graceful_stop import reset_graceful_stop
+
+        reset_graceful_stop()
+
+        correctness = StubReviewerAgent(
+            review_kind="correctness",
+            review_payloads=[
+                SubmitReviewPayload(
+                    approved=False,
+                    findings=(ReviewFindingPayload(severity="minor", issue="x"),),
+                )
+                for _ in range(3)
+            ],
+        )
+        completeness = StubReviewerAgent(
+            review_kind="completeness",
+            review_payloads=[SubmitReviewPayload(approved=True, findings=()) for _ in range(3)],
+        )
+        squadron = StubFlySquadron(
+            correctness=correctness,
+            completeness=completeness,
+            coder=StubCodingAgent(
+                implement_payloads=[SubmitImplementationPayload(summary="i1")],
+                fix_payloads=[SubmitFixResultPayload(summary="f") for _ in range(5)],
+            ),
+        )
+
+        async def _create_bead_fails(*_args: Any, **_kw: Any) -> Any:
+            raise RuntimeError("bd create exploded")
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.select_next_bead",
+                new=AsyncMock(side_effect=[_bead("b-1"), _NO_MORE]),
+            ),
+            patch(
+                "maverick.library.actions.validation.run_independent_gate",
+                new=AsyncMock(return_value=_gate_passed()),
+            ),
+            patch(
+                "maverick.library.actions.jj.jj_commit_bead",
+                new=AsyncMock(return_value={"change_id": "c", "success": True}),
+            ),
+            patch(
+                "maverick.library.actions.beads.mark_bead_complete",
+                new=AsyncMock(
+                    return_value=MarkBeadCompleteResult(success=True, bead_id="b-1", error=None)
+                ),
+            ),
+            patch(
+                "maverick.beads.client.BeadClient.create_bead",
+                new=_create_bead_fails,
+            ),
+        ):
+            app = build_fly_application(
+                squadron=squadron,  # type: ignore[arg-type]
+                event_queue=queue,
+                epic_id="e-1",
+                cwd=str(tmp_path),
+                max_beads=10,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=FLY_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        _, _, state = driver.result
+        # human bead creation failed → empty id but the commit still ran.
+        assert state["human_bead_id"] == ""
+        assert state["commit_ok"] is True
+        assert state["needs_human_review"] is True
+
+
 class TestFlyBurrGracefulStop:
     async def test_graceful_stop_exits_loop(self, tmp_path: Path) -> None:
         """Setting the flag mid-run terminates after current bead."""


### PR DESCRIPTION
## Summary

- Restores the pre-migration ``_create_human_bead`` behaviour on top of the Burr fly graph: when review rounds (or a fix request) exhaust without approval, a ``bd`` ``TASK``/``REVIEW`` bead is created and assigned to the human reviewer with labels ``["assumption-review", "needs-human-review"]``.
- The commit still lands (carrying the existing ``Tag: needs-human-review`` trailer), so the assumption bead points back at a concrete change. ``BeadClient`` failures are non-fatal — we log a warning and the commit still runs.
- Findings from the final review round are persisted into ``state["last_review_findings"]`` and inlined into the new bead's description so curators can read the escalation reason without re-running anything.

## Closes
- #111 (Gap 3: human-bead creation on review failure)

## Changes
- ``src/maverick/workflows/fly_beads/actions.py`` — review now writes ``last_review_findings`` on every escalation path; new ``create_human_bead`` action lives between ``review`` and ``commit``.
- ``src/maverick/workflows/fly_beads/burr_graph.py`` — wires the new action into the graph with transitions ``review → create_human_bead`` (gated on ``needs_human_review``) and ``create_human_bead → commit``; threads ``flight_plan_name`` through to the action.
- ``src/maverick/workflows/fly_beads/workflow.py`` — extracts ``flight_plan_name`` from ``run_meta.plan_name`` when an epic_id resolves a run.
- ``tests/unit/workflows/fly_beads/test_burr_graph.py`` — two new tests:
  - happy escalation: 3 unhappy review rounds → ``create_human_bead`` runs → ``commit`` runs → bead shape (``TASK``/``REVIEW``/``assignee="human"``/labels) is asserted, ``set_state`` is called with ``source_bead`` + ``flight_plan``, and ``bead_events`` carries ``tag="needs-human-review"`` for the CLI summary.
  - failure escalation: ``BeadClient.create_bead`` raising is non-fatal — ``human_bead_id`` is empty, ``commit_ok`` is true.

## Test plan
- [x] ``make ci`` — 3356 passed
- [x] ``uv run pytest tests/unit/workflows/fly_beads/`` — 45 passed (43 prior + 2 new)
- [ ] Smoke check on sample-maverick-project once Gap 4+ also lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)