### PR TITLE
feat(burr): escalate decomposer tier on transient refuel detail failures (#116)

### DIFF
--- a/src/maverick/workflows/refuel_maverick/actions.py
+++ b/src/maverick/workflows/refuel_maverick/actions.py
@@ -6,12 +6,15 @@ as of Phase 4 of the xoscar → Burr migration.
 Known gaps relative to the pre-migration supervisor (queued for
 follow-up):
 
-* Briefing + outline + bead-creation: full parity with the xoscar
-  supervisor.
-* Detail fan-out: single-tier dispatch only. Per-unit retry-on-timeout
-  budget (``MAX_DETAIL_RETRIES = 1``) preserved; **tier escalation is
-  not implemented** in this PR — if a unit fails after retries we
-  abandon it. Implementing tier escalation is queued as a follow-up.
+* Detail fan-out: per-unit retry budget is ``MAX_DETAIL_RETRIES = 1``
+  at the current tier. On ``airframe.errors.RuntimeTransientError``
+  the unit escalates one rung on the decomposer tier ladder and
+  retries; timeouts and persistent no-payload outcomes stay
+  abandoned at the current tier (matching the pre-migration
+  ``_try_one_tier`` policy). True per-tier runtime bindings — so
+  the escalated tier maps to a *different* model — are wired
+  through ``runtime_for_agent("decompose")`` today and will
+  benefit from later substrate work to support per-tier overrides.
 * Cache integration: ``initial_payload`` cache reads pass through
   (resume from a previously-cached run still works), but **the Burr
   driver does not write cache files**. Re-running a Burr-mode refuel
@@ -339,41 +342,71 @@ async def outline(
     return {"work_unit_count": unit_count}, state.update(outline=outline_dict)
 
 
+_REFUEL_TIER_LADDER: tuple[str, ...] = (
+    _DEFAULT_TIER,
+    "trivial",
+    "simple",
+    "moderate",
+    "complex",
+)
+
+
+def _refuel_tier_for_level(level: int) -> str:
+    """Pick the decomposer tier name for an escalation level."""
+    if level <= 0:
+        return _REFUEL_TIER_LADDER[0]
+    if level >= len(_REFUEL_TIER_LADDER):
+        return _REFUEL_TIER_LADDER[-1]
+    return _REFUEL_TIER_LADDER[level]
+
+
 async def _run_one_detail(
     *,
     unit_id: str,
     decomposer: DecomposerAgent,
     retries_remaining: int,
     events: asyncio.Queue[ProgressEvent | None],
-) -> dict[str, Any] | None:
+) -> tuple[dict[str, Any] | None, str]:
     """Run detail for a single unit with retry-on-timeout budget.
 
-    Returns the typed details dict on success, or ``None`` if the
-    unit was abandoned (no payload after retries).
+    Returns ``(detail_or_None, failure_kind)`` where ``failure_kind`` is
+    one of ``""`` (success), ``"timeout"``, ``"transient"``, or
+    ``"no_payload"``. ``transient`` lets the caller escalate to the
+    next tier; the others propagate up as abandon.
     """
+    from airframe.errors import RuntimeTransientError
+
     label = unit_id
     await events.put(AgentStarted(step_name="decompose", agent_name=label, provider=""))
     t0 = time.monotonic()
     attempts = retries_remaining + 1
     last_payload: dict[str, Any] | None = None
+    failure_kind = "no_payload"
+    last_error: str | None = None
     for attempt in range(attempts):
         try:
             payload = await decomposer.detail(unit_ids=(unit_id,))
         except TimeoutError:
             if attempt + 1 >= attempts:
+                failure_kind = "timeout"
+                last_error = "timed out"
                 break
             continue
+        except RuntimeTransientError as exc:
+            failure_kind = "transient"
+            last_error = str(exc)
+            break
         if not isinstance(payload, SubmitDetailsPayload):
             raise TypeError(
                 f"decomposer.detail returned {type(payload).__name__}, "
                 f"expected SubmitDetailsPayload"
             )
         payload_dict = dump_supervisor_payload(payload)
-        # Only accept the payload if it contains an entry for this unit.
         details = payload_dict.get("details", []) or []
         matching = [d for d in details if (d.get("id") or d.get("unit_id")) == unit_id]
         if matching:
             last_payload = matching[0]
+            failure_kind = ""
             break
         if attempt + 1 >= attempts:
             break
@@ -384,10 +417,56 @@ async def _run_one_detail(
             agent_name=label,
             duration_seconds=time.monotonic() - t0,
             success=last_payload is not None,
-            error=None if last_payload is not None else "no payload after retries",
+            error=last_error if last_payload is None else None,
         )
     )
-    return last_payload
+    return last_payload, failure_kind
+
+
+async def _run_detail_with_escalation(
+    *,
+    unit_id: str,
+    squadron: RefuelSquadron,
+    retries_remaining: int,
+    events: asyncio.Queue[ProgressEvent | None],
+) -> dict[str, Any] | None:
+    """Run one unit's detail pass with per-unit tier escalation.
+
+    On ``RuntimeTransientError``, bumps to the next tier on
+    :data:`_REFUEL_TIER_LADDER` and re-acquires a decomposer from the
+    pool for that tier. Returns the unit's detail payload on success
+    or ``None`` once the ladder is exhausted (or a non-transient
+    failure terminates the loop). Timeouts and persistent
+    no-payload outcomes are treated as final at the current tier —
+    they don't escalate.
+    """
+    level = 0
+    max_level = len(_REFUEL_TIER_LADDER) - 1
+    while True:
+        tier = _refuel_tier_for_level(level)
+        decomposer = await squadron.decomposer_pool.acquire(tier)
+        try:
+            detail, failure = await _run_one_detail(
+                unit_id=unit_id,
+                decomposer=decomposer,
+                retries_remaining=retries_remaining,
+                events=events,
+            )
+        finally:
+            await squadron.decomposer_pool.release(decomposer, tier)
+        if detail is not None:
+            return detail
+        if failure != "transient" or level >= max_level:
+            return None
+        next_tier = _refuel_tier_for_level(level + 1)
+        await _put_output(
+            events,
+            "decompose",
+            f"Unit {unit_id}: transient failure on tier '{tier}'; escalating to '{next_tier}'",
+            level="warning",
+            metadata={"unit_id": unit_id, "from_tier": tier, "to_tier": next_tier},
+        )
+        level += 1
 
 
 @action(
@@ -423,16 +502,12 @@ async def detail_fan_out(
 
     async def _one(unit_id: str) -> None:
         async with sem:
-            decomposer = await squadron.decomposer_pool.acquire(_DEFAULT_TIER)
-            try:
-                detail = await _run_one_detail(
-                    unit_id=unit_id,
-                    decomposer=decomposer,
-                    retries_remaining=MAX_DETAIL_RETRIES,
-                    events=events,
-                )
-            finally:
-                await squadron.decomposer_pool.release(decomposer, _DEFAULT_TIER)
+            detail = await _run_detail_with_escalation(
+                unit_id=unit_id,
+                squadron=squadron,
+                retries_remaining=MAX_DETAIL_RETRIES,
+                events=events,
+            )
         async with lock:
             if detail is None:
                 abandoned.append(unit_id)

--- a/tests/unit/workflows/refuel_maverick/test_burr_graph.py
+++ b/tests/unit/workflows/refuel_maverick/test_burr_graph.py
@@ -370,6 +370,152 @@ class TestRefuelBurrGraphHappyPath:
         assert squadron.built_briefings == []
 
 
+class TestRefuelBurrDetailEscalation:
+    async def test_transient_on_default_tier_escalates_and_succeeds(self, tmp_path: Path) -> None:
+        """Detail call raises transient → next tier acquired → unit succeeds."""
+        from airframe.errors import RuntimeTransientError
+
+        outline = _make_outline(unit_ids=("u-1",))
+        # The first ``detail()`` call raises transient; the retry on
+        # the escalated tier succeeds. ``outline()`` must still work.
+        squadron = StubRefuelSquadron(
+            outline_payload=outline,
+            detail_payloads=[_make_details(("u-1",))],
+        )
+        original_detail = squadron._decomposer.detail
+        detail_calls = {"n": 0}
+
+        async def _first_detail_raises(**kwargs: Any) -> SubmitDetailsPayload:
+            detail_calls["n"] += 1
+            if detail_calls["n"] == 1:
+                raise RuntimeTransientError("rate limited")
+            return await original_detail(**kwargs)
+
+        squadron._decomposer.detail = _first_detail_raises  # type: ignore[assignment]
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.create_beads",
+                new=AsyncMock(return_value=_make_bead_result()),
+            ),
+            patch(
+                "maverick.library.actions.beads.wire_dependencies",
+                new=AsyncMock(return_value=_make_wire_result()),
+            ),
+        ):
+            app = build_refuel_application(
+                squadron=squadron,
+                event_queue=queue,
+                raw_content="x",
+                briefing_prompt="x",
+                codebase_context=_empty_codebase_context(),
+                open_bead_context=None,
+                runway_context_text=None,
+                plan_name="p",
+                plan_objective="o",
+                cwd=str(tmp_path),
+                skip_briefing=True,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=REFUEL_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        _, _, state = driver.result
+        # Detail eventually landed and the unit was not abandoned.
+        assert state["abandoned_unit_ids"] == []
+        assert any(d.get("id") == "u-1" for d in state["accumulated_details"])
+        # The pool was acquired for the outline + the failed default
+        # tier + the escalated trivial tier. Release count matches.
+        acquired = squadron.decomposer_pool.acquire_calls
+        assert acquired == ["default", "default", "trivial"]
+        assert squadron.decomposer_pool.release_calls == acquired
+        # The escalation actually re-ran ``detail``.
+        assert detail_calls["n"] == 2
+
+    async def test_transient_exhausts_ladder_abandons_unit(self, tmp_path: Path) -> None:
+        """Every tier raises transient → unit is abandoned, no detail recorded."""
+        from airframe.errors import RuntimeTransientError
+
+        outline = _make_outline(unit_ids=("u-1",))
+
+        class _AlwaysRaisingDecomposer:
+            def __init__(self) -> None:
+                self.detail_calls = 0
+
+            async def outline(self, **_kw: Any) -> SubmitOutlinePayload:
+                return outline
+
+            async def detail(self, **_kw: Any) -> SubmitDetailsPayload:
+                self.detail_calls += 1
+                raise RuntimeTransientError(f"upstream fault #{self.detail_calls}")
+
+            async def fix(self, **_kw: Any) -> Any:
+                raise AssertionError("fix should not be called when all details fail")
+
+        always_raising = _AlwaysRaisingDecomposer()
+        squadron = StubRefuelSquadron(outline_payload=outline)
+        # Outline still uses the stub agent; only swap the agent the
+        # pool hands out *after* the outline action has run. Easiest:
+        # leave outline alone and route subsequent acquires to the
+        # raising stub.
+        original_acquire = squadron.decomposer_pool.acquire
+
+        async def _acquire_route(tier: str) -> Any:
+            await original_acquire(tier)  # records the call
+            if (
+                always_raising.detail_calls == 0
+                and tier == "default"
+                and (outline_acquired["n"] == 0)
+            ):
+                outline_acquired["n"] = 1
+                return squadron._decomposer  # outline uses original
+            return always_raising
+
+        outline_acquired = {"n": 0}
+        squadron.decomposer_pool.acquire = _acquire_route  # type: ignore[assignment]
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.create_beads",
+                new=AsyncMock(return_value=_make_bead_result()),
+            ),
+            patch(
+                "maverick.library.actions.beads.wire_dependencies",
+                new=AsyncMock(return_value=_make_wire_result()),
+            ),
+        ):
+            app = build_refuel_application(
+                squadron=squadron,
+                event_queue=queue,
+                raw_content="x",
+                briefing_prompt="x",
+                codebase_context=_empty_codebase_context(),
+                open_bead_context=None,
+                runway_context_text=None,
+                plan_name="p",
+                plan_objective="o",
+                cwd=str(tmp_path),
+                skip_briefing=True,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=REFUEL_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        _, _, state = driver.result
+        # All 5 rungs of the ladder tried (transients escalate
+        # immediately, so each tier sees exactly one call).
+        assert always_raising.detail_calls == 5
+        assert "u-1" in state["abandoned_unit_ids"]
+        assert all(d.get("id") != "u-1" for d in state["accumulated_details"])
+        # Outline acquired once on "default" + each of the 5 detail
+        # tiers acquired once = 6 total.
+        assert len(squadron.decomposer_pool.acquire_calls) == 6
+        assert len(squadron.decomposer_pool.release_calls) == 6
+        # The detail-side calls cycled through the full tier ladder.
+        detail_tiers = squadron.decomposer_pool.acquire_calls[1:]
+        assert detail_tiers == ["default", "trivial", "simple", "moderate", "complex"]
+
+
 class TestRefuelBurrGraphValidationLoop:
     async def test_fix_loop_runs_when_validation_fails_then_passes(self, tmp_path: Path) -> None:
         """First validate produces gaps → request_fix → validate (passes)."""


### PR DESCRIPTION
## Summary

- Restores per-unit tier escalation on the Burr ``refuel`` detail fan-out. The new ``_run_detail_with_escalation`` helper walks the shared decomposer tier ladder (``default → trivial → simple → moderate → complex``); on ``airframe.errors.RuntimeTransientError`` the unit releases the failing tier's decomposer, re-acquires from the next rung, and retries.
- Timeouts and persistent no-payload outcomes still abandon at the current tier — that matches the pre-migration ``_try_one_tier`` policy, which only escalated transients and treated timeouts/no-tool-call as final.
- The escalated tier name is what reaches ``DecomposerAgentPool.acquire``; turning that into a *different* model is a separate substrate task (``runtime_for_agent("decompose")`` resolves a single binding today). The actions-layer side of the gap is closed regardless.

## Closes
- #116 (Gap 8: refuel detail tier escalation)

## Changes
- ``src/maverick/workflows/refuel_maverick/actions.py`` — extracts ``_REFUEL_TIER_LADDER`` + ``_refuel_tier_for_level``. ``_run_one_detail`` now returns ``(detail, failure_kind)`` so the wrapper can branch on transient vs. non-transient failures; ``detail_fan_out`` delegates the per-unit work to ``_run_detail_with_escalation``.
- ``src/maverick/workflows/refuel_maverick/actions.py`` (module docstring) — pulls "tier escalation is not implemented" off the known-gaps list and replaces it with a note about the runtime-binding follow-up needed for escalation to map to different models.
- ``tests/unit/workflows/refuel_maverick/test_burr_graph.py`` — two new tests under ``TestRefuelBurrDetailEscalation``:
  - one unit's first detail raises transient → escalated tier acquired (verified via ``pool.acquire_calls``) → unit lands the payload.
  - every tier raises transient → all 5 rungs walked → unit lands in ``abandoned_unit_ids``.

## Test plan
- [x] ``make ci`` — 3366 passed
- [x] ``uv run pytest tests/unit/workflows/refuel_maverick/`` — 52 passed (50 prior + 2 new)
- [ ] Manual smoke against sample-maverick-project — deferred until Gap 9 (cache write-back) also lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)