### PR TITLE
chore: enforce 7-day supply-chain cooldown on dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
       time: "06:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 10
+    # Supply-chain cooldown: hold newly published versions for 7 days so a
+    # compromised release can be detected/yanked before it's proposed. The
+    # first-party airframe-agents package is exempt.
+    cooldown:
+      default-days: 7
+      exclude:
+        - "airframe-agents"
     labels:
       - "dependencies"
       - "python"
@@ -42,6 +49,8 @@ updates:
       time: "06:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "github-actions"
@@ -60,6 +69,8 @@ updates:
       time: "06:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "devcontainer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,3 +191,12 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "@abstractmethod",
 ]
+
+[tool.uv]
+# Supply-chain cooldown: ignore distributions uploaded in the last 7 days so a
+# malicious release has time to be detected/yanked before it can be resolved.
+# Relative (rolling) window; relies on PyPI's PEP 700 upload-time metadata.
+exclude-newer = "7 days"
+# First-party package is exempt (false = no cooldown) so our own releases are
+# installable immediately.
+exclude-newer-package = { airframe-agents = false }


### PR DESCRIPTION
## Supply-chain cooldown (7-day minimum release age)

Part of an org-wide rollout hardening get2knowio repos against supply-chain attacks. A newly published dependency version must age **7 days** before it can be installed/resolved or proposed by Dependabot — giving time for a malicious release to be detected and yanked. Security updates are never delayed (Dependabot cooldown applies to *version* updates only).

Config schema verified against current official docs (not training data).

### Changes
- **uv (`pyproject.toml`)** — `exclude-newer = "7 days"` plus `exclude-newer-package = { airframe-agents = false }` so the first-party **airframe-agents** package is exempt.
- **Dependabot** — `cooldown: { default-days: 7 }` on `uv` (with `exclude: [airframe-agents]`), `github-actions`, and `devcontainers`.
