### PR TITLE
docs(readme): drop internal 'Pattern D' jargon

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,10 +335,11 @@ Apache Burr Application (one per workflow run)
       parallel_briefings + contrarian_briefing → synthesize_briefing
         → generate → done
   │
-airframe Pattern D runtime (one AgentRuntime per role)
+airframe runtime (one AgentRuntime per role)
   ClaudeCodeRuntime, CopilotRuntime, OpenCodeRuntime,
   OpenCodeGoRuntime, OpenCodeZenRuntime, OpenRouterRuntime,
-  BedrockRuntime — each fronts its vendor SDK directly.
+  BedrockRuntime — each fronts its vendor SDK directly behind a
+  uniform Runtime protocol (execute / reset / validate_binding).
 ```
 
 ### How Agents Communicate
@@ -360,7 +361,7 @@ doing work; the `StructuredOutput` tool is for reporting results.
 |----------|-----------|
 | Language | Python 3.11+ |
 | Package Manager | uv |
-| Agent Runtime | [airframe](https://github.com/get2knowio/airframe) Pattern D — one `AgentRuntime` per role |
+| Agent Runtime | [airframe](https://github.com/get2knowio/airframe) — one `AgentRuntime` per role, vendor SDKs behind a uniform protocol |
 | Workflow Engine | [Apache Burr](https://github.com/apache/burr) — state machines of `@action`-decorated async functions |
 | Structured Output | Pydantic + `format=json_schema` (via airframe `StructuredOutput`) |
 | CLI | Click + Rich |


### PR DESCRIPTION
## Summary

The README mentioned "airframe Pattern D" twice without context. That label comes from ``docs/migration-recommendation.md``, which compared several substrate options (Patterns A–E) — useful as a historical decision record, meaningless to a first-time reader hitting the README.

Two small edits:

1. **Architecture diagram bottom block** — "airframe Pattern D runtime" → "airframe runtime", plus a trailing line that names the actual Runtime protocol surface (``execute`` / ``reset`` / ``validate_binding``) so the reader sees what "uniform protocol" actually means.
2. **Technology Stack row** — replaced the parenthetical "Pattern D" with a one-line explanation: "vendor SDKs behind a uniform protocol".

The migration memo still uses the Pattern D label as a historical decision artefact; that's the right place for it.

## Test plan
- [x] ``grep -in 'pattern d' README.md`` — 0 hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)