### PR TITLE
feat(burr): wire fly watch mode through the Burr select_next_bead loop (#112)

### DIFF
--- a/src/maverick/workflows/fly_beads/actions.py
+++ b/src/maverick/workflows/fly_beads/actions.py
@@ -127,7 +127,7 @@ async def init_state(state: State) -> tuple[dict[str, Any], State]:
 
 
 @action(
-    reads=["completed_bead_ids", "processed_count"],
+    reads=["completed_bead_ids", "processed_count", "idle_polls"],
     writes=[
         "current_bead",
         "current_bead_id",
@@ -138,6 +138,7 @@ async def init_state(state: State) -> tuple[dict[str, Any], State]:
         "bead_failed",
         "needs_human_review",
         "review_rounds",
+        "idle_polls",
     ],
 )
 async def select_next_bead(
@@ -147,16 +148,24 @@ async def select_next_bead(
     cwd: str,
     max_beads: int,
     events: asyncio.Queue[ProgressEvent | None],
+    watch: bool = False,
+    watch_interval: int = 30,
+    max_idle_polls: int = 60,
 ) -> tuple[dict[str, Any], State]:
     """Pick the next ready bead — or signal end-of-stream.
 
-    Three conditions terminate the loop:
+    Four conditions terminate the loop:
 
     1. Graceful-stop flag has been set (Ctrl-C between beads).
     2. ``max_beads`` cap reached (``0`` means unlimited).
-    3. No ready bead is available (``select_next_bead`` returns
-       ``found=False``). The Burr driver doesn't implement
-       ``watch`` mode in Phase 3 — bead-empty terminates immediately.
+    3. No ready bead is available AND ``watch`` is false.
+    4. No ready bead is available AND ``watch`` is true but the
+       ``max_idle_polls`` cap is reached.
+
+    In watch mode (case 4), when ``bd`` reports no ready bead and the
+    idle cap hasn't been hit yet, the action sleeps ``watch_interval``
+    seconds, increments ``idle_polls``, and leaves ``current_bead=None``
+    so the graph cycles back into ``select_next_bead`` for another try.
     """
     from maverick.library.actions.beads import select_next_bead as bd_select
     from maverick.workflows.fly_beads.graceful_stop import (
@@ -188,9 +197,25 @@ async def select_next_bead(
     result = await bd_select(epic_id=epic_id, cwd=cwd)
     bead_dict = result.to_dict()
     if not bead_dict.get("found"):
-        return {"loop_done": True, "loop_done_reason": "no_more_beads"}, state.update(
+        idle_polls = int(state.get("idle_polls", 0))
+        if watch and idle_polls < max_idle_polls:
+            idle_polls += 1
+            await _put_output(
+                events,
+                "fly",
+                f"No beads ready; waiting ({idle_polls}/{max_idle_polls})",
+            )
+            await asyncio.sleep(max(0, watch_interval))
+            return {"loop_done": False, "idle_poll": idle_polls}, state.update(
+                current_bead=None,
+                current_bead_id="",
+                loop_done=False,
+                idle_polls=idle_polls,
+            )
+        reason = "watch_idle_exhausted" if watch else "no_more_beads"
+        return {"loop_done": True, "loop_done_reason": reason}, state.update(
             loop_done=True,
-            loop_done_reason="no_more_beads",
+            loop_done_reason=reason,
             current_bead=None,
             current_bead_id="",
         )
@@ -204,6 +229,7 @@ async def select_next_bead(
             current_bead_id="",
             loop_done=False,
             skipped_count=state.get("skipped_count", 0) + 1,
+            idle_polls=0,
         )
 
     return {"loop_done": False, "current_bead_id": bead_id}, state.update(
@@ -215,6 +241,7 @@ async def select_next_bead(
         bead_failed=False,
         needs_human_review=False,
         review_rounds=0,
+        idle_polls=0,
     )
 
 

--- a/src/maverick/workflows/fly_beads/burr_graph.py
+++ b/src/maverick/workflows/fly_beads/burr_graph.py
@@ -79,6 +79,9 @@ def build_fly_application(
     validation_commands: dict[str, tuple[str, ...]] | None = None,
     project_type: str = "rust",
     flight_plan_name: str = "",
+    watch: bool = False,
+    watch_interval: int = 30,
+    max_idle_polls: int = 60,
 ) -> Any:
     """Build the ``Application`` for one fly run."""
     hook = ProgressEventHook(
@@ -97,6 +100,9 @@ def build_fly_application(
                 cwd=cwd,
                 max_beads=max_beads,
                 events=event_queue,
+                watch=watch,
+                watch_interval=watch_interval,
+                max_idle_polls=max_idle_polls,
             ),
             process_bead_start=fly_actions.process_bead_start,
             implement=fly_actions.implement.bind(squadron=squadron, events=event_queue),
@@ -153,6 +159,8 @@ def build_fly_application(
             commit_ok=False,
             last_review_findings=[],
             human_bead_id="",
+            # Watch mode: count of consecutive empty-poll cycles.
+            idle_polls=0,
         )
         .with_hooks(hook)
         .with_entrypoint("init_state")

--- a/src/maverick/workflows/fly_beads/workflow.py
+++ b/src/maverick/workflows/fly_beads/workflow.py
@@ -344,17 +344,18 @@ class FlyBeadsWorkflow(PythonWorkflow):
 
         # ----------------------------------------------------------------
         # Bead loop — driven by the Burr application around the
-        # FlySquadron. ``watch`` mode + ``watch_interval`` are accepted
-        # on the input contract for CLI back-compat but are not yet
-        # implemented on the Burr driver (Phase 3 simplification).
+        # FlySquadron. Watch mode keeps the loop alive after the bead
+        # queue drains, polling for newly-ready beads every
+        # ``watch_interval`` seconds up to a fixed idle cap.
         # ----------------------------------------------------------------
-        _ = (watch, watch_interval)  # noqa: F841 — accepted but unused
         burr_result = await self._run_fly_with_burr(
             epic_id=epic_id,
             cwd=cwd,
             max_beads=max_beads,
             completed_bead_ids=completed_bead_ids,
             flight_plan_name=flight_plan_name,
+            watch=watch,
+            watch_interval=watch_interval,
         )
         beads_succeeded = int(burr_result.get("beads_completed", 0))
         beads_failed = int(burr_result.get("beads_failed", 0))
@@ -404,6 +405,8 @@ class FlyBeadsWorkflow(PythonWorkflow):
         max_beads: int = MAX_BEADS,
         completed_bead_ids: set[str] | None = None,
         flight_plan_name: str = "",
+        watch: bool = False,
+        watch_interval: int = 30,
     ) -> dict[str, Any]:
         """Run the fly bead loop via the Burr-backed driver.
 
@@ -417,6 +420,8 @@ class FlyBeadsWorkflow(PythonWorkflow):
             max_beads=max_beads,
             completed_bead_ids=tuple(completed_bead_ids or ()),
             flight_plan_name=flight_plan_name,
+            watch=watch,
+            watch_interval=watch_interval,
         )
 
 
@@ -447,6 +452,8 @@ async def _run_fly_with_burr_impl(
     max_beads: int,
     completed_bead_ids: tuple[str, ...],
     flight_plan_name: str = "",
+    watch: bool = False,
+    watch_interval: int = 30,
 ) -> dict[str, Any]:
     """Drive the fly Burr application; return the same shape as xoscar.
 
@@ -476,6 +483,8 @@ async def _run_fly_with_burr_impl(
             validation_commands=None,
             project_type=getattr(workflow._config, "project_type", "rust") or "rust",
             flight_plan_name=flight_plan_name,
+            watch=watch,
+            watch_interval=watch_interval,
         )
         driver = BurrWorkflowDriver(
             app,

--- a/tests/unit/workflows/fly_beads/test_burr_graph.py
+++ b/tests/unit/workflows/fly_beads/test_burr_graph.py
@@ -572,6 +572,104 @@ class TestFlyBurrHumanBeadCreation:
         assert state["needs_human_review"] is True
 
 
+class TestFlyBurrWatchMode:
+    async def test_watch_polls_then_exits_on_idle_cap(self, tmp_path: Path) -> None:
+        """Watch mode polls past an empty cycle, then exits when the cap is hit."""
+        from maverick.workflows.fly_beads.graceful_stop import reset_graceful_stop
+
+        reset_graceful_stop()
+
+        # Sequence: empty (poll 1) → bead → empty (poll 1) → empty
+        # (poll 2 = cap) → empty (cap hit → exit).
+        select_calls = AsyncMock(
+            side_effect=[_NO_MORE, _bead("b-1"), _NO_MORE, _NO_MORE, _NO_MORE]
+        )
+        sleep_calls: list[float] = []
+
+        async def _instant_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        squadron = StubFlySquadron()
+
+        with (
+            patch("maverick.library.actions.beads.select_next_bead", new=select_calls),
+            patch(
+                "maverick.library.actions.validation.run_independent_gate",
+                new=AsyncMock(return_value=_gate_passed()),
+            ),
+            patch(
+                "maverick.library.actions.jj.jj_commit_bead",
+                new=AsyncMock(return_value={"change_id": "c", "success": True}),
+            ),
+            patch(
+                "maverick.library.actions.beads.mark_bead_complete",
+                new=AsyncMock(
+                    return_value=MarkBeadCompleteResult(success=True, bead_id="b-1", error=None)
+                ),
+            ),
+            patch("maverick.workflows.fly_beads.actions.asyncio.sleep", new=_instant_sleep),
+        ):
+            app = build_fly_application(
+                squadron=squadron,  # type: ignore[arg-type]
+                event_queue=queue,
+                epic_id="e-1",
+                cwd=str(tmp_path),
+                max_beads=10,
+                watch=True,
+                watch_interval=7,
+                max_idle_polls=2,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=FLY_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        _, _, state = driver.result
+        # Bead processed; watch then exited after the idle cap was hit.
+        assert state["succeeded_count"] == 1
+        assert state["loop_done_reason"] == "watch_idle_exhausted"
+        # One sleep for the first empty cycle, two for the post-bead cycles.
+        assert sleep_calls == [7, 7, 7]
+        # idle_polls stops at the cap.
+        assert state["idle_polls"] == 2
+        # Pre-bead empty cycle resets idle_polls when a bead is found.
+        assert select_calls.await_count == 5
+
+    async def test_no_watch_exits_immediately_on_empty(self, tmp_path: Path) -> None:
+        """Without ``watch``, the first empty poll terminates the loop."""
+        from maverick.workflows.fly_beads.graceful_stop import reset_graceful_stop
+
+        reset_graceful_stop()
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        squadron = StubFlySquadron()
+        sleep_calls: list[float] = []
+
+        async def _instant_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        with (
+            patch(
+                "maverick.library.actions.beads.select_next_bead",
+                new=AsyncMock(side_effect=[_NO_MORE]),
+            ),
+            patch("maverick.workflows.fly_beads.actions.asyncio.sleep", new=_instant_sleep),
+        ):
+            app = build_fly_application(
+                squadron=squadron,  # type: ignore[arg-type]
+                event_queue=queue,
+                epic_id="e-1",
+                cwd=str(tmp_path),
+                max_beads=10,
+                watch=False,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=FLY_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        _, _, state = driver.result
+        assert state["loop_done_reason"] == "no_more_beads"
+        assert sleep_calls == []  # no watch ⇒ no polling sleep
+
+
 class TestFlyBurrGracefulStop:
     async def test_graceful_stop_exits_loop(self, tmp_path: Path) -> None:
         """Setting the flag mid-run terminates after current bead."""


### PR DESCRIPTION
## Summary

- Restores the pre-migration ``--watch`` behaviour on top of the Burr fly graph. When the bead queue drains and ``--watch`` is set, ``select_next_bead`` now sleeps ``watch_interval`` seconds, increments an ``idle_polls`` counter in state, and cycles back through the existing ``select_next_bead → select_next_bead`` self-transition. After ``max_idle_polls`` consecutive empty cycles the loop terminates with ``loop_done_reason="watch_idle_exhausted"``.
- ``idle_polls`` resets to zero whenever a bead is found (or a checkpointed bead is skipped), so a long-running watch session that periodically receives new work doesn't accumulate spurious idle counts.
- Without ``--watch``, behaviour is unchanged: the first empty poll terminates the loop with ``no_more_beads`` (no sleep).

## Closes
- #112 (Gap 4: fly watch mode)

## Changes
- ``src/maverick/workflows/fly_beads/actions.py`` — ``select_next_bead`` accepts ``watch`` / ``watch_interval`` / ``max_idle_polls``, tracks ``idle_polls``, branches between sleep-and-cycle vs terminate on the empty path.
- ``src/maverick/workflows/fly_beads/burr_graph.py`` — plumbs the three params through ``bind()`` and seeds ``idle_polls=0`` in initial state.
- ``src/maverick/workflows/fly_beads/workflow.py`` — stops swallowing ``watch`` / ``watch_interval`` from inputs and forwards them through ``_run_fly_with_burr`` and ``_run_fly_with_burr_impl``.
- ``tests/unit/workflows/fly_beads/test_burr_graph.py`` — two new tests under ``TestFlyBurrWatchMode``:
  - watch-on: empty → bead → 2 empty cycles → cap exhausted. Asserts the right sleep cadence, that idle_polls resets when the bead is found, and the exit reason is ``watch_idle_exhausted``.
  - watch-off: first empty poll terminates with ``no_more_beads`` and no sleep is recorded.

## Test plan
- [x] ``make ci`` — 3358 passed
- [x] ``uv run pytest tests/unit/workflows/fly_beads/`` — 47 passed (45 prior + 2 new)
- [ ] Manual smoke against sample-maverick-project (``maverick fly --watch --watch-interval 5``) — deferred until later gaps land

🤖 Generated with [Claude Code](https://claude.com/claude-code)