### PR TITLE
feat(refuel): deterministic Spec Kit ingestion mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,12 +522,30 @@ Beads-only workflow model. All development is driven by beads (`bd` CLI).
 | ---------------------------------------------------- | ------------------------------------ |
 | `maverick plan generate <name> --from-prd <file>`    | Flight plan from PRD                 |
 | `maverick refuel <plan-name>`                        | Decompose plan into beads            |
+| `maverick refuel <feature> --speckit [--dry-run\|--enrich]` | Deterministic Spec Kit ingestion |
 | `maverick fly --epic <id>`                           | Implement beads (actor-mailbox)      |
 | `maverick land [--eject\|--finalize]`                | Curate history and merge             |
 | `maverick workspace status\|clean`                   | Manage hidden workspace              |
 | `maverick init`                                      | Initialize a Maverick project        |
 | `maverick brief [--watch]`                           | Bead status                          |
 | `maverick runway seed\|consolidate`                  | Manage knowledge store               |
+
+### refuel (Spec Kit ingestion mode)
+
+For Spec Kit-managed repositories (`specs/NNN-name/{spec.md,tasks.md}`),
+`maverick refuel` can deterministically ingest a feature's task list
+into beads instead of AI-decomposing a flight plan — zero model calls,
+one epic + one task bead per open task, with IDs/phases/`[P]`
+markers/file scope preserved and dependencies wired as a phase barrier.
+Mode is auto-detected from repository shape or forced with `--speckit`;
+`NAME` resolves via exact directory name, `NNN` prefix, or exact name
+suffix. `--dry-run` previews the full plan with zero writes; `--enrich`
+opts into one batched model call that attaches verification commands to
+new task beads (the only step that may touch a model on this path). Delta
+re-runs (e.g. after `tasks.md` grows) append only new tasks under the
+existing epic — no duplicate epics. See
+`src/maverick/speckit/` (parsing/detection/plan-building) and
+`src/maverick/workflows/refuel_speckit/` (the workflow).
 
 ### fly
 

--- a/specs/048-speckit-refuel-ingestion/checklists/requirements.md
+++ b/specs/048-speckit-refuel-ingestion/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Spec Kit Ingestion Mode for Refuel
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Domain terms that necessarily appear (task identifiers like T001, `[P]` markers,
+  `specs/NNN-name/` layout, command names like `maverick refuel`) are the feature's
+  subject matter — the user-facing contract being ingested — not implementation
+  leakage.
+- "Behaves like existing refuel dry-run" from the user description could not be
+  taken literally (refuel has no dry-run today); the interpretation is documented
+  in Assumptions rather than raised as a clarification, since Maverick has an
+  established dry-run convention to follow.
+- Re-run behavior (FR-014) was resolved in clarification (Session 2026-07-23):
+  delta ingestion under the existing open epic, no duplicate epics.

--- a/specs/048-speckit-refuel-ingestion/contracts/bead-encoding.md
+++ b/specs/048-speckit-refuel-ingestion/contracts/bead-encoding.md
@@ -1,0 +1,70 @@
+# Contract: Bead encoding of Spec Kit artifacts
+
+**Feature**: 048-speckit-refuel-ingestion
+
+How ingestion encodes Spec Kit content into beads. This is a public interface: `fly` consumes it (prompts read `title` + `description`; AC-check parses `## Verification` from `description`), and delta re-runs depend on the state keys.
+
+## Epic bead
+
+| Facet | Value |
+| --- | --- |
+| type / priority | `epic` / 1 |
+| title | Feature title from spec.md (fallback: feature dir name) |
+| labels (at creation) | `speckit` |
+| description | Markdown: feature summary line, `## Success Criteria` (SC bullets from spec.md), `## Source` (repo-relative feature dir path) |
+| state (post-creation) | `speckit_feature=<dir basename>` (delta-run lookup key); `flight_plan_name=<dir basename>` only if implementation verification shows `select_next_bead` requires it (D12) |
+| chaining | blocked-by tail of existing open-epic chain, exactly as classic refuel (`workflow.py:625-654` pattern) — first run only |
+
+## Task bead
+
+| Facet | Value |
+| --- | --- |
+| type / priority | `task` / 2 |
+| parent | the feature's epic (`parent_id` at creation) |
+| title | `"<task_id>: <description>"`, truncated to 490 chars |
+| labels (at creation) | `speckit` |
+| state (post-creation) | `speckit_task_id=T###` (delta identity — REQUIRED), `speckit_phase=<n>`, `speckit_parallel=true\|false` |
+
+### Task bead `description` (work-unit markdown consumed by fly)
+
+```markdown
+## Task
+<full task text from tasks.md> (Phase <n>: <phase title>[, Story USn][, parallel-eligible])
+
+## Acceptance Criteria
+- <task text restated as the completion claim>
+- <story USn acceptance scenarios, verbatim, if task is story-labeled>   # clarification Q3
+
+## File Scope
+- <extracted file path>  (section omitted when no paths parsed)
+
+## Verification
+- <deterministic file-scope checks (rg-based existence checks)>
+- <commands found verbatim in task text, if any>
+- <enrichment-supplied commands, when --enrich succeeded>
+```
+
+Constraints:
+- `## Verification` is never empty (fly's AC-check gate executes only `rg/grep/cargo/make` commands from it — D8).
+- No content is exclusive to bead state: everything an implementer needs is in `description` (fly reads nothing else — D2).
+- Description is NOT truncated (unlike classic refuel's 500-char cap).
+
+## Dependency edges
+
+`BeadDependency(blocker_id, blocked_id, dep_type=BLOCKS)` via `BeadClient.add_dependency`, from `IngestionPlan.edges`:
+
+1. intra-phase serial chain between consecutive non-`[P]` tasks;
+2. explicit `depends on T###` notes;
+3. phase barrier: sinks(phase n) × sources(phase n+1);
+4. story-dependency section pairs (where not already implied).
+
+Delta runs: blocker IDs of previously ingested tasks resolve via `existing_task_map` (state lookup); edges from *completed* tasks are dropped (already satisfied). Graph validated acyclic before any write.
+
+## Delta identity rules
+
+- Epic lookup: open epic (`query("type=epic AND status=open")`) whose state `speckit_feature` equals the resolved feature dir basename. Zero → fresh run. One → delta run. Multiple → error (corrupt state; message lists epic IDs).
+- Task identity: child bead state `speckit_task_id` == tasks.md task ID. Title text is display-only and carries no identity.
+
+## Run metadata
+
+`RunMetadata(run_id, plan_name=<feature dir basename>, epic_id, started_at, completed_at, status)` written to `<cwd>/.maverick/runs/<run_id>/metadata.json` on real runs only — statuses `refueling` → `refueled`/`failed`, matching classic refuel so `find_latest_run`-based hints and `brief` work unchanged (FR-016).

--- a/specs/048-speckit-refuel-ingestion/contracts/cli-refuel-speckit.md
+++ b/specs/048-speckit-refuel-ingestion/contracts/cli-refuel-speckit.md
@@ -1,0 +1,72 @@
+# Contract: `maverick refuel` Spec Kit mode CLI surface
+
+**Feature**: 048-speckit-refuel-ingestion
+
+## Command
+
+```
+maverick refuel <NAME> [--speckit] [--dry-run] [--enrich] [existing flags]
+```
+
+`NAME` resolution (FR-001, D11):
+
+| Input form | Resolves to |
+| --- | --- |
+| `048-speckit-refuel-ingestion` | `specs/048-speckit-refuel-ingestion/` (exact dir name) |
+| `048` | the unique dir with that `NNN` prefix |
+| `speckit-refuel-ingestion` | the unique dir with that exact name suffix |
+| classic plan name | `.maverick/plans/<name>/flight-plan.md` (existing behavior) |
+
+## New flags
+
+| Flag | Default | Behavior |
+| --- | --- | --- |
+| `--speckit` | off | Force ingestion mode. Error if `NAME` doesn't resolve to a Spec Kit-shaped dir. |
+| `--dry-run` | off | Full resolve/parse/validate/plan; print complete preview; zero writes (no beads, no state, no run metadata, no chaining). Exit 0. |
+| `--enrich` | off | One-shot LLM pass attaching verification commands to new task beads. Failure → warning, ingestion continues. Only step that may touch a model. |
+
+Existing flags on the speckit path: `--session-log` honored; `--auto-commit` honored (commits refuel output via jj snapshot, as classic); `--skip-briefing` ignored with a warning (no briefing exists on this path); `--plans-dir` ignored for speckit resolution; `--list-steps` lists the speckit step names when combined with `--speckit`.
+
+## Mode dispatch
+
+| `NAME` resolves to | `--speckit` | Result |
+| --- | --- | --- |
+| speckit only | any | speckit ingestion; mode announced: `Using Spec Kit ingestion (specs/048-…)` |
+| classic only | absent | classic refuel (unchanged) |
+| classic only | present | error E02 |
+| both | absent | error E01 (disambiguate) |
+| both | present | speckit ingestion |
+| neither | any | error E02 |
+
+## Exit codes
+
+| Code | Condition |
+| --- | --- |
+| 0 (SUCCESS) | Ingestion complete; delta no-op ("no new tasks"); any `--dry-run` that validates |
+| 1 (FAILURE) | E01–E07 below; bd not ready (`verify_bd_ready`, unchanged) |
+
+## Error catalog (all on stderr via `err_console`, Rich-formatted, no raw tracebacks)
+
+| ID | Trigger | Message must include |
+| --- | --- | --- |
+| E01 | Name matches classic AND speckit | Both paths found; rerun with `--speckit` or rename |
+| E02 | `--speckit` (or speckit-only name) unresolvable | What was looked for (`specs/<query>*/` with `spec.md` + `tasks.md`) and where |
+| E03 | Ambiguous speckit match | All candidate directories listed |
+| E04 | Unsupported template version | `unsupported template version <X>, supported: <range>` |
+| E05 | Parse error | File path, line number, expected structure, suggested fix |
+| E06 | Validation error (duplicate task ID / unknown dep ref / cycle) | Offending task ID(s) and line number(s) |
+| E07 | Nothing to ingest (zero open tasks, first run) | Counts of completed/total tasks; no epic is created |
+
+## Output (success)
+
+- Human-readable phase lines per CLI standards (Rich, no emoji, `[green]✓[/]`), one completion line per step with timing.
+- Summary block: epic ID, N tasks created, M skipped (completed), K skipped (already ingested), edge count, warnings.
+- Delta no-op prints: `No new tasks to ingest for <feature> (epic <id> up to date).`
+- Final hint (non-dry-run): `Next: maverick fly --epic <id>` (via existing `find_latest_run` path — FR-016).
+- Dry-run prints the same summary prefixed `Dry run — no beads created.` and a per-task table (ID, title, phase, [P], blockers).
+
+## Invariants
+
+- Zero model invocations unless `--enrich` (FR-010).
+- No `bd` write before all validation passes (FR-015).
+- Dry-run and real run derive output from the same `IngestionPlan` object (SC-005).

--- a/specs/048-speckit-refuel-ingestion/contracts/tasks-md-grammar.md
+++ b/specs/048-speckit-refuel-ingestion/contracts/tasks-md-grammar.md
@@ -1,0 +1,52 @@
+# Contract: Supported Spec Kit artifact grammar
+
+**Feature**: 048-speckit-refuel-ingestion
+**Supported template versions**: `>=0.14,<0.15` (constant `SUPPORTED_SPECKIT_RANGE` in `speckit/detect.py`)
+**Version source**: `.specify/init-options.json` → `speckit_version`. Absent file/field → status `unknown`: warn and parse structurally (D5).
+
+## Feature directory shape
+
+```
+specs/NNN-name/
+├── spec.md      REQUIRED
+├── tasks.md     REQUIRED
+└── plan.md      optional (noted if absent; never parsed for structure)
+```
+
+`NNN` = 3+ digits. Shape check failure → E02.
+
+## tasks.md grammar (line-oriented)
+
+```ebnf
+tasks_file      = { ignored_line | phase_section } ;
+phase_section   = phase_heading , { task_line | ignored_line } ;
+phase_heading   = "## Phase " , integer , [ ":" , title_text ] ;
+task_line       = "- [" , (" " | "x" | "X") , "] " , task_id ,
+                  [ " [P]" ] , [ " [US" , integer , "]" ] , " " , description ;
+task_id         = "T" , 3*digit ;
+```
+
+- **Phase headings**: `## Phase <n>: <title>`. Numbers must be strictly increasing in file order (violation → E05). Content before the first phase heading is ignored.
+- **Task lines**: only recognized *inside* a phase section. Marker order is fixed: checkbox, ID, `[P]`, `[USn]`, description. A line matching `- [ ]`/`- [x]` inside a phase that does **not** match the full task grammar is a **hard error** (E05: file, line, expected pattern, suggestion) — never silently skipped (SC-002).
+- **Ignored lines**: prose, `**Checkpoint**` lines, `###` subheadings, blank lines, HTML comments, fenced code blocks (fence-aware skipping), and any `## ` heading that is not `## Phase …` (terminates the current phase section).
+- **Explicit dependencies** (parsed from description text, case-insensitive): `(depends on T012[, T013…])` or `depends on: T012[, T013…]`. Referenced IDs must exist in the file (E06).
+- **File paths**: whitespace-delimited tokens in the description containing `/` and a file extension, or ending in `/`. Extraction is best-effort (empty is valid).
+- **Duplicate task IDs** anywhere in the file → E06 with both line numbers.
+- **Dependencies section** (optional): a `## Dependencies` (or `## Dependencies & Execution Order`) section; lines matching `US<n>: Depends on US<m>[, US<k>…]` add story-level dependency pairs. All other content in that section is ignored (the phase barrier already encodes phase ordering).
+
+## spec.md extraction (best-effort except where noted)
+
+| Element | Pattern | On absence |
+| --- | --- | --- |
+| Feature title | `# Feature Specification: <title>` (fallback: first `# ` heading) | fallback: feature dir name |
+| Success criteria | bullets matching `- **SC-\d+**: …` under `## Success Criteria` | warning; epic description omits section |
+| Story scenarios | `### User Story <n> …` sections → items under `**Acceptance Scenarios**` | tasks labeled with a missing story get task text only + warning |
+
+spec.md that exists but yields no title and no success criteria and no stories → E05 (likely not a Spec Kit spec).
+
+## Guarantees
+
+1. **Deterministic**: identical inputs → identical `SpeckitFeature` (pure functions, no I/O in `parser.py`).
+2. **Total accounting**: every task-shaped line inside a phase is either a parsed task or a hard error — no third outcome.
+3. **Error quality**: every E05/E06 carries file path, 1-based line number, expected structure, and a suggested fix.
+4. **Version gate**: `unsupported` version fails (E04) before any file is parsed; `unknown` warns and proceeds.

--- a/specs/048-speckit-refuel-ingestion/data-model.md
+++ b/specs/048-speckit-refuel-ingestion/data-model.md
@@ -1,0 +1,149 @@
+# Data Model: Spec Kit Ingestion Mode for Refuel
+
+**Feature**: 048-speckit-refuel-ingestion | **Date**: 2026-07-23
+
+All new models are frozen Pydantic (per Guardrail 3), living in `src/maverick/speckit/models.py` unless noted. Existing bead models (`maverick.beads.models`) are reused unchanged.
+
+## Parsing layer (`speckit/models.py`)
+
+### SpeckitTask
+
+One task line from tasks.md.
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `task_id` | `str` | Matches `T\d{3,}`; unique within the feature (duplicate → parse error) |
+| `description` | `str` | Full task text after markers; non-empty |
+| `completed` | `bool` | `[x]` → True, `[ ]` → False |
+| `parallel` | `bool` | `[P]` marker present |
+| `story_id` | `str \| None` | From `[USn]` marker (e.g. `"US1"`) |
+| `phase_number` | `int` | Owning phase (≥ 1) |
+| `file_paths` | `tuple[str, ...]` | Path tokens extracted from description (may be empty) |
+| `explicit_deps` | `tuple[str, ...]` | Task IDs from `depends on Txxx[, Tyyy]` notes; every referenced ID must exist (unknown → parse error) |
+| `line_number` | `int` | 1-based source line in tasks.md (for error reporting and stable ordering) |
+
+### SpeckitPhase
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `number` | `int` | From `## Phase <n>:` heading; strictly increasing in file order |
+| `title` | `str` | Heading text after the colon |
+| `tasks` | `tuple[SpeckitTask, ...]` | In file order; a phase may be empty (warning, not error) |
+
+### ParsedSpec
+
+Extraction from spec.md.
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `title` | `str` | From `# Feature Specification: <title>` (fallback: first H1) |
+| `success_criteria` | `tuple[str, ...]` | `SC-\d+` bullets under Success Criteria → Measurable Outcomes |
+| `story_scenarios` | `dict[str, tuple[str, ...]]` | Key `"USn"` → that story's Acceptance Scenarios items; stories without scenarios map to empty tuple |
+
+### SpeckitFeature
+
+Aggregate of one feature directory (output of the parse step).
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `feature_dir` | `Path` | Absolute resolved `specs/NNN-name/` |
+| `feature_name` | `str` | Directory basename (e.g. `048-speckit-refuel-ingestion`) |
+| `spec` | `ParsedSpec` | Required (spec.md must exist) |
+| `phases` | `tuple[SpeckitPhase, ...]` | Required (tasks.md must exist); ≥ 1 open task overall or ingestion fails ("nothing to ingest") |
+| `story_deps` | `tuple[tuple[str, str], ...]` | `(dependent_story, blocker_story)` pairs from the Dependencies section (e.g. `("US2", "US1")`) |
+| `has_plan` | `bool` | plan.md present (absence → note, not error) |
+
+### TemplateCompatibility (`speckit/detect.py`)
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `vendored_version` | `str \| None` | `speckit_version` from `.specify/init-options.json`; None if absent |
+| `supported_range` | `str` | Constant, initially `>=0.14,<0.15` |
+| `status` | `Literal["supported", "unsupported", "unknown"]` | `unsupported` → fail upfront; `unknown` → warn + structural parsing |
+
+### FeatureResolution (`speckit/detect.py`)
+
+CLI-boundary dispatch result.
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `query` | `str` | The `<name>` argument as given |
+| `speckit_dir` | `Path \| None` | Resolved feature dir (exact name / `NNN` prefix / exact suffix); multiple candidates → `AmbiguousFeatureError` listing them |
+| `flight_plan_path` | `Path \| None` | Classic `.maverick/plans/<name>/flight-plan.md` if it exists |
+| `mode` | `Literal["speckit", "classic", "ambiguous", "unresolved"]` | Both non-None without `--speckit` → `ambiguous` |
+
+## Ingestion-plan layer (`speckit/build.py`)
+
+### PlannedBead
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `task_id` | `str` | Source task ID (epic uses sentinel `"EPIC"`) |
+| `definition` | `BeadDefinition` (existing) | `title` = `"T012: <desc>"` (≤ 490 chars) for tasks, feature title for the epic; `description` = full work-unit markdown per contracts/bead-encoding.md; `labels` include `"speckit"` |
+| `state` | `dict[str, str]` | Post-creation `set_state` payload: `speckit_task_id`, `speckit_phase`, `speckit_parallel` (task) or `speckit_feature` (epic) |
+
+### IngestionPlan
+
+Complete, validated, side-effect-free description of one run (the dry-run rendering and the real run consume this same object — parity by construction).
+
+| Field | Type | Rules |
+| --- | --- | --- |
+| `feature` | `SpeckitFeature` | Source |
+| `epic` | `PlannedBead \| None` | None on delta runs (existing epic adopted) |
+| `existing_epic_id` | `str \| None` | Set on delta runs |
+| `new_tasks` | `tuple[PlannedBead, ...]` | Open tasks not previously ingested, in execution-safe order |
+| `skipped_completed` | `tuple[str, ...]` | Task IDs checked `[x]` |
+| `skipped_existing` | `tuple[str, ...]` | Task IDs already ingested under the epic (delta) |
+| `edges` | `tuple[tuple[str, str], ...]` | `(blocker_task_id, blocked_task_id)` pairs; validated acyclic; on delta runs may reference existing bead IDs via `existing_task_map` |
+| `existing_task_map` | `dict[str, str]` | `task_id → bead_id` for previously ingested tasks (delta edge wiring) |
+
+**Validation rules enforced at build time (before any write — FR-015)**: unique task IDs; explicit deps reference known IDs; dependency graph acyclic; ≥ 1 new task OR delta no-op flagged; story labels referenced by tasks exist in spec (missing story → warning, scenarios omitted).
+
+### Derived dependency edges (from clarification Q2)
+
+For each phase `p` (in order):
+1. **Intra-phase serial chain**: each non-`[P]` task depends on the nearest preceding non-`[P]` task in `p`.
+2. **Explicit notes**: each `explicit_deps` entry adds `(dep, task)`.
+3. **Phase barrier**: `sinks(p) × sources(p+1)` — sinks = tasks in `p` with no intra-phase dependents; sources = tasks in `p+1` with no intra-phase blockers. Transitivity through chains yields the full barrier.
+4. **Story deps**: for `(US_b, US_a)` in `story_deps`, add sink-of-`US_a` × source-of-`US_b` edges only where the blocked task is not already reachable from the blocker via edges from rules 1–3 (graph reachability check, computed before cycle validation).
+
+On delta runs, edges whose blocker is an already-ingested task resolve through `existing_task_map`; edges whose blocker is a *completed* (skipped) task are dropped (already satisfied).
+
+## Workflow layer (`workflows/refuel_speckit/models.py`)
+
+### SpeckitRefuelResult
+
+Dataclass mirroring `RefuelMaverickResult.to_dict()` conventions (`workflows/refuel_maverick/models.py:225`).
+
+| Field | Type |
+| --- | --- |
+| `feature_name` | `str` |
+| `epic_id` | `str` (real or `dry-run-epic`) |
+| `created_bead_ids` | `list[str]` |
+| `skipped_completed` / `skipped_existing` | `list[str]` |
+| `edge_count` | `int` |
+| `delta_run` | `bool` |
+| `dry_run` | `bool` |
+| `enriched` | `bool` |
+| `warnings` | `list[str]` |
+
+## State transitions
+
+```
+tasks.md task:  [ ] unchecked ──ingest──▶ bead (open) ──fly──▶ bead (closed)
+                [x] checked   ──ingest──▶ skipped_completed (no bead)
+re-run:         unchecked + bead exists ─▶ skipped_existing (no new bead)
+                unchecked + no bead     ─▶ new bead under existing epic (delta)
+epic:           first run → created + chained behind open-epic tail
+                delta run → adopted (existing_epic_id); no new epic, no re-chaining
+```
+
+## Relationships
+
+```
+SpeckitFeature 1──* SpeckitPhase 1──* SpeckitTask
+SpeckitFeature 1──1 ParsedSpec (story_scenarios keyed by SpeckitTask.story_id)
+IngestionPlan 1──* PlannedBead ──1 BeadDefinition (existing model)
+IngestionPlan edges ──▶ BeadDependency (existing model) at execution time
+epic bead 1──* task beads (bd parent/child) ──▶ state carries speckit_* provenance
+```

--- a/specs/048-speckit-refuel-ingestion/plan.md
+++ b/specs/048-speckit-refuel-ingestion/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: Spec Kit Ingestion Mode for Refuel
+
+**Branch**: `048-speckit-refuel-ingestion` | **Date**: 2026-07-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/048-speckit-refuel-ingestion/spec.md`
+
+## Summary
+
+Add a deterministic ingestion path to `maverick refuel` for Spec Kit-managed repositories: parse `specs/NNN-name/{spec.md,plan.md,tasks.md}` with a fixed grammar (no LLM decomposition), create one epic bead + one task bead per open task, preserve task IDs / phases / `[P]` markers / file scope, wire dependencies as a phase barrier plus explicit notes, chain the epic behind existing open epics, support delta re-runs under the existing epic, and offer `--dry-run` plus an opt-in single-call LLM enrichment pass for verification commands.
+
+Technical approach: a new pure-parsing package `src/maverick/speckit/` (modeled on `src/maverick/flight/parser.py`) feeding a new lightweight `PythonWorkflow` (`src/maverick/workflows/refuel_speckit/`) that reuses the existing `library/actions/beads.py` actions (`create_beads`, `wire_dependencies` — both already `dry_run`-capable) and `BeadClient` directly, bypassing Burr, `RefuelSquadron`, and the actor stack entirely. CLI mode dispatch lives in `cli/commands/refuel/_group.py`.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (`from __future__ import annotations`)
+**Primary Dependencies**: Pydantic (frozen models), Click + Rich (CLI), existing `maverick.beads.BeadClient` (async `bd` CLI wrapper), `maverick.library.actions.beads` (create/wire actions with `dry_run`), `maverick.flight.parser` primitives as precedent, structlog, persona-agent pattern from `maverick.agents.personas` for optional enrichment
+**Storage**: beads database via `bd` CLI (`.beads/`); run metadata JSON in `<cwd>/.maverick/runs/<run_id>/` (`maverick.runway.run_metadata`); no new storage
+**Testing**: pytest + pytest-asyncio + xdist via `make test` / `make test-fast`; existing Spec Kit fixtures in `tests/unit/beads/conftest.py` (`SAMPLE_TASKS_MD`, `spec_dir_with_tasks`, `spec_dir_with_deps`, `mock_runner` BeadClient stubbing)
+**Target Platform**: Linux/macOS developer checkouts (jj-colocated repos, per Guardrail 0)
+**Project Type**: single project (existing `src/maverick/` package layout)
+**Performance Goals**: ingestion of a typical feature (≤50 tasks) completes in < 30 s wall clock with zero LLM calls (SC-001); parsing itself is pure CPU (< 100 ms), the budget is `bd` subprocess calls (~2 per bead + deps)
+**Constraints**: no model invocation on the default path (FR-010); no partial bead trees on validation failure — validate fully before first write (FR-015); no `Path.cwd()` below the CLI boundary (Guardrail 7); all VCS writes via jj, all bead writes via `BeadClient`
+**Scale/Scope**: task lists of 10–100 tasks, 3–10 phases; one feature dir per run; supported template range = Spec Kit 0.14.x initially
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle / Guardrail | Compliance |
+| --- | --- |
+| I. Async-first | PASS — parser is pure sync functions on in-memory strings (no I/O); all file reads via async loaders; all `bd` calls via async `BeadClient`/`CommandRunner`; no `subprocess.run` anywhere |
+| II. Separation of concerns | PASS — deterministic decomposition lives in workflow/actions (not agents); the only agent involvement is the opt-in enrichment persona, which supplies judgment (verification commands) and owns no side effects |
+| III. Dependency injection | PASS — parser takes strings; workflow receives `cwd`, config, and inputs from the CLI boundary; `BeadClient` constructed per-workflow with explicit `cwd`; enrichment runtime via `runtime_for_agent()` |
+| IV. Fail gracefully | PASS — enrichment failure degrades to warning (FR-011); parse/validation errors fail before any write with file:line context (FR-012/FR-015); partial-creation reporting on interrupt |
+| V. Test-first | PASS — parser grammar, delta logic, and dep-graph builder are pure functions designed for table-driven tests; fixtures already exist in `tests/unit/beads/conftest.py` |
+| VI. Simplicity | PASS — no Burr graph, no squadron, no actor pool on this path; a plain sequential `PythonWorkflow` |
+| Guardrail 0/7 (cwd threading) | PASS — CLI resolves `cwd = Path.cwd().resolve()` once; every layer receives explicit `cwd` |
+| Guardrail 2 (deterministic ops in workflows) | PASS — bead creation/wiring/chaining owned by the workflow via typed actions |
+| Guardrail 3 (typed contracts) | PASS — new frozen Pydantic models for parsed artifacts and ingestion plan; reuse `BeadDefinition`/`BeadDependency` |
+| Guardrail 5 (one canonical wrapper) | PASS — all `bd` interaction via `BeadClient`/`library/actions/beads.py`; no new subprocess wrappers |
+| Debt prevention (module size, package-per-workflow) | PASS — new `speckit/` package split into `models/parser/detect/build`; new `workflows/refuel_speckit/` package with `constants.py`, `models.py`, `workflow.py` |
+
+No violations → Complexity Tracking not needed.
+
+**Post-design re-check (after Phase 1)**: PASS — design artifacts introduce no new projects, no global state, no agent-owned side effects; the enrichment agent is a one-shot persona following the existing `VerificationPropertiesAgent` pattern (`workflows/refuel_maverick/workflow.py:363`).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/048-speckit-refuel-ingestion/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── cli-refuel-speckit.md    # CLI surface: flags, mode dispatch, exit codes, error text
+│   ├── tasks-md-grammar.md      # Supported Spec Kit template grammar + version range
+│   └── bead-encoding.md         # How beads encode Spec Kit provenance (titles, state keys, description sections, dep edges)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/maverick/
+├── speckit/                         # NEW: deterministic Spec Kit artifact layer (pure, no bd/VCS side effects)
+│   ├── __init__.py                  # re-exports public surface
+│   ├── models.py                    # frozen Pydantic: SpeckitFeature, SpeckitTask, SpeckitPhase, ParsedSpec, TemplateCompatibility
+│   ├── parser.py                    # pure grammar functions (modeled on flight/parser.py): tasks.md, spec.md success criteria + story scenarios
+│   ├── detect.py                    # feature-dir resolution, shape detection, vendored-version compatibility check
+│   ├── build.py                     # IngestionPlan builder: bead definitions, phase-barrier + explicit dep edges, delta filtering
+│   └── errors.py                    # SpeckitError(MaverickError) hierarchy backing error catalog E01–E07
+├── workflows/
+│   └── refuel_speckit/              # NEW: package-per-workflow (no Burr, no squadron)
+│       ├── __init__.py
+│       ├── constants.py             # step names: RESOLVE_FEATURE, CHECK_TEMPLATE, PARSE_ARTIFACTS, PLAN_INGESTION, ENRICH, CREATE_BEADS, WIRE_DEPS, CHAIN_EPIC, RECORD_RUN, COMMIT_OUTPUT
+│       ├── models.py                # SpeckitRefuelResult (mirrors RefuelMaverickResult.to_dict() shape)
+│       └── workflow.py              # SpeckitRefuelWorkflow(PythonWorkflow): sequential driver incl. dry-run + delta
+├── agents/
+│   └── personas.py                  # MODIFIED: add SpeckitEnrichmentAgent (one-shot persona, provider_tier="generate")
+├── cli/commands/refuel/
+│   └── _group.py                    # MODIFIED: add --speckit / --dry-run / --enrich, mode auto-detection + dispatch
+└── beads/                           # UNCHANGED: BeadClient reused as-is
+
+tests/unit/
+├── speckit/                         # NEW: parser/detect/build table tests (reuse SAMPLE_TASKS_MD fixtures)
+├── workflows/refuel_speckit/        # NEW: workflow tests with stubbed BeadClient runner
+└── cli/commands/refuel/             # MODIFIED: mode-dispatch + flag tests
+```
+
+**Structure Decision**: single-project layout following the repo's package-per-workflow convention (`workflows/refuel_speckit/` mirrors `workflows/refuel_maverick/`). Parsing is a standalone `speckit/` package (not inside the workflow) because detection is also needed at the CLI boundary for mode dispatch, and pure parsing deserves isolated table-driven tests.
+
+## Complexity Tracking
+
+No constitution violations — table intentionally empty.

--- a/specs/048-speckit-refuel-ingestion/quickstart.md
+++ b/specs/048-speckit-refuel-ingestion/quickstart.md
@@ -1,0 +1,81 @@
+# Quickstart: Validating Spec Kit Ingestion
+
+**Feature**: 048-speckit-refuel-ingestion
+
+Runnable scenarios proving the feature end-to-end. Contracts: [cli-refuel-speckit.md](contracts/cli-refuel-speckit.md), [tasks-md-grammar.md](contracts/tasks-md-grammar.md), [bead-encoding.md](contracts/bead-encoding.md).
+
+## Prerequisites
+
+- `bd` on PATH and `.beads/` initialized in the target repo (`maverick init` / `bd init`)
+- A Spec Kit feature dir `specs/NNN-name/` with `spec.md` + `tasks.md` (fixture generators: `spec_dir_with_tasks` / `spec_dir_with_deps` in `tests/unit/beads/conftest.py`)
+- No provider auth needed except Scenario 6 (`--enrich`)
+
+## Scenario 1 — Dry-run preview (safe first contact)
+
+```bash
+maverick refuel 048 --speckit --dry-run
+```
+
+Expect: mode announcement, per-task table (ID, title, phase, `[P]`, blockers), skipped-completed list, `Dry run — no beads created.`, exit 0. Verify zero writes: `bd query "type=epic AND status=open" --json` unchanged; no new `.maverick/runs/` entry.
+
+## Scenario 2 — Fresh ingestion + fly handoff
+
+```bash
+maverick refuel 048 --speckit
+bd show <epic-id> --json          # labels: ["speckit"], state.speckit_feature=<dir name>
+bd list --parent <epic-id> --flat --json   # one task bead per unchecked task, titles "T###: …"
+bd ready --parent <epic-id> --limit 10 --json  # ONLY phase-1 sources are ready
+maverick fly --epic <epic-id> --max-beads 1    # implementer receives full work-unit markdown
+```
+
+Expect: summary (epic ID, N created, M skipped-completed, edge count), `Next: maverick fly --epic <id>` hint, exit 0. SC-002 check: created count + skipped count == total tasks in tasks.md; every ID present exactly once. SC-003 check: `bd ready` never surfaces a task whose phase predecessors or explicit deps are open.
+
+## Scenario 3 — Epic chaining
+
+With an open epic from a previous refuel (classic or speckit), run Scenario 2. Expect the new epic blocked by the previous open-epic tail: new tasks absent from `bd ready` until the prior epic closes.
+
+## Scenario 4 — Delta re-run (converge-style growth)
+
+```bash
+maverick refuel 048 --speckit          # ingests T001–T0NN
+# append "- [ ] T0XX [P] [US2] New task in src/new.py" to a later phase of tasks.md
+maverick refuel 048 --speckit          # delta
+maverick refuel 048 --speckit          # no-op
+```
+
+Expect: run 2 creates exactly one bead under the *same* epic (no second epic; `skipped_existing` lists prior IDs); run 3 exits 0 with `No new tasks to ingest…`. `bd query "type=epic AND status=open"` shows one epic for the feature throughout.
+
+## Scenario 5 — Failure modes (each exits 1, no partial state)
+
+| Setup | Expected error |
+| --- | --- |
+| Duplicate `T005` line in tasks.md | E06: both line numbers; zero beads created |
+| `(depends on T999)` where T999 undefined | E06: referencing task + missing ID + line |
+| Corrupt a task line (e.g. `- [ ] do stuff` inside a phase) | E05: file, line, expected pattern, suggested fix |
+| Set `.specify/init-options.json` `speckit_version` to `"0.99.0"` | E04: `unsupported template version 0.99.0, supported: >=0.14,<0.15` |
+| Name matches both a classic plan and a specs dir | E01: disambiguation instructions |
+| All tasks checked `[x]` (first run) | E07: nothing to ingest; no epic created |
+
+After each: verify no epic/tasks were created (validation precedes writes — FR-015).
+
+## Scenario 6 — Optional enrichment
+
+```bash
+maverick refuel 048 --speckit --enrich          # requires provider auth for the "generate" tier
+```
+
+Expect: identical bead set/graph to Scenario 2; each new task bead's `## Verification` gains model-supplied commands. Then break provider auth and re-run (fresh feature): warning about enrichment degradation, ingestion still succeeds, exit 0.
+
+## Scenario 7 — Zero-model guarantee
+
+Run Scenarios 1–5 with no provider credentials configured. All behave identically (FR-010/SC-001). Any model-call attempt on the default path is a bug.
+
+## Automated validation
+
+```bash
+make test-fast            # unit: parser grammar tables, build/delta logic, CLI dispatch
+make test                 # + workflow tests with stubbed BeadClient runner
+make ci                   # pre-push gate
+```
+
+Key suites (added by this feature): `tests/unit/speckit/`, `tests/unit/workflows/refuel_speckit/`, `tests/unit/cli/commands/refuel/`.

--- a/specs/048-speckit-refuel-ingestion/research.md
+++ b/specs/048-speckit-refuel-ingestion/research.md
@@ -1,0 +1,83 @@
+# Research: Spec Kit Ingestion Mode for Refuel
+
+**Feature**: 048-speckit-refuel-ingestion | **Date**: 2026-07-23
+
+All Technical Context unknowns resolved. Decisions below are grounded in codebase exploration (file:line references verified 2026-07-23).
+
+## D1. Separate workflow vs. branching inside RefuelMaverickWorkflow
+
+- **Decision**: New `SpeckitRefuelWorkflow(PythonWorkflow)` in `src/maverick/workflows/refuel_speckit/`; do not thread a speckit branch through `RefuelMaverickWorkflow`.
+- **Rationale**: The existing refuel drives a Burr state machine (`workflows/refuel_maverick/burr_graph.py:66`) whose middle (briefing → decompose → validate → create_beads) is exactly what this feature replaces with a parser. Reusing it would mean stubbing 6 of 9 steps and entering `RefuelSquadron` (`squadron/refuel.py:31`) for nothing — the deterministic path needs no agent runtime at all. `library/actions/beads.create_beads` and `wire_dependencies` (`library/actions/beads.py:30`, `:109`) construct their own `BeadClient`, accept explicit `cwd`, and already implement `dry_run`, so a plain sequential `PythonWorkflow` covers everything. Repo convention is package-per-workflow (CLAUDE.md Debt Prevention #3).
+- **Alternatives considered**: (a) Branch inside `RefuelMaverickWorkflow._run_impl` — rejected: two unrelated control flows in one 900-line module already near the refactor threshold. (b) Pure CLI-side implementation without a workflow (like `land`) — rejected: loses `ProgressEvent` rendering, checkpointing conventions, and run-metadata symmetry with classic refuel that FR-016 requires.
+
+## D2. How task beads must be shaped for `fly` to consume them
+
+- **Decision**: Pack complete work-unit markdown into each task bead's `description` — sections `## Task`, `## Acceptance Criteria`, `## File Scope`, `## Verification` — and put the Spec Kit task ID in the title (`T012: Create Entity model …`).
+- **Rationale**: `fly` reads *only* `title` + `description`: the implementer prompt is built from them (`workflows/fly_beads/actions.py:308`), the reviewer passes `description` as the work-unit markdown (`:648-663`), and the AC-check re-parses `## Verification` commands out of the description (`:450-467`, executing only `rg/grep/cargo/make` commands). There is no separate acceptance-criteria field on a bead. Classic refuel's `(instructions or task)[:500]` truncation (`workflows/refuel_maverick/actions.py:845`) is a known lossy shortcut — the ingestion path must not repeat it.
+- **Alternatives considered**: bead `state` key-value pairs for AC content — rejected: `fly` never reads state for prompt content; state is for machine metadata (see D4).
+
+## D3. Phase-barrier dependency wiring without cross-products
+
+- **Decision**: Wire edges as **sinks(phase N) × sources(phase N+1)**, where within a phase: consecutive non-`[P]` tasks form a serial chain (each depends on the nearest preceding non-`[P]` task), `[P]` tasks have no implicit intra-phase dependencies, and explicit `depends on Txxx` notes in task text add edges. *Sources* = tasks with no intra-phase blockers; *sinks* = tasks with no intra-phase dependents. Transitivity through the intra-phase chains yields the full barrier guarantee (clarification Q2) with far fewer edges than the cross-product.
+- **Rationale**: `bd` enforces readiness from dependency edges (`bd ready` only returns unblocked beads — `beads/client.py:239`), so the graph shape directly controls `fly` execution order. The existing `wire_dependencies` action wires category-based structural deps (`library/actions/beads.py:109-222`) which don't express Spec Kit phases; a purpose-built edge computation in `speckit/build.py` emitting `BeadDependency` pairs is simpler than forcing phases into `BeadCategory` semantics. Edges are validated acyclic before creation (defense against pathological explicit notes).
+- **Alternatives considered**: (a) Full cross-product barrier — rejected per clarification (O(n²) edges). (b) Per-phase milestone beads as barrier nodes — rejected: `BeadType` supports only `epic|task` (`beads/models.py:14`); synthetic no-op tasks would surface in `bd ready` and confuse `fly`.
+
+## D4. Provenance encoding + delta re-run detection
+
+- **Decision**: On the epic: `set_state(epic_id, {"speckit_feature": "<dir-name>"})` (mirrors the existing `flight_plan_name` attachment, `workflows/refuel_maverick/workflow.py:613`). On each task bead: `set_state(bead_id, {"speckit_task_id": "T012", "speckit_phase": "3", "speckit_parallel": "true|false"})`, plus label `speckit` at creation. Delta detection: find the open epic whose `speckit_feature` state matches the resolved feature dir (via `query("type=epic AND status=open")` + `show()` per candidate); enumerate its children (`BeadClient.children`, `client.py:359`) and their `speckit_task_id` states; ingest only unchecked tasks whose ID is not already present.
+- **Rationale**: Task IDs are the stable identity across tasks.md growth (clarification Q1 — converge appends tasks). State keys survive title edits and are the established mechanism (`BeadDetails.state`, `beads/models.py:185`). Labels are creation-only (`client.py:157`) so mutable identity belongs in state.
+- **Alternatives considered**: matching by title prefix `T###:` — kept as a human-readable convention but rejected as the identity mechanism (titles are truncated at 490 chars and editable).
+
+## D5. Template version check source
+
+- **Decision**: Read `speckit_version` from the target repo's `.specify/init-options.json`; compare against a declared supported range constant (initially `>=0.14,<0.15`) in `speckit/detect.py`. Outside range → fail upfront with `unsupported template version X, supported: Y` (FR-012). If the file or field is **absent** (older Spec Kit or hand-rolled layout), emit a warning and proceed to structural parsing — grammar-level errors then carry the divergence reporting.
+- **Rationale**: This repo's own `.specify/init-options.json` carries `"speckit_version": "0.14.0"` — it is the version record Spec Kit vendors. Clarification Q4 chose fixed-grammar + upfront check; absent metadata is "unknown", not "outside range", and hard-failing every pre-metadata repo would block legitimate users whose artifacts parse cleanly.
+- **Alternatives considered**: fingerprinting `.specify/templates/tasks-template.md` structure — rejected: templates are user-editable post-vendoring; version metadata is the intended contract.
+
+## D6. tasks.md grammar (fixed, 0.14.x shape)
+
+- **Decision**: Line-oriented grammar (full EBNF in `contracts/tasks-md-grammar.md`): phase headings `## Phase <n>: <title>`; task lines `- [ ]`/`- [x]` + `T\d{3,}` + optional `[P]` + optional `[US\d+]` + description; explicit deps parsed from `(depends on T012, T013)` / `depends on: …` in task text; file paths extracted by path-token heuristic (`\S+\.\S+` tokens containing `/`, matching `flight/parser.py` file-scope conventions); `## Dependencies*` section parsed for `US2: Depends on US1` story-level entries (expanded to story-sink → story-source edges). Unrecognized `- [ ]` lines inside a phase are hard parse errors (file:line, expected pattern, suggestion); prose/checkpoints/other headings are ignored.
+- **Rationale**: Grammar is already exercised by fixtures `SAMPLE_TASKS_MD` / `SAMPLE_TASKS_MD_WITH_DEPS` (`tests/unit/beads/conftest.py:20`, `:50`) matching the vendored `tasks-template.md`. Strictness on task-shaped lines (vs. silently skipping) is what makes FR-012's "actionable error" and SC-002's "zero tasks dropped" testable.
+- **Alternatives considered**: markdown-AST parsing (e.g., markdown-it) — rejected: new dependency for a line-oriented format; `flight/parser.py` proves regex-per-line is sufficient and debuggable here.
+
+## D7. spec.md extraction for acceptance criteria
+
+- **Decision**: From spec.md extract (a) `## Success Criteria` → `### Measurable Outcomes` bullets (`SC-\d+`) for the **epic** description, and (b) per user story `### User Story <n> …` → its `**Acceptance Scenarios**` numbered list, attached to task beads carrying the matching `[USn]` label (clarification Q3). Unlabeled tasks get task text + file scope only.
+- **Rationale**: Both structures are fixed by the vendored `spec-template.md`; extraction reuses the `_split_h2_sections`/`_split_h3_sections` pattern from `flight/parser.py:145,:174`.
+- **Alternatives considered**: copying global SCs onto every task — rejected per clarification (unverifiable per-bead noise).
+
+## D8. Default verification content (no-enrichment path)
+
+- **Decision**: Without `--enrich`, each task bead's `## Verification` section contains deterministic file-scope checks (existence checks derived from parsed file paths, e.g. `rg --files -g '<path>'`) plus any commands already present in the task text. With `--enrich`, a one-shot persona agent may replace/augment these with real test/lint commands.
+- **Rationale**: `fly`'s AC-check executes only `rg/grep/cargo/make` commands from `## Verification` (`fly_beads/actions.py:450-467`) and classic refuel's `WorkUnitSpec` treats verification as mandatory non-empty (`workflows/refuel_maverick/models.py:80`); an empty section would silently weaken the fly gate. File-existence checks are the strongest claim derivable without judgment.
+- **Alternatives considered**: defaulting to `make test` — rejected: target repos aren't guaranteed a Makefile; wrong-by-default commands would fail every AC check.
+
+## D9. Enrichment agent shape
+
+- **Decision**: `SpeckitEnrichmentAgent` added to `agents/personas.py` as a one-shot persona (`provider_tier = "generate"`), invoked per ingestion run (single batched prompt over all new tasks, returning verification commands per task ID); wired via `runtime_for_agent("generate", agents_config=config.agents)`. Opt-in via `--enrich`; any failure logs a structured warning and ingestion proceeds unenriched (FR-011). Enrichment runs **before** bead creation so dry-run can preview enriched output.
+- **Rationale**: Persona agents are the established lightest LLM pattern — exactly how `DERIVE_VERIFICATION` uses `VerificationPropertiesAgent` (`workflows/refuel_maverick/workflow.py:363-392`); no squadron/pool needed. Tier resolution goes through `runtime_for_agent` / `binding_for_role` (`runtime/agent_factory.py:84`, `:50`; `"generate"` ∈ `KNOWN_ROLES`).
+- **Alternatives considered**: per-task enrichment calls — rejected: N model calls for marginal quality; batching keeps cost O(1) per run.
+
+## D10. Dry-run mechanics
+
+- **Decision**: `--dry-run` CLI flag threads a `dry_run: bool` workflow input. The workflow runs every step through ingestion-plan construction and validation identically, passes `dry_run=True` to `create_beads`/`wire_dependencies` (which already return synthetic IDs without touching `bd` — `library/actions/beads.py:55`), skips `set_state`/epic-chaining/run-metadata writes, and renders the full would-be plan (epic, tasks, edges, skipped) via `emit_output` plus the result dict.
+- **Rationale**: Reuses the actions' built-in dry-run seam rather than inventing a parallel preview path, which guarantees SC-005's "preview matches the subsequent real run" by construction. `land --dry-run` (`cli/commands/land.py:321`) establishes the print-plan-then-exit UX convention.
+- **Alternatives considered**: CLI-side inline preview bypassing the workflow — rejected in D1 (loses parity guarantees and event rendering).
+
+## D11. Mode auto-detection and dispatch at the CLI boundary
+
+- **Decision**: In `cli/commands/refuel/_group.py`: resolve `<name>` against both `(cwd)/.maverick/plans/<name>/flight-plan.md` (classic) and `(cwd)/specs/` (speckit: exact dir name, `NNN` prefix, or exact name-suffix match — FR-001). Dispatch: `--speckit` forces speckit (error if unresolvable as speckit); both match without flag → error asking for disambiguation; exactly one match → dispatch accordingly, announcing the selected mode. Detection logic lives in `speckit/detect.py` (returns a typed resolution result), keeping the CLI thin.
+- **Rationale**: Detection is needed before choosing which workflow to instantiate, so it must sit at the CLI boundary (Guardrail 7: CLI resolves, layers below receive). Shape check = directory contains `spec.md` + `tasks.md` (plan.md optional per spec Assumptions).
+- **Alternatives considered**: a separate `maverick refuel-speckit` command — rejected: the spec's UX is one refuel verb with auto-detection.
+
+## D12. Run metadata + fly handoff
+
+- **Decision**: Write `RunMetadata(plan_name=<feature-dir-name>, epic_id=…, status="refueled")` via `maverick.runway.run_metadata.write_metadata` exactly as classic refuel does, so the CLI's existing `find_latest_run` hint (`cli/commands/refuel/_group.py:153-158`) prints `Next: maverick fly --epic <id>` unchanged (FR-016). Do **not** write `.maverick/plans/<name>/` work-unit files — bead descriptions are the single source of work-unit content on this path. Verify at implementation that `select_next_bead`'s `flight_plan_name` epic-state read (`library/actions/beads.py:342-347`) tolerates absence; if not, set `flight_plan_name` state to the feature dir name as a compatibility shim.
+- **Rationale**: FR-016 requires follow-on commands to work unchanged; run metadata is the integration point. Duplicating work-unit files would create a second source of truth the delta path would have to reconcile.
+- **Alternatives considered**: emitting `.maverick/plans/` files for parity — rejected: nothing on the fly path reads them for prompt content (D2), and tasks.md remains the user-facing source.
+
+## D13. Failure-ordering and partial-creation reporting
+
+- **Decision**: Strict validate-then-write ordering: resolution → version check → parse (all files) → ingestion-plan build (incl. duplicate-ID, unknown-dep-ref, cycle checks, delta filtering) must all succeed before the first `bd` write (FR-015). During creation, track created IDs; on midway failure, the error report lists created epic/bead IDs; recovery is the delta re-run (already-created task IDs are skipped next run — D4 makes interruption self-healing).
+- **Rationale**: `create_beads` creates epic-then-children sequentially (`library/actions/beads.py:30-107`); there is no transaction in `bd`, so pre-validation + idempotent delta is the only route to "no partial trees on *validation* failure" plus graceful recovery from *runtime* failure.
+- **Alternatives considered**: compensating deletes on failure — rejected: `bd` close ≠ delete, and destructive cleanup on a failure path violates fail-graceful expectations.

--- a/specs/048-speckit-refuel-ingestion/spec.md
+++ b/specs/048-speckit-refuel-ingestion/spec.md
@@ -1,0 +1,147 @@
+# Feature Specification: Spec Kit Ingestion Mode for Refuel
+
+**Feature Branch**: `048-speckit-refuel-ingestion`
+**Created**: 2026-07-23
+**Status**: Draft
+**Input**: User description: "Add a Spec Kit ingestion mode to refuel. Given a feature directory produced by GitHub Spec Kit (specs/NNN-name/ containing spec.md, plan.md, tasks.md, with templates vendored under .specify/), maverick refuel <feature> --speckit (or auto-detection of the directory shape) creates one epic bead for the spec and one task bead per task in tasks.md — preserving task IDs, phase grouping, [P] parallelism markers, file scope, and dependency ordering. New epics chain behind existing open epics exactly as refuel does today. Per-bead acceptance criteria come from the task text plus spec.md success criteria; an optional slim enrichment pass may attach verification commands, but there is no LLM decomposition — the parser replaces it for speckit-managed repos. Parsing targets the template version vendored in the target repo and fails with actionable errors when the format diverges. Dry-run behaves like existing refuel dry-run."
+
+## Clarifications
+
+### Session 2026-07-23
+
+- Q: How should re-running ingestion behave for a feature that already has an open ingestion-created epic? → A: Delta ingestion — add work items only for tasks not previously ingested (e.g., converge-added ones), skip already-ingested and completed tasks; no duplicate epic.
+- Q: When a task has no explicit dependency note, how are cross-phase dependencies derived? → A: Phase barrier + explicit notes — a task cannot start until the previous phase completes, plus any explicit "depends on Txxx" edges; within a phase, [P] tasks are mutually independent and unmarked tasks are serialized.
+- Q: Which spec content becomes acceptance criteria on which work item? → A: Story-scoped — a task with a [USn] label gets task text + that story's acceptance scenarios; unlabeled tasks get task text only; the epic carries the feature-wide success criteria.
+- Q: What does "targeting the vendored template version" mean operationally? → A: Fixed supported grammar + compatibility check — ingestion supports a declared range of Spec Kit template versions; the repo's vendored version is verified upfront and unsupported versions fail with a clear "unsupported version X, supported: Y" error.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Ingest a Spec Kit feature into work items (Priority: P1)
+
+A developer manages their repository with GitHub Spec Kit. They have already produced a feature directory (`specs/NNN-name/`) containing a specification, a plan, and a dependency-ordered task list. Instead of asking an AI model to re-decompose work that Spec Kit has already decomposed, they run `maverick refuel <feature> --speckit` and get one epic work item for the feature plus one task work item per entry in the task list — with the original task identifiers, phase grouping, parallelism markers, file scope, and dependency ordering carried over faithfully. The implementation workflow (`maverick fly`) can then pick up the work items exactly as it does for work items produced by today's refuel.
+
+**Why this priority**: This is the core value of the feature — a deterministic, zero-model-cost path from a Spec Kit task list to executable work items. Without it, nothing else in this feature matters.
+
+**Independent Test**: In a repository containing a well-formed Spec Kit feature directory, run the ingestion command and verify that the created work items match the task list one-for-one (identifiers, ordering, dependencies, phases) and that the epic chains behind any pre-existing open epic.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with a well-formed Spec Kit feature directory containing a spec, a plan, and a task list with 20 tasks across 4 phases, **When** the user runs `maverick refuel <feature> --speckit`, **Then** exactly one epic work item and 20 task work items are created, each task work item carrying its original task identifier, phase, story label (if any), parallelism marker, and file scope.
+2. **Given** the same feature directory, **When** ingestion completes, **Then** dependency ordering is preserved: no task can become ready before its preceding phase fully completes, explicit per-task dependency notes add further blocking edges, tasks marked parallel-eligible within a phase have no dependencies on one another, and unmarked tasks within a phase are ordered sequentially.
+3. **Given** an existing open epic from a previous refuel run, **When** a Spec Kit ingestion creates a new epic, **Then** the new epic is blocked by the most recent existing open epic, identical to today's refuel chaining behavior.
+4. **Given** a task list where some tasks are already checked off as complete, **When** ingestion runs, **Then** completed tasks are not turned into open work items and are reported as skipped.
+5. **Given** each created task work item, **When** its acceptance criteria are inspected, **Then** they include the task's own text (including file scope), plus — for tasks labeled with a user story — that story's acceptance scenarios from the specification, so an implementer can verify completion without reading the Spec Kit artifacts. The epic work item carries the feature-wide success criteria.
+6. **Given** a completed ingestion, **When** the user inspects usage or cost records, **Then** no AI model was invoked for decomposition.
+
+---
+
+### User Story 2 - Auto-detection of Spec Kit feature directories (Priority: P2)
+
+A developer in a Spec Kit-managed repository runs `maverick refuel <feature>` without the explicit mode flag. Maverick recognizes that the named feature resolves to a Spec Kit-shaped directory (a `specs/NNN-name/` directory with a spec and task list, with Spec Kit templates vendored in the repository) and automatically uses the ingestion path instead of the AI-decomposition path.
+
+**Why this priority**: Removes a footgun — users shouldn't need to remember a flag when the repository shape already makes the intent unambiguous. But the explicit flag from Story 1 already delivers the full value, so this is a convenience layer.
+
+**Independent Test**: Run refuel without the flag against a Spec Kit feature directory and verify ingestion mode is chosen and announced; run it against a classic flight-plan name and verify existing behavior is untouched.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with vendored Spec Kit templates and a feature directory containing a spec and task list, **When** the user runs `maverick refuel <feature>` without the mode flag, **Then** the ingestion path is selected automatically and the chosen mode is clearly announced in the output.
+2. **Given** a feature name that resolves to a classic flight plan (`.maverick/plans/<name>/flight-plan.md`) and not to a Spec Kit directory, **When** the user runs refuel, **Then** the existing decomposition behavior runs unchanged.
+3. **Given** a name that matches both a classic flight plan and a Spec Kit feature directory, **When** the user runs refuel without the flag, **Then** the command stops and asks the user to disambiguate (e.g., by passing the explicit flag) rather than silently picking one.
+4. **Given** the explicit `--speckit` flag and a feature that does not resolve to a Spec Kit-shaped directory, **When** the user runs refuel, **Then** the command fails with an error stating what was looked for and where.
+
+---
+
+### User Story 3 - Preview ingestion without creating anything (Priority: P2)
+
+Before committing to an ingestion, a developer runs the command in dry-run mode to see exactly which epic and task work items would be created — titles, identifiers, phases, dependency edges, and skipped completed tasks — without any work items being created or repository state changing.
+
+**Why this priority**: Ingestion creates many linked work items at once; a preview builds trust and catches parsing surprises cheaply. It is not required for the core path to function.
+
+**Independent Test**: Run dry-run against a valid feature directory, verify the printed plan matches the task list, and verify the work-item store is untouched afterward.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid Spec Kit feature directory, **When** the user runs the ingestion with dry-run, **Then** the full set of would-be work items (epic + tasks, with identifiers, phases, dependencies, and skipped tasks) is displayed and zero work items are created.
+2. **Given** a malformed task list, **When** the user runs dry-run, **Then** the same actionable parse error is reported as a real run would produce — dry-run validates, not just previews.
+
+---
+
+### User Story 4 - Optional enrichment with verification commands (Priority: P3)
+
+A developer opts into a slim enrichment pass at ingestion time. For each task work item, the enrichment attaches concrete verification commands (e.g., which test or check command proves the task done) derived from the repository's conventions. Enrichment never adds, removes, splits, or reorders tasks — the task list remains the single source of truth for decomposition.
+
+**Why this priority**: Improves downstream implementation quality but the ingested work items are already actionable without it. Strictly additive.
+
+**Independent Test**: Run ingestion with enrichment enabled and verify each work item gains verification commands while the set of work items, their identifiers, and their dependency graph are identical to an un-enriched run.
+
+**Acceptance Scenarios**:
+
+1. **Given** enrichment is enabled, **When** ingestion completes, **Then** the set of work items and their dependency graph are byte-for-byte identical to a non-enriched run except for the added verification metadata.
+2. **Given** enrichment fails or is unavailable, **When** ingestion runs, **Then** the ingestion still completes successfully without enrichment and the degradation is reported as a warning, not an error.
+3. **Given** enrichment is not requested, **When** ingestion runs, **Then** no AI model is invoked at any point.
+
+---
+
+### Edge Cases
+
+- **Empty or all-complete task list**: the feature directory parses but contains zero open tasks — the command fails with a message explaining there is nothing to ingest (no orphan epic is created).
+- **Missing plan file**: `plan.md` is absent but spec and tasks are present — ingestion proceeds (the plan is context, not structure) and notes the absence.
+- **Duplicate task identifiers** in the task list — ingestion fails with an error naming the duplicated identifier and its line numbers.
+- **Dependency references to unknown task identifiers** — ingestion fails naming the referencing task, the missing identifier, and the line.
+- **Unsupported template version**: the repository's vendored Spec Kit version falls outside the supported range — ingestion fails upfront with "unsupported template version X, supported: Y" before reading any artifacts.
+- **Template divergence**: the artifacts are from a supported version but don't match the expected structure (e.g., hand-edited section headings, unrecognized task-line format) — ingestion fails with an error that names the file, the line, what was expected, and what to fix; no partial set of work items is left behind.
+- **Re-running ingestion for a feature that already has an open epic** — the run performs a delta ingestion: only tasks not previously ingested become new work items under the existing epic; if there are none, the run is a reported no-op. No duplicate epic or duplicate task work items are ever created.
+- **Interrupted ingestion** (failure partway through creating work items) — the run reports which items were created; a subsequent run's delta ingestion picks up the remaining tasks under the same epic rather than starting over.
+- **Feature reference ambiguity**: the argument matches multiple `specs/` directories (e.g., by partial name) — the command lists the candidates and asks the user to be precise.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The refuel command MUST accept a feature reference that resolves to a Spec Kit feature directory (`specs/NNN-name/`), matching by full directory name, by number prefix, or by exact name suffix.
+- **FR-002**: The system MUST support an explicit Spec Kit mode flag on refuel; when set, refuel MUST use the ingestion path and MUST fail with an actionable error if the resolved directory is not Spec Kit-shaped.
+- **FR-003**: When no mode flag is given, the system MUST auto-detect Spec Kit shape (feature directory with a spec file and task-list file, plus Spec Kit templates vendored in the repository) and select the ingestion path, announcing the selected mode. If the feature reference resolves to both a classic flight plan and a Spec Kit directory, the system MUST stop and ask the user to disambiguate.
+- **FR-004**: Ingestion MUST create exactly one epic work item per run, derived from the feature's specification (title, summary, and success criteria), and MUST link it to the source feature directory for later traceability.
+- **FR-005**: Ingestion MUST create exactly one task work item per open (unchecked) task in the task list, and MUST skip tasks already checked complete, reporting the skipped count.
+- **FR-006**: Each task work item MUST preserve, from its source task line: the task identifier (e.g., T001), the phase it belongs to, its story label if present (e.g., US1), its parallelism marker if present ([P]), and the file paths named in the task text.
+- **FR-007**: Ingestion MUST reproduce the task list's dependency ordering as work-item dependencies using a phase barrier plus explicit notes: no task may become ready until every task in the preceding phase is complete (the barrier wired efficiently, without a full cross-product of edges); explicit per-task dependency annotations (e.g., "depends on T012, T013") add further edges; within a phase, parallel-marked tasks carry no dependencies on one another and unmarked tasks are serialized in listed order. The implementation workflow's ready-work ordering over the ingested items MUST match a valid execution order of the task list.
+- **FR-008**: Each task work item's acceptance criteria MUST include the full task text (including file scope); tasks carrying a story label MUST additionally include that user story's acceptance scenarios from the specification, so completion is verifiable from the work item alone. Unlabeled tasks (setup, foundational, polish) carry task text only. The feature-wide success criteria live on the epic work item, not on individual tasks.
+- **FR-009**: A newly created epic MUST chain behind the most recent existing open epic exactly as today's refuel does (new epic blocked by the tail of the open-epic chain).
+- **FR-010**: The ingestion path MUST NOT invoke any AI model for decomposition under any circumstances; parsing is fully deterministic.
+- **FR-011**: An optional, explicitly requested enrichment pass MAY attach verification commands to task work items. Enrichment MUST NOT add, remove, split, merge, or reorder work items or dependencies, and enrichment failure MUST degrade to a warning, never fail the ingestion.
+- **FR-012**: Ingestion MUST support a declared range of Spec Kit template versions (initially the 0.14.x shape) via a fixed parsing grammar. Before parsing, it MUST check the version vendored in the target repository against that range and fail upfront with "unsupported template version X, supported: Y" when outside it. When artifacts within a supported version diverge structurally from the grammar, ingestion MUST fail before creating any work items, with an error naming the file, line, the expected structure, and a suggested fix.
+- **FR-013**: The command MUST offer a dry-run mode that performs full resolution, parsing, and validation and displays the complete set of would-be work items (epic, tasks, dependencies, skipped tasks) without creating any work items or modifying repository state.
+- **FR-014**: If the resolved feature already has an open epic previously created by ingestion, the command MUST NOT create a second epic. Instead it MUST perform a delta ingestion: create work items only for open tasks not previously ingested under that epic (e.g., tasks appended to the task list after the first run), wire their dependencies into the existing graph, and report already-ingested and completed tasks as skipped. A delta run that finds no new tasks MUST succeed as a no-op and say so.
+- **FR-015**: Ingestion failures after partial work-item creation MUST report exactly which items were created; validation failures (parse errors, unknown references, duplicates) MUST be detected before any work item is created.
+- **FR-016**: Ingestion MUST record run metadata (including the created epic identifier) the same way today's refuel does, so follow-on commands (e.g., the "next: fly --epic <id>" hint and brief/status views) work unchanged.
+
+### Key Entities
+
+- **Spec Kit feature directory**: A directory `specs/NNN-name/` produced by Spec Kit, containing a specification (`spec.md`, with success criteria and user stories), an optional plan (`plan.md`), and a task list (`tasks.md`).
+- **Task entry**: One line of the task list — identifier (T-number), completion checkbox, optional parallelism marker `[P]`, optional story label `[USn]`, description text including file paths, and membership in a phase.
+- **Phase**: A named, ordered grouping of task entries (e.g., Setup, Foundational, per-story phases, Polish) with declared cross-phase dependency rules.
+- **Epic work item**: The single parent bead created per ingestion, carrying the feature's title, summary, success criteria, and a link to the source directory; chained behind existing open epics.
+- **Task work item**: A child bead created from one open task entry, carrying preserved task metadata, acceptance criteria, and dependency edges; consumable by the implementation workflow unchanged.
+- **Dependency edge**: A blocking relationship between two work items derived from the phase barrier (a task starts only after the preceding phase completes), intra-phase sequencing of unmarked tasks, and any explicit per-task dependency notes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For a well-formed feature directory, ingestion completes in under 30 seconds and invokes zero AI models (zero token cost) — compared to today's multi-minute, model-driven decomposition.
+- **SC-002**: 100% of open tasks in the task list appear as work items with their original identifiers; zero tasks are dropped, duplicated, or renamed across a corpus of representative Spec Kit feature directories.
+- **SC-003**: For every ingested feature, the order in which the implementation workflow surfaces ready work items is a valid execution order of the source task list (no task surfaces before its declared prerequisites) in 100% of cases.
+- **SC-004**: 100% of malformed-input failures identify the offending file and line and state what was expected; zero malformed runs leave partially created work items behind.
+- **SC-005**: Dry-run creates zero work items and zero repository changes in 100% of runs, while its preview matches the subsequent real run's output exactly for an unchanged input.
+- **SC-006**: A user who has never read the Spec Kit artifacts can determine, from a single task work item alone, what to do and how to verify completion (task text, file scope, and — for story-labeled tasks — the story's acceptance scenarios are all present on the item).
+
+## Assumptions
+
+- **Refuel has no dry-run today**: the current refuel command exposes `--list-steps` but no `--dry-run`. "Behaves like existing refuel dry-run" is interpreted as: introduce a dry-run consistent with Maverick's existing dry-run conventions (e.g., `land --dry-run`) — full validation and a complete preview, zero mutations.
+- **Completed tasks are skipped**: tasks checked `[x]` in the task list are treated as already done and are not ingested as open work items. They are reported, not silently ignored.
+- **Plan file is optional**: `plan.md` provides context only; its absence does not block ingestion. The spec file and task-list file are both required.
+- **Delta re-runs**: re-ingesting a feature with an existing open ingestion-created epic adds only not-yet-ingested tasks under that epic (task lists legitimately grow, e.g., via convergence assessments that append tasks). Task identity for delta detection is the task identifier within the feature's epic.
+- **Supported template baseline**: ingestion ships a fixed grammar for a declared range of Spec Kit template versions (initially the 0.14.x shape: `Phase N:` headings, `- [ ] T### [P?] [US?] description` task lines, a Dependencies & Execution Order section). The version vendored in the target repository (e.g., recorded by Spec Kit's init metadata) is checked upfront; unsupported versions fail fast per FR-012 rather than being parsed adaptively.
+- **Explicit dependency notes**: free-text per-task dependency annotations (e.g., "depends on T012, T013") are honored as additional dependency edges when present and parseable; phase ordering and intra-phase sequencing remain the structural baseline.
+- **Enrichment scope**: the optional enrichment pass is the only model-touching step, is off by default, and attaches only verification metadata (commands/checks), never structural changes.

--- a/specs/048-speckit-refuel-ingestion/tasks.md
+++ b/specs/048-speckit-refuel-ingestion/tasks.md
@@ -1,0 +1,196 @@
+# Tasks: Spec Kit Ingestion Mode for Refuel
+
+**Input**: Design documents from `/specs/048-speckit-refuel-ingestion/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included — the project constitution mandates test-first (Principle V: TDD red-green-refactor; Debt Prevention: "Tests are not optional"). Test tasks precede their implementation tasks and must fail before implementation.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1 = core ingestion, US2 = auto-detection, US3 = dry-run, US4 = enrichment)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Single project per plan.md: `src/maverick/`, `tests/` at repository root.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Package skeletons and shared test fixtures for all subsequent work
+
+- [X] T001 Create package skeletons: `src/maverick/speckit/{__init__.py,models.py,parser.py,detect.py,build.py,errors.py}` and `src/maverick/workflows/refuel_speckit/{__init__.py,constants.py,models.py,workflow.py}` (module docstrings + `from __future__ import annotations` only; `__init__.py` re-exports to be filled as modules land)
+- [X] T002 [P] Define the Spec Kit error hierarchy in `src/maverick/speckit/errors.py`: `SpeckitError(MaverickError)`, `SpeckitParseError` (fields: file, line, expected, suggestion), `SpeckitValidationError` (duplicate IDs / unknown dep refs / cycles), `AmbiguousFeatureError` (candidates list), `UnsupportedTemplateError` (found version, supported range), `NothingToIngestError` — matching error catalog E01–E07 in contracts/cli-refuel-speckit.md; unit tests in `tests/unit/speckit/test_errors.py` asserting message content
+- [X] T003 [P] Create `tests/unit/speckit/conftest.py` and `tests/unit/workflows/refuel_speckit/conftest.py`: reuse/extend the Spec Kit fixtures from `tests/unit/beads/conftest.py` (`SAMPLE_TASKS_MD`, `SAMPLE_TASKS_MD_WITH_DEPS`, `spec_dir_with_tasks`, `spec_dir_with_deps`, `mock_runner` BeadClient stubbing pattern); add a full-featured fixture feature dir (multi-phase, `[P]`/`[US]` markers, checked tasks, explicit `depends on` notes, fenced code block, Dependencies section) plus a matching spec.md with SC bullets and story Acceptance Scenarios
+
+**Checkpoint**: Skeletons importable, fixtures available — foundational work can begin
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The pure parsing/detection layer every user story depends on (data-model.md parsing layer; contracts/tasks-md-grammar.md)
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T004 [P] Write failing tests for the frozen Pydantic models in `tests/unit/speckit/test_models.py`: `SpeckitTask` (task_id pattern, non-empty description), `SpeckitPhase`, `ParsedSpec`, `SpeckitFeature`, `TemplateCompatibility` status literals, `FeatureResolution` mode literals — per data-model.md field rules
+- [X] T005 Implement `src/maverick/speckit/models.py` (all frozen Pydantic models from data-model.md parsing layer) until T004 passes
+- [X] T006 [P] Write failing table-driven tests for the tasks.md grammar in `tests/unit/speckit/test_parser_tasks.py`: happy path (phases, `[P]`, `[USn]`, checked/unchecked, line numbers), explicit `depends on T###` extraction, file-path token extraction, fenced-code-block skipping, non-`## Phase` heading terminating a section, Dependencies-section story pairs, and hard errors E05 (malformed task-shaped line, non-increasing phase numbers — with file/line/expected/suggestion) and E06 (duplicate task ID with both line numbers, unknown dep ref)
+- [X] T007 [P] Write failing tests for spec.md extraction in `tests/unit/speckit/test_parser_spec.py`: title extraction + fallback, `SC-\d+` bullets, per-story Acceptance Scenarios keyed `USn`, empty-spec E05 case, missing-sections warnings
+- [X] T008 Implement the tasks.md grammar in `src/maverick/speckit/parser.py` (pure functions, no I/O — model on `src/maverick/flight/parser.py` primitives) until T006 passes
+- [X] T009 Implement spec.md extraction in `src/maverick/speckit/parser.py` (`_split_h2_sections`/`_split_h3_sections`-style helpers) until T007 passes
+- [X] T010 [P] Write failing tests for detection in `tests/unit/speckit/test_detect.py`: name resolution (exact dir / `NNN` prefix / exact suffix / multiple candidates → `AmbiguousFeatureError`), shape check (spec.md + tasks.md required, plan.md optional), classic-vs-speckit `FeatureResolution` modes, version gate (`supported` / `unsupported` → `UnsupportedTemplateError` / missing metadata → `unknown` + warning) reading `.specify/init-options.json`
+- [X] T011 Implement `src/maverick/speckit/detect.py` (`resolve_feature()`, `check_template_compatibility()`, `SUPPORTED_SPECKIT_RANGE = ">=0.14,<0.15"`) until T010 passes
+
+**Checkpoint**: `SpeckitFeature` can be produced from any fixture dir; all error paths typed — user stories can now proceed
+
+---
+
+## Phase 3: User Story 1 - Ingest a Spec Kit feature into work items (Priority: P1) 🎯 MVP
+
+**Goal**: `maverick refuel <feature> --speckit` deterministically creates one epic + one task bead per open task with preserved IDs/phases/markers/file scope, phase-barrier + explicit dependency wiring, epic chaining, delta re-runs, and run metadata — zero LLM calls.
+
+**Independent Test**: quickstart.md Scenarios 2–5 — ingest a fixture feature dir with a stubbed (unit) or real (integration) `bd`, verify bead set, ready-ordering, chaining, delta, and fail-before-write.
+
+### Tests for User Story 1
+
+- [X] T012 [P] [US1] Write failing tests for dependency-edge derivation in `tests/unit/speckit/test_build_edges.py`: intra-phase serial chain of non-`[P]` tasks, `[P]` tasks with no implicit intra-phase deps, phase barrier as sinks(N)×sources(N+1) with transitivity assertion (topological order = valid tasks.md execution order), explicit-note edges, story-dep edges only when not implied, cycle detection → `SpeckitValidationError`, delta edge resolution through `existing_task_map` and dropping edges from completed blockers — per data-model.md "Derived dependency edges"
+- [X] T013 [P] [US1] Write failing tests for ingestion-plan building in `tests/unit/speckit/test_build_plan.py`: `PlannedBead` titles (`T###: …` ≤ 490 chars), description markdown exactly per contracts/bead-encoding.md (Task/Acceptance Criteria with story scenarios/File Scope/never-empty Verification with rg-based file checks), epic `PlannedBead` (SC bullets, Source section), `skipped_completed`, delta filtering (`skipped_existing`, no epic on delta), build-time validation failures before any plan is returned, zero-open-tasks → `NothingToIngestError`
+- [X] T014 [US1] Implement edge derivation in `src/maverick/speckit/build.py` until T012 passes
+- [X] T015 [US1] Implement `IngestionPlan`/`PlannedBead` building in `src/maverick/speckit/build.py` (description assembly, default verification per research D8, delta filtering, acyclic validation) until T013 passes
+- [X] T016 [P] [US1] Write failing workflow tests in `tests/unit/workflows/refuel_speckit/test_workflow.py` using the `mock_runner` BeadClient stubbing pattern: fresh run (epic + tasks + `set_state` provenance calls + dependency wiring + epic chaining behind open-epic tail + `RunMetadata` written with status refueled), delta run (existing epic adopted via `speckit_feature` state, only new tasks created, no re-chaining), multiple matching open epics → error, mid-creation failure reports created IDs, validation failure → zero `bd` write calls (FR-015)
+
+### Implementation for User Story 1
+
+- [X] T017 [US1] Implement `src/maverick/workflows/refuel_speckit/constants.py` (step names: `RESOLVE_FEATURE`, `CHECK_TEMPLATE`, `PARSE_ARTIFACTS`, `PLAN_INGESTION`, `ENRICH`, `CREATE_BEADS`, `WIRE_DEPS`, `CHAIN_EPIC`, `RECORD_RUN`, `COMMIT_OUTPUT`, `WORKFLOW_NAME = "refuel-speckit"`) and `src/maverick/workflows/refuel_speckit/models.py` (`SpeckitRefuelResult` dataclass with `to_dict()`, per data-model.md workflow layer)
+- [X] T018 [US1] Implement `SpeckitRefuelWorkflow(PythonWorkflow)` in `src/maverick/workflows/refuel_speckit/workflow.py` until T016 passes: sequential steps with `ProgressEvent` emission, delta epic lookup (`query("type=epic AND status=open")` + `show()` state match), `library/actions/beads.create_beads` + `wire_dependencies` + `BeadClient.add_dependency` for barrier/explicit edges, `set_state` provenance (epic `speckit_feature`; task `speckit_task_id`/`speckit_phase`/`speckit_parallel`), epic chaining (mirror `workflows/refuel_maverick/workflow.py:625-654`), `RunMetadata` via `maverick.runway.run_metadata`, partial-failure ID reporting, `COMMIT_OUTPUT` step honoring `auto_commit` via jj snapshot (mirror classic refuel's `COMMIT_OUTPUT` in `workflows/refuel_maverick/workflow.py`), explicit `cwd` threading throughout (no `Path.cwd()`)
+- [X] T019 [US1] Verify `select_next_bead`'s `flight_plan_name` epic-state read (`src/maverick/library/actions/beads.py:342-347`) tolerates a speckit epic without that state key (research D12); if not, set `flight_plan_name=<feature dir basename>` on the epic in `workflow.py` and cover with a test in `tests/unit/workflows/refuel_speckit/test_workflow.py`
+- [X] T020 [P] [US1] Write failing CLI tests in `tests/unit/cli/commands/refuel/test_speckit_dispatch.py`: `--speckit` forces ingestion mode with mode announcement, `--speckit` + unresolvable name → E02, error rendering for E04–E07 (Rich `err_console`, no tracebacks), `--list-steps` with `--speckit` lists the speckit step names, `--skip-briefing` on the speckit path warns and is ignored, success summary + `Next: maverick fly --epic <id>` hint via `find_latest_run`
+- [X] T021 [US1] Implement the `--speckit` flag and explicit-mode dispatch in `src/maverick/cli/commands/refuel/_group.py` (resolve `cwd` once, call `speckit.detect.resolve_feature`, dispatch to `SpeckitRefuelWorkflow` via `execute_python_workflow`, keep classic path untouched) until T020 passes
+
+**Checkpoint**: MVP — explicit `--speckit` ingestion works end-to-end including delta re-runs; `fly` can implement the resulting beads
+
+---
+
+## Phase 4: User Story 2 - Auto-detection of Spec Kit feature directories (Priority: P2)
+
+**Goal**: `maverick refuel <feature>` without the flag picks the right mode from repository shape; ambiguity stops with clear instructions.
+
+**Independent Test**: run refuel without `--speckit` against speckit-only, classic-only, both-match, and neither fixtures; verify dispatch matrix in contracts/cli-refuel-speckit.md.
+
+- [X] T022 [P] [US2] Write failing tests for the auto-detection dispatch matrix in `tests/unit/cli/commands/refuel/test_speckit_dispatch.py`: speckit-only → ingestion with announcement, classic-only → classic workflow unchanged, both → E01 disambiguation error, neither → E02, both + `--speckit` → ingestion
+- [X] T023 [US2] Implement no-flag auto-detection in `src/maverick/cli/commands/refuel/_group.py` using `FeatureResolution.mode` (dispatch matrix per contract; announce selected mode via `console`) until T022 passes
+
+**Checkpoint**: Flag-free UX complete; classic refuel behavior verifiably unchanged
+
+---
+
+## Phase 5: User Story 3 - Preview ingestion without creating anything (Priority: P2)
+
+**Goal**: `--dry-run` renders the complete would-be plan (epic, tasks, edges, skipped) with zero writes, and validates identically to a real run.
+
+**Independent Test**: quickstart.md Scenario 1 — dry-run against valid and malformed fixtures; assert zero `bd` mutations and preview/real-run parity.
+
+- [X] T024 [P] [US3] Write failing tests in `tests/unit/workflows/refuel_speckit/test_dry_run.py`: dry-run issues zero `bd` write commands (assert against `mock_runner` call list), skips `set_state`/chaining/run-metadata, renders per-task preview (ID, title, phase, `[P]`, blockers) + `Dry run — no beads created.` summary, parse/validation errors surface identically to real runs, result dict marks `dry_run=True` with same planned content as a real run over the same fixture (SC-005 parity), and dry-run over a delta state (existing epic in stub) previews only new tasks with `skipped_existing` listed and still writes nothing
+- [X] T025 [US3] Implement dry-run: add `--dry-run` flag in `src/maverick/cli/commands/refuel/_group.py`, thread `dry_run` workflow input in `src/maverick/workflows/refuel_speckit/workflow.py`, pass `dry_run=True` to `create_beads`/`wire_dependencies`, branch out state/chaining/metadata writes, emit preview via `emit_output` until T024 passes
+
+**Checkpoint**: Safe preview complete; SC-005 verifiable
+
+---
+
+## Phase 6: User Story 4 - Optional enrichment with verification commands (Priority: P3)
+
+**Goal**: Opt-in `--enrich` runs one batched persona-agent call that attaches verification commands to new task beads; failure degrades to a warning; structure never changes.
+
+**Independent Test**: quickstart.md Scenario 6 — enriched run has identical bead set/graph with augmented `## Verification`; broken provider auth still ingests with a warning.
+
+- [X] T026 [P] [US4] Write failing tests in `tests/unit/speckit/test_enrichment.py` and `tests/unit/workflows/refuel_speckit/test_enrichment_step.py`: batched prompt covers all new tasks in one call, per-task command parsing merges into `## Verification` without touching any other description section, task set/edges byte-identical to unenriched plan otherwise, agent failure → structured warning + successful unenriched ingestion, no model construction at all when `--enrich` absent (FR-010), and `--dry-run --enrich` previews enriched verification content without any `bd` writes (research D9)
+- [X] T027 [P] [US4] Add `SpeckitEnrichmentAgent` to `src/maverick/agents/personas.py` (one-shot persona, `provider_tier = "generate"`, modeled on `VerificationPropertiesAgent`; single batched prompt over task IDs + descriptions, returns commands keyed by task ID)
+- [X] T028 [US4] Wire enrichment into `src/maverick/workflows/refuel_speckit/workflow.py` (`ENRICH` step between `PLAN_INGESTION` and `CREATE_BEADS`, so dry-run previews enriched output) and add `--enrich` flag in `src/maverick/cli/commands/refuel/_group.py`, runtime via `runtime_for_agent("generate", agents_config=config.agents)`, failure → warning path, until T026 passes
+
+**Checkpoint**: All four user stories independently functional
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T029 [P] Add integration test `tests/integration/test_speckit_refuel.py` (marked for `make test-integration`; skips when `bd` unavailable) automating quickstart.md Scenarios 2 and 4 against a real temp `bd` database: fresh ingest → ready-order assertion → delta append → no-op run; log elapsed wall-clock per run and warn (not fail) if ingestion exceeds the SC-001 30 s bound
+- [X] T030 [P] Update docs: CLAUDE.md CLI Workflows table (refuel speckit mode, `--dry-run`, `--enrich`) and `maverick refuel` Click help text/examples in `src/maverick/cli/commands/refuel/_group.py`
+- [X] T031 Run `make format-fix && make ci` and fix all fallout (ruff, strict mypy, full test suite); confirm quickstart.md Scenario 7 (zero-model guarantee) by grepping the speckit/refuel_speckit packages for agent/runtime imports outside the enrichment path
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Foundational. Core MVP.
+- **US2 (Phase 4)**: Depends on Foundational + T021 (dispatch code it extends). Touches only `_group.py` + its test file.
+- **US3 (Phase 5)**: Depends on US1 (T018 workflow, T021 CLI).
+- **US4 (Phase 6)**: Depends on US1 (T015 plan builder, T018 workflow); independent of US2/US3.
+- **Polish (Phase 7)**: Depends on desired user stories being complete (T029 needs US1; T030–T031 last)
+
+### Within User Story 1
+
+- T012, T013 (tests) before T014, T015 (build.py implementation); T014 before T015 (same file)
+- T016 (workflow tests) before T017 → T018 → T019
+- T020 (CLI tests) before T021; T021 after T018 (dispatch target must exist)
+
+### Parallel Opportunities
+
+- Phase 1: T002 ∥ T003 (after T001)
+- Phase 2: T004 ∥ T006 ∥ T007 ∥ T010 (all test files, distinct); then T005 ∥ (T008→T009) ∥ T011
+- Phase 3: T012 ∥ T013 ∥ T016 ∥ T020 (four distinct test files); T014→T015 ∥ T017
+- US2 ∥ US4 once their prerequisites land (distinct files)
+- Phase 7: T029 ∥ T030
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Write all US1 test files together (distinct files, all designed to fail first):
+Task: "Edge-derivation tests in tests/unit/speckit/test_build_edges.py"
+Task: "Plan-builder tests in tests/unit/speckit/test_build_plan.py"
+Task: "Workflow tests in tests/unit/workflows/refuel_speckit/test_workflow.py"
+Task: "CLI dispatch tests in tests/unit/cli/commands/refuel/test_speckit_dispatch.py"
+
+# Then implement in dependency order:
+Task: "build.py edges (T014) then plan builder (T015)" ∥ Task: "constants.py + models.py (T017)"
+Task: "workflow.py (T018)" → Task: "flight_plan_name shim check (T019)" → Task: "CLI --speckit (T021)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Phases 1–2 (Setup + Foundational: models, parser, detect)
+2. Phase 3 (US1): explicit `--speckit` ingestion incl. delta + chaining
+3. **STOP and VALIDATE**: quickstart.md Scenarios 2–5 + `make test-fast`
+4. MVP is shippable — auto-detection, dry-run, and enrichment are additive
+
+### Incremental Delivery
+
+1. Setup + Foundational → parser provably correct on fixtures
+2. US1 → deterministic ingestion usable via explicit flag (MVP)
+3. US2 → flag-free UX
+4. US3 → dry-run preview
+5. US4 → optional enrichment
+6. Polish → integration test, docs, `make ci` green
+
+---
+
+## Notes
+
+- Every implementation task is gated by a named failing-test task (constitution Principle V)
+- `[P]` tasks touch different files with no dependency on an incomplete task
+- FR-010 invariant: nothing outside T027/T028 may import agent/runtime machinery
+- Commit after each task or logical group (`bead(<id>)` prefixes when driven via maverick itself)

--- a/src/maverick/agents/personas.py
+++ b/src/maverick/agents/personas.py
@@ -24,6 +24,7 @@ FIXER_TIMEOUT_SECONDS = 1800
 SEED_TIMEOUT_SECONDS = 1800
 CURATOR_TIMEOUT_SECONDS = 600
 VERIFICATION_TIMEOUT_SECONDS = 600
+SPECKIT_ENRICHMENT_TIMEOUT_SECONDS = 600
 
 
 class ConsolidatorAgent(Agent):
@@ -129,15 +130,46 @@ class VerificationPropertiesAgent(Agent):
         return await self._execute_text_via_runtime(prompt, timeout=VERIFICATION_TIMEOUT_SECONDS)
 
 
+class SpeckitEnrichmentAgent(Agent):
+    """Runs one batched pass suggesting verification commands for Spec Kit tasks.
+
+    Opt-in via ``maverick refuel --speckit --enrich``. Returns free text
+    in the fixed ``### T###`` + bullet-list format that
+    ``maverick.speckit.enrichment.parse_enrichment_response`` expects —
+    following the same lightweight persona pattern as
+    :class:`VerificationPropertiesAgent` rather than a structured payload.
+    """
+
+    provider_tier: ClassVar[str] = "generate"
+    persona_name: ClassVar[str | None] = "maverick.flight-plan-generator"
+
+    def __init__(
+        self,
+        *,
+        runtime: AgentRuntime,
+        cwd: str,
+        cost_sink: CostSink | None = None,
+        tag: str | None = None,
+    ) -> None:
+        super().__init__(runtime=runtime, cwd=cwd, cost_sink=cost_sink, tag=tag)
+
+    async def enrich(self, prompt: str) -> str:
+        return await self._execute_text_via_runtime(
+            prompt, timeout=SPECKIT_ENRICHMENT_TIMEOUT_SECONDS
+        )
+
+
 __all__ = [
     "CONSOLIDATOR_TIMEOUT_SECONDS",
     "CURATOR_TIMEOUT_SECONDS",
     "FIXER_TIMEOUT_SECONDS",
     "SEED_TIMEOUT_SECONDS",
+    "SPECKIT_ENRICHMENT_TIMEOUT_SECONDS",
     "VERIFICATION_TIMEOUT_SECONDS",
     "ConsolidatorAgent",
     "CuratorAgent",
     "RunwaySeedAgent",
+    "SpeckitEnrichmentAgent",
     "ValidationFixerAgent",
     "VerificationPropertiesAgent",
 ]

--- a/src/maverick/cli/commands/refuel/_group.py
+++ b/src/maverick/cli/commands/refuel/_group.py
@@ -1,7 +1,8 @@
 """``maverick refuel`` command.
 
-Decomposes a flight plan into beads (work units) using the Thespian
-actor system for parallel agent execution.
+Decomposes a flight plan into beads (work units), either via AI
+decomposition (classic path) or deterministic Spec Kit ingestion
+(``--speckit`` / auto-detected).
 """
 
 from __future__ import annotations
@@ -49,7 +50,28 @@ from maverick.cli.context import ExitCode, async_command
     "--plans-dir",
     default=DEFAULT_PLANS_DIR,
     show_default=True,
-    help="Base plans directory.",
+    help="Base plans directory. Ignored in Spec Kit ingestion mode.",
+)
+@click.option(
+    "--speckit",
+    is_flag=True,
+    default=False,
+    help="Force Spec Kit ingestion mode (parse specs/NNN-name/ deterministically).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Spec Kit mode only: preview the ingestion plan; make zero writes.",
+)
+@click.option(
+    "--enrich",
+    is_flag=True,
+    default=False,
+    help=(
+        "Spec Kit mode only: one-shot model pass attaching verification "
+        "commands to new task beads."
+    ),
 )
 @click.pass_context
 @async_command
@@ -61,17 +83,27 @@ async def refuel(
     skip_briefing: bool,
     auto_commit: bool,
     plans_dir: str,
+    speckit: bool,
+    dry_run: bool,
+    enrich: bool,
 ) -> None:
     """Decompose a flight plan into beads.
 
-    NAME is a kebab-case plan name. The flight plan is read from
-    .maverick/plans/<name>/flight-plan.md.
+    NAME resolves to a classic flight plan
+    (.maverick/plans/<name>/flight-plan.md) or, in a Spec Kit-managed
+    repository, a ``specs/NNN-name/`` feature directory (exact name,
+    ``NNN`` prefix, or exact name suffix) — auto-detected from
+    repository shape, or forced with ``--speckit``.
 
     Examples:
 
         maverick refuel my-feature
 
         maverick refuel my-feature --skip-briefing
+
+        maverick refuel 048 --speckit --dry-run
+
+        maverick refuel 048-my-feature --speckit
     """
     # Preflight: bd installed AND .beads initialized. Catches missing
     # setup in seconds rather than after the full briefing+decompose
@@ -81,6 +113,235 @@ async def refuel(
 
     verify_bd_ready()
 
+    # Refuel runs in the user's checkout. ``maverick init`` runs
+    # ``jj git init --colocate`` so the cwd is always a jj+git repo,
+    # which means every jj-only action (jj_commit_bead, jj log, etc.)
+    # works without vcs detection. Bead commits and plan files land
+    # directly on the user's current branch.
+    cwd = Path.cwd().resolve()
+
+    from maverick.cli.common import cli_error_handler
+
+    with cli_error_handler():
+        use_speckit, speckit_dir = _dispatch_mode(
+            name, speckit_flag=speckit, cwd=cwd, plans_dir=plans_dir, list_steps=list_steps
+        )
+
+    if use_speckit:
+        # In list-steps mode the feature need not resolve to a concrete
+        # directory (the step list is static), so speckit_dir may be None.
+        if not list_steps:
+            assert speckit_dir is not None
+            console.print(f"[dim]Using Spec Kit ingestion ({speckit_dir})[/]")
+        if skip_briefing:
+            console.print(
+                "[yellow]Warning:[/yellow] --skip-briefing has no effect in "
+                "Spec Kit ingestion mode (there is no briefing step)"
+            )
+        await _run_speckit_refuel(
+            ctx,
+            speckit_dir=speckit_dir,
+            cwd=cwd,
+            list_steps=list_steps,
+            session_log=session_log,
+            dry_run=dry_run,
+            enrich=enrich,
+            auto_commit=auto_commit,
+        )
+        return
+
+    if dry_run:
+        console.print(
+            "[yellow]Warning:[/yellow] --dry-run only applies to Spec Kit "
+            "ingestion mode and is ignored on the classic refuel path "
+            "(this run will write beads)"
+        )
+    if enrich:
+        console.print(
+            "[yellow]Warning:[/yellow] --enrich only applies to Spec Kit "
+            "ingestion mode and is ignored on the classic refuel path"
+        )
+
+    await _run_classic_refuel(
+        ctx,
+        name=name,
+        cwd=cwd,
+        list_steps=list_steps,
+        session_log=session_log,
+        skip_briefing=skip_briefing,
+        auto_commit=auto_commit,
+        plans_dir=plans_dir,
+    )
+
+
+def _dispatch_mode(
+    name: str, *, speckit_flag: bool, cwd: Path, plans_dir: str, list_steps: bool = False
+) -> tuple[bool, Path | None]:
+    """Resolve NAME against classic + Spec Kit shapes and pick a mode.
+
+    Args:
+        name: The ``NAME`` argument as given on the command line.
+        speckit_flag: Whether ``--speckit`` was passed (forces ingestion).
+        cwd: Repository root.
+        plans_dir: The CLI's ``--plans-dir`` — threaded through so a
+            classic plan under a non-default directory still resolves.
+        list_steps: Whether ``--list-steps`` was passed. When True,
+            resolution failures degrade to a mode choice rather than
+            raising — the step list is static and useful to inspect
+            before the plan/feature exists.
+
+    Returns:
+        ``(use_speckit, speckit_dir)`` — ``speckit_dir`` is set whenever
+        ``use_speckit`` is True and NAME resolves; it may be None in
+        ``list_steps`` mode, where the concrete directory is not needed.
+
+    Raises:
+        SpeckitError: E01 (ambiguous — both match), E02 (unresolvable).
+        AmbiguousFeatureError: E03 (multiple Spec Kit candidates).
+    """
+    from maverick.speckit.detect import resolve_feature
+    from maverick.speckit.errors import SpeckitError
+
+    resolution = resolve_feature(name, cwd=cwd, plans_dir=plans_dir)
+
+    if speckit_flag:
+        if resolution.speckit_dir is None:
+            if list_steps:
+                # Listing steps doesn't need a resolved feature directory.
+                return True, None
+            raise SpeckitError(
+                f"--speckit given but {name!r} does not resolve to a Spec Kit "
+                f"feature directory (looked for specs/{name}*/ with spec.md "
+                "and tasks.md)"
+            )
+        return True, resolution.speckit_dir
+
+    if resolution.mode == "ambiguous":
+        if list_steps:
+            # Both shapes exist; show the Spec Kit steps for the listing.
+            return True, resolution.speckit_dir
+        raise SpeckitError(
+            f"{name!r} matches both a classic flight plan "
+            f"({resolution.flight_plan_path}) and a Spec Kit feature "
+            f"({resolution.speckit_dir}). Rerun with --speckit to select "
+            "ingestion, or rename one of them to disambiguate."
+        )
+    if resolution.mode == "speckit":
+        return True, resolution.speckit_dir
+    if resolution.mode == "classic":
+        return False, None
+
+    if list_steps:
+        # Nothing resolves yet (e.g. the plan hasn't been created); default
+        # to the classic step list so ``--list-steps`` stays inspectable.
+        return False, None
+    plans_input = Path(plans_dir)
+    plans_base = plans_input if plans_input.is_absolute() else cwd / plans_input
+    raise SpeckitError(
+        f"could not resolve {name!r} to a flight plan or Spec Kit feature "
+        f"(looked in {plans_base / name} and specs/{name}*/)"
+    )
+
+
+async def _run_speckit_refuel(
+    ctx: click.Context,
+    *,
+    speckit_dir: Path | None,
+    cwd: Path,
+    list_steps: bool,
+    session_log: Path | None,
+    dry_run: bool,
+    enrich: bool,
+    auto_commit: bool,
+) -> None:
+    """Dispatch to :class:`SpeckitRefuelWorkflow`."""
+    from maverick.workflows.refuel_speckit.constants import (
+        CHAIN_EPIC,
+        CHECK_TEMPLATE,
+        COMMIT_OUTPUT,
+        CREATE_BEADS,
+        ENRICH,
+        PARSE_ARTIFACTS,
+        PLAN_INGESTION,
+        RECORD_RUN,
+        RESOLVE_FEATURE,
+        WIRE_DEPS,
+        WORKFLOW_NAME,
+    )
+
+    steps = [
+        RESOLVE_FEATURE,
+        CHECK_TEMPLATE,
+        PARSE_ARTIFACTS,
+        PLAN_INGESTION,
+        ENRICH,
+        CREATE_BEADS,
+        WIRE_DEPS,
+        CHAIN_EPIC,
+        RECORD_RUN,
+        COMMIT_OUTPUT,
+    ]
+
+    if list_steps:
+        from maverick.cli.workflow_executor import _display_name
+
+        console.print(f"[bold]Workflow: {WORKFLOW_NAME}[/]")
+        console.print()
+        console.print("[bold]Steps:[/]")
+        for i, step_name in enumerate(steps, 1):
+            console.print(f"  {i}. {_display_name(step_name)}")
+        console.print()
+        raise SystemExit(ExitCode.SUCCESS)
+
+    # Past the list-steps short-circuit an actual run needs a resolved dir.
+    assert speckit_dir is not None
+
+    from maverick.cli.workflow_executor import (
+        PythonWorkflowRunConfig,
+        execute_python_workflow,
+    )
+    from maverick.workflows.refuel_speckit import SpeckitRefuelWorkflow
+
+    workflow_inputs: dict[str, object] = {
+        "feature_dir": str(speckit_dir),
+        "cwd": str(cwd),
+        "dry_run": dry_run,
+        "enrich": enrich,
+        "auto_commit": auto_commit,
+    }
+
+    await execute_python_workflow(
+        ctx,
+        PythonWorkflowRunConfig(
+            workflow_class=SpeckitRefuelWorkflow,
+            inputs=workflow_inputs,
+            session_log_path=session_log,
+        ),
+    )
+
+    if dry_run:
+        return
+
+    from maverick.runway.run_metadata import find_latest_run
+
+    meta = find_latest_run(speckit_dir.name, base=cwd)
+    if meta and meta.epic_id:
+        console.print()
+        console.print(f"[dim]Next:[/] [bold]maverick fly --epic {meta.epic_id}[/]")
+
+
+async def _run_classic_refuel(
+    ctx: click.Context,
+    *,
+    name: str,
+    cwd: Path,
+    list_steps: bool,
+    session_log: Path | None,
+    skip_briefing: bool,
+    auto_commit: bool,
+    plans_dir: str,
+) -> None:
+    """Dispatch to :class:`RefuelMaverickWorkflow` (unchanged classic path)."""
     from maverick.cli.workflow_executor import (
         PythonWorkflowRunConfig,
         execute_python_workflow,
@@ -119,13 +380,6 @@ async def refuel(
             console.print(f"  {i}. {_display_name(step_name)}")
         console.print()
         raise SystemExit(ExitCode.SUCCESS)
-
-    # Refuel runs in the user's checkout. ``maverick init`` runs
-    # ``jj git init --colocate`` so the cwd is always a jj+git repo,
-    # which means every jj-only action (jj_commit_bead, jj log, etc.)
-    # works without vcs detection. Bead commits and plan files land
-    # directly on the user's current branch.
-    cwd = Path.cwd().resolve()
 
     plans_input = Path(plans_dir)
     plans_base = plans_input if plans_input.is_absolute() else cwd / plans_input

--- a/src/maverick/speckit/__init__.py
+++ b/src/maverick/speckit/__init__.py
@@ -1,0 +1,64 @@
+"""Deterministic Spec Kit artifact layer — parsing, detection, and
+ingestion-plan building. No ``bd``/VCS side effects; see
+``maverick.workflows.refuel_speckit`` for the workflow that consumes it.
+"""
+
+from __future__ import annotations
+
+from maverick.speckit.build import (
+    EPIC_TASK_ID,
+    IngestionPlan,
+    PlannedBead,
+    build_ingestion_plan,
+    derive_dependency_edges,
+)
+from maverick.speckit.detect import (
+    SUPPORTED_SPECKIT_RANGE,
+    FeatureResolution,
+    TemplateCompatibility,
+    check_template_compatibility,
+    resolve_feature,
+)
+from maverick.speckit.enrichment import (
+    apply_enrichment,
+    build_enrichment_prompt,
+    parse_enrichment_response,
+)
+from maverick.speckit.errors import (
+    AmbiguousFeatureError,
+    NothingToIngestError,
+    SpeckitError,
+    SpeckitParseError,
+    SpeckitValidationError,
+    UnsupportedTemplateError,
+)
+from maverick.speckit.models import ParsedSpec, SpeckitFeature, SpeckitPhase, SpeckitTask
+from maverick.speckit.parser import parse_spec_md, parse_tasks_md
+
+__all__ = [
+    "EPIC_TASK_ID",
+    "SUPPORTED_SPECKIT_RANGE",
+    "AmbiguousFeatureError",
+    "FeatureResolution",
+    "IngestionPlan",
+    "NothingToIngestError",
+    "ParsedSpec",
+    "PlannedBead",
+    "SpeckitError",
+    "SpeckitFeature",
+    "SpeckitParseError",
+    "SpeckitPhase",
+    "SpeckitTask",
+    "SpeckitValidationError",
+    "TemplateCompatibility",
+    "UnsupportedTemplateError",
+    "apply_enrichment",
+    "build_enrichment_prompt",
+    "build_ingestion_plan",
+    "check_template_compatibility",
+    "derive_dependency_edges",
+    "parse_enrichment_response",
+    "parse_spec_md",
+    "parse_tasks_md",
+    "resolve_feature",
+]

--- a/src/maverick/speckit/build.py
+++ b/src/maverick/speckit/build.py
@@ -1,0 +1,497 @@
+"""IngestionPlan builder: bead definitions, dependency edges, delta filtering.
+
+See ``specs/048-speckit-refuel-ingestion/data-model.md`` "Ingestion-plan
+layer" and ``research.md`` D3/D13 for the rules this module implements.
+
+Edge identifier convention: an edge endpoint is either a Spec Kit task ID
+(``T\\d{3,}``, still to be resolved to a bead ID once the workflow creates
+it) or an already-resolved ``bd`` bead ID for a previously ingested task
+(delta runs). ``bd`` bead IDs never collide with the ``T\\d{3,}`` pattern,
+so callers can tell them apart with a single regex check.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from maverick.beads.models import BeadCategory, BeadDefinition, BeadType
+from maverick.speckit.errors import NothingToIngestError, SpeckitValidationError
+from maverick.speckit.models import SpeckitFeature, SpeckitPhase, SpeckitTask
+
+#: Sentinel task_id for the epic's PlannedBead (data-model.md).
+EPIC_TASK_ID = "EPIC"
+
+_MAX_TITLE_LENGTH = 490
+_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+_COMMAND_PREFIXES = ("rg ", "grep ", "cargo ", "make ")
+
+
+class PlannedBead(BaseModel):
+    """Intent to create one bead as part of an ingestion run."""
+
+    model_config = ConfigDict(frozen=True)
+
+    task_id: str = Field(description="Source task ID; EPIC_TASK_ID for the epic")
+    definition: BeadDefinition
+    state: dict[str, str] = Field(default_factory=dict)
+
+
+class IngestionPlan(BaseModel):
+    """Complete, validated, side-effect-free description of one ingestion run.
+
+    The dry-run rendering and the real run consume this same object —
+    parity by construction (SC-005).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    feature: SpeckitFeature
+    epic: PlannedBead | None = None
+    existing_epic_id: str | None = None
+    new_tasks: tuple[PlannedBead, ...] = ()
+    skipped_completed: tuple[str, ...] = ()
+    skipped_existing: tuple[str, ...] = ()
+    edges: tuple[tuple[str, str], ...] = ()
+    existing_task_map: dict[str, str] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Dependency edge derivation
+# ---------------------------------------------------------------------------
+
+
+def _serial_chain_edges(phase: SpeckitPhase) -> list[tuple[str, str]]:
+    """Rule 1: each non-[P] task depends on the nearest preceding non-[P] task."""
+    edges: list[tuple[str, str]] = []
+    prev: str | None = None
+    for task in phase.tasks:
+        if not task.parallel:
+            if prev is not None:
+                edges.append((prev, task.task_id))
+            prev = task.task_id
+    return edges
+
+
+def _phase_sources(phase: SpeckitPhase, chain_edges: list[tuple[str, str]]) -> list[str]:
+    """Tasks in *phase* with no intra-phase (chain) blocker."""
+    blocked = {b for _a, b in chain_edges}
+    return [t.task_id for t in phase.tasks if t.task_id not in blocked]
+
+
+def _phase_sinks(phase: SpeckitPhase, chain_edges: list[tuple[str, str]]) -> list[str]:
+    """Tasks in *phase* with no intra-phase (chain) dependent."""
+    blockers = {a for a, _b in chain_edges}
+    return [t.task_id for t in phase.tasks if t.task_id not in blockers]
+
+
+def _story_endpoints(ids: set[str], intra_edges: list[tuple[str, str]], *, want: str) -> list[str]:
+    """Sinks/sources of a story's own task set, restricted to edges internal to it."""
+    if want == "sink":
+        blockers = {a for a, _b in intra_edges}
+        return [i for i in ids if i not in blockers]
+    blocked = {b for _a, b in intra_edges}
+    return [i for i in ids if i not in blocked]
+
+
+def _reachable_from(start: str, adjacency: dict[str, set[str]]) -> set[str]:
+    seen: set[str] = set()
+    stack = [start]
+    while stack:
+        node = stack.pop()
+        for nxt in adjacency.get(node, ()):
+            if nxt not in seen:
+                seen.add(nxt)
+                stack.append(nxt)
+    return seen
+
+
+def _detect_cycle(edges: list[tuple[str, str]]) -> tuple[str, ...]:
+    """Return the node sequence of a cycle if one exists, else an empty tuple."""
+    adjacency: dict[str, list[str]] = {}
+    nodes: set[str] = set()
+    for a, b in edges:
+        adjacency.setdefault(a, []).append(b)
+        nodes.add(a)
+        nodes.add(b)
+
+    white, gray, black = 0, 1, 2
+    color: dict[str, int] = {}
+    path: list[str] = []
+
+    def visit(node: str) -> tuple[str, ...] | None:
+        color[node] = gray
+        path.append(node)
+        for nxt in adjacency.get(node, ()):
+            state = color.get(nxt, white)
+            if state == gray:
+                cycle_start = path.index(nxt)
+                return tuple(path[cycle_start:])
+            if state == white:
+                result = visit(nxt)
+                if result:
+                    return result
+        color[node] = black
+        path.pop()
+        return None
+
+    for node in nodes:
+        if color.get(node, white) == white:
+            result = visit(node)
+            if result:
+                return result
+    return ()
+
+
+def derive_dependency_edges(
+    phases: tuple[SpeckitPhase, ...],
+    story_deps: tuple[tuple[str, str], ...] = (),
+) -> tuple[tuple[str, str], ...]:
+    """Derive ``(blocker_task_id, blocked_task_id)`` edges from tasks.md structure.
+
+    Implements the four edge rules from data-model.md "Derived dependency
+    edges": intra-phase serial chains, explicit ``depends on`` notes, the
+    phase barrier (sinks x sources, transitively covered by the chains),
+    and story-level dependencies added only where not already implied.
+
+    Args:
+        phases: Ordered phases (as parsed by :func:`maverick.speckit.parser.parse_tasks_md`).
+        story_deps: ``(dependent_story, blocker_story)`` pairs.
+
+    Returns:
+        Deduplicated edges in first-derived order.
+
+    Raises:
+        SpeckitValidationError: The derived graph contains a cycle (E06).
+    """
+    edges: list[tuple[str, str]] = []
+    phase_chain_edges: dict[int, list[tuple[str, str]]] = {}
+
+    for phase in phases:
+        chain = _serial_chain_edges(phase)
+        phase_chain_edges[phase.number] = chain
+        edges.extend(chain)
+        for task in phase.tasks:
+            for dep in task.explicit_deps:
+                edges.append((dep, task.task_id))
+
+    for i in range(len(phases) - 1):
+        p, p_next = phases[i], phases[i + 1]
+        sinks = _phase_sinks(p, phase_chain_edges[p.number])
+        sources = _phase_sources(p_next, phase_chain_edges[p_next.number])
+        for sink in sinks:
+            for source in sources:
+                edges.append((sink, source))
+
+    if story_deps:
+        story_tasks: dict[str, list[SpeckitTask]] = {}
+        for phase in phases:
+            for task in phase.tasks:
+                if task.story_id:
+                    story_tasks.setdefault(task.story_id, []).append(task)
+
+        adjacency: dict[str, set[str]] = {}
+        for a, b in edges:
+            adjacency.setdefault(a, set()).add(b)
+
+        for dependent_story, blocker_story in story_deps:
+            blocker_tasks = story_tasks.get(blocker_story, [])
+            dependent_tasks = story_tasks.get(dependent_story, [])
+            if not blocker_tasks or not dependent_tasks:
+                continue
+            blocker_ids = {t.task_id for t in blocker_tasks}
+            dependent_ids = {t.task_id for t in dependent_tasks}
+            intra_blocker_edges = [
+                (a, b) for a, b in edges if a in blocker_ids and b in blocker_ids
+            ]
+            intra_dependent_edges = [
+                (a, b) for a, b in edges if a in dependent_ids and b in dependent_ids
+            ]
+            story_sinks = _story_endpoints(blocker_ids, intra_blocker_edges, want="sink")
+            story_sources = _story_endpoints(dependent_ids, intra_dependent_edges, want="source")
+            for blocker_id in story_sinks:
+                reachable = _reachable_from(blocker_id, adjacency)
+                for dependent_id in story_sources:
+                    if dependent_id in reachable or dependent_id == blocker_id:
+                        continue
+                    edges.append((blocker_id, dependent_id))
+                    adjacency.setdefault(blocker_id, set()).add(dependent_id)
+
+    cycle = _detect_cycle(edges)
+    if cycle:
+        raise SpeckitValidationError(
+            f"dependency cycle detected: {' -> '.join(cycle)}",
+            cycle=cycle,
+        )
+
+    seen: set[tuple[str, str]] = set()
+    deduped: list[tuple[str, str]] = []
+    for edge in edges:
+        if edge not in seen:
+            seen.add(edge)
+            deduped.append(edge)
+    return tuple(deduped)
+
+
+def _resolve_delta_edges(
+    edges: tuple[tuple[str, str], ...],
+    *,
+    completed_ids: set[str],
+    existing_task_map: dict[str, str],
+    new_task_ids: set[str],
+) -> tuple[tuple[str, str], ...]:
+    """Restrict edges to those blocking a new task; resolve/drop the blocker side."""
+    resolved: list[tuple[str, str]] = []
+    for blocker, blocked in edges:
+        if blocked not in new_task_ids:
+            continue
+        if blocker in completed_ids:
+            continue
+        resolved_blocker = existing_task_map.get(blocker, blocker)
+        resolved.append((resolved_blocker, blocked))
+    return tuple(resolved)
+
+
+# ---------------------------------------------------------------------------
+# Bead content assembly (contracts/bead-encoding.md)
+# ---------------------------------------------------------------------------
+
+
+def _truncate_title(text: str, limit: int = _MAX_TITLE_LENGTH) -> str:
+    return text if len(text) <= limit else text[:limit]
+
+
+def _extract_verbatim_commands(text: str) -> tuple[str, ...]:
+    """Best-effort extraction of backtick-quoted rg/grep/cargo/make commands."""
+    commands = []
+    for match in _INLINE_CODE_RE.findall(text):
+        stripped = match.strip()
+        if stripped.startswith(_COMMAND_PREFIXES):
+            commands.append(stripped)
+    return tuple(commands)
+
+
+def _build_verification_lines(task: SpeckitTask, feature: SpeckitFeature) -> list[str]:
+    lines = [f"rg --files -g '{path}'" for path in task.file_paths]
+    lines.extend(_extract_verbatim_commands(task.description))
+    if not lines:
+        # Fallback: confirm the source feature directory itself exists —
+        # a trivially-true but non-empty check (D8: never leave the AC-check
+        # gate with nothing to run).
+        lines.append(f"rg --files -g '{feature.feature_name}'")
+    return lines
+
+
+def _build_task_description(
+    task: SpeckitTask,
+    phase: SpeckitPhase,
+    feature: SpeckitFeature,
+) -> str:
+    context_bits = [f"Phase {phase.number}: {phase.title}"]
+    if task.story_id:
+        context_bits.append(f"Story {task.story_id}")
+    if task.parallel:
+        context_bits.append("parallel-eligible")
+
+    lines = [
+        "## Task",
+        f"{task.description} ({', '.join(context_bits)})",
+        "",
+        "## Acceptance Criteria",
+        f"- {task.description}",
+    ]
+    if task.story_id:
+        for scenario in feature.spec.story_scenarios.get(task.story_id, ()):
+            lines.append(f"- {scenario}")
+
+    if task.file_paths:
+        lines.extend(["", "## File Scope"])
+        lines.extend(f"- {path}" for path in task.file_paths)
+
+    lines.extend(["", "## Verification"])
+    lines.extend(f"- {cmd}" for cmd in _build_verification_lines(task, feature))
+
+    return "\n".join(lines)
+
+
+def _build_task_planned_bead(
+    task: SpeckitTask,
+    phase: SpeckitPhase,
+    feature: SpeckitFeature,
+) -> PlannedBead:
+    title = _truncate_title(f"{task.task_id}: {task.description}")
+    definition = BeadDefinition(
+        title=title,
+        bead_type=BeadType.TASK,
+        priority=2,
+        category=BeadCategory.USER_STORY,
+        description=_build_task_description(task, phase, feature),
+        phase_names=[phase.title],
+        user_story_id=task.story_id,
+        task_ids=[task.task_id],
+        labels=["speckit"],
+    )
+    return PlannedBead(
+        task_id=task.task_id,
+        definition=definition,
+        state={
+            "speckit_task_id": task.task_id,
+            "speckit_phase": str(task.phase_number),
+            "speckit_parallel": "true" if task.parallel else "false",
+        },
+    )
+
+
+def _build_epic_description(feature: SpeckitFeature) -> str:
+    lines = [f"{feature.spec.title or feature.feature_name} — ingested from Spec Kit."]
+    if feature.spec.success_criteria:
+        lines.extend(["", "## Success Criteria"])
+        lines.extend(f"- {sc}" for sc in feature.spec.success_criteria)
+    lines.extend(["", "## Source", f"- specs/{feature.feature_name}/"])
+    return "\n".join(lines)
+
+
+def _build_epic_planned_bead(feature: SpeckitFeature) -> PlannedBead:
+    title = _truncate_title(feature.spec.title or feature.feature_name)
+    all_task_ids = [task.task_id for phase in feature.phases for task in phase.tasks]
+    definition = BeadDefinition(
+        title=title,
+        bead_type=BeadType.EPIC,
+        priority=1,
+        category=BeadCategory.USER_STORY,
+        description=_build_epic_description(feature),
+        phase_names=[phase.title for phase in feature.phases],
+        task_ids=all_task_ids,
+        labels=["speckit"],
+    )
+    return PlannedBead(
+        task_id=EPIC_TASK_ID,
+        definition=definition,
+        state={"speckit_feature": feature.feature_name},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ingestion plan
+# ---------------------------------------------------------------------------
+
+
+def build_ingestion_plan(
+    feature: SpeckitFeature,
+    *,
+    existing_epic_id: str | None = None,
+    existing_task_map: dict[str, str] | None = None,
+) -> tuple[IngestionPlan, tuple[str, ...]]:
+    """Build a fully validated :class:`IngestionPlan` from a parsed feature.
+
+    All validation (unique IDs already enforced by the parser; explicit
+    deps resolve; acyclic dependency graph) completes before this
+    function returns — no ``bd`` write may occur before that (FR-015).
+
+    Args:
+        feature: The parsed Spec Kit feature.
+        existing_epic_id: Set on delta runs (an open epic already exists
+            for this feature). ``None`` on a fresh run.
+        existing_task_map: ``task_id -> bead_id`` for previously ingested
+            tasks (delta runs only).
+
+    Returns:
+        A two-tuple of ``(plan, warnings)``.
+
+    Raises:
+        NothingToIngestError: Every task in the feature is already
+            completed (E07 — first-run only; a delta no-op where all
+            *remaining* tasks are already ingested is not an error).
+        SpeckitValidationError: Duplicate IDs, unknown dep refs, or a
+            dependency cycle.
+    """
+    existing_task_map = dict(existing_task_map or {})
+    warnings: list[str] = []
+
+    all_pairs = [(phase, task) for phase in feature.phases for task in phase.tasks]
+    total_count = len(all_pairs)
+    completed_pairs = [(phase, task) for phase, task in all_pairs if task.completed]
+    open_pairs = [(phase, task) for phase, task in all_pairs if not task.completed]
+
+    if not open_pairs:
+        raise NothingToIngestError(
+            f"nothing to ingest for {feature.feature_name}: all {total_count} "
+            "tasks are already completed",
+            completed_count=len(completed_pairs),
+            total_count=total_count,
+        )
+
+    skipped_completed = tuple(task.task_id for _phase, task in completed_pairs)
+    skipped_existing = tuple(
+        task.task_id for _phase, task in open_pairs if task.task_id in existing_task_map
+    )
+    new_pairs = [
+        (phase, task) for phase, task in open_pairs if task.task_id not in existing_task_map
+    ]
+
+    # Full-graph validation (rules 1-4 + acyclicity) regardless of delta status.
+    derived_edges = derive_dependency_edges(feature.phases, feature.story_deps)
+
+    for _phase, task in all_pairs:
+        if task.story_id and task.story_id not in feature.spec.story_scenarios:
+            warnings.append(
+                f"task {task.task_id} labeled {task.story_id}, but spec.md has no "
+                "matching User Story section — scenarios omitted"
+            )
+
+    if not new_pairs:
+        return (
+            IngestionPlan(
+                feature=feature,
+                epic=None,
+                existing_epic_id=existing_epic_id,
+                new_tasks=(),
+                skipped_completed=skipped_completed,
+                skipped_existing=skipped_existing,
+                edges=(),
+                existing_task_map=existing_task_map,
+            ),
+            tuple(warnings),
+        )
+
+    completed_ids = {task.task_id for _phase, task in completed_pairs}
+    new_task_ids = {task.task_id for _phase, task in new_pairs}
+    resolved_edges = _resolve_delta_edges(
+        derived_edges,
+        completed_ids=completed_ids,
+        existing_task_map=existing_task_map,
+        new_task_ids=new_task_ids,
+    )
+
+    new_tasks = tuple(_build_task_planned_bead(task, phase, feature) for phase, task in new_pairs)
+
+    epic: PlannedBead | None = None
+    if existing_epic_id is None:
+        epic = _build_epic_planned_bead(feature)
+        if not feature.spec.success_criteria:
+            warnings.append(
+                f"{feature.feature_name}: spec.md has no Success Criteria section "
+                "— epic description omits it"
+            )
+
+    plan = IngestionPlan(
+        feature=feature,
+        epic=epic,
+        existing_epic_id=existing_epic_id,
+        new_tasks=new_tasks,
+        skipped_completed=skipped_completed,
+        skipped_existing=skipped_existing,
+        edges=resolved_edges,
+        existing_task_map=existing_task_map,
+    )
+    return plan, tuple(warnings)
+
+
+__all__ = [
+    "EPIC_TASK_ID",
+    "IngestionPlan",
+    "PlannedBead",
+    "build_ingestion_plan",
+    "derive_dependency_edges",
+]

--- a/src/maverick/speckit/detect.py
+++ b/src/maverick/speckit/detect.py
@@ -1,0 +1,219 @@
+"""Feature-dir resolution, shape detection, and template version gating.
+
+See ``specs/048-speckit-refuel-ingestion/research.md`` D5 and D11 for the
+rationale, and ``contracts/cli-refuel-speckit.md`` for the NAME
+resolution table this module implements.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from maverick.speckit.errors import AmbiguousFeatureError
+
+#: Initially 0.14.x — bump when a new Spec Kit template shape is verified.
+SUPPORTED_SPECKIT_RANGE = ">=0.14,<0.15"
+
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)(?:\.(\d+))?")
+_RANGE_CLAUSE_RE = re.compile(r"^(>=|<=|>|<|==)\s*(.+)$")
+_NNN_PREFIX_RE = re.compile(r"^\d{3,}-")
+
+#: Default base directory for classic flight plans, relative to the repo
+#: root. Mirrors ``maverick.cli.commands.flight_plan._group.DEFAULT_PLANS_DIR``
+#: without importing the CLI layer into this pure artifact module.
+_DEFAULT_PLANS_DIR = ".maverick/plans"
+
+
+class TemplateCompatibility(BaseModel):
+    """Result of checking the vendored Spec Kit template version."""
+
+    model_config = ConfigDict(frozen=True)
+
+    vendored_version: str | None = None
+    supported_range: str = SUPPORTED_SPECKIT_RANGE
+    status: Literal["supported", "unsupported", "unknown"]
+
+
+class FeatureResolution(BaseModel):
+    """CLI-boundary dispatch result for a ``maverick refuel <name>`` call."""
+
+    model_config = ConfigDict(frozen=True)
+
+    query: str
+    speckit_dir: Path | None = None
+    flight_plan_path: Path | None = None
+    mode: Literal["speckit", "classic", "ambiguous", "unresolved"]
+
+
+def _parse_version(version: str) -> tuple[int, int, int]:
+    m = _VERSION_RE.match(version.strip())
+    if not m:
+        raise ValueError(f"unparseable version: {version!r}")
+    major, minor, patch = m.group(1), m.group(2), m.group(3) or "0"
+    return int(major), int(minor), int(patch)
+
+
+def _version_satisfies(version: tuple[int, int, int], range_str: str) -> bool:
+    for part in range_str.split(","):
+        clause_m = _RANGE_CLAUSE_RE.match(part.strip())
+        if not clause_m:
+            continue
+        op, bound_str = clause_m.group(1), clause_m.group(2)
+        bound = _parse_version(bound_str)
+        if op == ">=" and not version >= bound:
+            return False
+        if op == "<=" and not version <= bound:
+            return False
+        if op == ">" and not version > bound:
+            return False
+        if op == "<" and not version < bound:
+            return False
+        if op == "==" and version != bound:
+            return False
+    return True
+
+
+def check_template_compatibility(cwd: Path) -> TemplateCompatibility:
+    """Read ``.specify/init-options.json`` and gate on ``speckit_version``.
+
+    Absent file/field -> ``"unknown"`` (warn and proceed structurally,
+    per D5). Unparseable version -> ``"unknown"``. Outside
+    :data:`SUPPORTED_SPECKIT_RANGE` -> ``"unsupported"`` (caller should
+    fail upfront with E04).
+
+    Args:
+        cwd: Repository root (not the feature dir — version metadata is
+            per-repo).
+
+    Returns:
+        A :class:`TemplateCompatibility`.
+    """
+    init_options_path = cwd / ".specify" / "init-options.json"
+    if not init_options_path.is_file():
+        return TemplateCompatibility(vendored_version=None, status="unknown")
+
+    try:
+        data = json.loads(init_options_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return TemplateCompatibility(vendored_version=None, status="unknown")
+
+    version = data.get("speckit_version") if isinstance(data, dict) else None
+    if not version:
+        return TemplateCompatibility(vendored_version=None, status="unknown")
+
+    try:
+        parsed = _parse_version(str(version))
+    except ValueError:
+        return TemplateCompatibility(vendored_version=str(version), status="unknown")
+
+    status: Literal["supported", "unsupported"] = (
+        "supported" if _version_satisfies(parsed, SUPPORTED_SPECKIT_RANGE) else "unsupported"
+    )
+    return TemplateCompatibility(vendored_version=str(version), status=status)
+
+
+def _has_speckit_shape(path: Path) -> bool:
+    return path.is_dir() and (path / "spec.md").is_file() and (path / "tasks.md").is_file()
+
+
+def _find_speckit_dir(cwd: Path, query: str) -> Path | None:
+    """Resolve *query* to a single ``specs/NNN-name/`` directory.
+
+    Match order: exact directory name, then (unique) ``NNN`` prefix or
+    exact name suffix among shape-valid directories.
+
+    Raises:
+        AmbiguousFeatureError: More than one directory matches (E03).
+    """
+    specs_dir = cwd / "specs"
+    if not specs_dir.is_dir():
+        return None
+
+    exact = specs_dir / query
+    if _has_speckit_shape(exact):
+        return exact
+
+    candidates: list[Path] = []
+    for child in sorted(specs_dir.iterdir()):
+        if not _has_speckit_shape(child):
+            continue
+        name = child.name
+        if name == query:
+            continue
+        prefix_match = (
+            query.isdigit() and _NNN_PREFIX_RE.match(name) and name.startswith(f"{query}-")
+        )
+        if prefix_match or name.endswith(f"-{query}"):
+            candidates.append(child)
+
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+
+    raise AmbiguousFeatureError(
+        f"multiple Spec Kit feature directories match {query!r}: "
+        + ", ".join(str(c) for c in candidates),
+        query=query,
+        candidates=tuple(str(c) for c in candidates),
+    )
+
+
+def resolve_feature(
+    query: str, *, cwd: Path, plans_dir: str = _DEFAULT_PLANS_DIR
+) -> FeatureResolution:
+    """Resolve *query* against both classic and Spec Kit dispatch shapes.
+
+    Args:
+        query: The ``NAME`` argument as given on the command line.
+        cwd: Repository root.
+        plans_dir: Base directory (absolute, or relative to *cwd*) where
+            classic flight plans live. Must match the CLI's ``--plans-dir``
+            so a plan under a non-default directory still resolves as
+            ``"classic"``.
+
+    Returns:
+        A :class:`FeatureResolution` describing which mode(s) matched.
+
+    Raises:
+        AmbiguousFeatureError: Multiple Spec Kit directories match (E03).
+    """
+    speckit_dir = _find_speckit_dir(cwd, query)
+
+    plans_input = Path(plans_dir)
+    plans_base = plans_input if plans_input.is_absolute() else cwd / plans_input
+    flight_plan_path: Path | None = None
+    candidate_fp = plans_base / query / "flight-plan.md"
+    if candidate_fp.is_file():
+        flight_plan_path = candidate_fp
+
+    mode: Literal["speckit", "classic", "ambiguous", "unresolved"]
+    if speckit_dir is not None and flight_plan_path is not None:
+        mode = "ambiguous"
+    elif speckit_dir is not None:
+        mode = "speckit"
+    elif flight_plan_path is not None:
+        mode = "classic"
+    else:
+        mode = "unresolved"
+
+    return FeatureResolution(
+        query=query,
+        speckit_dir=speckit_dir,
+        flight_plan_path=flight_plan_path,
+        mode=mode,
+    )
+
+
+__all__ = [
+    "SUPPORTED_SPECKIT_RANGE",
+    "FeatureResolution",
+    "TemplateCompatibility",
+    "check_template_compatibility",
+    "resolve_feature",
+]

--- a/src/maverick/speckit/enrichment.py
+++ b/src/maverick/speckit/enrichment.py
@@ -1,0 +1,105 @@
+"""Optional enrichment: batched verification-command suggestions.
+
+One model call covers every new task bead in a run (research D9). The
+response is parsed into commands keyed by task ID and merged into each
+task's ``## Verification`` section — no other section, and no task/edge
+structure, ever changes (contracts/bead-encoding.md).
+"""
+
+from __future__ import annotations
+
+import re
+
+from maverick.speckit.build import IngestionPlan, PlannedBead
+
+# Accept 2- or 3-hash headings: the batched prompt lists each task under a
+# ``## T###`` heading, and models frequently echo that depth in the reply
+# even though the requested format is ``### T###``. Tolerating both keeps
+# enrichment from silently yielding zero commands.
+_TASK_HEADING_RE = re.compile(r"^#{2,3}\s+(T\d{3,})\s*$")
+_BULLET_RE = re.compile(r"^-\s+(.+)$")
+
+
+def build_enrichment_prompt(new_tasks: tuple[PlannedBead, ...]) -> str:
+    """Build one batched prompt covering every new task bead.
+
+    Args:
+        new_tasks: The plan's new task beads (never the epic).
+
+    Returns:
+        A single prompt requesting a fixed ``### T### `` + bullet-list
+        response format, one section per task ID.
+    """
+    lines = [
+        "For each task below, suggest 1-3 concrete shell commands that would "
+        "verify the task is complete (e.g. running its tests, linting the "
+        "changed files, or checking a build). Reply using EXACTLY this "
+        "format, one section per task ID, in the same order as given:",
+        "",
+        "### T###",
+        "- <command>",
+        "",
+    ]
+    for pb in new_tasks:
+        lines.append(f"## {pb.task_id}")
+        lines.append(pb.definition.description)
+        lines.append("")
+    return "\n".join(lines)
+
+
+def parse_enrichment_response(text: str) -> dict[str, list[str]]:
+    """Parse the batched enrichment response into commands keyed by task ID."""
+    commands: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        heading_m = _TASK_HEADING_RE.match(line.strip())
+        if heading_m:
+            current = heading_m.group(1)
+            commands.setdefault(current, [])
+            continue
+        if current is None:
+            continue
+        bullet_m = _BULLET_RE.match(line.strip())
+        if bullet_m:
+            commands[current].append(bullet_m.group(1).strip())
+    return commands
+
+
+def _augment_verification(description: str, extra_commands: list[str]) -> str:
+    """Append *extra_commands* to the description's ``## Verification`` section.
+
+    Every other section is left untouched.
+    """
+    if not extra_commands:
+        return description
+    marker = "## Verification"
+    extra_lines = "\n".join(f"- {c}" for c in extra_commands)
+    if marker not in description:
+        # Shouldn't happen (Verification is never empty per contract), but
+        # degrade gracefully by appending a new section.
+        return f"{description}\n\n{marker}\n{extra_lines}"
+    return f"{description}\n{extra_lines}"
+
+
+def apply_enrichment(
+    plan: IngestionPlan,
+    commands_by_task: dict[str, list[str]],
+) -> IngestionPlan:
+    """Return a new :class:`IngestionPlan` with new tasks' verification augmented.
+
+    Only ``description`` changes on affected task beads; task set, edges,
+    and every other field are byte-identical to the unenriched plan.
+    """
+    new_tasks = []
+    for pb in plan.new_tasks:
+        extra = commands_by_task.get(pb.task_id, [])
+        if not extra:
+            new_tasks.append(pb)
+            continue
+        augmented_description = _augment_verification(pb.definition.description, extra)
+        new_definition = pb.definition.model_copy(update={"description": augmented_description})
+        new_tasks.append(pb.model_copy(update={"definition": new_definition}))
+    return plan.model_copy(update={"new_tasks": tuple(new_tasks)})
+
+
+__all__ = ["apply_enrichment", "build_enrichment_prompt", "parse_enrichment_response"]

--- a/src/maverick/speckit/errors.py
+++ b/src/maverick/speckit/errors.py
@@ -1,0 +1,153 @@
+"""Spec Kit ingestion exception hierarchy.
+
+Backs the error catalog in ``contracts/cli-refuel-speckit.md`` (E01-E07).
+E01 (name matches both classic and speckit) and E02 (unresolvable name)
+are raised as plain :class:`SpeckitError` from the CLI dispatch layer —
+their messages are fully determined by resolution context and need no
+extra structured fields. E03-E07 carry structured fields callers can
+render or inspect programmatically.
+"""
+
+from __future__ import annotations
+
+from maverick.exceptions.base import MaverickError
+
+
+class SpeckitError(MaverickError):
+    """Base exception for Spec Kit ingestion errors.
+
+    Attributes:
+        message: Human-readable error message.
+    """
+
+
+class SpeckitParseError(SpeckitError):
+    """Hard grammar violation in a Spec Kit artifact (E05).
+
+    Attributes:
+        message: Human-readable error message.
+        file: Path to the file that failed to parse.
+        line: 1-based line number where the violation occurred.
+        expected: Description of the expected structure.
+        suggestion: Suggested fix for the offending line.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        file: str,
+        line: int,
+        expected: str,
+        suggestion: str,
+    ) -> None:
+        self.file = file
+        self.line = line
+        self.expected = expected
+        self.suggestion = suggestion
+        super().__init__(message)
+
+
+class SpeckitValidationError(SpeckitError):
+    """Graph/identity validation failure (E06): duplicate task ID,
+    unknown dependency reference, or a dependency cycle.
+
+    Attributes:
+        message: Human-readable error message.
+        file: Path to the file containing the offending reference(s).
+        task_id: The task ID involved in the violation, if applicable.
+        lines: Line numbers implicated (e.g. both lines of a duplicate).
+        unknown_ref: The unresolved dependency ID, if applicable.
+        cycle: Task IDs forming a dependency cycle, if applicable.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        file: str | None = None,
+        task_id: str | None = None,
+        lines: tuple[int, ...] = (),
+        unknown_ref: str | None = None,
+        cycle: tuple[str, ...] = (),
+    ) -> None:
+        self.file = file
+        self.task_id = task_id
+        self.lines = lines
+        self.unknown_ref = unknown_ref
+        self.cycle = cycle
+        super().__init__(message)
+
+
+class AmbiguousFeatureError(SpeckitError):
+    """Ambiguous feature resolution — multiple candidates found (E01/E03).
+
+    Attributes:
+        message: Human-readable error message.
+        query: The name argument as given.
+        candidates: All matching candidate paths/labels, for display.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        query: str,
+        candidates: tuple[str, ...],
+    ) -> None:
+        self.query = query
+        self.candidates = candidates
+        super().__init__(message)
+
+
+class UnsupportedTemplateError(SpeckitError):
+    """Vendored Spec Kit template version is outside the supported range (E04).
+
+    Attributes:
+        message: Human-readable error message.
+        found_version: The vendored version that failed the range check.
+        supported_range: The declared supported version range.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        found_version: str,
+        supported_range: str,
+    ) -> None:
+        self.found_version = found_version
+        self.supported_range = supported_range
+        super().__init__(message)
+
+
+class NothingToIngestError(SpeckitError):
+    """Every task in the feature is already completed (E07): no epic,
+    zero beads created.
+
+    Attributes:
+        message: Human-readable error message.
+        completed_count: Number of tasks checked ``[x]``.
+        total_count: Total number of tasks in the feature.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        completed_count: int,
+        total_count: int,
+    ) -> None:
+        self.completed_count = completed_count
+        self.total_count = total_count
+        super().__init__(message)
+
+
+__all__ = [
+    "AmbiguousFeatureError",
+    "NothingToIngestError",
+    "SpeckitError",
+    "SpeckitParseError",
+    "SpeckitValidationError",
+    "UnsupportedTemplateError",
+]

--- a/src/maverick/speckit/models.py
+++ b/src/maverick/speckit/models.py
@@ -1,0 +1,96 @@
+"""Frozen Pydantic models for the Spec Kit parsing layer.
+
+See ``specs/048-speckit-refuel-ingestion/data-model.md`` for the field
+rules these models encode.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_TASK_ID_RE = re.compile(r"^T\d{3,}$")
+
+
+class SpeckitTask(BaseModel):
+    """One task line parsed from tasks.md."""
+
+    model_config = ConfigDict(frozen=True)
+
+    task_id: str = Field(description="Matches T\\d{3,}; unique within the feature")
+    description: str = Field(description="Full task text after markers")
+    completed: bool = Field(description="[x] -> True, [ ] -> False")
+    parallel: bool = Field(description="[P] marker present")
+    story_id: str | None = Field(default=None, description="From [USn] marker")
+    phase_number: int = Field(ge=1, description="Owning phase")
+    file_paths: tuple[str, ...] = Field(
+        default=(), description="Path tokens extracted from description"
+    )
+    explicit_deps: tuple[str, ...] = Field(
+        default=(), description="Task IDs from 'depends on Txxx' notes"
+    )
+    line_number: int = Field(ge=1, description="1-based source line in tasks.md")
+
+    @field_validator("task_id")
+    @classmethod
+    def _task_id_must_match_pattern(cls, v: str) -> str:
+        if not _TASK_ID_RE.match(v):
+            raise ValueError(f"task_id must match T\\d{{3,}}, got: {v!r}")
+        return v
+
+    @field_validator("description")
+    @classmethod
+    def _description_must_not_be_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("description must not be empty")
+        return v
+
+
+class SpeckitPhase(BaseModel):
+    """A ``## Phase <n>: <title>`` section from tasks.md."""
+
+    model_config = ConfigDict(frozen=True)
+
+    number: int = Field(ge=1, description="From the phase heading; strictly increasing")
+    title: str = Field(default="", description="Heading text after the colon")
+    tasks: tuple[SpeckitTask, ...] = Field(default=(), description="In file order")
+
+
+class ParsedSpec(BaseModel):
+    """Extraction from spec.md."""
+
+    model_config = ConfigDict(frozen=True)
+
+    title: str = Field(default="", description="From the H1; fallback handled by caller")
+    success_criteria: tuple[str, ...] = Field(
+        default=(), description="SC-\\d+ bullets under Success Criteria"
+    )
+    story_scenarios: dict[str, tuple[str, ...]] = Field(
+        default_factory=dict,
+        description="Key 'USn' -> that story's Acceptance Scenarios items",
+    )
+
+
+class SpeckitFeature(BaseModel):
+    """Aggregate of one feature directory — the output of the parse step."""
+
+    model_config = ConfigDict(frozen=True)
+
+    feature_dir: Path = Field(description="Absolute resolved specs/NNN-name/")
+    feature_name: str = Field(description="Directory basename")
+    spec: ParsedSpec = Field(description="Required — spec.md must exist")
+    phases: tuple[SpeckitPhase, ...] = Field(description="Required — tasks.md must exist")
+    story_deps: tuple[tuple[str, str], ...] = Field(
+        default=(), description="(dependent_story, blocker_story) pairs"
+    )
+    has_plan: bool = Field(default=False, description="plan.md present")
+
+
+__all__ = [
+    "ParsedSpec",
+    "SpeckitFeature",
+    "SpeckitPhase",
+    "SpeckitTask",
+]

--- a/src/maverick/speckit/parser.py
+++ b/src/maverick/speckit/parser.py
@@ -1,0 +1,394 @@
+"""Pure grammar functions for Spec Kit artifacts (tasks.md, spec.md).
+
+Modeled on ``maverick.flight.parser``: no I/O, deterministic, table-driven.
+See ``specs/048-speckit-refuel-ingestion/contracts/tasks-md-grammar.md``
+for the grammar this module implements.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from maverick.speckit.errors import SpeckitParseError, SpeckitValidationError
+from maverick.speckit.models import ParsedSpec, SpeckitPhase, SpeckitTask
+
+
+@dataclass
+class _OpenPhase:
+    """Mutable accumulator for the phase currently being parsed."""
+
+    number: int
+    title: str
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns
+# ---------------------------------------------------------------------------
+
+_PHASE_HEADING_RE = re.compile(r"^## Phase (\d+)(?::\s*(.*))?$")
+_DEPENDENCIES_HEADING_RE = re.compile(r"^## Dependencies(?:\s*&\s*Execution Order)?\s*$")
+_OTHER_H2_RE = re.compile(r"^## ")
+_CHECKBOX_SHAPE_RE = re.compile(r"^-\s+\[[ xX]\]")
+_TASK_LINE_RE = re.compile(r"^-\s+\[([ xX])\]\s+(T\d{3,})( \[P\])?(?: \[US(\d+)\])?\s+(.+)$")
+_STORY_DEP_RE = re.compile(
+    r"^-\s+(US\d+):\s*Depends on\s+(US\d+(?:\s*,\s*US\d+)*)\.?\s*$",
+    re.IGNORECASE,
+)
+_DEPENDS_ON_RE = re.compile(r"\(?depends on:?\s*((?:T\d{3,}\s*,?\s*)+)\)?", re.IGNORECASE)
+_TASK_ID_TOKEN_RE = re.compile(r"T\d{3,}")
+_FENCE_RE = re.compile(r"^\s*```")
+_HTML_COMMENT_END_RE = re.compile(r"-->")
+
+_TITLE_RE = re.compile(r"^# Feature Specification:\s*(.+)$", re.MULTILINE)
+_H1_FALLBACK_RE = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+_SC_BULLET_RE = re.compile(r"^-\s+(\*\*SC-\d+\*\*:.*)$")
+_STORY_HEADING_RE = re.compile(r"^User Story\s+(\d+)\b")
+_NUMBERED_ITEM_RE = re.compile(r"^\d+\.\s+(.+)$")
+
+
+# ---------------------------------------------------------------------------
+# tasks.md grammar
+# ---------------------------------------------------------------------------
+
+
+def _extract_file_paths(text: str) -> tuple[str, ...]:
+    """Best-effort extraction of file-path tokens from a description.
+
+    Whitespace-delimited tokens containing ``/`` and either a file
+    extension or a trailing ``/``.
+    """
+    paths: list[str] = []
+    for raw_tok in text.split():
+        tok = raw_tok.strip(".,;:()[]{}'\"")
+        if "/" not in tok:
+            continue
+        if tok.endswith("/") or re.search(r"\.[A-Za-z0-9_]+$", tok):
+            paths.append(tok)
+    return tuple(paths)
+
+
+def _extract_explicit_deps(text: str) -> tuple[str, ...]:
+    """Extract explicit `depends on T012[, T013]` references from a description."""
+    m = _DEPENDS_ON_RE.search(text)
+    if not m:
+        return ()
+    return tuple(_TASK_ID_TOKEN_RE.findall(m.group(1)))
+
+
+def parse_tasks_md(
+    content: str,
+    *,
+    file: str = "tasks.md",
+) -> tuple[tuple[SpeckitPhase, ...], tuple[tuple[str, str], ...]]:
+    """Parse tasks.md into ordered phases plus story-level dependency pairs.
+
+    Pure function — no I/O. Deterministic: identical input always
+    produces identical output (contract guarantee #1).
+
+    Args:
+        content: Raw tasks.md text.
+        file: File path used in error messages (for multi-file callers).
+
+    Returns:
+        Two-tuple of (phases in file order, story_deps as
+        (dependent_story, blocker_story) pairs).
+
+    Raises:
+        SpeckitParseError: Malformed task-shaped line, or non-increasing
+            phase numbers (E05).
+        SpeckitValidationError: Duplicate task ID, or unknown explicit
+            dependency reference (E06).
+    """
+    phases: list[SpeckitPhase] = []
+    current_phase: _OpenPhase | None = None
+    current_tasks: list[SpeckitTask] = []
+    seen_task_ids: dict[str, int] = {}
+    all_tasks: list[SpeckitTask] = []
+    story_deps: list[tuple[str, str]] = []
+    last_phase_number: int | None = None
+
+    in_fence = False
+    in_comment = False
+    in_dependencies_section = False
+
+    def _finalize_phase() -> None:
+        nonlocal current_phase, current_tasks
+        if current_phase is not None:
+            phases.append(
+                SpeckitPhase(
+                    number=current_phase.number,
+                    title=current_phase.title,
+                    tasks=tuple(current_tasks),
+                )
+            )
+        current_phase = None
+        current_tasks = []
+
+    for line_number, raw_line in enumerate(content.splitlines(), start=1):
+        line = raw_line.rstrip()
+
+        if in_fence:
+            if _FENCE_RE.match(line):
+                in_fence = False
+            continue
+        if _FENCE_RE.match(line):
+            in_fence = True
+            continue
+
+        # Only a line that *starts* with ``<!--`` opens a comment block —
+        # matching ``<!--`` anywhere (e.g. a trailing inline comment on a
+        # task line) would silently drop that task, and an unclosed inline
+        # ``<!--`` would swallow every following line until ``-->``.
+        comment_line = line.lstrip()
+        if in_comment:
+            if _HTML_COMMENT_END_RE.search(line):
+                in_comment = False
+            continue
+        if comment_line.startswith("<!--") and not _HTML_COMMENT_END_RE.search(line):
+            in_comment = True
+            continue
+        if comment_line.startswith("<!--") and _HTML_COMMENT_END_RE.search(line):
+            continue
+
+        phase_m = _PHASE_HEADING_RE.match(line)
+        if phase_m:
+            _finalize_phase()
+            in_dependencies_section = False
+            number = int(phase_m.group(1))
+            if last_phase_number is not None and number <= last_phase_number:
+                raise SpeckitParseError(
+                    f"{file}:{line_number}: phase numbers must be strictly "
+                    f"increasing (got {number} after {last_phase_number})",
+                    file=file,
+                    line=line_number,
+                    expected="## Phase <n>: <title> with n > previous phase number",
+                    suggestion=f"renumber this phase to {last_phase_number + 1} or higher",
+                )
+            last_phase_number = number
+            current_phase = _OpenPhase(number=number, title=(phase_m.group(2) or "").strip())
+            current_tasks = []
+            continue
+
+        if _DEPENDENCIES_HEADING_RE.match(line):
+            _finalize_phase()
+            in_dependencies_section = True
+            continue
+
+        if _OTHER_H2_RE.match(line):
+            _finalize_phase()
+            in_dependencies_section = False
+            continue
+
+        if in_dependencies_section:
+            dep_m = _STORY_DEP_RE.match(line.strip())
+            if dep_m:
+                dependent_story = dep_m.group(1).upper()
+                blockers = [b.strip().upper() for b in dep_m.group(2).split(",")]
+                for blocker in blockers:
+                    story_deps.append((dependent_story, blocker))
+            continue
+
+        if current_phase is None:
+            continue
+
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("**Checkpoint"):
+            continue
+        if stripped.startswith("### "):
+            continue
+
+        if _CHECKBOX_SHAPE_RE.match(line):
+            task_m = _TASK_LINE_RE.match(line)
+            if not task_m:
+                raise SpeckitParseError(
+                    f"{file}:{line_number}: malformed task line: {line!r}",
+                    file=file,
+                    line=line_number,
+                    expected=(
+                        "- [ ] T### [P] [USn] description "
+                        "(checkbox, task ID, optional [P], optional [USn], description)"
+                    ),
+                    suggestion="add a T### task ID immediately after the checkbox",
+                )
+            checkbox, task_id, p_marker, story_num, description = task_m.groups()
+            if task_id in seen_task_ids:
+                raise SpeckitValidationError(
+                    f"{file}: duplicate task ID {task_id} at lines "
+                    f"{seen_task_ids[task_id]} and {line_number}",
+                    file=file,
+                    task_id=task_id,
+                    lines=(seen_task_ids[task_id], line_number),
+                )
+            seen_task_ids[task_id] = line_number
+
+            task = SpeckitTask(
+                task_id=task_id,
+                description=description.strip(),
+                completed=checkbox.lower() == "x",
+                parallel=p_marker is not None,
+                story_id=f"US{story_num}" if story_num else None,
+                phase_number=current_phase.number,
+                file_paths=_extract_file_paths(description),
+                explicit_deps=_extract_explicit_deps(description),
+                line_number=line_number,
+            )
+            current_tasks.append(task)
+            all_tasks.append(task)
+            continue
+
+        # Prose / other ignored content inside a phase section.
+        continue
+
+    _finalize_phase()
+
+    # Validate explicit dependency references against the full task-ID set.
+    for task in all_tasks:
+        for dep_id in task.explicit_deps:
+            if dep_id not in seen_task_ids:
+                raise SpeckitValidationError(
+                    f"{file}:{task.line_number}: task {task.task_id} references "
+                    f"unknown dependency {dep_id}",
+                    file=file,
+                    task_id=task.task_id,
+                    lines=(task.line_number,),
+                    unknown_ref=dep_id,
+                )
+
+    return tuple(phases), tuple(story_deps)
+
+
+# ---------------------------------------------------------------------------
+# spec.md extraction
+# ---------------------------------------------------------------------------
+
+
+def _split_h2_sections(body: str) -> dict[str, str]:
+    """Split a Markdown body on ``## `` headings (heading text -> content)."""
+    sections: dict[str, str] = {}
+    current_key: str | None = None
+    current_lines: list[str] = []
+    for line in body.splitlines():
+        if line.startswith("## "):
+            if current_key is not None:
+                sections[current_key] = "\n".join(current_lines).strip()
+            current_key = line[3:].strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+    if current_key is not None:
+        sections[current_key] = "\n".join(current_lines).strip()
+    return sections
+
+
+def _split_h3_sections(body: str) -> dict[str, str]:
+    """Split a Markdown body on ``### `` sub-headings (heading text -> content)."""
+    sections: dict[str, str] = {}
+    current_key: str | None = None
+    current_lines: list[str] = []
+    for line in body.splitlines():
+        if line.startswith("### "):
+            if current_key is not None:
+                sections[current_key] = "\n".join(current_lines).strip()
+            current_key = line[4:].strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+    if current_key is not None:
+        sections[current_key] = "\n".join(current_lines).strip()
+    return sections
+
+
+def _find_h2_prefixed(h2: dict[str, str], prefix: str) -> str:
+    """Find an h2 section whose heading text starts with *prefix*.
+
+    Headings sometimes carry a trailing annotation (e.g.
+    ``## Success Criteria *(mandatory)*``), so exact-key lookup would
+    miss them.
+    """
+    for key, value in h2.items():
+        if key.strip().startswith(prefix):
+            return value
+    return ""
+
+
+def _extract_success_criteria(content: str) -> tuple[str, ...]:
+    h2 = _split_h2_sections(content)
+    sc_section = _find_h2_prefixed(h2, "Success Criteria")
+    bullets: list[str] = []
+    for line in sc_section.splitlines():
+        m = _SC_BULLET_RE.match(line.strip())
+        if m:
+            bullets.append(m.group(1).strip())
+    return tuple(bullets)
+
+
+def _extract_story_scenarios(content: str) -> dict[str, tuple[str, ...]]:
+    h3 = _split_h3_sections(content)
+    result: dict[str, tuple[str, ...]] = {}
+    for heading, body in h3.items():
+        m = _STORY_HEADING_RE.match(heading.strip())
+        if not m:
+            continue
+        story_id = f"US{m.group(1)}"
+        idx = body.find("**Acceptance Scenarios**")
+        scenario_text = body[idx:] if idx != -1 else ""
+        items: list[str] = []
+        for line in scenario_text.splitlines():
+            im = _NUMBERED_ITEM_RE.match(line.strip())
+            if im:
+                items.append(im.group(1).strip())
+        result[story_id] = tuple(items)
+    return result
+
+
+def parse_spec_md(content: str, *, file: str = "spec.md") -> ParsedSpec:
+    """Extract title, success criteria, and per-story scenarios from spec.md.
+
+    Pure function — no I/O. Best-effort except where noted (contract:
+    ``tasks-md-grammar.md`` spec.md extraction table).
+
+    Args:
+        content: Raw spec.md text.
+        file: File path used in error messages.
+
+    Returns:
+        A :class:`ParsedSpec`.
+
+    Raises:
+        SpeckitParseError: spec.md yields no title, no success criteria,
+            and no story scenarios (E05 — likely not a Spec Kit spec).
+    """
+    title_m = _TITLE_RE.search(content)
+    if title_m:
+        title = title_m.group(1).strip()
+    else:
+        h1_m = _H1_FALLBACK_RE.search(content)
+        title = h1_m.group(1).strip() if h1_m else ""
+
+    success_criteria = _extract_success_criteria(content)
+    story_scenarios = _extract_story_scenarios(content)
+
+    if not title and not success_criteria and not story_scenarios:
+        raise SpeckitParseError(
+            f"{file}: no title, success criteria, or story scenarios found "
+            "(this does not look like a Spec Kit spec.md)",
+            file=file,
+            line=1,
+            expected="# Feature Specification: <title> plus ## Success Criteria",
+            suggestion="verify this file was generated by Spec Kit's specify template",
+        )
+
+    return ParsedSpec(
+        title=title,
+        success_criteria=success_criteria,
+        story_scenarios=story_scenarios,
+    )
+
+
+__all__ = [
+    "parse_spec_md",
+    "parse_tasks_md",
+]

--- a/src/maverick/workflows/refuel_speckit/__init__.py
+++ b/src/maverick/workflows/refuel_speckit/__init__.py
@@ -1,0 +1,8 @@
+"""SpeckitRefuelWorkflow package — deterministic Spec Kit ingestion."""
+
+from __future__ import annotations
+
+from maverick.workflows.refuel_speckit.models import SpeckitRefuelResult
+from maverick.workflows.refuel_speckit.workflow import SpeckitRefuelWorkflow
+
+__all__ = ["SpeckitRefuelResult", "SpeckitRefuelWorkflow"]

--- a/src/maverick/workflows/refuel_speckit/constants.py
+++ b/src/maverick/workflows/refuel_speckit/constants.py
@@ -1,0 +1,17 @@
+"""Constants for SpeckitRefuelWorkflow."""
+
+from __future__ import annotations
+
+# Step names
+RESOLVE_FEATURE = "resolve_feature"
+CHECK_TEMPLATE = "check_template"
+PARSE_ARTIFACTS = "parse_artifacts"
+PLAN_INGESTION = "plan_ingestion"
+ENRICH = "enrich"
+CREATE_BEADS = "create_beads"
+WIRE_DEPS = "wire_deps"
+CHAIN_EPIC = "chain_epic"
+RECORD_RUN = "record_run"
+COMMIT_OUTPUT = "commit_output"
+
+WORKFLOW_NAME: str = "refuel-speckit"

--- a/src/maverick/workflows/refuel_speckit/models.py
+++ b/src/maverick/workflows/refuel_speckit/models.py
@@ -1,0 +1,56 @@
+"""Models for SpeckitRefuelWorkflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class SpeckitRefuelResult:
+    """Final output from SpeckitRefuelWorkflow.
+
+    Mirrors ``RefuelMaverickResult.to_dict()`` conventions
+    (``workflows/refuel_maverick/models.py``).
+
+    Attributes:
+        feature_name: Resolved feature directory basename.
+        epic_id: Real bead ID, or ``"dry-run-epic"`` on a dry run.
+        created_bead_ids: Task bead IDs created this run.
+        skipped_completed: Task IDs checked ``[x]`` (not ingested).
+        skipped_existing: Task IDs already ingested under the epic (delta).
+        edge_count: Number of dependency edges wired.
+        delta_run: Whether an existing epic was adopted.
+        dry_run: Whether this run performed zero writes.
+        enriched: Whether ``--enrich`` succeeded for this run.
+        warnings: Non-fatal warnings collected during the run.
+    """
+
+    feature_name: str
+    epic_id: str
+    created_bead_ids: tuple[str, ...] = field(default=())
+    skipped_completed: tuple[str, ...] = field(default=())
+    skipped_existing: tuple[str, ...] = field(default=())
+    edge_count: int = 0
+    delta_run: bool = False
+    dry_run: bool = False
+    enriched: bool = False
+    warnings: tuple[str, ...] = field(default=())
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a plain dictionary for WorkflowResult.final_output."""
+        return {
+            "feature_name": self.feature_name,
+            "epic_id": self.epic_id,
+            "created_bead_ids": list(self.created_bead_ids),
+            "skipped_completed": list(self.skipped_completed),
+            "skipped_existing": list(self.skipped_existing),
+            "edge_count": self.edge_count,
+            "delta_run": self.delta_run,
+            "dry_run": self.dry_run,
+            "enriched": self.enriched,
+            "warnings": list(self.warnings),
+        }
+
+
+__all__ = ["SpeckitRefuelResult"]

--- a/src/maverick/workflows/refuel_speckit/workflow.py
+++ b/src/maverick/workflows/refuel_speckit/workflow.py
@@ -1,0 +1,555 @@
+"""SpeckitRefuelWorkflow — deterministic Spec Kit ingestion pipeline.
+
+Bypasses Burr, RefuelSquadron, and the actor stack entirely (research D1):
+a plain sequential :class:`PythonWorkflow` that parses tasks.md/spec.md
+with a fixed grammar and talks to ``bd`` directly via :class:`BeadClient`.
+Zero model invocations unless ``--enrich`` is passed (FR-010).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import uuid
+from pathlib import Path
+from typing import Any
+
+from maverick.exceptions import WorkflowError
+from maverick.logging import get_logger
+from maverick.speckit.build import IngestionPlan, build_ingestion_plan
+from maverick.speckit.detect import SUPPORTED_SPECKIT_RANGE, check_template_compatibility
+from maverick.speckit.errors import NothingToIngestError, SpeckitError, UnsupportedTemplateError
+from maverick.speckit.models import SpeckitFeature
+from maverick.speckit.parser import parse_spec_md, parse_tasks_md
+from maverick.workflows.base import PythonWorkflow
+from maverick.workflows.refuel_speckit.constants import (
+    CHAIN_EPIC,
+    CHECK_TEMPLATE,
+    COMMIT_OUTPUT,
+    CREATE_BEADS,
+    ENRICH,
+    PARSE_ARTIFACTS,
+    PLAN_INGESTION,
+    RECORD_RUN,
+    RESOLVE_FEATURE,
+    WIRE_DEPS,
+    WORKFLOW_NAME,
+)
+from maverick.workflows.refuel_speckit.models import SpeckitRefuelResult
+
+logger = get_logger(__name__)
+
+_TASK_ID_RE = re.compile(r"^T\d{3,}$")
+
+
+def _resolve_bead_id(identifier: str, created_map: dict[str, str]) -> str:
+    """Resolve an edge endpoint to a bead ID.
+
+    Edge endpoints are either a Spec Kit task ID (resolved via
+    *created_map*, populated by this run's own bead creation) or an
+    already-resolved bead ID from a prior run (delta edges) — passed
+    through unchanged.
+    """
+    if _TASK_ID_RE.match(identifier) and identifier in created_map:
+        return created_map[identifier]
+    return identifier
+
+
+class SpeckitRefuelWorkflow(PythonWorkflow):
+    """Deterministic Spec Kit ingestion: parse tasks.md, create beads, wire deps.
+
+    Args:
+        config: Project configuration (MaverickConfig).
+        checkpoint_store: Optional checkpoint persistence backend.
+        workflow_name: Identifier for this workflow instance.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        if "workflow_name" not in kwargs:
+            kwargs["workflow_name"] = WORKFLOW_NAME
+        super().__init__(**kwargs)
+
+    async def _run(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Execute the Spec Kit ingestion pipeline.
+
+        Args:
+            inputs: Required: ``feature_dir`` (str, already resolved by the
+                CLI), ``cwd`` (str). Optional: ``dry_run`` (bool),
+                ``enrich`` (bool), ``auto_commit`` (bool).
+
+        Returns:
+            Output dict matching :meth:`SpeckitRefuelResult.to_dict`.
+        """
+        feature_dir_str: str = inputs.get("feature_dir", "")
+        cwd_str: str = inputs.get("cwd", "")
+        if not feature_dir_str:
+            raise WorkflowError("'feature_dir' input is required")
+        if not cwd_str:
+            raise WorkflowError("'cwd' input is required")
+
+        cwd = Path(cwd_str)
+        dry_run: bool = bool(inputs.get("dry_run", False))
+        enrich: bool = bool(inputs.get("enrich", False))
+        auto_commit: bool = bool(inputs.get("auto_commit", False))
+        warnings: list[str] = []
+
+        # ------------------------------------------------------------
+        # Step 1: Resolve feature
+        # ------------------------------------------------------------
+        await self.emit_step_started(RESOLVE_FEATURE, display_label="Resolving feature")
+        feature_dir = Path(feature_dir_str)
+        if not (feature_dir / "spec.md").is_file() or not (feature_dir / "tasks.md").is_file():
+            await self.emit_step_failed(
+                RESOLVE_FEATURE, f"{feature_dir} is not a Spec Kit feature directory"
+            )
+            raise SpeckitError(f"{feature_dir} is missing spec.md and/or tasks.md")
+        feature_name = feature_dir.name
+        await self.emit_output(RESOLVE_FEATURE, f"Using Spec Kit feature: {feature_dir}")
+        await self.emit_step_completed(RESOLVE_FEATURE, output={"feature_dir": str(feature_dir)})
+
+        # ------------------------------------------------------------
+        # Step 2: Check template compatibility
+        # ------------------------------------------------------------
+        await self.emit_step_started(CHECK_TEMPLATE, display_label="Checking template version")
+        compat = check_template_compatibility(cwd)
+        if compat.status == "unsupported":
+            await self.emit_step_failed(
+                CHECK_TEMPLATE,
+                f"unsupported template version {compat.vendored_version}, "
+                f"supported: {compat.supported_range}",
+            )
+            raise UnsupportedTemplateError(
+                f"unsupported template version {compat.vendored_version}, "
+                f"supported: {compat.supported_range}",
+                found_version=compat.vendored_version or "",
+                supported_range=compat.supported_range,
+            )
+        if compat.status == "unknown":
+            msg = (
+                "Spec Kit template version unknown "
+                f"(supported range: {SUPPORTED_SPECKIT_RANGE}) — proceeding structurally"
+            )
+            warnings.append(msg)
+            await self.emit_output(CHECK_TEMPLATE, msg, level="warning")
+        await self.emit_step_completed(CHECK_TEMPLATE, output={"status": compat.status})
+
+        # ------------------------------------------------------------
+        # Step 3: Parse artifacts
+        # ------------------------------------------------------------
+        await self.emit_step_started(PARSE_ARTIFACTS, display_label="Parsing Spec Kit artifacts")
+        try:
+            tasks_content = await asyncio.to_thread(
+                (feature_dir / "tasks.md").read_text, encoding="utf-8"
+            )
+            spec_content = await asyncio.to_thread(
+                (feature_dir / "spec.md").read_text, encoding="utf-8"
+            )
+        except OSError as exc:
+            await self.emit_step_failed(PARSE_ARTIFACTS, str(exc))
+            raise SpeckitError(f"failed to read Spec Kit artifacts: {exc}") from exc
+
+        phases, story_deps = parse_tasks_md(tasks_content, file=str(feature_dir / "tasks.md"))
+        parsed_spec = parse_spec_md(spec_content, file=str(feature_dir / "spec.md"))
+        feature = SpeckitFeature(
+            feature_dir=feature_dir,
+            feature_name=feature_name,
+            spec=parsed_spec,
+            phases=phases,
+            story_deps=story_deps,
+            has_plan=(feature_dir / "plan.md").is_file(),
+        )
+        total_tasks = sum(len(p.tasks) for p in phases)
+        await self.emit_output(
+            PARSE_ARTIFACTS,
+            f"Parsed {len(phases)} phases, {total_tasks} tasks",
+        )
+        await self.emit_step_completed(
+            PARSE_ARTIFACTS, output={"phase_count": len(phases), "task_count": total_tasks}
+        )
+
+        # ------------------------------------------------------------
+        # Delta lookup: find an existing open epic for this feature.
+        # ------------------------------------------------------------
+        from maverick.beads.client import BeadClient
+
+        client = BeadClient(cwd=cwd)
+        existing_epic_id, existing_task_map = await self._find_existing_epic(client, feature_name)
+
+        # ------------------------------------------------------------
+        # Step 4: Plan ingestion
+        # ------------------------------------------------------------
+        await self.emit_step_started(PLAN_INGESTION, display_label="Planning ingestion")
+        try:
+            plan, plan_warnings = build_ingestion_plan(
+                feature,
+                existing_epic_id=existing_epic_id,
+                existing_task_map=existing_task_map,
+            )
+        except NothingToIngestError as exc:
+            await self.emit_step_failed(PLAN_INGESTION, str(exc))
+            raise
+        warnings.extend(plan_warnings)
+        for w in plan_warnings:
+            await self.emit_output(PLAN_INGESTION, w, level="warning")
+        await self.emit_output(
+            PLAN_INGESTION,
+            f"{len(plan.new_tasks)} new, {len(plan.skipped_completed)} completed, "
+            f"{len(plan.skipped_existing)} already ingested",
+        )
+        await self.emit_step_completed(
+            PLAN_INGESTION,
+            output={
+                "new_tasks": len(plan.new_tasks),
+                "skipped_completed": len(plan.skipped_completed),
+                "skipped_existing": len(plan.skipped_existing),
+                "edges": len(plan.edges),
+            },
+        )
+
+        delta_run = existing_epic_id is not None
+
+        # Delta no-op: nothing new to create, but not an error.
+        if not plan.new_tasks:
+            await self.emit_step_started(RECORD_RUN, display_label="Recording run")
+            if not dry_run and existing_epic_id:
+                await self._record_run(cwd, feature_name, existing_epic_id, "refueled")
+            await self.emit_output(
+                RECORD_RUN,
+                f"No new tasks to ingest for {feature_name} (epic {existing_epic_id} up to date).",
+            )
+            await self.emit_step_completed(RECORD_RUN, output={"created": 0})
+            result = SpeckitRefuelResult(
+                feature_name=feature_name,
+                epic_id=existing_epic_id or "",
+                skipped_completed=plan.skipped_completed,
+                skipped_existing=plan.skipped_existing,
+                delta_run=delta_run,
+                dry_run=dry_run,
+                warnings=tuple(warnings),
+            )
+            return result.to_dict()
+
+        # ------------------------------------------------------------
+        # Step 5 (optional): Enrichment
+        # ------------------------------------------------------------
+        enriched = False
+        if enrich:
+            plan, enrich_warning = await self._run_enrichment(plan, cwd=cwd)
+            if enrich_warning:
+                warnings.append(enrich_warning)
+            else:
+                enriched = True
+
+        # ------------------------------------------------------------
+        # Step 6: Create beads
+        # ------------------------------------------------------------
+        await self.emit_step_started(CREATE_BEADS, display_label="Creating beads")
+        created_map: dict[str, str] = {}
+        epic_id: str
+        if dry_run:
+            epic_id = existing_epic_id or "dry-run-epic"
+            for i, pb in enumerate(plan.new_tasks):
+                created_map[pb.task_id] = f"dry-run-{i}"
+        else:
+            if plan.epic is not None:
+                try:
+                    created_epic = await client.create_bead(plan.epic.definition)
+                except Exception as exc:
+                    await self.emit_step_failed(CREATE_BEADS, str(exc))
+                    raise SpeckitError(f"epic creation failed: {exc}") from exc
+                epic_id = created_epic.bd_id
+            else:
+                epic_id = existing_epic_id or ""
+
+            for pb in plan.new_tasks:
+                try:
+                    created = await client.create_bead(pb.definition, parent_id=epic_id)
+                except Exception as exc:
+                    await self.emit_step_failed(
+                        CREATE_BEADS,
+                        f"bead creation failed after creating {list(created_map.values())}: {exc}",
+                    )
+                    raise SpeckitError(
+                        f"bead creation failed partway through (created: "
+                        f"{list(created_map.values())}): {exc}"
+                    ) from exc
+                created_map[pb.task_id] = created.bd_id
+
+        await self.emit_output(
+            CREATE_BEADS,
+            f"{'Would create' if dry_run else 'Created'} epic {epic_id} + "
+            f"{len(plan.new_tasks)} task beads",
+        )
+        if dry_run:
+            for pb in plan.new_tasks:
+                blockers = [blocker for blocker, blocked in plan.edges if blocked == pb.task_id]
+                blocker_text = ", ".join(blockers) if blockers else "none"
+                phase = pb.state.get("speckit_phase", "?")
+                parallel_marker = " [P]" if pb.state.get("speckit_parallel") == "true" else ""
+                await self.emit_output(
+                    CREATE_BEADS,
+                    f"{pb.task_id}: {pb.definition.title}{parallel_marker} "
+                    f"(phase {phase}, blocked by: {blocker_text})",
+                )
+            if plan.skipped_completed:
+                await self.emit_output(
+                    CREATE_BEADS,
+                    f"Skipped (completed): {', '.join(plan.skipped_completed)}",
+                )
+            if plan.skipped_existing:
+                await self.emit_output(
+                    CREATE_BEADS,
+                    f"Skipped (already ingested): {', '.join(plan.skipped_existing)}",
+                )
+            await self.emit_output(CREATE_BEADS, "Dry run — no beads created.")
+        await self.emit_step_completed(
+            CREATE_BEADS, output={"epic_id": epic_id, "created": list(created_map.values())}
+        )
+
+        # ------------------------------------------------------------
+        # Step 7: Provenance state (skipped on dry-run)
+        # ------------------------------------------------------------
+        if not dry_run:
+            if plan.epic is not None:
+                await client.set_state(epic_id, plan.epic.state)
+            for pb in plan.new_tasks:
+                await client.set_state(created_map[pb.task_id], pb.state)
+
+        # ------------------------------------------------------------
+        # Step 8: Wire dependencies
+        # ------------------------------------------------------------
+        await self.emit_step_started(WIRE_DEPS, display_label="Wiring dependencies")
+        wired_count = 0
+        if not dry_run:
+            from maverick.beads.models import BeadDependency
+
+            for blocker, blocked in plan.edges:
+                blocker_id = _resolve_bead_id(blocker, created_map)
+                blocked_id = _resolve_bead_id(blocked, created_map)
+                try:
+                    await client.add_dependency(
+                        BeadDependency(blocker_id=blocker_id, blocked_id=blocked_id)
+                    )
+                    wired_count += 1
+                except Exception as exc:
+                    logger.warning(
+                        "speckit_dependency_wiring_failed",
+                        blocker_id=blocker_id,
+                        blocked_id=blocked_id,
+                        error=str(exc),
+                    )
+                    warnings.append(f"failed to wire {blocker_id} -> {blocked_id}: {exc}")
+        else:
+            wired_count = len(plan.edges)
+        await self.emit_output(WIRE_DEPS, f"Wired {wired_count} dependency edges")
+        await self.emit_step_completed(WIRE_DEPS, output={"wired": wired_count})
+
+        # ------------------------------------------------------------
+        # Step 9: Chain epic behind existing open epics (fresh runs only)
+        # ------------------------------------------------------------
+        if plan.epic is not None and not dry_run:
+            await self.emit_step_started(CHAIN_EPIC, display_label="Chaining epic")
+            chained_behind = await self._chain_epic(client, epic_id)
+            if chained_behind:
+                await self.emit_output(
+                    CHAIN_EPIC,
+                    f"New epic blocked by {chained_behind} — "
+                    "tasks start when prior epic completes",
+                )
+            await self.emit_step_completed(CHAIN_EPIC, output={"blocked_by": chained_behind})
+
+        # ------------------------------------------------------------
+        # Step 10: Record run metadata (skipped on dry-run)
+        # ------------------------------------------------------------
+        if not dry_run:
+            await self._record_run(cwd, feature_name, epic_id, "refueled")
+
+        # ------------------------------------------------------------
+        # Step 11 (optional): Auto-commit
+        # ------------------------------------------------------------
+        if auto_commit and not dry_run:
+            await self._commit_output(feature_name)
+
+        result = SpeckitRefuelResult(
+            feature_name=feature_name,
+            epic_id=epic_id,
+            created_bead_ids=tuple(created_map.values()),
+            skipped_completed=plan.skipped_completed,
+            skipped_existing=plan.skipped_existing,
+            edge_count=wired_count,
+            delta_run=delta_run,
+            dry_run=dry_run,
+            enriched=enriched,
+            warnings=tuple(warnings),
+        )
+        return result.to_dict()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _find_existing_epic(
+        self,
+        client: Any,
+        feature_name: str,
+    ) -> tuple[str | None, dict[str, str]]:
+        """Find the open epic (if any) whose ``speckit_feature`` state matches.
+
+        Returns:
+            ``(epic_id, existing_task_map)`` — both empty/None on a fresh run.
+
+        Raises:
+            SpeckitError: More than one open epic claims this feature (corrupt state).
+        """
+        try:
+            epics = await client.query("type=epic AND status=open")
+        except Exception as exc:
+            logger.debug("speckit_epic_query_failed", error=str(exc))
+            return None, {}
+
+        matches = []
+        for epic_summary in epics:
+            try:
+                details = await client.show(epic_summary.id)
+            except Exception:
+                continue
+            if details.state.get("speckit_feature") == feature_name:
+                matches.append(details)
+
+        if not matches:
+            return None, {}
+        if len(matches) > 1:
+            ids = ", ".join(d.id for d in matches)
+            raise SpeckitError(f"multiple open epics claim speckit_feature={feature_name}: {ids}")
+
+        epic_details = matches[0]
+        existing_task_map: dict[str, str] = {}
+        try:
+            children = await client.children(epic_details.id)
+        except Exception:
+            children = []
+        for child in children:
+            try:
+                child_details = await client.show(child.id)
+            except Exception:
+                continue
+            task_id = child_details.state.get("speckit_task_id")
+            if task_id:
+                existing_task_map[task_id] = child.id
+
+        return epic_details.id, existing_task_map
+
+    async def _chain_epic(self, client: Any, new_epic_id: str) -> str | None:
+        """Chain *new_epic_id* behind the tail of existing open epics."""
+        from maverick.beads.models import BeadDependency
+
+        try:
+            all_beads = await client.query("type=epic AND status=open")
+        except Exception as exc:
+            logger.warning("speckit_chain_epic_query_failed", error=str(exc))
+            return None
+        existing_epics = [b for b in all_beads if b.id != new_epic_id]
+        if not existing_epics:
+            return None
+        tail_epic = existing_epics[-1]
+        try:
+            await client.add_dependency(
+                BeadDependency(blocker_id=tail_epic.id, blocked_id=new_epic_id)
+            )
+        except Exception as exc:
+            logger.warning("speckit_chain_epic_failed", error=str(exc))
+            return None
+        return tail_epic.id
+
+    async def _record_run(self, cwd: Path, feature_name: str, epic_id: str, status: str) -> None:
+        from maverick.runway.run_metadata import RunMetadata, write_metadata
+
+        run_id = uuid.uuid4().hex[:8]
+        run_dir = cwd / ".maverick" / "runs" / run_id
+        meta = RunMetadata(
+            run_id=run_id,
+            plan_name=feature_name,
+            epic_id=epic_id,
+            status=status,
+        )
+        await asyncio.to_thread(write_metadata, run_dir, meta)
+
+    async def _commit_output(self, feature_name: str) -> None:
+        from maverick.library.actions.jj import jj_snapshot_changes
+
+        await self.emit_step_started(COMMIT_OUTPUT, display_label="Committing refuel output")
+        try:
+            snap = await jj_snapshot_changes(message=f"chore: refuel {feature_name} (speckit)")
+            if snap.success and snap.committed:
+                sha_preview = (snap.commit_sha or "")[:8]
+                await self.emit_output(COMMIT_OUTPUT, f"Committed refuel output ({sha_preview})")
+                await self.emit_step_completed(
+                    COMMIT_OUTPUT, {"committed": True, "commit_sha": snap.commit_sha}
+                )
+            elif snap.success:
+                await self.emit_output(
+                    COMMIT_OUTPUT, "Working directory clean — nothing to commit"
+                )
+                await self.emit_step_completed(COMMIT_OUTPUT, {"committed": False})
+            else:
+                await self.emit_output(COMMIT_OUTPUT, snap.error or "commit failed", level="error")
+                await self.emit_step_completed(
+                    COMMIT_OUTPUT, {"committed": False, "error": snap.error}
+                )
+        except Exception as exc:
+            await self.emit_step_failed(COMMIT_OUTPUT, str(exc))
+            logger.warning("speckit_auto_commit_failed", error=str(exc))
+
+    async def _run_enrichment(
+        self,
+        plan: IngestionPlan,
+        *,
+        cwd: Path,
+    ) -> tuple[IngestionPlan, str | None]:
+        """Attach model-supplied verification commands to new task beads.
+
+        Runs a single batched call so cost stays O(1) per run (research
+        D9). Any failure degrades to a warning — ingestion proceeds
+        unenriched (FR-011). Nothing here imports agent/runtime
+        machinery unless this method actually runs (FR-010).
+
+        Returns:
+            ``(plan, warning)`` — *plan* is unchanged (with augmented
+            ``## Verification`` sections) on success, or the original
+            *plan* plus a warning message on failure.
+        """
+        await self.emit_step_started(ENRICH, display_label="Enriching verification commands")
+        applied = 0
+        try:
+            from maverick.agents.personas import SpeckitEnrichmentAgent
+            from maverick.config import load_config
+            from maverick.runtime.agent_factory import runtime_for_agent
+            from maverick.speckit.enrichment import (
+                apply_enrichment,
+                build_enrichment_prompt,
+                parse_enrichment_response,
+            )
+
+            config = load_config()
+            runtime, _ = runtime_for_agent("generate", agents_config=config.agents)
+            prompt = build_enrichment_prompt(plan.new_tasks)
+            async with SpeckitEnrichmentAgent(runtime=runtime, cwd=str(cwd)) as agent:
+                response_text = await agent.enrich(prompt)
+            commands_by_task = parse_enrichment_response(response_text)
+            enriched_plan = apply_enrichment(plan, commands_by_task)
+            # Count tasks that actually received commands — a model may
+            # return commands for only a subset of the requested task IDs.
+            applied = sum(1 for pb in plan.new_tasks if commands_by_task.get(pb.task_id))
+        except Exception as exc:
+            logger.warning("speckit_enrichment_failed", error=str(exc))
+            warning = f"enrichment failed (non-fatal): {exc}"
+            await self.emit_output(ENRICH, warning, level="warning")
+            await self.emit_step_completed(ENRICH, output={"enriched": False})
+            return plan, warning
+
+        await self.emit_output(ENRICH, f"Enriched {applied} of {len(plan.new_tasks)} task beads")
+        await self.emit_step_completed(ENRICH, output={"enriched": True, "applied": applied})
+        return enriched_plan, None
+
+
+__all__ = ["SpeckitRefuelWorkflow"]

--- a/tests/integration/test_speckit_refuel.py
+++ b/tests/integration/test_speckit_refuel.py
@@ -1,0 +1,153 @@
+"""Integration test: Spec Kit ingestion against a real ``bd`` database.
+
+Automates quickstart.md Scenario 2 (fresh ingest + ready-order) and
+Scenario 4 (delta re-run + no-op), exercising the real ``bd`` CLI rather
+than a stub. Skips entirely when ``bd`` isn't on PATH.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from maverick.beads.client import BeadClient
+from maverick.workflows.refuel_speckit.workflow import SpeckitRefuelWorkflow
+
+pytestmark = pytest.mark.integration
+
+#: SC-001: ingestion of a typical feature completes in < 30s wall clock.
+_SC_001_BOUND_SECONDS = 30.0
+
+_TASKS_MD = """\
+## Phase 1: Setup
+
+- [ ] T001 Initialize project
+- [ ] T002 [P] Create config file in src/config.py
+
+## Phase 2: Core
+
+- [ ] T003 Implement core feature in src/core.py
+- [ ] T004 [P] Add supporting util in src/util.py
+"""
+_SPEC_MD = """\
+# Feature Specification: Integration Sample
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: The feature works end to end.
+"""
+
+if shutil.which("bd") is None:
+    pytest.skip("bd CLI not available on PATH", allow_module_level=True)
+
+
+@pytest.fixture
+def bd_repo(tmp_path: Path) -> Path:
+    """A tmp directory with a real, initialized ``bd`` database."""
+    subprocess.run(
+        ["bd", "init", "--non-interactive"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    return tmp_path
+
+
+def _make_feature_dir(cwd: Path, name: str = "048-integration-sample") -> Path:
+    feature_dir = cwd / "specs" / name
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "tasks.md").write_text(_TASKS_MD, encoding="utf-8")
+    (feature_dir / "spec.md").write_text(_SPEC_MD, encoding="utf-8")
+    return feature_dir
+
+
+async def _run(cwd: Path, feature_dir: Path, **overrides: object) -> dict[str, object]:
+    workflow = SpeckitRefuelWorkflow(config=MagicMock())
+    inputs: dict[str, object] = {
+        "feature_dir": str(feature_dir),
+        "cwd": str(cwd),
+        "dry_run": False,
+        "enrich": False,
+        "auto_commit": False,
+    }
+    inputs.update(overrides)
+    async for _event in workflow.execute(inputs):
+        pass
+    assert workflow.result is not None
+    assert workflow.result.success, workflow.result
+    output = workflow.result.final_output
+    assert isinstance(output, dict)
+    return output
+
+
+@pytest.mark.asyncio
+async def test_speckit_refuel_lifecycle(bd_repo: Path) -> None:
+    feature_dir = _make_feature_dir(bd_repo)
+    client = BeadClient(cwd=bd_repo)
+
+    # --- Scenario 2: fresh ingest -------------------------------------
+    start = time.monotonic()
+    output = await _run(bd_repo, feature_dir)
+    elapsed = time.monotonic() - start
+    if elapsed > _SC_001_BOUND_SECONDS:
+        import warnings
+
+        warnings.warn(
+            f"speckit ingestion took {elapsed:.1f}s, exceeding the SC-001 "
+            f"{_SC_001_BOUND_SECONDS}s bound",
+            stacklevel=1,
+        )
+
+    epic_id = output["epic_id"]
+    assert len(output["created_bead_ids"]) == 4
+
+    epic_details = await client.show(epic_id)
+    assert epic_details.state.get("speckit_feature") == "048-integration-sample"
+    assert "speckit" in epic_details.labels
+
+    children = await client.children(epic_id)
+    assert len(children) == 4
+
+    # SC-003: bd ready only surfaces phase-1 sources (T001, T002) — not
+    # phase-2 tasks, which are blocked by the phase barrier.
+    ready = await client.ready(epic_id, limit=10)
+    ready_titles = {r.title for r in ready}
+    assert any(t.startswith("T001:") for t in ready_titles) or any(
+        t.startswith("T002:") for t in ready_titles
+    )
+    assert not any(t.startswith("T003:") for t in ready_titles)
+    assert not any(t.startswith("T004:") for t in ready_titles)
+
+    # --- Scenario 4: delta append --------------------------------------
+    tasks_path = feature_dir / "tasks.md"
+    tasks_path.write_text(
+        tasks_path.read_text(encoding="utf-8")
+        + "\n## Phase 3: Polish\n\n- [ ] T005 [P] Add docs in src/docs.py\n",
+        encoding="utf-8",
+    )
+
+    delta_output = await _run(bd_repo, feature_dir)
+    assert delta_output["delta_run"] is True
+    assert delta_output["epic_id"] == epic_id
+    assert len(delta_output["created_bead_ids"]) == 1
+    assert set(delta_output["skipped_existing"]) == {"T001", "T002", "T003", "T004"}
+
+    # --- Scenario 4: no-op ----------------------------------------------
+    noop_output = await _run(bd_repo, feature_dir)
+    assert noop_output["created_bead_ids"] == []
+    assert noop_output["delta_run"] is True
+
+    open_epics = await client.query("type=epic AND status=open")
+    matching = [
+        e
+        for e in open_epics
+        if (await client.show(e.id)).state.get("speckit_feature") == "048-integration-sample"
+    ]
+    assert len(matching) == 1

--- a/tests/unit/cli/commands/refuel/test_flight_plan.py
+++ b/tests/unit/cli/commands/refuel/test_flight_plan.py
@@ -54,6 +54,23 @@ class TestRefuelFromPlan:
         ):
             yield
 
+    @pytest.fixture(autouse=True)
+    def _stub_flight_plan(self, refuel_env: Path) -> None:
+        """Create ``.maverick/plans/my-feature/flight-plan.md``.
+
+        Mode auto-detection (048-speckit-refuel-ingestion) resolves NAME
+        against both classic and Spec Kit shapes before dispatching —
+        the classic path now requires the flight plan to actually exist
+        on disk to resolve as "classic" (previously the CLI dispatched
+        unconditionally and only the mocked-out workflow would have
+        noticed a missing file).
+        """
+        plan_dir = refuel_env / ".maverick" / "plans" / "my-feature"
+        plan_dir.mkdir(parents=True, exist_ok=True)
+        (plan_dir / "flight-plan.md").write_text(
+            "---\nname: my-feature\n---\n\n## Objective\n\nTest.\n", encoding="utf-8"
+        )
+
     def test_list_steps_prints_step_names_and_exits(
         self,
         cli_runner: CliRunner,

--- a/tests/unit/cli/commands/refuel/test_speckit_dispatch.py
+++ b/tests/unit/cli/commands/refuel/test_speckit_dispatch.py
@@ -1,0 +1,246 @@
+"""Tests for ``maverick refuel`` Spec Kit mode dispatch and flags.
+
+Covers the CLI dispatch matrix in
+``contracts/cli-refuel-speckit.md``: explicit ``--speckit``,
+auto-detection, and the E01-E07 error catalog.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from maverick.main import cli
+
+_PATCH_EXECUTE = "maverick.cli.workflow_executor.execute_python_workflow"
+
+_TASKS_MD = """\
+## Phase 1: Setup
+
+- [ ] T001 Initialize project
+"""
+_SPEC_MD = "# Feature Specification: Sample\n"
+
+
+@pytest.fixture(autouse=True)
+def _mock_bd_available():
+    with (
+        patch("shutil.which", return_value="/usr/bin/bd"),
+        patch("maverick.beads.client.BeadClient.is_initialized", return_value=True),
+    ):
+        yield
+
+
+def _make_speckit_dir(base: Path, name: str = "048-sample-feature") -> Path:
+    feature_dir = base / "specs" / name
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "tasks.md").write_text(_TASKS_MD, encoding="utf-8")
+    (feature_dir / "spec.md").write_text(_SPEC_MD, encoding="utf-8")
+    return feature_dir
+
+
+def _make_classic_dir(base: Path, name: str = "my-feature") -> Path:
+    plan_dir = base / ".maverick" / "plans" / name
+    plan_dir.mkdir(parents=True)
+    (plan_dir / "flight-plan.md").write_text(
+        "---\nname: my-feature\n---\n\n## Objective\n\nTest.\n", encoding="utf-8"
+    )
+    return plan_dir / "flight-plan.md"
+
+
+class TestExplicitSpeckitFlag:
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_speckit_flag_forces_ingestion_mode(
+        self, mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        feature_dir = _make_speckit_dir(refuel_env)
+
+        result = cli_runner.invoke(cli, ["refuel", "048", "--speckit"])
+
+        assert result.exit_code == 0, result.output
+        assert "Using Spec Kit ingestion" in result.output
+        mock_execute.assert_called_once()
+        run_config = mock_execute.call_args[0][1]
+        from maverick.workflows.refuel_speckit import SpeckitRefuelWorkflow
+
+        assert run_config.workflow_class is SpeckitRefuelWorkflow
+        assert run_config.inputs["feature_dir"] == str(feature_dir)
+
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_speckit_flag_with_unresolvable_name_is_e02(
+        self, _mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        result = cli_runner.invoke(cli, ["refuel", "nonexistent", "--speckit"])
+
+        assert result.exit_code == 1
+        assert "does not resolve" in result.output
+        assert "Traceback" not in result.output
+
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_list_steps_with_speckit_lists_speckit_steps(
+        self, _mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        _make_speckit_dir(refuel_env)
+
+        result = cli_runner.invoke(cli, ["refuel", "048", "--speckit", "--list-steps"])
+
+        assert result.exit_code == 0, result.output
+        assert "Resolve Feature" in result.output
+        assert "Check Template" in result.output
+        assert "Parse Artifacts" in result.output
+        assert "Plan Ingestion" in result.output
+        assert "Create Beads" in result.output
+        assert "Wire Deps" in result.output
+        assert "Chain Epic" in result.output
+        _mock_execute.assert_not_called()
+
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_skip_briefing_on_speckit_path_warns_and_is_ignored(
+        self, mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        _make_speckit_dir(refuel_env)
+
+        result = cli_runner.invoke(cli, ["refuel", "048", "--speckit", "--skip-briefing"])
+
+        assert result.exit_code == 0, result.output
+        assert "Warning" in result.output
+        assert "no effect" in result.output
+        mock_execute.assert_called_once()
+
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_success_hint_prints_fly_command(
+        self, mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        _make_speckit_dir(refuel_env)
+        runs_dir = refuel_env / ".maverick" / "runs" / "abc12345"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "metadata.json").write_text(
+            '{"run_id": "abc12345", "plan_name": "048-sample-feature", '
+            '"epic_id": "epic-1", "status": "refueled", "started_at": "2026-01-01T00:00:00", '
+            '"completed_at": ""}',
+            encoding="utf-8",
+        )
+
+        result = cli_runner.invoke(cli, ["refuel", "048", "--speckit"])
+
+        assert result.exit_code == 0, result.output
+        assert "maverick fly --epic epic-1" in result.output
+
+
+class TestListStepsWithoutResolution:
+    """``--list-steps`` must stay inspectable before a plan/feature exists."""
+
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_list_steps_without_resolution_falls_back_to_classic(
+        self, _mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        # NAME resolves to neither a classic plan nor a Spec Kit feature.
+        result = cli_runner.invoke(cli, ["refuel", "not-created-yet", "--list-steps"])
+
+        assert result.exit_code == 0, result.output
+        # Classic step list is shown (no error about unresolvable name).
+        assert "could not resolve" not in result.output
+        assert "Briefing" in result.output or "Decompose" in result.output
+        _mock_execute.assert_not_called()
+
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_speckit_list_steps_without_resolution_lists_speckit_steps(
+        self, _mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        result = cli_runner.invoke(cli, ["refuel", "not-created-yet", "--speckit", "--list-steps"])
+
+        assert result.exit_code == 0, result.output
+        assert "does not resolve" not in result.output
+        assert "Resolve Feature" in result.output
+        assert "Plan Ingestion" in result.output
+        _mock_execute.assert_not_called()
+
+
+class TestAutoDetection:
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_speckit_only_dispatches_to_ingestion(
+        self, mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        _make_speckit_dir(refuel_env)
+
+        result = cli_runner.invoke(cli, ["refuel", "048-sample-feature"])
+
+        assert result.exit_code == 0, result.output
+        assert "Using Spec Kit ingestion" in result.output
+        run_config = mock_execute.call_args[0][1]
+        from maverick.workflows.refuel_speckit import SpeckitRefuelWorkflow
+
+        assert run_config.workflow_class is SpeckitRefuelWorkflow
+
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_classic_only_dispatches_to_classic_unchanged(
+        self, mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        _make_classic_dir(refuel_env)
+
+        result = cli_runner.invoke(cli, ["refuel", "my-feature"])
+
+        assert result.exit_code == 0, result.output
+        assert "Using Spec Kit ingestion" not in result.output
+        run_config = mock_execute.call_args[0][1]
+        from maverick.workflows.refuel_maverick import RefuelMaverickWorkflow
+
+        assert run_config.workflow_class is RefuelMaverickWorkflow
+
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_both_match_without_flag_is_e01(
+        self, _mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        _make_speckit_dir(refuel_env, name="048-my-feature")
+        _make_classic_dir(refuel_env, name="048-my-feature")
+
+        result = cli_runner.invoke(cli, ["refuel", "048-my-feature"])
+
+        assert result.exit_code == 1
+        assert "matches both" in result.output
+        assert "--speckit" in result.output
+        assert "Traceback" not in result.output
+
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_both_match_with_flag_dispatches_to_speckit(
+        self, mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        _make_speckit_dir(refuel_env, name="048-my-feature")
+        _make_classic_dir(refuel_env, name="048-my-feature")
+
+        result = cli_runner.invoke(cli, ["refuel", "048-my-feature", "--speckit"])
+
+        assert result.exit_code == 0, result.output
+        run_config = mock_execute.call_args[0][1]
+        from maverick.workflows.refuel_speckit import SpeckitRefuelWorkflow
+
+        assert run_config.workflow_class is SpeckitRefuelWorkflow
+
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_neither_matches_is_e02(
+        self, _mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        result = cli_runner.invoke(cli, ["refuel", "does-not-exist"])
+
+        assert result.exit_code == 1
+        assert "could not resolve" in result.output
+        assert "Traceback" not in result.output
+
+
+class TestErrorRendering:
+    @patch(_PATCH_EXECUTE, new_callable=AsyncMock)
+    def test_ambiguous_speckit_candidates_is_e03(
+        self, _mock_execute: AsyncMock, cli_runner: CliRunner, refuel_env: Path
+    ) -> None:
+        _make_speckit_dir(refuel_env, name="048-feature-a")
+        _make_speckit_dir(refuel_env, name="048-feature-b")
+
+        result = cli_runner.invoke(cli, ["refuel", "048", "--speckit"])
+
+        assert result.exit_code == 1
+        assert "048-feature-a" in result.output
+        assert "048-feature-b" in result.output
+        assert "Traceback" not in result.output

--- a/tests/unit/speckit/conftest.py
+++ b/tests/unit/speckit/conftest.py
@@ -1,0 +1,105 @@
+"""Shared fixtures for speckit parser/detect/build tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+#: Full-featured tasks.md: multi-phase, [P]/[USn] markers, checked tasks,
+#: an explicit "depends on" note, a fenced code block containing a
+#: task-shaped line (must be skipped), and a Dependencies section.
+FULL_TASKS_MD = """\
+# Tasks: Sample Feature
+
+## Phase 1: Setup
+
+- [ ] T001 Initialize project
+- [x] T002 [P] Already completed setup task
+- [ ] T003 [P] Create config file in src/config.py
+
+## Phase 2: Foundational
+
+- [ ] T004 Create core model in src/models.py (depends on T003)
+- [ ] T005 Implement base service in src/service.py
+
+```
+# fenced code block containing a task-shaped line that must be skipped
+- [ ] T999 this looks like a task but is inside a fence
+```
+
+## Phase 3: User Story 1 - Core Feature (Priority: P1)
+
+- [ ] T006 [P] [US1] Implement feature A in src/feature_a.py
+- [ ] T007 [US1] Add tests for feature A in tests/test_feature_a.py
+
+## Phase 4: User Story 2 - Extended Feature (Priority: P2)
+
+- [ ] T008 [US2] Implement feature B in src/feature_b.py
+- [x] T009 [US2] Already completed extended task
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+- [ ] T010 [P] Run linting
+- [ ] T011 [P] Fix type errors
+
+## Dependencies & Execution Order
+
+- US2: Depends on US1
+"""
+
+#: spec.md matching FULL_TASKS_MD: SC bullets and per-story Acceptance
+#: Scenarios for US1/US2.
+FULL_SPEC_MD = """\
+# Feature Specification: Sample Feature
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Core Feature (Priority: P1)
+
+Some narrative text describing story 1.
+
+**Acceptance Scenarios**:
+
+1. **Given** a thing, **When** an action, **Then** an outcome for story 1.
+2. **Given** another thing, **When** another action, **Then** another outcome.
+
+### User Story 2 - Extended Feature (Priority: P2)
+
+More narrative text describing story 2.
+
+**Acceptance Scenarios**:
+
+1. **Given** something extended, **When** acting, **Then** an extended outcome.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The feature does the thing within a time bound.
+- **SC-002**: Every task carries through unmodified.
+"""
+
+
+@pytest.fixture
+def full_tasks_md() -> str:
+    return FULL_TASKS_MD
+
+
+@pytest.fixture
+def full_spec_md() -> str:
+    return FULL_SPEC_MD
+
+
+@pytest.fixture
+def speckit_feature_dir(temp_dir: Path) -> Path:
+    """Full-featured Spec Kit feature directory under a temp repo root.
+
+    Layout: ``<temp_dir>/specs/048-sample-feature/{spec.md,tasks.md,plan.md}``.
+    """
+    feature_dir = temp_dir / "specs" / "048-sample-feature"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "tasks.md").write_text(FULL_TASKS_MD, encoding="utf-8")
+    (feature_dir / "spec.md").write_text(FULL_SPEC_MD, encoding="utf-8")
+    (feature_dir / "plan.md").write_text("# Plan\n\nImplementation plan.", encoding="utf-8")
+    return feature_dir

--- a/tests/unit/speckit/test_build_edges.py
+++ b/tests/unit/speckit/test_build_edges.py
@@ -1,0 +1,211 @@
+"""Tests for dependency-edge derivation (maverick.speckit.build)."""
+
+from __future__ import annotations
+
+import pytest
+
+from maverick.speckit.build import derive_dependency_edges
+from maverick.speckit.errors import SpeckitValidationError
+from maverick.speckit.models import SpeckitPhase, SpeckitTask
+
+
+def _task(
+    task_id: str,
+    *,
+    phase_number: int,
+    parallel: bool = False,
+    story_id: str | None = None,
+    explicit_deps: tuple[str, ...] = (),
+    line_number: int = 1,
+) -> SpeckitTask:
+    return SpeckitTask(
+        task_id=task_id,
+        description=f"do {task_id}",
+        completed=False,
+        parallel=parallel,
+        story_id=story_id,
+        phase_number=phase_number,
+        explicit_deps=explicit_deps,
+        line_number=line_number,
+    )
+
+
+class TestIntraPhaseChain:
+    def test_serial_chain_of_non_parallel_tasks(self) -> None:
+        phase = SpeckitPhase(
+            number=1,
+            title="Setup",
+            tasks=(
+                _task("T001", phase_number=1),
+                _task("T002", phase_number=1),
+                _task("T003", phase_number=1),
+            ),
+        )
+        edges = derive_dependency_edges((phase,))
+        assert ("T001", "T002") in edges
+        assert ("T002", "T003") in edges
+
+    def test_parallel_tasks_have_no_implicit_intra_phase_deps(self) -> None:
+        phase = SpeckitPhase(
+            number=1,
+            title="Setup",
+            tasks=(
+                _task("T001", phase_number=1, parallel=True),
+                _task("T002", phase_number=1, parallel=True),
+            ),
+        )
+        edges = derive_dependency_edges((phase,))
+        assert edges == ()
+
+    def test_phase_barrier_is_transitive_across_serial_chain(self) -> None:
+        """Only sinks/sources need connecting — the barrier is a valid
+        execution order thanks to transitivity through the chains."""
+        phase1 = SpeckitPhase(
+            number=1,
+            title="Setup",
+            tasks=(_task("T001", phase_number=1), _task("T002", phase_number=1)),
+        )
+        phase2 = SpeckitPhase(
+            number=2,
+            title="Next",
+            tasks=(_task("T003", phase_number=2), _task("T004", phase_number=2)),
+        )
+        edges = derive_dependency_edges((phase1, phase2))
+        # sink of phase 1 is T002 (last in chain); source of phase 2 is T003.
+        assert ("T002", "T003") in edges
+        # T001 already reaches T003 transitively via T001->T002->T003.
+        assert ("T001", "T003") not in edges
+
+    def test_parallel_tasks_are_both_sinks_and_sources_for_barrier(self) -> None:
+        phase1 = SpeckitPhase(
+            number=1,
+            title="Setup",
+            tasks=(_task("T001", phase_number=1, parallel=True),),
+        )
+        phase2 = SpeckitPhase(
+            number=2,
+            title="Next",
+            tasks=(_task("T002", phase_number=2, parallel=True),),
+        )
+        edges = derive_dependency_edges((phase1, phase2))
+        assert ("T001", "T002") in edges
+
+
+class TestExplicitDeps:
+    def test_explicit_dep_edge_added(self) -> None:
+        phase = SpeckitPhase(
+            number=1,
+            title="Setup",
+            tasks=(
+                _task("T001", phase_number=1, parallel=True),
+                _task("T002", phase_number=1, parallel=True, explicit_deps=("T001",)),
+            ),
+        )
+        edges = derive_dependency_edges((phase,))
+        assert ("T001", "T002") in edges
+
+
+class TestTopologicalValidity:
+    def test_full_edge_set_is_a_valid_execution_order(self) -> None:
+        """Build a Kahn's-algorithm topological sort from the derived
+        edges and verify it recovers a valid tasks.md-consistent order."""
+        phase1 = SpeckitPhase(
+            number=1,
+            title="Setup",
+            tasks=(
+                _task("T001", phase_number=1),
+                _task("T002", phase_number=1, parallel=True),
+                _task("T003", phase_number=1, parallel=True),
+            ),
+        )
+        phase2 = SpeckitPhase(
+            number=2,
+            title="Next",
+            tasks=(_task("T004", phase_number=2),),
+        )
+        edges = derive_dependency_edges((phase1, phase2))
+
+        all_ids = {"T001", "T002", "T003", "T004"}
+        indegree = dict.fromkeys(all_ids, 0)
+        adjacency: dict[str, list[str]] = {i: [] for i in all_ids}
+        for a, b in edges:
+            adjacency[a].append(b)
+            indegree[b] += 1
+
+        ready = [i for i in all_ids if indegree[i] == 0]
+        order: list[str] = []
+        while ready:
+            node = ready.pop()
+            order.append(node)
+            for nxt in adjacency[node]:
+                indegree[nxt] -= 1
+                if indegree[nxt] == 0:
+                    ready.append(nxt)
+
+        assert set(order) == all_ids
+        assert order.index("T001") < order.index("T004")
+        assert order.index("T002") < order.index("T004")
+        assert order.index("T003") < order.index("T004")
+
+
+class TestStoryDeps:
+    def test_story_dep_not_duplicated_when_already_reachable(self) -> None:
+        phase1 = SpeckitPhase(
+            number=1,
+            title="US1",
+            tasks=(_task("T001", phase_number=1, story_id="US1"),),
+        )
+        phase2 = SpeckitPhase(
+            number=2,
+            title="US2",
+            tasks=(_task("T002", phase_number=2, story_id="US2"),),
+        )
+        edges = derive_dependency_edges((phase1, phase2), story_deps=(("US2", "US1"),))
+        assert edges == (("T001", "T002"),)
+
+    def test_story_dep_adds_edge_when_stories_interleaved_in_same_phase(self) -> None:
+        phase = SpeckitPhase(
+            number=1,
+            title="Mixed",
+            tasks=(
+                _task("T001", phase_number=1, parallel=True, story_id="US1"),
+                _task("T002", phase_number=1, parallel=True, story_id="US2"),
+            ),
+        )
+        edges = derive_dependency_edges((phase,), story_deps=(("US2", "US1"),))
+        assert ("T001", "T002") in edges
+
+
+class TestCycleDetection:
+    def test_cycle_from_explicit_deps_raises(self) -> None:
+        phase = SpeckitPhase(
+            number=1,
+            title="Setup",
+            tasks=(
+                _task("T001", phase_number=1, parallel=True, explicit_deps=("T002",)),
+                _task("T002", phase_number=1, parallel=True, explicit_deps=("T001",)),
+            ),
+        )
+        with pytest.raises(SpeckitValidationError) as exc_info:
+            derive_dependency_edges((phase,))
+        assert exc_info.value.cycle
+
+
+class TestDeltaEdgeResolution:
+    def test_edges_resolve_through_existing_task_map_and_drop_completed_blockers(self) -> None:
+        from maverick.speckit.build import _resolve_delta_edges
+
+        edges = (("T001", "T002"), ("T003", "T004"), ("T005", "T004"))
+        resolved = _resolve_delta_edges(
+            edges,
+            completed_ids={"T003"},
+            existing_task_map={"T001": "bead-abc"},
+            new_task_ids={"T002", "T004"},
+        )
+        # T001->T002: T002 is new, T001 resolves to its bead ID.
+        assert ("bead-abc", "T002") in resolved
+        # T003->T004: T003 is completed -> dropped.
+        assert not any(blocker == "T003" for blocker, _blocked in resolved)
+        # T005->T004: T005 is neither completed nor existing -> passes through
+        # as a bare task ID (resolved via created_map once T005 itself is created).
+        assert ("T005", "T004") in resolved

--- a/tests/unit/speckit/test_build_plan.py
+++ b/tests/unit/speckit/test_build_plan.py
@@ -1,0 +1,210 @@
+"""Tests for ingestion-plan building (maverick.speckit.build.build_ingestion_plan)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from maverick.speckit.build import EPIC_TASK_ID, build_ingestion_plan
+from maverick.speckit.errors import NothingToIngestError
+from maverick.speckit.models import ParsedSpec, SpeckitFeature, SpeckitPhase, SpeckitTask
+from maverick.speckit.parser import parse_spec_md, parse_tasks_md
+
+
+def _feature_from_fixture(feature_dir: Path, tasks_md: str, spec_md: str) -> SpeckitFeature:
+    phases, story_deps = parse_tasks_md(tasks_md)
+    spec = parse_spec_md(spec_md)
+    return SpeckitFeature(
+        feature_dir=feature_dir,
+        feature_name=feature_dir.name,
+        spec=spec,
+        phases=phases,
+        story_deps=story_deps,
+        has_plan=True,
+    )
+
+
+@pytest.fixture
+def feature(speckit_feature_dir: Path, full_tasks_md: str, full_spec_md: str) -> SpeckitFeature:
+    return _feature_from_fixture(speckit_feature_dir, full_tasks_md, full_spec_md)
+
+
+class TestFreshRun:
+    def test_epic_and_new_tasks_created(self, feature: SpeckitFeature) -> None:
+        plan, warnings = build_ingestion_plan(feature)
+        assert plan.epic is not None
+        assert plan.epic.task_id == EPIC_TASK_ID
+        assert plan.existing_epic_id is None
+        # 11 tasks total, 2 completed (T002, T009) -> 9 new.
+        assert len(plan.new_tasks) == 9
+        assert set(plan.skipped_completed) == {"T002", "T009"}
+        assert plan.skipped_existing == ()
+
+    def test_task_title_format_and_length(self, feature: SpeckitFeature) -> None:
+        plan, _warnings = build_ingestion_plan(feature)
+        titles = {pb.task_id: pb.definition.title for pb in plan.new_tasks}
+        assert titles["T001"].startswith("T001: ")
+        assert all(len(t) <= 490 for t in titles.values())
+
+    def test_task_description_sections(self, feature: SpeckitFeature) -> None:
+        plan, _warnings = build_ingestion_plan(feature)
+        by_id = {pb.task_id: pb for pb in plan.new_tasks}
+        desc = by_id["T003"].definition.description
+        assert "## Task" in desc
+        assert "## Acceptance Criteria" in desc
+        assert "## File Scope" in desc
+        assert "src/config.py" in desc
+        assert "## Verification" in desc
+        assert "rg --files -g 'src/config.py'" in desc
+
+    def test_story_task_description_includes_scenarios(self, feature: SpeckitFeature) -> None:
+        plan, _warnings = build_ingestion_plan(feature)
+        by_id = {pb.task_id: pb for pb in plan.new_tasks}
+        desc = by_id["T006"].definition.description
+        assert "outcome for story 1" in desc
+
+    def test_verification_never_empty(self, feature: SpeckitFeature) -> None:
+        plan, _warnings = build_ingestion_plan(feature)
+        for pb in plan.new_tasks:
+            assert "## Verification" in pb.definition.description
+            section = pb.definition.description.split("## Verification")[1]
+            assert section.strip().startswith("-")
+
+    def test_epic_description_has_success_criteria_and_source(
+        self, feature: SpeckitFeature
+    ) -> None:
+        plan, _warnings = build_ingestion_plan(feature)
+        assert plan.epic is not None
+        desc = plan.epic.definition.description
+        assert "## Success Criteria" in desc
+        assert "## Source" in desc
+        assert "specs/048-sample-feature/" in desc
+
+    def test_task_state_carries_provenance(self, feature: SpeckitFeature) -> None:
+        plan, _warnings = build_ingestion_plan(feature)
+        by_id = {pb.task_id: pb for pb in plan.new_tasks}
+        assert by_id["T003"].state == {
+            "speckit_task_id": "T003",
+            "speckit_phase": "1",
+            "speckit_parallel": "true",
+        }
+        assert by_id["T001"].state["speckit_parallel"] == "false"
+
+    def test_epic_state_carries_feature_name(self, feature: SpeckitFeature) -> None:
+        plan, _warnings = build_ingestion_plan(feature)
+        assert plan.epic is not None
+        assert plan.epic.state == {"speckit_feature": "048-sample-feature"}
+
+    def test_edges_present_and_acyclic(self, feature: SpeckitFeature) -> None:
+        plan, _warnings = build_ingestion_plan(feature)
+        assert len(plan.edges) > 0
+
+    def test_labels_include_speckit(self, feature: SpeckitFeature) -> None:
+        plan, _warnings = build_ingestion_plan(feature)
+        assert plan.epic is not None
+        assert "speckit" in plan.epic.definition.labels
+        for pb in plan.new_tasks:
+            assert "speckit" in pb.definition.labels
+
+
+class TestDeltaRun:
+    def test_only_new_tasks_included_no_epic(self, feature: SpeckitFeature) -> None:
+        existing_task_map = {"T001": "bead-t001", "T003": "bead-t003"}
+        plan, _warnings = build_ingestion_plan(
+            feature,
+            existing_epic_id="epic-existing",
+            existing_task_map=existing_task_map,
+        )
+        assert plan.epic is None
+        assert plan.existing_epic_id == "epic-existing"
+        new_ids = {pb.task_id for pb in plan.new_tasks}
+        assert "T001" not in new_ids
+        assert "T003" not in new_ids
+        assert set(plan.skipped_existing) == {"T001", "T003"}
+
+    def test_delta_edges_resolve_through_existing_task_map(self, feature: SpeckitFeature) -> None:
+        existing_task_map = {"T003": "bead-t003"}
+        plan, _warnings = build_ingestion_plan(
+            feature,
+            existing_epic_id="epic-existing",
+            existing_task_map=existing_task_map,
+        )
+        blockers = {blocker for blocker, _blocked in plan.edges}
+        assert "bead-t003" in blockers
+        assert "T003" not in blockers
+
+    def test_delta_no_op_when_all_open_tasks_already_ingested(
+        self, feature: SpeckitFeature
+    ) -> None:
+        all_open_ids = [
+            t.task_id for phase in feature.phases for t in phase.tasks if not t.completed
+        ]
+        existing_task_map = {tid: f"bead-{tid}" for tid in all_open_ids}
+        plan, _warnings = build_ingestion_plan(
+            feature,
+            existing_epic_id="epic-existing",
+            existing_task_map=existing_task_map,
+        )
+        assert plan.new_tasks == ()
+        assert plan.epic is None
+        assert set(plan.skipped_existing) == set(all_open_ids)
+
+
+class TestValidationBeforeWrite:
+    def test_zero_open_tasks_raises_nothing_to_ingest(self, tmp_path: Path) -> None:
+        tasks_md = """\
+## Phase 1: Setup
+
+- [x] T001 Already done
+- [x] T002 Also done
+"""
+        spec_md = "# Feature Specification: All Done\n"
+        feature_dir = tmp_path / "specs" / "999-all-done"
+        feature = _feature_from_fixture(feature_dir, tasks_md, spec_md)
+
+        with pytest.raises(NothingToIngestError) as exc_info:
+            build_ingestion_plan(feature)
+        assert exc_info.value.completed_count == 2
+        assert exc_info.value.total_count == 2
+
+    def test_missing_story_scenarios_produces_warning(self, tmp_path: Path) -> None:
+        tasks_md = """\
+## Phase 1: Setup
+
+- [ ] T001 [US9] A task labeled with a story that has no scenarios
+"""
+        feature_dir = tmp_path / "specs" / "998-no-story"
+        feature = SpeckitFeature(
+            feature_dir=feature_dir,
+            feature_name=feature_dir.name,
+            spec=ParsedSpec(title="No Story"),
+            phases=parse_tasks_md(tasks_md)[0],
+        )
+        _plan, warnings = build_ingestion_plan(feature)
+        assert any("US9" in w for w in warnings)
+
+    def test_missing_success_criteria_produces_warning(self, tmp_path: Path) -> None:
+        feature_dir = tmp_path / "specs" / "997-no-sc"
+        phase = SpeckitPhase(
+            number=1,
+            title="Setup",
+            tasks=(
+                SpeckitTask(
+                    task_id="T001",
+                    description="do a thing",
+                    completed=False,
+                    parallel=False,
+                    phase_number=1,
+                    line_number=1,
+                ),
+            ),
+        )
+        feature = SpeckitFeature(
+            feature_dir=feature_dir,
+            feature_name=feature_dir.name,
+            spec=ParsedSpec(title="No SC"),
+            phases=(phase,),
+        )
+        _plan, warnings = build_ingestion_plan(feature)
+        assert any("Success Criteria" in w for w in warnings)

--- a/tests/unit/speckit/test_detect.py
+++ b/tests/unit/speckit/test_detect.py
@@ -1,0 +1,129 @@
+"""Tests for maverick.speckit.detect (resolution + version gate)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from maverick.speckit.detect import (
+    SUPPORTED_SPECKIT_RANGE,
+    check_template_compatibility,
+    resolve_feature,
+)
+from maverick.speckit.errors import AmbiguousFeatureError
+
+
+class TestResolveFeatureNameForms:
+    def test_exact_directory_name(self, speckit_feature_dir: Path, temp_dir: Path) -> None:
+        resolution = resolve_feature("048-sample-feature", cwd=temp_dir)
+        assert resolution.mode == "speckit"
+        assert resolution.speckit_dir == speckit_feature_dir
+
+    def test_nnn_prefix(self, speckit_feature_dir: Path, temp_dir: Path) -> None:
+        resolution = resolve_feature("048", cwd=temp_dir)
+        assert resolution.mode == "speckit"
+        assert resolution.speckit_dir == speckit_feature_dir
+
+    def test_exact_suffix(self, speckit_feature_dir: Path, temp_dir: Path) -> None:
+        resolution = resolve_feature("sample-feature", cwd=temp_dir)
+        assert resolution.mode == "speckit"
+        assert resolution.speckit_dir == speckit_feature_dir
+
+    def test_multiple_candidates_raise_ambiguous_feature_error(self, temp_dir: Path) -> None:
+        for name in ["048-sample-feature", "048-other-feature"]:
+            d = temp_dir / "specs" / name
+            d.mkdir(parents=True)
+            (d / "spec.md").write_text("# Feature Specification: X\n")
+            (d / "tasks.md").write_text("## Phase 1: Setup\n\n- [ ] T001 A thing\n")
+
+        with pytest.raises(AmbiguousFeatureError) as exc_info:
+            resolve_feature("048", cwd=temp_dir)
+        assert len(exc_info.value.candidates) == 2
+
+    def test_missing_spec_or_tasks_not_a_candidate(self, temp_dir: Path) -> None:
+        d = temp_dir / "specs" / "048-partial"
+        d.mkdir(parents=True)
+        (d / "spec.md").write_text("# Feature Specification: X\n")
+        # no tasks.md
+
+        resolution = resolve_feature("048", cwd=temp_dir)
+        assert resolution.mode == "unresolved"
+
+
+class TestResolveFeatureClassicMode:
+    def test_classic_flight_plan_only(self, temp_dir: Path) -> None:
+        plan_dir = temp_dir / ".maverick" / "plans" / "my-feature"
+        plan_dir.mkdir(parents=True)
+        (plan_dir / "flight-plan.md").write_text("---\nname: my-feature\n---\n")
+
+        resolution = resolve_feature("my-feature", cwd=temp_dir)
+        assert resolution.mode == "classic"
+        assert resolution.flight_plan_path == plan_dir / "flight-plan.md"
+
+    def test_neither_matches_is_unresolved(self, temp_dir: Path) -> None:
+        resolution = resolve_feature("nonexistent", cwd=temp_dir)
+        assert resolution.mode == "unresolved"
+        assert resolution.speckit_dir is None
+        assert resolution.flight_plan_path is None
+
+    def test_both_match_is_ambiguous(self, speckit_feature_dir: Path, temp_dir: Path) -> None:
+        plan_dir = temp_dir / ".maverick" / "plans" / "048-sample-feature"
+        plan_dir.mkdir(parents=True)
+        (plan_dir / "flight-plan.md").write_text("---\nname: 048-sample-feature\n---\n")
+
+        resolution = resolve_feature("048-sample-feature", cwd=temp_dir)
+        assert resolution.mode == "ambiguous"
+        assert resolution.speckit_dir is not None
+        assert resolution.flight_plan_path is not None
+
+
+class TestTemplateCompatibility:
+    def test_supported_version(self, temp_dir: Path) -> None:
+        specify_dir = temp_dir / ".specify"
+        specify_dir.mkdir(parents=True)
+        (specify_dir / "init-options.json").write_text(json.dumps({"speckit_version": "0.14.0"}))
+
+        compat = check_template_compatibility(temp_dir)
+        assert compat.status == "supported"
+        assert compat.vendored_version == "0.14.0"
+        assert compat.supported_range == SUPPORTED_SPECKIT_RANGE
+
+    def test_unsupported_version(self, temp_dir: Path) -> None:
+        specify_dir = temp_dir / ".specify"
+        specify_dir.mkdir(parents=True)
+        (specify_dir / "init-options.json").write_text(json.dumps({"speckit_version": "0.99.0"}))
+
+        compat = check_template_compatibility(temp_dir)
+        assert compat.status == "unsupported"
+        assert compat.vendored_version == "0.99.0"
+
+    def test_missing_file_is_unknown(self, temp_dir: Path) -> None:
+        compat = check_template_compatibility(temp_dir)
+        assert compat.status == "unknown"
+        assert compat.vendored_version is None
+
+    def test_missing_field_is_unknown(self, temp_dir: Path) -> None:
+        specify_dir = temp_dir / ".specify"
+        specify_dir.mkdir(parents=True)
+        (specify_dir / "init-options.json").write_text(json.dumps({"ai": "claude"}))
+
+        compat = check_template_compatibility(temp_dir)
+        assert compat.status == "unknown"
+
+    def test_boundary_below_range_is_unsupported(self, temp_dir: Path) -> None:
+        specify_dir = temp_dir / ".specify"
+        specify_dir.mkdir(parents=True)
+        (specify_dir / "init-options.json").write_text(json.dumps({"speckit_version": "0.13.9"}))
+
+        compat = check_template_compatibility(temp_dir)
+        assert compat.status == "unsupported"
+
+    def test_boundary_at_upper_exclusive_is_unsupported(self, temp_dir: Path) -> None:
+        specify_dir = temp_dir / ".specify"
+        specify_dir.mkdir(parents=True)
+        (specify_dir / "init-options.json").write_text(json.dumps({"speckit_version": "0.15.0"}))
+
+        compat = check_template_compatibility(temp_dir)
+        assert compat.status == "unsupported"

--- a/tests/unit/speckit/test_enrichment.py
+++ b/tests/unit/speckit/test_enrichment.py
@@ -1,0 +1,118 @@
+"""Tests for maverick.speckit.enrichment (prompt building, response parsing, apply)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from maverick.speckit.build import build_ingestion_plan
+from maverick.speckit.enrichment import (
+    apply_enrichment,
+    build_enrichment_prompt,
+    parse_enrichment_response,
+)
+from maverick.speckit.models import SpeckitFeature
+from maverick.speckit.parser import parse_spec_md, parse_tasks_md
+
+
+def _feature(tmp_path: Path, tasks_md: str, spec_md: str) -> SpeckitFeature:
+    feature_dir = tmp_path / "specs" / "048-enrich-sample"
+    phases, story_deps = parse_tasks_md(tasks_md)
+    return SpeckitFeature(
+        feature_dir=feature_dir,
+        feature_name=feature_dir.name,
+        spec=parse_spec_md(spec_md),
+        phases=phases,
+        story_deps=story_deps,
+    )
+
+
+_TASKS_MD = """\
+## Phase 1: Setup
+
+- [ ] T001 Initialize project
+- [ ] T002 [P] Create config file in src/config.py
+"""
+_SPEC_MD = "# Feature Specification: Enrich Sample\n"
+
+
+class TestBuildEnrichmentPrompt:
+    def test_prompt_covers_all_new_tasks_in_one_call(self, tmp_path: Path) -> None:
+        feature = _feature(tmp_path, _TASKS_MD, _SPEC_MD)
+        plan, _warnings = build_ingestion_plan(feature)
+
+        prompt = build_enrichment_prompt(plan.new_tasks)
+
+        assert "T001" in prompt
+        assert "T002" in prompt
+        assert prompt.count("## T001") == 1
+        assert prompt.count("## T002") == 1
+
+
+class TestParseEnrichmentResponse:
+    def test_parses_commands_keyed_by_task_id(self) -> None:
+        response = """\
+### T001
+- rg --files -g 'src/foo.py'
+- cargo test test_foo
+
+### T002
+- make lint
+"""
+        parsed = parse_enrichment_response(response)
+        assert parsed == {
+            "T001": ["rg --files -g 'src/foo.py'", "cargo test test_foo"],
+            "T002": ["make lint"],
+        }
+
+    def test_ignores_prose_outside_task_sections(self) -> None:
+        response = "Some preamble.\n\n### T001\n- make test\n\nSome trailing notes.\n"
+        parsed = parse_enrichment_response(response)
+        assert parsed == {"T001": ["make test"]}
+
+    def test_empty_response_yields_empty_dict(self) -> None:
+        assert parse_enrichment_response("") == {}
+
+
+class TestApplyEnrichment:
+    def test_merges_commands_into_verification_only(self, tmp_path: Path) -> None:
+        feature = _feature(tmp_path, _TASKS_MD, _SPEC_MD)
+        plan, _warnings = build_ingestion_plan(feature)
+        commands_by_task = {"T001": ["make test-t001"], "T002": ["make test-t002"]}
+
+        enriched = apply_enrichment(plan, commands_by_task)
+
+        by_id = {pb.task_id: pb for pb in enriched.new_tasks}
+        assert "make test-t001" in by_id["T001"].definition.description
+        assert "make test-t002" in by_id["T002"].definition.description
+
+        # Every other section is untouched.
+        original_by_id = {pb.task_id: pb for pb in plan.new_tasks}
+        for task_id in ("T001", "T002"):
+            original_sections = original_by_id[task_id].definition.description.split(
+                "## Verification"
+            )[0]
+            enriched_sections = by_id[task_id].definition.description.split("## Verification")[0]
+            assert original_sections == enriched_sections
+
+    def test_task_set_and_edges_identical_to_unenriched_plan(self, tmp_path: Path) -> None:
+        feature = _feature(tmp_path, _TASKS_MD, _SPEC_MD)
+        plan, _warnings = build_ingestion_plan(feature)
+
+        enriched = apply_enrichment(plan, {"T001": ["make test"]})
+
+        assert enriched.edges == plan.edges
+        assert [pb.task_id for pb in enriched.new_tasks] == [pb.task_id for pb in plan.new_tasks]
+        assert enriched.skipped_completed == plan.skipped_completed
+        assert enriched.skipped_existing == plan.skipped_existing
+
+    def test_task_with_no_suggested_commands_is_unchanged(self, tmp_path: Path) -> None:
+        feature = _feature(tmp_path, _TASKS_MD, _SPEC_MD)
+        plan, _warnings = build_ingestion_plan(feature)
+
+        enriched = apply_enrichment(plan, {"T001": ["make test"]})
+
+        by_id = {pb.task_id: pb for pb in enriched.new_tasks}
+        original_by_id = {pb.task_id: pb for pb in plan.new_tasks}
+        assert (
+            by_id["T002"].definition.description == original_by_id["T002"].definition.description
+        )

--- a/tests/unit/speckit/test_errors.py
+++ b/tests/unit/speckit/test_errors.py
@@ -1,0 +1,85 @@
+"""Tests for the Spec Kit error hierarchy."""
+
+from __future__ import annotations
+
+from maverick.exceptions.base import MaverickError
+from maverick.speckit.errors import (
+    AmbiguousFeatureError,
+    NothingToIngestError,
+    SpeckitError,
+    SpeckitParseError,
+    SpeckitValidationError,
+    UnsupportedTemplateError,
+)
+
+
+def test_speckit_error_is_a_maverick_error() -> None:
+    assert issubclass(SpeckitError, MaverickError)
+
+
+def test_speckit_parse_error_carries_file_line_expected_suggestion() -> None:
+    err = SpeckitParseError(
+        "malformed task line",
+        file="tasks.md",
+        line=12,
+        expected="- [ ] T### description",
+        suggestion="add a task ID",
+    )
+    assert isinstance(err, SpeckitError)
+    assert err.file == "tasks.md"
+    assert err.line == 12
+    assert err.expected == "- [ ] T### description"
+    assert err.suggestion == "add a task ID"
+    assert "malformed task line" in str(err)
+
+
+def test_speckit_validation_error_carries_duplicate_id_context() -> None:
+    err = SpeckitValidationError(
+        "duplicate task ID T005",
+        file="tasks.md",
+        task_id="T005",
+        lines=(10, 20),
+    )
+    assert err.task_id == "T005"
+    assert err.lines == (10, 20)
+    assert "T005" in str(err)
+
+
+def test_speckit_validation_error_carries_unknown_ref() -> None:
+    err = SpeckitValidationError(
+        "unknown dependency T999",
+        task_id="T001",
+        unknown_ref="T999",
+    )
+    assert err.unknown_ref == "T999"
+
+
+def test_ambiguous_feature_error_carries_candidates() -> None:
+    err = AmbiguousFeatureError(
+        "multiple matches",
+        query="048",
+        candidates=("specs/048-a", "specs/048-b"),
+    )
+    assert err.query == "048"
+    assert err.candidates == ("specs/048-a", "specs/048-b")
+
+
+def test_unsupported_template_error_carries_versions() -> None:
+    err = UnsupportedTemplateError(
+        "unsupported template version 0.99.0, supported: >=0.14,<0.15",
+        found_version="0.99.0",
+        supported_range=">=0.14,<0.15",
+    )
+    assert err.found_version == "0.99.0"
+    assert err.supported_range == ">=0.14,<0.15"
+    assert "0.99.0" in str(err)
+
+
+def test_nothing_to_ingest_error_carries_counts() -> None:
+    err = NothingToIngestError(
+        "nothing to ingest",
+        completed_count=5,
+        total_count=5,
+    )
+    assert err.completed_count == 5
+    assert err.total_count == 5

--- a/tests/unit/speckit/test_models.py
+++ b/tests/unit/speckit/test_models.py
@@ -1,0 +1,135 @@
+"""Tests for the frozen Pydantic models in maverick.speckit.models."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from maverick.speckit.models import ParsedSpec, SpeckitFeature, SpeckitPhase, SpeckitTask
+
+
+class TestSpeckitTask:
+    def test_valid_task(self) -> None:
+        task = SpeckitTask(
+            task_id="T001",
+            description="Do the thing",
+            completed=False,
+            parallel=False,
+            phase_number=1,
+            line_number=5,
+        )
+        assert task.task_id == "T001"
+        assert task.story_id is None
+        assert task.file_paths == ()
+        assert task.explicit_deps == ()
+
+    @pytest.mark.parametrize("bad_id", ["T1", "T12", "X001", "t001", ""])
+    def test_task_id_must_match_pattern(self, bad_id: str) -> None:
+        with pytest.raises(ValidationError):
+            SpeckitTask(
+                task_id=bad_id,
+                description="Do the thing",
+                completed=False,
+                parallel=False,
+                phase_number=1,
+                line_number=5,
+            )
+
+    def test_task_id_accepts_4_plus_digits(self) -> None:
+        task = SpeckitTask(
+            task_id="T1234",
+            description="Do the thing",
+            completed=False,
+            parallel=False,
+            phase_number=1,
+            line_number=5,
+        )
+        assert task.task_id == "T1234"
+
+    def test_description_must_not_be_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            SpeckitTask(
+                task_id="T001",
+                description="   ",
+                completed=False,
+                parallel=False,
+                phase_number=1,
+                line_number=5,
+            )
+
+    def test_is_frozen(self) -> None:
+        task = SpeckitTask(
+            task_id="T001",
+            description="Do the thing",
+            completed=False,
+            parallel=False,
+            phase_number=1,
+            line_number=5,
+        )
+        with pytest.raises((TypeError, ValidationError)):
+            task.completed = True  # type: ignore[misc]
+
+
+class TestSpeckitPhase:
+    def test_valid_phase(self) -> None:
+        task = SpeckitTask(
+            task_id="T001",
+            description="Do the thing",
+            completed=False,
+            parallel=False,
+            phase_number=1,
+            line_number=5,
+        )
+        phase = SpeckitPhase(number=1, title="Setup", tasks=(task,))
+        assert phase.number == 1
+        assert phase.tasks == (task,)
+
+    def test_phase_can_be_empty(self) -> None:
+        phase = SpeckitPhase(number=1, title="Empty phase")
+        assert phase.tasks == ()
+
+    def test_number_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            SpeckitPhase(number=0, title="Bad")
+
+
+class TestParsedSpec:
+    def test_defaults(self) -> None:
+        spec = ParsedSpec()
+        assert spec.title == ""
+        assert spec.success_criteria == ()
+        assert spec.story_scenarios == {}
+
+    def test_story_scenarios_keyed_by_story_id(self) -> None:
+        spec = ParsedSpec(
+            title="My Feature",
+            success_criteria=("**SC-001**: fast",),
+            story_scenarios={"US1": ("scenario one",), "US2": ()},
+        )
+        assert spec.story_scenarios["US1"] == ("scenario one",)
+        assert spec.story_scenarios["US2"] == ()
+
+
+class TestSpeckitFeature:
+    def test_valid_feature(self, tmp_path: Path) -> None:
+        feature_dir = tmp_path / "specs" / "001-test"
+        task = SpeckitTask(
+            task_id="T001",
+            description="Do the thing",
+            completed=False,
+            parallel=False,
+            phase_number=1,
+            line_number=5,
+        )
+        phase = SpeckitPhase(number=1, title="Setup", tasks=(task,))
+        feature = SpeckitFeature(
+            feature_dir=feature_dir,
+            feature_name="001-test",
+            spec=ParsedSpec(title="Test"),
+            phases=(phase,),
+        )
+        assert feature.feature_name == "001-test"
+        assert feature.has_plan is False
+        assert feature.story_deps == ()

--- a/tests/unit/speckit/test_parser_spec.py
+++ b/tests/unit/speckit/test_parser_spec.py
@@ -1,0 +1,67 @@
+"""Tests for spec.md extraction (maverick.speckit.parser.parse_spec_md)."""
+
+from __future__ import annotations
+
+import pytest
+
+from maverick.speckit.errors import SpeckitParseError
+from maverick.speckit.parser import parse_spec_md
+
+
+class TestTitleExtraction:
+    def test_title_from_feature_specification_heading(self, full_spec_md: str) -> None:
+        parsed = parse_spec_md(full_spec_md)
+        assert parsed.title == "Sample Feature"
+
+    def test_title_falls_back_to_first_h1(self) -> None:
+        content = "# Just A Heading\n\nSome content.\n"
+        parsed = parse_spec_md(content)
+        assert parsed.title == "Just A Heading"
+
+    def test_title_empty_when_no_heading_but_has_success_criteria(self) -> None:
+        content = "## Success Criteria\n\n### Measurable Outcomes\n\n- **SC-001**: fast\n"
+        parsed = parse_spec_md(content)
+        assert parsed.title == ""
+        assert parsed.success_criteria == ("**SC-001**: fast",)
+
+
+class TestSuccessCriteria:
+    def test_sc_bullets_extracted(self, full_spec_md: str) -> None:
+        parsed = parse_spec_md(full_spec_md)
+        assert len(parsed.success_criteria) == 2
+        assert all(sc.startswith("**SC-") for sc in parsed.success_criteria)
+
+    def test_missing_success_criteria_section_yields_empty_tuple(self) -> None:
+        content = "# Feature Specification: X\n\nNo success criteria here.\n"
+        parsed = parse_spec_md(content)
+        assert parsed.success_criteria == ()
+
+
+class TestStoryScenarios:
+    def test_scenarios_keyed_by_story_id(self, full_spec_md: str) -> None:
+        parsed = parse_spec_md(full_spec_md)
+        assert "US1" in parsed.story_scenarios
+        assert "US2" in parsed.story_scenarios
+        assert len(parsed.story_scenarios["US1"]) == 2
+        assert len(parsed.story_scenarios["US2"]) == 1
+
+    def test_story_without_scenarios_maps_to_empty_tuple(self) -> None:
+        content = """\
+# Feature Specification: X
+
+### User Story 1 - No Scenarios (Priority: P1)
+
+Narrative only, no Acceptance Scenarios subsection.
+"""
+        parsed = parse_spec_md(content)
+        assert parsed.story_scenarios["US1"] == ()
+
+
+class TestEmptySpec:
+    def test_empty_spec_raises_parse_error(self) -> None:
+        with pytest.raises(SpeckitParseError) as exc_info:
+            parse_spec_md("Just some prose with no structure at all.\n", file="spec.md")
+        err = exc_info.value
+        assert err.file == "spec.md"
+        assert err.expected
+        assert err.suggestion

--- a/tests/unit/speckit/test_parser_tasks.py
+++ b/tests/unit/speckit/test_parser_tasks.py
@@ -1,0 +1,204 @@
+"""Table-driven tests for the tasks.md grammar (maverick.speckit.parser)."""
+
+from __future__ import annotations
+
+import pytest
+
+from maverick.speckit.errors import SpeckitParseError, SpeckitValidationError
+from maverick.speckit.parser import parse_tasks_md
+
+
+class TestHappyPath:
+    def test_full_fixture_produces_five_phases(self, full_tasks_md: str) -> None:
+        phases, story_deps = parse_tasks_md(full_tasks_md)
+        assert [p.number for p in phases] == [1, 2, 3, 4, 5]
+        assert story_deps == (("US2", "US1"),)
+
+    def test_task_ids_preserved_in_file_order(self, full_tasks_md: str) -> None:
+        phases, _ = parse_tasks_md(full_tasks_md)
+        all_ids = [t.task_id for phase in phases for t in phase.tasks]
+        assert all_ids == [f"T{i:03d}" for i in range(1, 12)]
+
+    def test_parallel_marker_parsed(self, full_tasks_md: str) -> None:
+        phases, _ = parse_tasks_md(full_tasks_md)
+        by_id = {t.task_id: t for phase in phases for t in phase.tasks}
+        assert by_id["T003"].parallel is True
+        assert by_id["T001"].parallel is False
+        assert by_id["T006"].parallel is True
+
+    def test_story_marker_parsed(self, full_tasks_md: str) -> None:
+        phases, _ = parse_tasks_md(full_tasks_md)
+        by_id = {t.task_id: t for phase in phases for t in phase.tasks}
+        assert by_id["T006"].story_id == "US1"
+        assert by_id["T007"].story_id == "US1"
+        assert by_id["T008"].story_id == "US2"
+        assert by_id["T001"].story_id is None
+
+    def test_checked_vs_unchecked(self, full_tasks_md: str) -> None:
+        phases, _ = parse_tasks_md(full_tasks_md)
+        by_id = {t.task_id: t for phase in phases for t in phase.tasks}
+        assert by_id["T002"].completed is True
+        assert by_id["T009"].completed is True
+        assert by_id["T001"].completed is False
+
+    def test_line_numbers_are_stable_and_1_indexed(self, full_tasks_md: str) -> None:
+        phases, _ = parse_tasks_md(full_tasks_md)
+        by_id = {t.task_id: t for phase in phases for t in phase.tasks}
+        lines = full_tasks_md.splitlines()
+        for task_id, task in by_id.items():
+            assert lines[task.line_number - 1].strip().startswith("- [")
+            assert task_id in lines[task.line_number - 1]
+
+    def test_explicit_depends_on_extracted(self, full_tasks_md: str) -> None:
+        phases, _ = parse_tasks_md(full_tasks_md)
+        by_id = {t.task_id: t for phase in phases for t in phase.tasks}
+        assert by_id["T004"].explicit_deps == ("T003",)
+        assert by_id["T001"].explicit_deps == ()
+
+    def test_file_path_tokens_extracted(self, full_tasks_md: str) -> None:
+        phases, _ = parse_tasks_md(full_tasks_md)
+        by_id = {t.task_id: t for phase in phases for t in phase.tasks}
+        assert "src/config.py" in by_id["T003"].file_paths
+        assert "tests/test_feature_a.py" in by_id["T007"].file_paths
+        assert by_id["T001"].file_paths == ()
+
+    def test_fenced_code_block_is_skipped(self, full_tasks_md: str) -> None:
+        phases, _ = parse_tasks_md(full_tasks_md)
+        all_ids = {t.task_id for phase in phases for t in phase.tasks}
+        assert "T999" not in all_ids
+
+    def test_dependencies_section_story_pairs(self, full_tasks_md: str) -> None:
+        _, story_deps = parse_tasks_md(full_tasks_md)
+        assert ("US2", "US1") in story_deps
+
+    def test_dependencies_section_multiple_blockers(self) -> None:
+        content = """\
+## Phase 1: Setup
+
+- [ ] T001 Do a thing
+
+## Dependencies
+
+- US3: Depends on US1, US2
+"""
+        _, story_deps = parse_tasks_md(content)
+        assert set(story_deps) == {("US3", "US1"), ("US3", "US2")}
+
+    def test_prose_and_checkpoint_lines_ignored(self) -> None:
+        content = """\
+## Phase 1: Setup
+
+Some prose about this phase.
+
+**Checkpoint**: everything works
+
+- [ ] T001 Do a thing
+
+### A subheading
+
+more prose
+"""
+        phases, _ = parse_tasks_md(content)
+        assert len(phases) == 1
+        assert len(phases[0].tasks) == 1
+
+    def test_content_before_first_phase_heading_ignored(self) -> None:
+        content = """\
+# Tasks: Something
+
+**Input**: some preamble
+**Format**: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup
+
+- [ ] T001 Do a thing
+"""
+        phases, _ = parse_tasks_md(content)
+        assert len(phases) == 1
+        assert phases[0].tasks[0].task_id == "T001"
+
+    def test_non_phase_h2_terminates_phase_section(self) -> None:
+        content = """\
+## Phase 1: Setup
+
+- [ ] T001 Do a thing
+
+## Some Other Section
+
+- [ ] this is not parsed as a task since no active phase
+
+## Phase 2: Next
+
+- [ ] T002 Another thing
+"""
+        phases, _ = parse_tasks_md(content)
+        assert [p.number for p in phases] == [1, 2]
+        assert phases[0].tasks[0].task_id == "T001"
+        assert phases[1].tasks[0].task_id == "T002"
+
+    def test_phase_may_be_empty(self) -> None:
+        content = """\
+## Phase 1: Setup
+
+## Phase 2: Next
+
+- [ ] T001 A thing
+"""
+        phases, _ = parse_tasks_md(content)
+        assert phases[0].tasks == ()
+        assert phases[1].tasks[0].task_id == "T001"
+
+
+class TestHardErrors:
+    def test_malformed_task_shaped_line_raises_parse_error(self) -> None:
+        content = """\
+## Phase 1: Setup
+
+- [ ] do stuff without a task id
+"""
+        with pytest.raises(SpeckitParseError) as exc_info:
+            parse_tasks_md(content, file="tasks.md")
+        err = exc_info.value
+        assert err.file == "tasks.md"
+        assert err.line == 3
+        assert err.expected
+        assert err.suggestion
+
+    def test_non_increasing_phase_numbers_raises_parse_error(self) -> None:
+        content = """\
+## Phase 2: Second
+
+- [ ] T001 A thing
+
+## Phase 1: First (out of order)
+
+- [ ] T002 Another thing
+"""
+        with pytest.raises(SpeckitParseError) as exc_info:
+            parse_tasks_md(content)
+        assert "increasing" in str(exc_info.value)
+
+    def test_duplicate_task_id_raises_validation_error_with_both_lines(self) -> None:
+        content = """\
+## Phase 1: Setup
+
+- [ ] T001 First occurrence
+- [ ] T001 Second occurrence
+"""
+        with pytest.raises(SpeckitValidationError) as exc_info:
+            parse_tasks_md(content)
+        err = exc_info.value
+        assert err.task_id == "T001"
+        assert err.lines == (3, 4)
+
+    def test_unknown_dependency_reference_raises_validation_error(self) -> None:
+        content = """\
+## Phase 1: Setup
+
+- [ ] T001 Depends on T999 which does not exist
+"""
+        with pytest.raises(SpeckitValidationError) as exc_info:
+            parse_tasks_md(content)
+        err = exc_info.value
+        assert err.unknown_ref == "T999"
+        assert err.task_id == "T001"

--- a/tests/unit/workflows/refuel_speckit/conftest.py
+++ b/tests/unit/workflows/refuel_speckit/conftest.py
@@ -1,0 +1,91 @@
+"""Shared fixtures for SpeckitRefuelWorkflow tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from maverick.beads.models import BeadDetails, BeadSummary
+from maverick.workflows.refuel_speckit.workflow import SpeckitRefuelWorkflow
+
+#: tasks.md fixture mirroring tests/unit/speckit/conftest.py's FULL_TASKS_MD,
+#: kept small and dependency-free for fast workflow-level tests.
+WORKFLOW_TASKS_MD = """\
+## Phase 1: Setup
+
+- [ ] T001 Initialize project
+- [ ] T002 [P] Create config file in src/config.py
+
+## Phase 2: Core
+
+- [ ] T003 Implement core feature in src/core.py
+"""
+
+WORKFLOW_SPEC_MD = """\
+# Feature Specification: Workflow Sample
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: The feature works.
+"""
+
+
+def make_mock_bead_client(
+    *,
+    existing_epics: list[BeadSummary] | None = None,
+    epic_details_by_id: dict[str, BeadDetails] | None = None,
+    children_by_epic: dict[str, list[BeadSummary]] | None = None,
+    create_bead_side_effect: Any = None,
+) -> MagicMock:
+    """Build a MagicMock standing in for ``BeadClient``.
+
+    All async methods used by SpeckitRefuelWorkflow are stubbed:
+    ``create_bead``, ``add_dependency``, ``set_state``, ``query``,
+    ``show``, ``children``.
+    """
+    client = MagicMock()
+    epic_details_by_id = dict(epic_details_by_id or {})
+    children_by_epic = dict(children_by_epic or {})
+    counter = {"n": 0}
+
+    async def _default_create_bead(definition: Any, parent_id: str | None = None) -> Any:
+        counter["n"] += 1
+        return SimpleNamespace(bd_id=f"bead-{counter['n']}", definition=definition)
+
+    client.create_bead = AsyncMock(side_effect=create_bead_side_effect or _default_create_bead)
+    client.add_dependency = AsyncMock(return_value=None)
+    client.set_state = AsyncMock(return_value=None)
+    client.query = AsyncMock(return_value=existing_epics or [])
+
+    async def _show(bead_id: str) -> BeadDetails:
+        if bead_id in epic_details_by_id:
+            return epic_details_by_id[bead_id]
+        raise LookupError(bead_id)
+
+    client.show = AsyncMock(side_effect=_show)
+
+    async def _children(parent_id: str) -> list[BeadSummary]:
+        return children_by_epic.get(parent_id, [])
+
+    client.children = AsyncMock(side_effect=_children)
+    return client
+
+
+async def collect_events(
+    workflow: SpeckitRefuelWorkflow,
+    inputs: dict[str, Any],
+    *,
+    ignore_exception: bool = False,
+) -> tuple[list[Any], Any]:
+    """Drain the execute() generator and return (events, workflow.result)."""
+    events: list[Any] = []
+    try:
+        async for event in workflow.execute(inputs):
+            events.append(event)
+    except Exception:
+        if not ignore_exception:
+            raise
+    return events, workflow.result

--- a/tests/unit/workflows/refuel_speckit/test_dry_run.py
+++ b/tests/unit/workflows/refuel_speckit/test_dry_run.py
@@ -1,0 +1,216 @@
+"""Tests for --dry-run mechanics (SC-005 parity, zero writes)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from maverick.beads.models import BeadDetails, BeadSummary
+from maverick.workflows.refuel_speckit.workflow import SpeckitRefuelWorkflow
+from tests.unit.workflows.refuel_speckit.conftest import (
+    WORKFLOW_SPEC_MD,
+    WORKFLOW_TASKS_MD,
+    collect_events,
+    make_mock_bead_client,
+)
+
+_PATCH_CLIENT = "maverick.beads.client.BeadClient"
+
+
+def make_feature_dir(tmp_path: Path, name: str = "048-workflow-sample") -> Path:
+    feature_dir = tmp_path / "specs" / name
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "tasks.md").write_text(WORKFLOW_TASKS_MD, encoding="utf-8")
+    (feature_dir / "spec.md").write_text(WORKFLOW_SPEC_MD, encoding="utf-8")
+    return feature_dir
+
+
+def make_inputs(feature_dir: Path, cwd: Path, **overrides: object) -> dict[str, object]:
+    inputs: dict[str, object] = {
+        "feature_dir": str(feature_dir),
+        "cwd": str(cwd),
+        "dry_run": True,
+        "enrich": False,
+        "auto_commit": False,
+    }
+    inputs.update(overrides)
+    return inputs
+
+
+def _output_messages(events: list[object]) -> list[str]:
+    return [getattr(e, "message", "") for e in events if hasattr(e, "message")]
+
+
+class TestZeroWrites:
+    @pytest.mark.asyncio
+    async def test_dry_run_makes_zero_bd_write_calls(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        mock_client = make_mock_bead_client()
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, result = await collect_events(workflow, make_inputs(feature_dir, tmp_path))
+
+        assert result is not None and result.success
+        mock_client.create_bead.assert_not_called()
+        mock_client.add_dependency.assert_not_called()
+        mock_client.set_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_writes_no_run_metadata(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        mock_client = make_mock_bead_client()
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            await collect_events(workflow, make_inputs(feature_dir, tmp_path))
+
+        assert not (tmp_path / ".maverick" / "runs").exists()
+
+
+class TestPreviewRendering:
+    @pytest.mark.asyncio
+    async def test_renders_per_task_preview_and_summary(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        mock_client = make_mock_bead_client()
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            events, result = await collect_events(workflow, make_inputs(feature_dir, tmp_path))
+
+        assert result is not None and result.success
+        messages = _output_messages(events)
+        joined = "\n".join(messages)
+        assert "T001:" in joined
+        assert "T002:" in joined
+        assert "phase 1" in joined
+        assert "[P]" in joined  # T002 is parallel
+        assert "Dry run — no beads created." in messages
+
+    @pytest.mark.asyncio
+    async def test_parse_errors_surface_identically_to_real_runs(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = tmp_path / "specs" / "050-broken"
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "tasks.md").write_text(
+            "## Phase 1: Setup\n\n- [ ] not a valid task line\n", encoding="utf-8"
+        )
+        (feature_dir / "spec.md").write_text("# Feature Specification: Broken\n", encoding="utf-8")
+        mock_client = make_mock_bead_client()
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow_dry = SpeckitRefuelWorkflow(config=mock_config)
+            _events_dry, result_dry = await collect_events(
+                workflow_dry, make_inputs(feature_dir, tmp_path), ignore_exception=True
+            )
+            workflow_real = SpeckitRefuelWorkflow(config=mock_config)
+            _events_real, result_real = await collect_events(
+                workflow_real,
+                make_inputs(feature_dir, tmp_path, dry_run=False),
+                ignore_exception=True,
+            )
+
+        assert result_dry is not None and not result_dry.success
+        assert result_real is not None and not result_real.success
+
+
+class TestDryRunRealRunParity:
+    @pytest.mark.asyncio
+    async def test_dry_run_and_real_run_plan_same_content(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+
+        dry_client = make_mock_bead_client()
+        with patch(_PATCH_CLIENT, return_value=dry_client):
+            dry_workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, dry_result = await collect_events(
+                dry_workflow, make_inputs(feature_dir, tmp_path)
+            )
+
+        real_client = make_mock_bead_client()
+        with patch(_PATCH_CLIENT, return_value=real_client):
+            real_workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, real_result = await collect_events(
+                real_workflow, make_inputs(feature_dir, tmp_path, dry_run=False)
+            )
+
+        assert dry_result is not None and real_result is not None
+        dry_output = dry_result.final_output
+        real_output = real_result.final_output
+        assert dry_output["dry_run"] is True
+        assert real_output["dry_run"] is False
+        assert len(dry_output["created_bead_ids"]) == len(real_output["created_bead_ids"])
+        assert dry_output["skipped_completed"] == real_output["skipped_completed"]
+        assert dry_output["skipped_existing"] == real_output["skipped_existing"]
+        assert dry_output["edge_count"] == real_output["edge_count"]
+
+
+class TestDryRunDelta:
+    @pytest.mark.asyncio
+    async def test_dry_run_over_delta_previews_only_new_tasks_and_writes_nothing(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        existing_epic = BeadSummary(
+            id="epic-existing",
+            title="Workflow Sample",
+            status="open",
+            priority=1,
+            bead_type="epic",
+        )
+        existing_epic_details = BeadDetails(
+            id="epic-existing",
+            title="Workflow Sample",
+            bead_type="epic",
+            state={"speckit_feature": "048-workflow-sample"},
+        )
+        existing_child = BeadSummary(
+            id="bead-existing-t001",
+            title="T001: ...",
+            status="open",
+            priority=2,
+            bead_type="task",
+        )
+        mock_client = make_mock_bead_client(
+            existing_epics=[existing_epic],
+            epic_details_by_id={
+                "epic-existing": existing_epic_details,
+                "bead-existing-t001": BeadDetails(
+                    id="bead-existing-t001",
+                    title="T001",
+                    bead_type="task",
+                    state={"speckit_task_id": "T001"},
+                ),
+            },
+            children_by_epic={"epic-existing": [existing_child]},
+        )
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            events, result = await collect_events(workflow, make_inputs(feature_dir, tmp_path))
+
+        assert result is not None and result.success
+        output = result.final_output
+        assert output["delta_run"] is True
+        assert set(output["skipped_existing"]) == {"T001"}
+        assert len(output["created_bead_ids"]) == 2  # T002, T003 only
+
+        messages = _output_messages(events)
+        joined = "\n".join(messages)
+        assert "T001:" not in joined  # not previewed — already ingested
+        assert "T002:" in joined
+        assert "T003:" in joined
+
+        mock_client.create_bead.assert_not_called()
+        mock_client.add_dependency.assert_not_called()
+        mock_client.set_state.assert_not_called()

--- a/tests/unit/workflows/refuel_speckit/test_enrichment_step.py
+++ b/tests/unit/workflows/refuel_speckit/test_enrichment_step.py
@@ -1,0 +1,225 @@
+"""Tests for the workflow-level ENRICH step (--enrich)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from maverick.workflows.refuel_speckit.workflow import SpeckitRefuelWorkflow
+from tests.unit.workflows.refuel_speckit.conftest import (
+    WORKFLOW_SPEC_MD,
+    WORKFLOW_TASKS_MD,
+    collect_events,
+    make_mock_bead_client,
+)
+
+_PATCH_CLIENT = "maverick.beads.client.BeadClient"
+
+
+def make_feature_dir(tmp_path: Path, name: str = "048-workflow-sample") -> Path:
+    feature_dir = tmp_path / "specs" / name
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "tasks.md").write_text(WORKFLOW_TASKS_MD, encoding="utf-8")
+    (feature_dir / "spec.md").write_text(WORKFLOW_SPEC_MD, encoding="utf-8")
+    return feature_dir
+
+
+def make_inputs(feature_dir: Path, cwd: Path, **overrides: object) -> dict[str, object]:
+    inputs: dict[str, object] = {
+        "feature_dir": str(feature_dir),
+        "cwd": str(cwd),
+        "dry_run": False,
+        "enrich": False,
+        "auto_commit": False,
+    }
+    inputs.update(overrides)
+    return inputs
+
+
+_ENRICH_RESPONSE = """\
+### T001
+- make test-t001
+
+### T002
+- make test-t002
+
+### T003
+- make test-t003
+"""
+
+
+class TestEnrichmentSuccess:
+    @pytest.mark.asyncio
+    async def test_enrichment_augments_verification_and_ingests(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        mock_client = make_mock_bead_client()
+
+        mock_agent = MagicMock()
+        mock_agent.__aenter__ = AsyncMock(return_value=mock_agent)
+        mock_agent.__aexit__ = AsyncMock(return_value=False)
+        mock_agent.enrich = AsyncMock(return_value=_ENRICH_RESPONSE)
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch("maverick.config.load_config", return_value=mock_config),
+            patch(
+                "maverick.runtime.agent_factory.runtime_for_agent",
+                return_value=(MagicMock(), MagicMock()),
+            ),
+            patch(
+                "maverick.agents.personas.SpeckitEnrichmentAgent",
+                return_value=mock_agent,
+            ),
+        ):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, result = await collect_events(
+                workflow, make_inputs(feature_dir, tmp_path, enrich=True)
+            )
+
+        assert result is not None and result.success
+        output = result.final_output
+        assert output["enriched"] is True
+
+        created_descriptions = [
+            call.args[0].description for call in mock_client.create_bead.call_args_list
+        ]
+        assert any("make test-t001" in d for d in created_descriptions)
+
+
+class TestEnrichmentPartialCoverage:
+    @pytest.mark.asyncio
+    async def test_enrich_count_reflects_only_tasks_with_commands(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        mock_client = make_mock_bead_client()
+
+        # Model returns commands for only 1 of the 3 new tasks.
+        mock_agent = MagicMock()
+        mock_agent.__aenter__ = AsyncMock(return_value=mock_agent)
+        mock_agent.__aexit__ = AsyncMock(return_value=False)
+        mock_agent.enrich = AsyncMock(return_value="### T001\n- make test-t001\n")
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch("maverick.config.load_config", return_value=mock_config),
+            patch(
+                "maverick.runtime.agent_factory.runtime_for_agent",
+                return_value=(MagicMock(), MagicMock()),
+            ),
+            patch(
+                "maverick.agents.personas.SpeckitEnrichmentAgent",
+                return_value=mock_agent,
+            ),
+        ):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            events, result = await collect_events(
+                workflow, make_inputs(feature_dir, tmp_path, enrich=True)
+            )
+
+        assert result is not None and result.success
+        messages = [getattr(e, "message", "") for e in events if hasattr(e, "message")]
+        # Reports the actual applied count (1), not the total new-task count (3).
+        assert any("Enriched 1 of 3 task beads" in m for m in messages)
+
+
+class TestEnrichmentFailure:
+    @pytest.mark.asyncio
+    async def test_enrichment_failure_degrades_to_warning_and_still_ingests(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        mock_client = make_mock_bead_client()
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(
+                "maverick.runtime.agent_factory.runtime_for_agent",
+                side_effect=RuntimeError("no provider auth configured"),
+            ),
+        ):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, result = await collect_events(
+                workflow, make_inputs(feature_dir, tmp_path, enrich=True)
+            )
+
+        assert result is not None and result.success
+        output = result.final_output
+        assert output["enriched"] is False
+        assert any("enrichment failed" in w for w in output["warnings"])
+        # Ingestion still succeeded — all 3 tasks created unenriched.
+        assert len(output["created_bead_ids"]) == 3
+
+
+class TestNoModelConstructionWithoutEnrich:
+    @pytest.mark.asyncio
+    async def test_no_agent_or_runtime_import_when_enrich_absent(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        mock_client = make_mock_bead_client()
+
+        # Poison the agent-factory import path — if the workflow imports it
+        # at all on the non-enrich path, this raises and the run fails.
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch.dict(
+                sys.modules,
+                {
+                    "maverick.runtime.agent_factory": None,
+                    "maverick.agents.personas": None,
+                },
+            ),
+        ):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, result = await collect_events(
+                workflow, make_inputs(feature_dir, tmp_path, enrich=False)
+            )
+
+        assert result is not None and result.success
+        assert result.final_output["enriched"] is False
+
+
+class TestDryRunWithEnrich:
+    @pytest.mark.asyncio
+    async def test_dry_run_enrich_previews_enriched_content_with_zero_writes(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        mock_client = make_mock_bead_client()
+
+        mock_agent = MagicMock()
+        mock_agent.__aenter__ = AsyncMock(return_value=mock_agent)
+        mock_agent.__aexit__ = AsyncMock(return_value=False)
+        mock_agent.enrich = AsyncMock(return_value=_ENRICH_RESPONSE)
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch("maverick.config.load_config", return_value=mock_config),
+            patch(
+                "maverick.runtime.agent_factory.runtime_for_agent",
+                return_value=(MagicMock(), MagicMock()),
+            ),
+            patch(
+                "maverick.agents.personas.SpeckitEnrichmentAgent",
+                return_value=mock_agent,
+            ),
+        ):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, result = await collect_events(
+                workflow,
+                make_inputs(feature_dir, tmp_path, enrich=True, dry_run=True),
+            )
+
+        assert result is not None and result.success
+        output = result.final_output
+        assert output["dry_run"] is True
+        assert output["enriched"] is True
+        mock_client.create_bead.assert_not_called()
+        mock_client.add_dependency.assert_not_called()
+        mock_client.set_state.assert_not_called()

--- a/tests/unit/workflows/refuel_speckit/test_workflow.py
+++ b/tests/unit/workflows/refuel_speckit/test_workflow.py
@@ -1,0 +1,367 @@
+"""Tests for SpeckitRefuelWorkflow using a stubbed BeadClient."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from maverick.beads.models import BeadDetails, BeadSummary
+from maverick.workflows.refuel_speckit.workflow import SpeckitRefuelWorkflow
+from tests.unit.workflows.refuel_speckit.conftest import (
+    WORKFLOW_SPEC_MD,
+    WORKFLOW_TASKS_MD,
+    collect_events,
+    make_mock_bead_client,
+)
+
+_PATCH_CLIENT = "maverick.beads.client.BeadClient"
+
+
+def make_feature_dir(tmp_path: Path, name: str = "048-workflow-sample") -> Path:
+    feature_dir = tmp_path / "specs" / name
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "tasks.md").write_text(WORKFLOW_TASKS_MD, encoding="utf-8")
+    (feature_dir / "spec.md").write_text(WORKFLOW_SPEC_MD, encoding="utf-8")
+    return feature_dir
+
+
+def make_inputs(feature_dir: Path, cwd: Path, **overrides: object) -> dict[str, object]:
+    inputs: dict[str, object] = {
+        "feature_dir": str(feature_dir),
+        "cwd": str(cwd),
+        "dry_run": False,
+        "enrich": False,
+        "auto_commit": False,
+    }
+    inputs.update(overrides)
+    return inputs
+
+
+class TestFreshRun:
+    @pytest.mark.asyncio
+    async def test_creates_epic_tasks_deps_and_chains(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        other_epic = BeadSummary(
+            id="epic-other", title="Other feature", status="open", priority=1, bead_type="epic"
+        )
+        mock_client = make_mock_bead_client(
+            existing_epics=[other_epic],
+            epic_details_by_id={
+                "epic-other": BeadDetails(
+                    id="epic-other", title="Other feature", bead_type="epic", state={}
+                )
+            },
+        )
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, result = await collect_events(workflow, make_inputs(feature_dir, tmp_path))
+
+        assert result is not None
+        assert result.success
+        output = result.final_output
+        assert output["feature_name"] == "048-workflow-sample"
+        assert output["delta_run"] is False
+        assert output["dry_run"] is False
+        assert len(output["created_bead_ids"]) == 3  # T001, T002, T003
+        assert output["edge_count"] > 0
+
+        # Epic created first, then 3 task beads; set_state for epic + all tasks.
+        first_call_definition = mock_client.create_bead.call_args_list[0].args[0]
+        assert first_call_definition.bead_type.value == "epic"
+        assert mock_client.create_bead.call_count == 4  # epic + 3 tasks
+        assert mock_client.set_state.call_count == 4  # epic + 3 tasks
+        # Epic chained behind the pre-existing open epic.
+        chain_calls = [
+            c
+            for c in mock_client.add_dependency.call_args_list
+            if c.args[0].blocker_id == "epic-other"
+        ]
+        assert len(chain_calls) == 1
+
+        # Run metadata written with status "refueled".
+        runs_dir = tmp_path / ".maverick" / "runs"
+        assert runs_dir.is_dir()
+        run_dirs = list(runs_dir.iterdir())
+        assert len(run_dirs) == 1
+        import json
+
+        meta = json.loads((run_dirs[0] / "metadata.json").read_text())
+        assert meta["status"] == "refueled"
+        assert meta["plan_name"] == "048-workflow-sample"
+
+
+class TestDeltaRun:
+    @pytest.mark.asyncio
+    async def test_adopts_existing_epic_and_only_creates_new_tasks(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        existing_epic = BeadSummary(
+            id="epic-existing",
+            title="Workflow Sample",
+            status="open",
+            priority=1,
+            bead_type="epic",
+        )
+        existing_epic_details = BeadDetails(
+            id="epic-existing",
+            title="Workflow Sample",
+            bead_type="epic",
+            state={"speckit_feature": "048-workflow-sample"},
+        )
+        existing_child = BeadSummary(
+            id="bead-existing-t001", title="T001: ...", status="open", priority=2, bead_type="task"
+        )
+        mock_client = make_mock_bead_client(
+            existing_epics=[existing_epic],
+            epic_details_by_id={
+                "epic-existing": existing_epic_details,
+                "bead-existing-t001": BeadDetails(
+                    id="bead-existing-t001",
+                    title="T001",
+                    bead_type="task",
+                    state={"speckit_task_id": "T001"},
+                ),
+            },
+            children_by_epic={"epic-existing": [existing_child]},
+        )
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, result = await collect_events(workflow, make_inputs(feature_dir, tmp_path))
+
+        assert result is not None and result.success
+        output = result.final_output
+        assert output["delta_run"] is True
+        assert output["epic_id"] == "epic-existing"
+        assert set(output["skipped_existing"]) == {"T001"}
+        # Only T002 and T003 created (T001 already ingested).
+        assert len(output["created_bead_ids"]) == 2
+
+        # No new epic created — create_bead never called with an epic definition.
+        for call in mock_client.create_bead.call_args_list:
+            assert call.args[0].bead_type.value == "task"
+
+        # No re-chaining: epic wasn't (re-)created, so no chain-epic call
+        # should target "epic-existing" as the blocked side.
+        for call in mock_client.add_dependency.call_args_list:
+            assert call.args[0].blocked_id != "epic-existing"
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_all_open_tasks_already_ingested(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        existing_epic = BeadSummary(
+            id="epic-existing",
+            title="Workflow Sample",
+            status="open",
+            priority=1,
+            bead_type="epic",
+        )
+        existing_epic_details = BeadDetails(
+            id="epic-existing",
+            title="Workflow Sample",
+            bead_type="epic",
+            state={"speckit_feature": "048-workflow-sample"},
+        )
+        children = [
+            BeadSummary(id=f"bead-{tid}", title=tid, status="open", priority=2, bead_type="task")
+            for tid in ("T001", "T002", "T003")
+        ]
+        mock_client = make_mock_bead_client(
+            existing_epics=[existing_epic],
+            epic_details_by_id={
+                "epic-existing": existing_epic_details,
+                **{
+                    f"bead-{tid}": BeadDetails(
+                        id=f"bead-{tid}",
+                        title=tid,
+                        bead_type="task",
+                        state={"speckit_task_id": tid},
+                    )
+                    for tid in ("T001", "T002", "T003")
+                },
+            },
+            children_by_epic={"epic-existing": children},
+        )
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, result = await collect_events(workflow, make_inputs(feature_dir, tmp_path))
+
+        assert result is not None and result.success
+        output = result.final_output
+        assert output["created_bead_ids"] == []
+        mock_client.create_bead.assert_not_called()
+
+        # The no-op summary is emitted under a properly started+completed
+        # RECORD_RUN step (not attributed to a step the renderer never saw
+        # start).
+        from maverick.events import StepCompleted, StepStarted
+        from maverick.workflows.refuel_speckit.constants import RECORD_RUN
+
+        started = {e.step_name for e in _events if isinstance(e, StepStarted)}
+        completed = {e.step_name for e in _events if isinstance(e, StepCompleted)}
+        assert RECORD_RUN in started
+        assert RECORD_RUN in completed
+
+
+class TestMultipleMatchingEpics:
+    @pytest.mark.asyncio
+    async def test_raises_on_multiple_open_epics_for_same_feature(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        epic_a = BeadSummary(id="epic-a", title="A", status="open", priority=1, bead_type="epic")
+        epic_b = BeadSummary(id="epic-b", title="B", status="open", priority=1, bead_type="epic")
+        mock_client = make_mock_bead_client(
+            existing_epics=[epic_a, epic_b],
+            epic_details_by_id={
+                "epic-a": BeadDetails(
+                    id="epic-a",
+                    title="A",
+                    bead_type="epic",
+                    state={"speckit_feature": "048-workflow-sample"},
+                ),
+                "epic-b": BeadDetails(
+                    id="epic-b",
+                    title="B",
+                    bead_type="epic",
+                    state={"speckit_feature": "048-workflow-sample"},
+                ),
+            },
+        )
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, result = await collect_events(
+                workflow, make_inputs(feature_dir, tmp_path), ignore_exception=True
+            )
+
+        assert result is not None
+        assert not result.success
+        mock_client.create_bead.assert_not_called()
+
+
+class TestMidCreationFailure:
+    @pytest.mark.asyncio
+    async def test_reports_created_ids_on_partial_failure(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        call_count = {"n": 0}
+
+        async def _flaky_create_bead(definition: object, parent_id: str | None = None) -> object:
+            from types import SimpleNamespace
+
+            call_count["n"] += 1
+            if call_count["n"] == 3:  # epic (1) + first task (2) succeed, second task fails
+                raise RuntimeError("bd create timed out")
+            return SimpleNamespace(bd_id=f"bead-{call_count['n']}", definition=definition)
+
+        mock_client = make_mock_bead_client(create_bead_side_effect=_flaky_create_bead)
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, result = await collect_events(
+                workflow, make_inputs(feature_dir, tmp_path), ignore_exception=True
+            )
+
+        assert result is not None
+        assert not result.success
+        failed_steps = [r for r in result.step_results if not r.success]
+        assert any(
+            "bead-1" in (r.error or "") or "bead-2" in (r.error or "") for r in failed_steps
+        )
+
+
+class TestValidationBeforeWrite:
+    @pytest.mark.asyncio
+    async def test_all_completed_raises_before_any_bd_write(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = tmp_path / "specs" / "049-all-done"
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "tasks.md").write_text(
+            "## Phase 1: Setup\n\n- [x] T001 Already done\n", encoding="utf-8"
+        )
+        (feature_dir / "spec.md").write_text(
+            "# Feature Specification: All Done\n", encoding="utf-8"
+        )
+        mock_client = make_mock_bead_client()
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, result = await collect_events(
+                workflow, make_inputs(feature_dir, tmp_path), ignore_exception=True
+            )
+
+        assert result is not None
+        assert not result.success
+        mock_client.create_bead.assert_not_called()
+        # The underlying exception is a NothingToIngestError (E07).
+        assert workflow.result is not None
+
+
+class TestSelectNextBeadCompatibility:
+    """T019: select_next_bead's flight_plan_name epic-state read must
+    tolerate a speckit epic that never sets that key (research D12)."""
+
+    @pytest.mark.asyncio
+    async def test_select_next_bead_tolerates_missing_flight_plan_name(
+        self, tmp_path: Path
+    ) -> None:
+        from maverick.beads.models import ReadyBead
+        from maverick.library.actions.beads import select_next_bead
+
+        mock_client = make_mock_bead_client(
+            epic_details_by_id={
+                "epic-speckit": BeadDetails(
+                    id="epic-speckit",
+                    title="Speckit Feature",
+                    bead_type="epic",
+                    state={"speckit_feature": "048-workflow-sample"},
+                )
+            },
+        )
+        mock_client.ready = AsyncMock(
+            return_value=[
+                ReadyBead(id="bead-1", title="T001: do a thing", priority=2, bead_type="task")
+            ]
+        )
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            result = await select_next_bead(epic_id="epic-speckit", cwd=tmp_path)
+
+        assert result.found is True
+        assert result.flight_plan_name == ""
+
+
+class TestDryRun:
+    @pytest.mark.asyncio
+    async def test_dry_run_makes_zero_write_calls(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path)
+        mock_client = make_mock_bead_client()
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            _events, result = await collect_events(
+                workflow, make_inputs(feature_dir, tmp_path, dry_run=True)
+            )
+
+        assert result is not None and result.success
+        output = result.final_output
+        assert output["dry_run"] is True
+        assert len(output["created_bead_ids"]) == 3
+        mock_client.create_bead.assert_not_called()
+        mock_client.add_dependency.assert_not_called()
+        mock_client.set_state.assert_not_called()
+        assert not (tmp_path / ".maverick" / "runs").exists()


### PR DESCRIPTION
## Summary

Adds `maverick refuel <feature> --speckit`, a deterministic mode that ingests a Spec Kit feature's task list into beads — **one epic + one task bead per open task, zero model calls by default**. Task IDs, phases, `[P]` markers, and file scope are preserved; dependencies are wired as a phase barrier plus explicit `depends on`/story edges. Delta re-runs append only new tasks under the existing epic.

Implements feature `048-speckit-refuel-ingestion` (spec/plan/contracts included under `specs/048-speckit-refuel-ingestion/`).

## What's included

- **`src/maverick/speckit/`** — pure parsing/detection/plan-building (`models`, `parser`, `detect`, `build`, `enrichment`, `errors`). No bd/VCS side effects; zero agent/runtime imports.
- **`src/maverick/workflows/refuel_speckit/`** — `SpeckitRefuelWorkflow`: resolve → check template → parse → plan → (optional enrich) → create beads → wire deps → chain epic → record run → (optional commit).
- **CLI** — `--speckit` / `--dry-run` / `--enrich` flags with mode auto-detection (classic vs Spec Kit vs ambiguous vs unresolved) and the E01–E07 error catalog. `--list-steps` stays inspectable before the feature resolves.
- **`SpeckitEnrichmentAgent`** — opt-in one-shot batched pass attaching verification commands (the only path that may touch a model).

## Modes

| Flag | Behavior |
| --- | --- |
| _(none)_ | Auto-detects Spec Kit vs classic flight plan from repo shape |
| `--speckit` | Forces Spec Kit ingestion |
| `--dry-run` | Previews the full ingestion plan; makes zero **writes** |
| `--enrich` | One batched model call attaching `## Verification` commands |

## Testing

- 188 unit tests across parsing, edge derivation, plan building, workflow scenarios, dry-run parity, and the CLI dispatch matrix.
- One `bd`-gated integration test (fresh ingest, `bd ready` ordering, delta append, no-op).
- `make ci` green: **3497 passed, 1 skipped**; ruff + strict mypy clean.

## Note

Generic Spec Kit tooling scaffolding (`.claude/skills/speckit-*`, `.specify/*`) is intentionally left out of this PR — it's editor/workflow tooling installation, not part of the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)