### PR TITLE
feat(burr): write refuel artifacts back to the per-plan cache dir (#117)

### DIFF
--- a/src/maverick/workflows/refuel_maverick/actions.py
+++ b/src/maverick/workflows/refuel_maverick/actions.py
@@ -15,10 +15,14 @@ follow-up):
   the escalated tier maps to a *different* model — are wired
   through ``runtime_for_agent("decompose")`` today and will
   benefit from later substrate work to support per-tier overrides.
-* Cache integration: ``initial_payload`` cache reads pass through
-  (resume from a previously-cached run still works), but **the Burr
-  driver does not write cache files**. Re-running a Burr-mode refuel
-  starts from scratch; rerun on xoscar to re-populate caches.
+* Cache write-back: the workflow now passes a per-plan
+  ``cache_dir = <cwd>/.maverick/plans/<plan>/refuel-cache/``; the
+  ``synthesize_briefing``, ``outline``, and ``detail_fan_out``
+  actions persist their results there (``briefings.json``,
+  ``outline.json``, ``details/<unit_id>.json``). The read side —
+  loading these on a subsequent run to short-circuit re-generation
+  — is a separate follow-up; today the cache is write-only and
+  exists for manual inspection / future resume.
 * Quota error special-handling: treated like any other failure for now.
 * Fix-round merge: merges both ``details`` and ``work_units`` from
   the fix payload (handles the case where the fixer splits an
@@ -33,6 +37,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from burr.core import State, action
@@ -164,6 +169,36 @@ async def _put_output(
     )
 
 
+async def _write_cache_json(
+    path: Path,
+    payload: Any,
+    *,
+    events: asyncio.Queue[ProgressEvent | None] | None,
+    label: str,
+) -> None:
+    """Write ``payload`` to ``path`` as pretty-printed JSON.
+
+    Best-effort: any ``OSError`` (or other filesystem hiccup) is
+    logged as a warning via ``events`` and swallowed so the refuel
+    run still completes. Creates parent directories on demand.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(payload, indent=2, default=str, sort_keys=True),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        if events is not None:
+            await _put_output(
+                events,
+                "decompose",
+                f"Refuel cache write failed ({label}): {exc}",
+                level="warning",
+                metadata={"path": str(path), "label": label},
+            )
+
+
 # ---------------------------------------------------------------------------
 # Actions
 # ---------------------------------------------------------------------------
@@ -272,8 +307,19 @@ async def contrarian_briefing(
 
 
 @action(reads=["briefs"], writes=["briefing_markdown"])
-async def synthesize_briefing(state: State) -> tuple[dict[str, Any], State]:
-    """Render the four briefs into a single markdown block."""
+async def synthesize_briefing(
+    state: State,
+    *,
+    cache_dir: str = "",
+    events: asyncio.Queue[ProgressEvent | None] | None = None,
+) -> tuple[dict[str, Any], State]:
+    """Render the four briefs into a single markdown block.
+
+    When ``cache_dir`` is set, persists the raw brief payloads to
+    ``<cache_dir>/briefings.json`` so a subsequent run (manual or
+    automated resume) can rebuild from the same evidence without
+    spending agent budget. Cache failures are non-fatal.
+    """
     from maverick.preflight_briefing.serializer import serialize_briefs_to_markdown
 
     briefs = state["briefs"]
@@ -284,6 +330,13 @@ async def synthesize_briefing(state: State) -> tuple[dict[str, Any], State]:
         criteria=briefs.get("recon"),
         challenge=briefs.get("contrarian"),
     )
+    if cache_dir and briefs:
+        await _write_cache_json(
+            Path(cache_dir) / "briefings.json",
+            {"payloads": briefs},
+            events=events,
+            label="briefings",
+        )
     return {"briefing_markdown_length": len(md)}, state.update(briefing_markdown=md)
 
 
@@ -304,8 +357,14 @@ async def outline(
     *,
     squadron: RefuelSquadron,
     events: asyncio.Queue[ProgressEvent | None],
+    cache_dir: str = "",
 ) -> tuple[dict[str, Any], State]:
-    """Acquire a decomposer from the pool and run the outline pass."""
+    """Acquire a decomposer from the pool and run the outline pass.
+
+    When ``cache_dir`` is set, persists the outline payload to
+    ``<cache_dir>/outline.json`` after the agent returns. Cache
+    failures are non-fatal.
+    """
     await _put_output(events, "decompose", "Requesting outline")
     decomposer: DecomposerAgent = await squadron.decomposer_pool.acquire(_DEFAULT_TIER)
     await events.put(AgentStarted(step_name="decompose", agent_name="outline", provider=""))
@@ -339,6 +398,13 @@ async def outline(
         f"Outline produced {unit_count} work units",
         metadata={"work_unit_count": unit_count},
     )
+    if cache_dir:
+        await _write_cache_json(
+            Path(cache_dir) / "outline.json",
+            {"payload": outline_dict},
+            events=events,
+            label="outline",
+        )
     return {"work_unit_count": unit_count}, state.update(outline=outline_dict)
 
 
@@ -479,12 +545,16 @@ async def detail_fan_out(
     squadron: RefuelSquadron,
     events: asyncio.Queue[ProgressEvent | None],
     pool_size: int,
+    cache_dir: str = "",
 ) -> tuple[dict[str, Any], State]:
     """Fan out per-unit detail requests across the decomposer pool.
 
-    Phase 2 simplifications (see module docstring): single-tier
-    dispatch, no escalation, no cache write. Per-unit retry budget
-    matches the legacy ``MAX_DETAIL_RETRIES``.
+    Per-unit retry budget is ``MAX_DETAIL_RETRIES`` at the current
+    tier; transient failures escalate via
+    :func:`_run_detail_with_escalation`. When ``cache_dir`` is set,
+    each successful unit detail is persisted to
+    ``<cache_dir>/details/<unit_id>.json`` immediately so a
+    partially-successful fan-out is recoverable.
     """
     outline_dict = state["outline"]
     if outline_dict is None:
@@ -499,6 +569,7 @@ async def detail_fan_out(
     accumulated: list[dict[str, Any]] = []
     abandoned: list[str] = []
     lock = asyncio.Lock()
+    details_dir = Path(cache_dir) / "details" if cache_dir else None
 
     async def _one(unit_id: str) -> None:
         async with sem:
@@ -513,6 +584,13 @@ async def detail_fan_out(
                 abandoned.append(unit_id)
             else:
                 accumulated.append(detail)
+        if detail is not None and details_dir is not None:
+            await _write_cache_json(
+                details_dir / f"{unit_id}.json",
+                detail,
+                events=events,
+                label=f"detail/{unit_id}",
+            )
 
     await asyncio.gather(*(_one(u) for u in unit_ids))
 

--- a/src/maverick/workflows/refuel_maverick/burr_graph.py
+++ b/src/maverick/workflows/refuel_maverick/burr_graph.py
@@ -81,6 +81,7 @@ def build_refuel_application(
     decomposer_pool_size: int = 3,
     success_criteria_count: int = 0,
     expected_sc_refs: tuple[str, ...] = (),
+    cache_dir: str = "",
 ) -> Any:
     """Build the ``Application`` for one refuel run.
 
@@ -106,15 +107,20 @@ def build_refuel_application(
                 squadron=squadron,
                 events=event_queue,
             ),
-            synthesize_briefing=refuel_actions.synthesize_briefing,
+            synthesize_briefing=refuel_actions.synthesize_briefing.bind(
+                cache_dir=cache_dir,
+                events=event_queue,
+            ),
             outline=refuel_actions.outline.bind(
                 squadron=squadron,
                 events=event_queue,
+                cache_dir=cache_dir,
             ),
             detail_fan_out=refuel_actions.detail_fan_out.bind(
                 squadron=squadron,
                 events=event_queue,
                 pool_size=decomposer_pool_size,
+                cache_dir=cache_dir,
             ),
             validate=refuel_actions.validate.bind(
                 events=event_queue,

--- a/src/maverick/workflows/refuel_maverick/workflow.py
+++ b/src/maverick/workflows/refuel_maverick/workflow.py
@@ -881,6 +881,16 @@ class RefuelMaverickWorkflow(PythonWorkflow):
             decomposer_pool_cap=self._config.parallel.decomposer_pool_size,
         ) as squadron:
             event_queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+            # Per-plan refuel cache under
+            # ``<cwd>/.maverick/plans/<plan>/refuel-cache/`` so a
+            # later resume can read the raw artifacts. The actions
+            # treat ``cache_dir`` as advisory — empty disables writes
+            # and any OSError is swallowed with a warning.
+            cache_dir = (
+                str(ws_cwd / ".maverick" / "plans" / plan_name / "refuel-cache")
+                if plan_name
+                else ""
+            )
             app = build_refuel_application(
                 squadron=squadron,
                 event_queue=event_queue,
@@ -898,6 +908,7 @@ class RefuelMaverickWorkflow(PythonWorkflow):
                 decomposer_pool_size=self._config.parallel.decomposer_pool_size,
                 success_criteria_count=sc_count,
                 expected_sc_refs=sc_refs,
+                cache_dir=cache_dir,
             )
             driver = BurrWorkflowDriver(
                 app,

--- a/tests/unit/workflows/refuel_maverick/test_burr_graph.py
+++ b/tests/unit/workflows/refuel_maverick/test_burr_graph.py
@@ -516,6 +516,147 @@ class TestRefuelBurrDetailEscalation:
         assert detail_tiers == ["default", "trivial", "simple", "moderate", "complex"]
 
 
+class TestRefuelBurrCacheWriteBack:
+    async def test_outline_and_details_written_to_cache_dir(self, tmp_path: Path) -> None:
+        """Outline + per-unit details land at the expected cache paths."""
+        outline = _make_outline(unit_ids=("u-1", "u-2"))
+        squadron = StubRefuelSquadron(outline_payload=outline)
+        cache_dir = tmp_path / "refuel-cache"
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.create_beads",
+                new=AsyncMock(return_value=_make_bead_result()),
+            ),
+            patch(
+                "maverick.library.actions.beads.wire_dependencies",
+                new=AsyncMock(return_value=_make_wire_result()),
+            ),
+        ):
+            app = build_refuel_application(
+                squadron=squadron,
+                event_queue=queue,
+                raw_content="x",
+                briefing_prompt="x",
+                codebase_context=_empty_codebase_context(),
+                open_bead_context=None,
+                runway_context_text=None,
+                plan_name="my-plan",
+                plan_objective="o",
+                cwd=str(tmp_path),
+                skip_briefing=True,
+                cache_dir=str(cache_dir),
+            )
+            driver = BurrWorkflowDriver(app, halt_after=REFUEL_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        import json as _json
+
+        outline_path = cache_dir / "outline.json"
+        u1_path = cache_dir / "details" / "u-1.json"
+        u2_path = cache_dir / "details" / "u-2.json"
+        assert outline_path.exists()
+        assert u1_path.exists()
+        assert u2_path.exists()
+
+        outline_doc = _json.loads(outline_path.read_text())
+        assert "payload" in outline_doc
+        unit_ids = {u["id"] for u in outline_doc["payload"].get("work_units") or ()}
+        assert unit_ids == {"u-1", "u-2"}
+
+        u1_doc = _json.loads(u1_path.read_text())
+        assert u1_doc.get("id") == "u-1"
+
+    async def test_briefings_written_to_cache_dir(self, tmp_path: Path) -> None:
+        """``briefings.json`` lands alongside the outline/details files."""
+        squadron = StubRefuelSquadron()
+        cache_dir = tmp_path / "refuel-cache"
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.workflows.refuel_maverick.actions.SUPERVISOR_TOOL_PAYLOAD_MODELS",
+                {
+                    "submit_navigator_brief": SubmitNavigatorBriefPayload,
+                    "submit_structuralist_brief": SubmitStructuralistBriefPayload,
+                    "submit_recon_brief": SubmitReconBriefPayload,
+                    "submit_contrarian_brief": SubmitContrarianBriefPayload,
+                },
+            ),
+            patch(
+                "maverick.library.actions.beads.create_beads",
+                new=AsyncMock(return_value=_make_bead_result()),
+            ),
+            patch(
+                "maverick.library.actions.beads.wire_dependencies",
+                new=AsyncMock(return_value=_make_wire_result()),
+            ),
+        ):
+            app = build_refuel_application(
+                squadron=squadron,
+                event_queue=queue,
+                raw_content="x",
+                briefing_prompt="x",
+                codebase_context=_empty_codebase_context(),
+                open_bead_context=None,
+                runway_context_text=None,
+                plan_name="my-plan",
+                plan_objective="o",
+                cwd=str(tmp_path),
+                skip_briefing=False,
+                cache_dir=str(cache_dir),
+            )
+            driver = BurrWorkflowDriver(app, halt_after=REFUEL_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        import json as _json
+
+        briefings_path = cache_dir / "briefings.json"
+        assert briefings_path.exists()
+        doc = _json.loads(briefings_path.read_text())
+        assert set(doc.get("payloads", {}).keys()) == {
+            "navigator",
+            "structuralist",
+            "recon",
+            "contrarian",
+        }
+
+    async def test_empty_cache_dir_is_a_noop(self, tmp_path: Path) -> None:
+        """Default ``cache_dir=''`` writes nothing — preserves prior behaviour."""
+        squadron = StubRefuelSquadron()
+        cache_dir = tmp_path / "refuel-cache"
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.create_beads",
+                new=AsyncMock(return_value=_make_bead_result()),
+            ),
+            patch(
+                "maverick.library.actions.beads.wire_dependencies",
+                new=AsyncMock(return_value=_make_wire_result()),
+            ),
+        ):
+            app = build_refuel_application(
+                squadron=squadron,
+                event_queue=queue,
+                raw_content="x",
+                briefing_prompt="x",
+                codebase_context=_empty_codebase_context(),
+                open_bead_context=None,
+                runway_context_text=None,
+                plan_name="p",
+                plan_objective="o",
+                cwd=str(tmp_path),
+                skip_briefing=True,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=REFUEL_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        assert not cache_dir.exists()
+
+
 class TestRefuelBurrGraphValidationLoop:
     async def test_fix_loop_runs_when_validation_fails_then_passes(self, tmp_path: Path) -> None:
         """First validate produces gaps → request_fix → validate (passes)."""


### PR DESCRIPTION
## Summary

- Restores the write-back side of the refuel cache lost during the xoscar → Burr migration. The workflow now passes a per-plan ``cache_dir = <cwd>/.maverick/plans/<plan>/refuel-cache/`` through to the Burr graph, and three actions write their results into it as soon as they land:
  - ``synthesize_briefing`` → ``briefings.json`` (dict of brief name → payload)
  - ``outline`` → ``outline.json``
  - ``detail_fan_out`` → ``details/<unit_id>.json`` per successful unit
- A partially-successful detail fan-out is therefore recoverable: each unit's payload is on disk before the run finishes. Cache failures are non-fatal (best-effort writes with a structured warning on ``OSError``).
- The read side — loading these on a subsequent run to short-circuit re-generation — is intentionally out of scope and documented as the follow-up. Today the cache is write-only and exists for manual inspection / future resume.

## Closes
- #117 (Gap 9: refuel cache write-back)

## Changes
- ``src/maverick/workflows/refuel_maverick/actions.py`` — new ``_write_cache_json`` helper; ``synthesize_briefing``, ``outline``, and ``detail_fan_out`` accept a ``cache_dir`` kwarg (default ``""`` disables writes).
- ``src/maverick/workflows/refuel_maverick/burr_graph.py`` — ``build_refuel_application`` accepts ``cache_dir`` and binds it onto the three writing actions.
- ``src/maverick/workflows/refuel_maverick/workflow.py`` — computes the per-plan cache directory and passes it through.
- ``src/maverick/workflows/refuel_maverick/actions.py`` (module docstring) — pulls the "no cache write" bullet off the known-gaps list.
- ``tests/unit/workflows/refuel_maverick/test_burr_graph.py`` — three new tests under ``TestRefuelBurrCacheWriteBack`` covering outline + per-unit detail writes, briefings write, and the default-empty no-op path.

## Test plan
- [x] ``make ci`` — 3369 passed
- [x] ``uv run pytest tests/unit/workflows/refuel_maverick/`` — 55 passed (52 prior + 3 new)
- [ ] Manual smoke against sample-maverick-project — once this lands, a refuel run will start writing ``refuel-cache/`` next to existing plan artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)