### PR TITLE
feat(burr): escalate reviewer tier on transient runtime failures (#114)

### DIFF
--- a/src/maverick/workflows/fly_beads/actions.py
+++ b/src/maverick/workflows/fly_beads/actions.py
@@ -11,12 +11,11 @@ agents.
 **Known gaps relative to the pre-migration supervisor** (queued for
 follow-up; tracked in the repo as TODO items):
 
-* **Tier escalation** — single-tier dispatch only.
-* **Reviewer transient-failure escalation** — falls straight through
-  to ``needs-human-review``.
+* **Tier escalation (implementer)** — single-tier dispatch only.
 
 Graceful stop, watch mode, aggregate cross-bead review, human-bead
-creation on review exhaustion, and the Rust spec-check rules
+creation on review exhaustion, reviewer transient-failure escalation,
+and the Rust spec-check rules
 (``.unwrap()`` / ``.expect()`` / ``std::process::Command`` in async
 contexts) are all wired up.
 """
@@ -241,6 +240,7 @@ async def select_next_bead(
         needs_human_review=False,
         review_rounds=0,
         idle_polls=0,
+        reviewer_escalation_level=0,
     )
 
 
@@ -572,8 +572,14 @@ async def spec_check(
 
 
 @action(
-    reads=["current_bead", "current_bead_id"],
-    writes=["approved", "review_rounds", "needs_human_review", "last_review_findings"],
+    reads=["current_bead", "current_bead_id", "reviewer_escalation_level"],
+    writes=[
+        "approved",
+        "review_rounds",
+        "needs_human_review",
+        "last_review_findings",
+        "reviewer_escalation_level",
+    ],
 )
 async def review(
     state: State,
@@ -587,6 +593,14 @@ async def review(
     findings into ``state["last_review_findings"]`` so the downstream
     ``create_human_bead`` action can include them in the assumption
     bead's description.
+
+    On reviewer transient failures (airframe's ``RuntimeTransientError``
+    — 5xx, rate limits, network blips, runtime hangs), the action
+    escalates to the next configured tier and retries the same round.
+    The escalated tier sticks for the rest of the bead so we don't drop
+    back to a reviewer we just learned is unreliable. If every tier has
+    been tried and the failure persists, the action sets
+    ``needs_human_review=True`` and exits.
     """
     bead = state["current_bead"]
     bead_id = state["current_bead_id"]
@@ -598,14 +612,145 @@ async def review(
             last_review_findings=[],
         )
 
-    correctness = squadron.correctness_reviewer_for(DEFAULT_TIER)
-    completeness = squadron.completeness_reviewer_for(DEFAULT_TIER)
     description = bead.get("description", "")
     work_unit_md = description or None
 
     rounds_with_findings = 0
+    escalation_level = int(state.get("reviewer_escalation_level") or 0)
     for round_n in range(1, MAX_REVIEW_ROUNDS + 1):
-        # Run both reviewers in parallel (correctness + completeness).
+        # Run both reviewers in parallel (correctness + completeness),
+        # bumping the reviewer tier on transient failures until either
+        # a result lands or every tier has been tried.
+        results, escalation_level, transient_exhausted = await _review_round_with_escalation(
+            squadron=squadron,
+            events=events,
+            bead_id=bead_id,
+            description=description,
+            work_unit_md=work_unit_md,
+            initial_level=escalation_level,
+        )
+        if transient_exhausted:
+            return {"approved": False}, state.update(
+                approved=False,
+                review_rounds=rounds_with_findings,
+                needs_human_review=True,
+                last_review_findings=[
+                    f"Reviewer transient failure exhausted escalation: {transient_exhausted}"
+                ],
+                reviewer_escalation_level=escalation_level,
+            )
+        if results is None:
+            # Non-transient reviewer failure — already logged inside
+            # the helper.
+            return {"approved": False}, state.update(
+                approved=False,
+                review_rounds=rounds_with_findings,
+                needs_human_review=True,
+                last_review_findings=["Review crashed (non-transient)"],
+                reviewer_escalation_level=escalation_level,
+            )
+
+        approved = all(_payload_approved(p) for p in results)
+        if approved:
+            return {"approved": True, "rounds": rounds_with_findings}, state.update(
+                approved=True,
+                review_rounds=rounds_with_findings,
+                last_review_findings=[],
+                reviewer_escalation_level=escalation_level,
+            )
+
+        rounds_with_findings += 1
+        round_findings = _findings_list(results)
+        if round_n >= MAX_REVIEW_ROUNDS:
+            await _put_output(
+                events,
+                "review",
+                f"Review rounds exhausted after {round_n}; flagging needs-human-review",
+                level="warning",
+            )
+            return {"approved": False, "rounds": rounds_with_findings}, state.update(
+                approved=False,
+                review_rounds=rounds_with_findings,
+                needs_human_review=True,
+                last_review_findings=round_findings,
+                reviewer_escalation_level=escalation_level,
+            )
+
+        # Re-prompt the implementer to address review feedback.
+        ok = await _run_fix(
+            squadron=squadron,
+            events=events,
+            bead_id=bead_id,
+            phase="review",
+            round_n=round_n,
+            failure_message="\n".join(round_findings) or "(no specific findings)",
+        )
+        if not ok:
+            return {"approved": False, "rounds": rounds_with_findings}, state.update(
+                approved=False,
+                review_rounds=rounds_with_findings,
+                needs_human_review=True,
+                last_review_findings=round_findings,
+                reviewer_escalation_level=escalation_level,
+            )
+
+    return {"approved": False, "rounds": rounds_with_findings}, state.update(
+        approved=False,
+        review_rounds=rounds_with_findings,
+        needs_human_review=True,
+        last_review_findings=[],
+        reviewer_escalation_level=escalation_level,
+    )
+
+
+_REVIEWER_TIER_LADDER: tuple[str, ...] = (DEFAULT_TIER, "trivial", "simple", "moderate", "complex")
+
+
+def _reviewer_tier_for_level(level: int) -> str:
+    """Resolve the reviewer tier name for an escalation level.
+
+    Level ``0`` is the squadron default. Each transient failure bumps
+    one rung up :data:`_REVIEWER_TIER_LADDER`; once the top is reached
+    there are no further tiers to try.
+    """
+    if level <= 0:
+        return _REVIEWER_TIER_LADDER[0]
+    if level >= len(_REVIEWER_TIER_LADDER):
+        return _REVIEWER_TIER_LADDER[-1]
+    return _REVIEWER_TIER_LADDER[level]
+
+
+async def _review_round_with_escalation(
+    *,
+    squadron: FlySquadron,
+    events: asyncio.Queue[ProgressEvent | None],
+    bead_id: str,
+    description: str,
+    work_unit_md: str | None,
+    initial_level: int,
+) -> tuple[tuple[Any, Any] | None, int, str]:
+    """Send the correctness+completeness pair, escalating on transient failure.
+
+    Returns ``(results, new_level, transient_exhausted_msg)`` where:
+
+    * ``results`` is the ``(correctness, completeness)`` payload tuple
+      on success, or ``None`` on a non-transient crash.
+    * ``new_level`` is the escalation level the caller should persist
+      for the rest of the bead.
+    * ``transient_exhausted_msg`` is the empty string on success or a
+      non-transient crash, and the carried transient-error message
+      when every reviewer tier has been exhausted.
+    """
+    from airframe.errors import RuntimeTransientError
+
+    level = max(0, initial_level)
+    last_transient_error = ""
+    max_level = len(_REVIEWER_TIER_LADDER) - 1
+    while True:
+        tier_name = _reviewer_tier_for_level(level)
+        correctness = squadron.correctness_reviewer_for(tier_name)
+        completeness = squadron.completeness_reviewer_for(tier_name)
+
         with squadron.bead_context(bead_id=bead_id):
             t0 = time.monotonic()
             await events.put(
@@ -627,19 +772,84 @@ async def review(
                         briefing_context=None,
                     ),
                 )
-            except Exception as exc:  # noqa: BLE001
+            except RuntimeTransientError as exc:
+                last_transient_error = str(exc)
+                duration = time.monotonic() - t0
+                await events.put(
+                    AgentCompleted(
+                        step_name="review",
+                        agent_name="Correctness",
+                        duration_seconds=duration,
+                        success=False,
+                        error=last_transient_error,
+                    )
+                )
+                await events.put(
+                    AgentCompleted(
+                        step_name="review",
+                        agent_name="Completeness",
+                        duration_seconds=duration,
+                        success=False,
+                        error=last_transient_error,
+                    )
+                )
+                if level >= max_level:
+                    await _put_output(
+                        events,
+                        "review",
+                        (
+                            f"Reviewer transient failure exhausted escalation at "
+                            f"tier '{tier_name}': {last_transient_error}"
+                        ),
+                        level="error",
+                        metadata={"tier": tier_name, "transient": True, "exhausted": True},
+                    )
+                    return None, level, last_transient_error
+                next_level = level + 1
+                next_tier = _reviewer_tier_for_level(next_level)
+                await _put_output(
+                    events,
+                    "review",
+                    (
+                        f"Reviewer transient failure on tier '{tier_name}'; "
+                        f"escalating to '{next_tier}': {last_transient_error}"
+                    ),
+                    level="warning",
+                    metadata={
+                        "from_tier": tier_name,
+                        "to_tier": next_tier,
+                        "transient": True,
+                    },
+                )
+                level = next_level
+                continue
+            except Exception as exc:  # noqa: BLE001 — non-transient → bail to needs-human-review
+                duration = time.monotonic() - t0
+                await events.put(
+                    AgentCompleted(
+                        step_name="review",
+                        agent_name="Correctness",
+                        duration_seconds=duration,
+                        success=False,
+                        error=str(exc),
+                    )
+                )
+                await events.put(
+                    AgentCompleted(
+                        step_name="review",
+                        agent_name="Completeness",
+                        duration_seconds=duration,
+                        success=False,
+                        error=str(exc),
+                    )
+                )
                 await _put_output(
                     events,
                     "review",
                     f"Review failed: {exc}",
                     level="error",
                 )
-                return {"approved": False}, state.update(
-                    approved=False,
-                    review_rounds=rounds_with_findings,
-                    needs_human_review=True,
-                    last_review_findings=[f"Review crashed: {exc}"],
-                )
+                return None, level, ""
             duration = time.monotonic() - t0
         await events.put(
             AgentCompleted(
@@ -655,54 +865,7 @@ async def review(
                 duration_seconds=duration,
             )
         )
-
-        approved = all(_payload_approved(p) for p in results)
-        if approved:
-            return {"approved": True, "rounds": rounds_with_findings}, state.update(
-                approved=True,
-                review_rounds=rounds_with_findings,
-                last_review_findings=[],
-            )
-
-        rounds_with_findings += 1
-        round_findings = _findings_list(results)
-        if round_n >= MAX_REVIEW_ROUNDS:
-            await _put_output(
-                events,
-                "review",
-                f"Review rounds exhausted after {round_n}; flagging needs-human-review",
-                level="warning",
-            )
-            return {"approved": False, "rounds": rounds_with_findings}, state.update(
-                approved=False,
-                review_rounds=rounds_with_findings,
-                needs_human_review=True,
-                last_review_findings=round_findings,
-            )
-
-        # Re-prompt the implementer to address review feedback.
-        ok = await _run_fix(
-            squadron=squadron,
-            events=events,
-            bead_id=bead_id,
-            phase="review",
-            round_n=round_n,
-            failure_message="\n".join(round_findings) or "(no specific findings)",
-        )
-        if not ok:
-            return {"approved": False, "rounds": rounds_with_findings}, state.update(
-                approved=False,
-                review_rounds=rounds_with_findings,
-                needs_human_review=True,
-                last_review_findings=round_findings,
-            )
-
-    return {"approved": False, "rounds": rounds_with_findings}, state.update(
-        approved=False,
-        review_rounds=rounds_with_findings,
-        needs_human_review=True,
-        last_review_findings=[],
-    )
+        return results, level, ""
 
 
 def _payload_approved(payload: Any) -> bool:

--- a/src/maverick/workflows/fly_beads/burr_graph.py
+++ b/src/maverick/workflows/fly_beads/burr_graph.py
@@ -171,6 +171,9 @@ def build_fly_application(
             # Aggregate (cross-bead) review summary — None until the
             # post-loop ``aggregate_review`` action runs.
             aggregate_review_payload=None,
+            # Reviewer transient-failure escalation: per-bead step
+            # count up the tier ladder. Reset to 0 on each new bead.
+            reviewer_escalation_level=0,
         )
         .with_hooks(hook)
         .with_entrypoint("init_state")

--- a/tests/unit/workflows/fly_beads/test_burr_graph.py
+++ b/tests/unit/workflows/fly_beads/test_burr_graph.py
@@ -48,7 +48,13 @@ class _NullCM:
 
 
 class StubFlySquadron:
-    """Minimal stand-in for :class:`FlySquadron`."""
+    """Minimal stand-in for :class:`FlySquadron`.
+
+    ``correctness_by_tier`` / ``completeness_by_tier`` let tests
+    return distinct reviewer instances per tier name; the bare
+    ``correctness`` / ``completeness`` slots are the default fallback
+    when a tier-specific lookup misses.
+    """
 
     def __init__(
         self,
@@ -56,6 +62,8 @@ class StubFlySquadron:
         coder: StubCodingAgent | None = None,
         correctness: StubReviewerAgent | None = None,
         completeness: StubReviewerAgent | None = None,
+        correctness_by_tier: dict[str, StubReviewerAgent] | None = None,
+        completeness_by_tier: dict[str, StubReviewerAgent] | None = None,
     ) -> None:
         self.coder = coder or StubCodingAgent(
             implement_payloads=[SubmitImplementationPayload(summary="stub impl")],
@@ -69,15 +77,17 @@ class StubFlySquadron:
             review_kind="completeness",
             review_payloads=[SubmitReviewPayload(approved=True, findings=())],
         )
+        self.correctness_by_tier: dict[str, StubReviewerAgent] = correctness_by_tier or {}
+        self.completeness_by_tier: dict[str, StubReviewerAgent] = completeness_by_tier or {}
 
     def coder_for(self, _tier: str) -> StubCodingAgent:
         return self.coder
 
-    def correctness_reviewer_for(self, _tier: str) -> StubReviewerAgent:
-        return self.correctness
+    def correctness_reviewer_for(self, tier: str) -> StubReviewerAgent:
+        return self.correctness_by_tier.get(tier, self.correctness)
 
-    def completeness_reviewer_for(self, _tier: str) -> StubReviewerAgent:
-        return self.completeness
+    def completeness_reviewer_for(self, tier: str) -> StubReviewerAgent:
+        return self.completeness_by_tier.get(tier, self.completeness)
 
     def bead_context(self, **_kwargs: Any) -> _NullCM:
         return _NullCM()
@@ -570,6 +580,168 @@ class TestFlyBurrHumanBeadCreation:
         assert state["human_bead_id"] == ""
         assert state["commit_ok"] is True
         assert state["needs_human_review"] is True
+
+
+class TestFlyBurrReviewerTransientEscalation:
+    async def test_transient_failure_escalates_to_next_tier(self, tmp_path: Path) -> None:
+        """Transient reviewer error → bump tier → next tier approves → bead commits."""
+        from airframe.errors import RuntimeTransientError
+
+        from maverick.workflows.fly_beads.graceful_stop import reset_graceful_stop
+
+        reset_graceful_stop()
+
+        # Tier 0 (_default) correctness raises a transient. The action
+        # should escalate and re-run on the next-tier reviewer pair,
+        # which is the squadron's fallback ``correctness`` /
+        # ``completeness`` slots.
+        default_correctness = StubReviewerAgent(
+            review_kind="correctness",
+            review_payloads=[SubmitReviewPayload(approved=True, findings=())],
+        )
+        default_correctness.raise_error = RuntimeTransientError("rate limited")
+        default_completeness = StubReviewerAgent(
+            review_kind="completeness",
+            review_payloads=[SubmitReviewPayload(approved=True, findings=())],
+        )
+
+        squadron = StubFlySquadron(
+            correctness=StubReviewerAgent(
+                review_kind="correctness",
+                review_payloads=[SubmitReviewPayload(approved=True, findings=())],
+            ),
+            completeness=StubReviewerAgent(
+                review_kind="completeness",
+                review_payloads=[SubmitReviewPayload(approved=True, findings=())],
+            ),
+            correctness_by_tier={"_default": default_correctness},
+            completeness_by_tier={"_default": default_completeness},
+        )
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.select_next_bead",
+                new=AsyncMock(side_effect=[_bead("b-1"), _NO_MORE]),
+            ),
+            patch(
+                "maverick.library.actions.validation.run_independent_gate",
+                new=AsyncMock(return_value=_gate_passed()),
+            ),
+            patch(
+                "maverick.library.actions.jj.jj_commit_bead",
+                new=AsyncMock(return_value={"change_id": "c", "success": True}),
+            ),
+            patch(
+                "maverick.library.actions.beads.mark_bead_complete",
+                new=AsyncMock(
+                    return_value=MarkBeadCompleteResult(success=True, bead_id="b-1", error=None)
+                ),
+            ),
+        ):
+            app = build_fly_application(
+                squadron=squadron,  # type: ignore[arg-type]
+                event_queue=queue,
+                epic_id="e-1",
+                cwd=str(tmp_path),
+                max_beads=10,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=FLY_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        _, _, state = driver.result
+        # Escalation bumped the tier and the next tier approved.
+        assert state["reviewer_escalation_level"] == 1
+        assert state["approved"] is True
+        assert state["succeeded_count"] == 1
+        assert state["needs_human_review"] is False
+
+    async def test_transient_failure_exhausts_escalation_marks_human_review(
+        self, tmp_path: Path
+    ) -> None:
+        """Every tier raises transient → needs-human-review with error message."""
+        from airframe.errors import RuntimeTransientError
+
+        from maverick.workflows.fly_beads.graceful_stop import reset_graceful_stop
+
+        reset_graceful_stop()
+
+        # Both the per-tier dict and the bare fallback raise transients —
+        # because the action calls ``correctness_reviewer_for(tier)``
+        # for each level, we ensure every lookup hits a raising stub.
+        def _raising() -> StubReviewerAgent:
+            r = StubReviewerAgent(
+                review_kind="correctness",
+                review_payloads=[
+                    SubmitReviewPayload(approved=True, findings=()) for _ in range(2)
+                ],
+            )
+            r.raise_error = RuntimeTransientError("upstream fault")
+            return r
+
+        class _AlwaysRaising:
+            """Force every call to raise transient, regardless of how many tiers."""
+
+            def __init__(self, kind: str) -> None:
+                self.kind = kind
+                self.calls = 0
+
+            async def review(self, **_kwargs: Any) -> SubmitReviewPayload:
+                self.calls += 1
+                raise RuntimeTransientError(f"{self.kind} fault #{self.calls}")
+
+        correctness_always = _AlwaysRaising("correctness")
+        completeness_always = _AlwaysRaising("completeness")
+
+        squadron = StubFlySquadron()
+        # Override the tier-dispatch methods to always return the
+        # raising stubs.
+        squadron.correctness_reviewer_for = lambda _tier: correctness_always  # type: ignore[assignment]
+        squadron.completeness_reviewer_for = lambda _tier: completeness_always  # type: ignore[assignment]
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.select_next_bead",
+                new=AsyncMock(side_effect=[_bead("b-1"), _NO_MORE]),
+            ),
+            patch(
+                "maverick.library.actions.validation.run_independent_gate",
+                new=AsyncMock(return_value=_gate_passed()),
+            ),
+            patch(
+                "maverick.library.actions.jj.jj_commit_bead",
+                new=AsyncMock(return_value={"change_id": "c", "success": True}),
+            ),
+            patch(
+                "maverick.library.actions.beads.mark_bead_complete",
+                new=AsyncMock(
+                    return_value=MarkBeadCompleteResult(success=True, bead_id="b-1", error=None)
+                ),
+            ),
+        ):
+            app = build_fly_application(
+                squadron=squadron,  # type: ignore[arg-type]
+                event_queue=queue,
+                epic_id="e-1",
+                cwd=str(tmp_path),
+                max_beads=10,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=FLY_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        _, _, state = driver.result
+        # Climbed all 5 ladder rungs (level 0..4) and then exited.
+        assert state["reviewer_escalation_level"] == 4
+        assert state["needs_human_review"] is True
+        assert state["approved"] is False
+        # Each rung tried once → 5 correctness attempts; completeness
+        # may be cancelled mid-flight by the gather, so we only assert
+        # the lower bound for it.
+        assert correctness_always.calls == 5
+        # Finding text carries the exhaustion reason.
+        finding_text = " ".join(state["last_review_findings"])
+        assert "exhausted escalation" in finding_text
 
 
 class TestFlyBurrAggregateReview:


### PR DESCRIPTION
## Summary

- Restores the pre-migration ``_review_with_transient_escalation`` behaviour on top of the Burr fly review action. When the gather over correctness + completeness raises ``airframe.errors.RuntimeTransientError`` (5xx, rate limits, network blips, runtime hangs), the action now bumps to the next rung of the reviewer tier ladder (``_default → trivial → simple → moderate → complex``) and retries the same round on the higher-tier reviewer pair.
- The escalated tier persists across review rounds within a bead (so we don't drop back to a reviewer we just learned is unreliable) and resets when ``select_next_bead`` picks up a new bead. After all 5 rungs have been tried, the action sets ``needs_human_review=True`` and inlines the carried transient-error message into ``last_review_findings`` so the downstream ``create_human_bead`` row shows what failed.
- Non-transient failures (anything that isn't ``RuntimeTransientError``) keep the old behaviour: a single warning row + immediate ``needs_human_review`` for human triage.

## Closes
- #114 (Gap 6: reviewer transient-failure escalation)

## Changes
- ``src/maverick/workflows/fly_beads/actions.py`` — new ``_review_round_with_escalation`` helper + ``_REVIEWER_TIER_LADDER`` constant. The review action now reads/writes ``reviewer_escalation_level``; ``select_next_bead`` resets it on each new bead boundary.
- ``src/maverick/workflows/fly_beads/burr_graph.py`` — seeds ``reviewer_escalation_level=0`` in the initial state.
- ``src/maverick/workflows/fly_beads/actions.py`` (module docstring) — pulls reviewer transient-failure escalation off the "known gaps" list.
- ``tests/unit/workflows/fly_beads/test_burr_graph.py`` — adds ``correctness_by_tier`` / ``completeness_by_tier`` knobs to ``StubFlySquadron`` and two new tests under ``TestFlyBurrReviewerTransientEscalation``:
  - tier-0 raises transient → tier-1 approves → bead commits with ``reviewer_escalation_level=1``.
  - every tier raises → all 5 rungs walked → ``needs_human_review`` + exhaustion message in ``last_review_findings``.

## Test plan
- [x] ``make ci`` — 3362 passed
- [x] ``uv run pytest tests/unit/workflows/fly_beads/`` — 51 passed (49 prior + 2 new)
- [ ] Manual smoke against sample-maverick-project — deferred until later gaps land

🤖 Generated with [Claude Code](https://claude.com/claude-code)