### PR TITLE
feat(burr): port aggregate cross-bead review to the fly graph (#113)

### DIFF
--- a/src/maverick/workflows/fly_beads/actions.py
+++ b/src/maverick/workflows/fly_beads/actions.py
@@ -12,20 +12,13 @@ agents.
 follow-up; tracked in the repo as TODO items):
 
 * **Tier escalation** — single-tier dispatch only.
-* **Aggregate cross-bead review** — per-bead reviews run; the
-  post-loop ``_maybe_aggregate_review`` was not ported.
 * **Reviewer transient-failure escalation** — falls straight through
   to ``needs-human-review``.
-* **Human-bead creation** — the commit's ``Tag: needs-human-review``
-  trailer still lands, but no companion assumption bead is created
-  on ``bd``.
-* **Watch mode** — the loop terminates on bead-empty rather than
-  polling.
 
-Graceful stop is preserved. The Rust spec-check rules
+Graceful stop, watch mode, aggregate cross-bead review, human-bead
+creation on review exhaustion, and the Rust spec-check rules
 (``.unwrap()`` / ``.expect()`` / ``std::process::Command`` in async
-contexts) are now active again via
-:mod:`maverick.workflows.fly_beads._spec_check`.
+contexts) are all wired up.
 """
 
 from __future__ import annotations
@@ -50,12 +43,14 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "AGGREGATE_REVIEW_THRESHOLD",
     "DEFAULT_TIER",
     "MAX_GATE_FIX_ATTEMPTS",
     "MAX_REVIEW_ROUNDS",
     "MAX_SPEC_FIX_ATTEMPTS",
     "abandon_bead",
     "ac_check",
+    "aggregate_review",
     "commit",
     "create_human_bead",
     "gate",
@@ -72,6 +67,10 @@ __all__ = [
 MAX_REVIEW_ROUNDS: int = 3
 MAX_GATE_FIX_ATTEMPTS: int = 2
 MAX_SPEC_FIX_ATTEMPTS: int = 2
+
+# Aggregate review runs once after the bead loop when at least this
+# many beads have completed in the current run.
+AGGREGATE_REVIEW_THRESHOLD: int = 2
 
 DEFAULT_TIER: str = "_default"
 
@@ -960,3 +959,110 @@ async def record_outcome(state: State) -> tuple[dict[str, Any], State]:
         succeeded_count=state["succeeded_count"] + (1 if succeeded else 0),
         failed_count=state["failed_count"] + (0 if succeeded else 1),
     )
+
+
+# ---------------------------------------------------------------------------
+# Aggregate (cross-bead) review
+# ---------------------------------------------------------------------------
+
+
+@action(
+    reads=["completed_bead_ids", "bead_events", "succeeded_count"],
+    writes=["aggregate_review_payload"],
+)
+async def aggregate_review(
+    state: State,
+    *,
+    squadron: FlySquadron,
+    events: asyncio.Queue[ProgressEvent | None],
+    cwd: str,
+    epic_id: str,
+) -> tuple[dict[str, Any], State]:
+    """Run the epic-level cross-bead review after the bead loop ends.
+
+    Mirrors the pre-migration ``FlySupervisor._maybe_aggregate_review``:
+    gated on ``AGGREGATE_REVIEW_THRESHOLD`` successful beads, this asks
+    the correctness reviewer to look across the entire epic for
+    cross-bead consistency issues. The findings surface as a single
+    warning row when the aggregate review is not approved; they don't
+    block the run.
+    """
+    completed_ids: list[str] = list(state.get("completed_bead_ids") or ())
+    if len(completed_ids) < AGGREGATE_REVIEW_THRESHOLD:
+        return {"ran": False, "reason": "below_threshold"}, state.update(
+            aggregate_review_payload=None,
+        )
+
+    # Build "<id>: <title>" lines from the per-bead event ledger so the
+    # prompt mirrors the xoscar shape (titles are not on the
+    # completed_bead_ids list itself).
+    bead_events: list[dict[str, Any]] = list(state.get("bead_events") or ())
+    title_by_id: dict[str, str] = {e["bead_id"]: e.get("title", "") for e in bead_events}
+    bead_list = "\n".join(f"- {bid}: {title_by_id.get(bid, '')}" for bid in completed_ids)
+
+    diff_stat = await _safe_diff_stat(cwd)
+
+    reviewer = squadron.correctness_reviewer_for(DEFAULT_TIER)
+    label = "Aggregate review"
+    await events.put(AgentStarted(step_name="aggregate_review", agent_name=label, provider=""))
+    t0 = time.monotonic()
+    try:
+        payload = await reviewer.aggregate(
+            objective=epic_id or "epic",
+            bead_list=bead_list,
+            diff_stat=diff_stat,
+        )
+    except Exception as exc:  # noqa: BLE001 — non-fatal advisory step
+        await _put_output(
+            events,
+            "fly",
+            f"Aggregate review failed: {exc}",
+            level="warning",
+        )
+        await events.put(
+            AgentCompleted(
+                step_name="aggregate_review",
+                agent_name=label,
+                duration_seconds=time.monotonic() - t0,
+                success=False,
+                error=str(exc),
+            )
+        )
+        return {"ran": False, "error": str(exc)}, state.update(
+            aggregate_review_payload=None,
+        )
+
+    await events.put(
+        AgentCompleted(
+            step_name="aggregate_review",
+            agent_name=label,
+            duration_seconds=time.monotonic() - t0,
+        )
+    )
+
+    summary = dump_supervisor_payload(payload)
+    if not payload.approved:
+        finding_count = len(payload.findings)
+        await _put_output(
+            events,
+            "fly",
+            f"Aggregate review flagged {finding_count} cross-bead issue(s)",
+            level="warning",
+            metadata={"finding_count": finding_count},
+        )
+
+    return {"ran": True, "approved": payload.approved}, state.update(
+        aggregate_review_payload=summary,
+    )
+
+
+async def _safe_diff_stat(cwd: str) -> str:
+    """Return ``git diff --stat HEAD~1..HEAD`` or empty on any failure."""
+    from maverick.runners.command import CommandRunner
+
+    try:
+        runner = CommandRunner(cwd=Path(cwd))
+        result = await runner.run(["git", "diff", "--stat", "HEAD~1..HEAD"])
+        return result.stdout if result.returncode == 0 else ""
+    except Exception:  # noqa: BLE001 — advisory; empty diff stat is fine
+        return ""

--- a/src/maverick/workflows/fly_beads/burr_graph.py
+++ b/src/maverick/workflows/fly_beads/burr_graph.py
@@ -56,6 +56,7 @@ FLY_ACTION_LABELS: dict[str, str] = {
     "commit": "Committing",
     "abandon_bead": "Abandoning bead",
     "record_outcome": "Recording outcome",
+    "aggregate_review": "Aggregate review",
     "done": "Done",
 }
 
@@ -129,6 +130,12 @@ def build_fly_application(
             commit=fly_actions.commit.bind(cwd=cwd, events=event_queue),
             abandon_bead=fly_actions.abandon_bead.bind(events=event_queue),
             record_outcome=fly_actions.record_outcome,
+            aggregate_review=fly_actions.aggregate_review.bind(
+                squadron=squadron,
+                events=event_queue,
+                cwd=cwd,
+                epic_id=epic_id,
+            ),
             done=_done,
         )
         .with_state(
@@ -161,13 +168,18 @@ def build_fly_application(
             human_bead_id="",
             # Watch mode: count of consecutive empty-poll cycles.
             idle_polls=0,
+            # Aggregate (cross-bead) review summary — None until the
+            # post-loop ``aggregate_review`` action runs.
+            aggregate_review_payload=None,
         )
         .with_hooks(hook)
         .with_entrypoint("init_state")
         .with_transitions(
             ("init_state", "select_next_bead"),
-            # Loop exit
-            ("select_next_bead", "done", expr("loop_done")),
+            # Loop exit funnels through the aggregate (cross-bead)
+            # review so a finished epic gets a single end-of-run pass.
+            ("select_next_bead", "aggregate_review", expr("loop_done")),
+            ("aggregate_review", "done"),
             # Resumed-from-checkpoint bead → cycle without process
             ("select_next_bead", "select_next_bead", expr("current_bead is None")),
             ("select_next_bead", "process_bead_start"),

--- a/tests/unit/workflows/fly_beads/test_burr_graph.py
+++ b/tests/unit/workflows/fly_beads/test_burr_graph.py
@@ -572,6 +572,149 @@ class TestFlyBurrHumanBeadCreation:
         assert state["needs_human_review"] is True
 
 
+class TestFlyBurrAggregateReview:
+    async def test_two_beads_trigger_aggregate(self, tmp_path: Path) -> None:
+        """≥2 successful beads → ``aggregate_review`` runs before ``done``."""
+        from maverick.workflows.fly_beads.graceful_stop import reset_graceful_stop
+
+        reset_graceful_stop()
+
+        agg_calls: list[dict[str, Any]] = []
+
+        async def _fake_aggregate(
+            *, objective: str, bead_list: str, diff_stat: str
+        ) -> SubmitReviewPayload:
+            agg_calls.append(
+                {"objective": objective, "bead_list": bead_list, "diff_stat": diff_stat}
+            )
+            return SubmitReviewPayload(
+                approved=False,
+                findings=(
+                    ReviewFindingPayload(severity="major", issue="cross-bead inconsistency"),
+                ),
+            )
+
+        coder = StubCodingAgent(
+            implement_payloads=[
+                SubmitImplementationPayload(summary="i1"),
+                SubmitImplementationPayload(summary="i2"),
+            ],
+            fix_payloads=[SubmitFixResultPayload(summary="f") for _ in range(5)],
+        )
+        squadron = StubFlySquadron(coder=coder)
+        # Patch the .aggregate method directly on the per-tier reviewer
+        # stub the squadron will return.
+        squadron.correctness.aggregate = _fake_aggregate  # type: ignore[attr-defined]
+
+        async def _fake_diff_stat(*_args: Any, **_kw: Any) -> Any:
+            class _R:
+                returncode = 0
+                stdout = " src/foo.py | 12 ++++++++----\n"
+
+            return _R()
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.select_next_bead",
+                new=AsyncMock(side_effect=[_bead("b-1"), _bead("b-2"), _NO_MORE]),
+            ),
+            patch(
+                "maverick.library.actions.validation.run_independent_gate",
+                new=AsyncMock(return_value=_gate_passed()),
+            ),
+            patch(
+                "maverick.library.actions.jj.jj_commit_bead",
+                new=AsyncMock(return_value={"change_id": "c", "success": True}),
+            ),
+            patch(
+                "maverick.library.actions.beads.mark_bead_complete",
+                new=AsyncMock(
+                    return_value=MarkBeadCompleteResult(success=True, bead_id="x", error=None)
+                ),
+            ),
+            patch(
+                "maverick.runners.command.CommandRunner.run",
+                new=_fake_diff_stat,
+            ),
+        ):
+            app = build_fly_application(
+                squadron=squadron,  # type: ignore[arg-type]
+                event_queue=queue,
+                epic_id="e-1",
+                cwd=str(tmp_path),
+                max_beads=10,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=FLY_TERMINAL_ACTIONS, event_queue=queue)
+            events = await _collect(driver)
+
+        sequence = _action_sequence(events)
+        assert sequence[-2] == "aggregate_review"
+        assert sequence[-1] == "done"
+
+        assert len(agg_calls) == 1
+        call = agg_calls[0]
+        assert call["objective"] == "e-1"
+        assert "b-1" in call["bead_list"]
+        assert "b-2" in call["bead_list"]
+        assert "src/foo.py" in call["diff_stat"]
+
+        _, _, state = driver.result
+        assert state["aggregate_review_payload"] is not None
+        assert state["aggregate_review_payload"]["approved"] is False
+
+    async def test_single_bead_skips_aggregate(self, tmp_path: Path) -> None:
+        """1 successful bead → aggregate is below threshold → no-op."""
+        from maverick.workflows.fly_beads.graceful_stop import reset_graceful_stop
+
+        reset_graceful_stop()
+
+        called = False
+
+        async def _fail_if_called(*_args: Any, **_kw: Any) -> SubmitReviewPayload:
+            nonlocal called
+            called = True
+            return SubmitReviewPayload(approved=True, findings=())
+
+        squadron = StubFlySquadron()
+        squadron.correctness.aggregate = _fail_if_called  # type: ignore[attr-defined]
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.select_next_bead",
+                new=AsyncMock(side_effect=[_bead("b-1"), _NO_MORE]),
+            ),
+            patch(
+                "maverick.library.actions.validation.run_independent_gate",
+                new=AsyncMock(return_value=_gate_passed()),
+            ),
+            patch(
+                "maverick.library.actions.jj.jj_commit_bead",
+                new=AsyncMock(return_value={"change_id": "c", "success": True}),
+            ),
+            patch(
+                "maverick.library.actions.beads.mark_bead_complete",
+                new=AsyncMock(
+                    return_value=MarkBeadCompleteResult(success=True, bead_id="b-1", error=None)
+                ),
+            ),
+        ):
+            app = build_fly_application(
+                squadron=squadron,  # type: ignore[arg-type]
+                event_queue=queue,
+                epic_id="e-1",
+                cwd=str(tmp_path),
+                max_beads=10,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=FLY_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        assert called is False
+        _, _, state = driver.result
+        assert state["aggregate_review_payload"] is None
+
+
 class TestFlyBurrWatchMode:
     async def test_watch_polls_then_exits_on_idle_cap(self, tmp_path: Path) -> None:
         """Watch mode polls past an empty cycle, then exits when the cap is hit."""


### PR DESCRIPTION
## Summary

- Restores the pre-migration ``_maybe_aggregate_review`` behaviour on top of the Burr fly graph. The loop-exit transition ``select_next_bead → done`` is now ``select_next_bead → aggregate_review → done``, so every fly run ends with exactly one cross-bead pass when ≥2 beads succeeded in the run.
- The aggregate reviewer is asked to look at the combined ``"<id>: <title>"`` list plus a ``git diff --stat HEAD~1..HEAD`` snippet, matching the xoscar shape. When not approved, the action emits a single warning row carrying the finding count — the result is advisory only and doesn't fail the run.
- ``AGGREGATE_REVIEW_THRESHOLD = 2`` (preserved from the xoscar substrate). Below-threshold runs make ``aggregate_review`` a state-clearing no-op so the action is always safe to enter.

## Closes
- #113 (Gap 5: fly aggregate cross-bead review)

## Changes
- ``src/maverick/workflows/fly_beads/actions.py`` — new ``aggregate_review`` action + ``AGGREGATE_REVIEW_THRESHOLD`` constant; reviewer failures are caught and logged (state ends with ``aggregate_review_payload=None``).
- ``src/maverick/workflows/fly_beads/burr_graph.py`` — wires the new action into the graph and seeds ``aggregate_review_payload=None`` in the initial state.
- ``src/maverick/workflows/fly_beads/actions.py`` (module docstring) — pulls watch mode, aggregate review, and human-bead creation off the "known gaps" list now that they're wired up.
- ``tests/unit/workflows/fly_beads/test_burr_graph.py`` — two new tests:
  - threshold met: 2 succeeded beads → action runs, bead list + diff stat reach the reviewer, an unapproved payload surfaces on state.
  - below threshold: 1 succeeded bead → reviewer is never called, ``aggregate_review_payload`` stays ``None``.

## Test plan
- [x] ``make ci`` — 3360 passed
- [x] ``uv run pytest tests/unit/workflows/fly_beads/`` — 49 passed (47 prior + 2 new)
- [ ] Manual smoke against sample-maverick-project — deferred until later gaps land

🤖 Generated with [Claude Code](https://claude.com/claude-code)