### PR TITLE
feat(assumptions): add structured assumption ledger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -527,7 +527,8 @@ Beads-only workflow model. All development is driven by beads (`bd` CLI).
 | `maverick land [--eject\|--finalize]`                | Curate history and merge             |
 | `maverick workspace status\|clean`                   | Manage hidden workspace              |
 | `maverick init`                                      | Initialize a Maverick project        |
-| `maverick brief [--watch]`                           | Bead status                          |
+| `maverick brief [--watch\|--human]`                  | Bead status + assumption counts      |
+| `maverick review <bead-id> [--answer\|--waive]`      | Resolve a human-assigned bead         |
 | `maverick runway seed\|consolidate`                  | Manage knowledge store               |
 
 ### refuel (Spec Kit ingestion mode)
@@ -563,6 +564,35 @@ Three modes: `--approve` (default; curate → push → teardown),
 (create PR from preview branch → teardown). Uses CuratorAgent for
 intelligent reorg, with user approval. Falls back to git push when no
 workspace exists.
+
+Before curation, land runs the **assumption ledger gate**: any open
+`medium`/`high` assumption entry (including legacy escalation beads,
+treated as `medium`) blocks the command with a per-spec table and a
+`maverick review <id>` hint, exit non-zero. There is no bypass flag —
+`maverick review` (answer or waive) is the only way through. `--dry-run`
+still evaluates and prints the table but only exits non-zero at the end,
+after the rest of the preview runs.
+
+### Assumption ledger
+
+Agents report adopted assumptions (question / adopted answer /
+alternatives / severity) in the `assumptions` field of their
+`submit_implementation` / `submit_review` / `submit_fix_result`
+payloads. The fly workflow's `record_assumptions` action turns each
+into a structured bead under the owning epic (labels `assumption` +
+the legacy `assumption-review`/`needs-human-review` pair, so existing
+agent-skip and `brief --human` filters keep working unchanged), wires a
+`discovered-from` edge to the spawning bead, and the `commit` action
+stamps it with the jj change ID. Severity drives enforcement: `low` is
+`bd defer`red (advisory only, never blocks); `medium`/`high` block
+`maverick land`; `high` additionally gains a `blocks` edge onto the
+next spec's epic (wired at recording time and at `refuel --speckit`'s
+epic-chaining step), so downstream work never becomes `bd ready` until
+the entry is answered or waived via `maverick review <id>`.
+`maverick brief` reports per-spec assumption counts (open/answered/
+waived × severity, plus a legacy bucket) as a spec-quality signal. All
+ledger logic lives in `src/maverick/assumptions/` — see
+`specs/049-assumption-ledger/` for the full contract.
 
 ## Dependencies
 

--- a/specs/049-assumption-ledger/checklists/requirements.md
+++ b/specs/049-assumption-ledger/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Assumption Ledger
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- `bd ready` and change identifiers (jj change IDs) appear in the spec because
+  they are user-facing domain concepts named in the feature description (the
+  human's existing queue tool and the VCS identity of committed work), not
+  implementation choices introduced by the spec. Wording elsewhere stays
+  tool-agnostic ("ready-queue listing", "change identifier(s)").
+- Informed defaults documented in Assumptions instead of clarification markers:
+  entries extend existing assumption beads; recording is agent-initiated;
+  "next spec" = next in run execution order; waivers are human-only and
+  audited; missing/invalid severity defaults to medium.
+- Reconcile mechanics explicitly out of scope per the feature description.

--- a/specs/049-assumption-ledger/contracts/README.md
+++ b/specs/049-assumption-ledger/contracts/README.md
@@ -1,0 +1,12 @@
+# Contracts: Assumption Ledger
+
+Interfaces this feature exposes or changes. Details that belong to the data
+shape live in [../data-model.md](../data-model.md); this directory pins the
+consumer-visible behavior.
+
+| Contract | File |
+|----------|------|
+| Agent payload additions (structured output schema) | [payloads.md](payloads.md) |
+| Ledger operations API (`maverick.assumptions`) | [ledger-api.md](ledger-api.md) |
+| CLI behavior (land gate, review answer/waive, brief section) | [cli.md](cli.md) |
+| Bead conventions (labels, state keys, edges) | see [../data-model.md](../data-model.md) — the bead shape IS the persistence contract |

--- a/specs/049-assumption-ledger/contracts/cli.md
+++ b/specs/049-assumption-ledger/contracts/cli.md
@@ -1,0 +1,51 @@
+# Contract: CLI Behavior
+
+## `maverick land` — assumption gate (FR-006)
+
+Position: after the commits-above-base check and human-review manifest
+display, before curation begins.
+
+| Condition | Behavior |
+|-----------|----------|
+| No open medium/high entries | Gate passes silently; land proceeds as today |
+| ≥1 open medium/high entry (incl. legacy treated as medium) | Print a blocking table — ID, severity, owning spec, question (truncated) — grouped by owning spec, then a hint: `Resolve with: maverick review <id>`; exit non-zero before any curation/push |
+| `--dry-run` | Gate still evaluates and prints its table, the rest of the preview continues (no writes as always), and the command exits non-zero at the end if the gate would block a real land |
+
+No bypass flag exists (clarification #3). Waiving via `maverick review` is the
+audited escape hatch.
+
+## `maverick review <bead-id>` — answer / waive (FR-009)
+
+Existing command extended for ledger entries (beads labeled `assumption`):
+
+- Displays the full entry: question, adopted answer, alternatives, severity
+  (with `(defaulted)` marker when applicable), owning spec, change stamps
+  (or `unstamped`), and the discovered-from source bead.
+- **Answer flow**: prompts for (or accepts via option) answer text → records
+  answer, closes bead. Empty answer rejected.
+- **Waive flow**: requires a reason (option or prompt) → records
+  who (git user name resolved via GitPython config, per Guardrail 8) /
+  when (UTC ISO-8601) / why, closes bead. Empty reason rejected.
+- Legacy escalation beads (no `assumption` label) keep today's review
+  behavior unchanged.
+- Output via Rich console per CLI standards (no emoji, `[green]✓[/]` style).
+
+## `maverick brief` — per-spec assumption counts (FR-010, clarification #5)
+
+- Default text view: compact `Assumptions` table — one row per spec
+  (including zero rows for epics with no entries): columns
+  `Spec | Open (L/M/H) | Answered | Waived | Legacy`.
+- `--human` view: unchanged human queue table, plus the counts table.
+- `--format json`: adds an `assumption_counts` array mirroring
+  `PerSpecAssumptionCounts`.
+- Beads store absent/uninitialized: section omitted (matches existing brief
+  degradation behavior).
+
+## `bd ready` (unchanged, verified behavior)
+
+- Medium/high entries appear as ready human-assigned beads (FR-008).
+- Low entries are deferred at creation and do not appear.
+- Agent-side `select_next_bead` continues to skip them via the existing
+  label filter — no contract change.
+- A high-severity entry's `blocks` edge onto the next spec's epic keeps that
+  epic's work out of `bd ready` until the entry is closed (FR-007).

--- a/specs/049-assumption-ledger/contracts/ledger-api.md
+++ b/specs/049-assumption-ledger/contracts/ledger-api.md
@@ -1,0 +1,67 @@
+# Contract: Ledger Operations API (`maverick.assumptions`)
+
+Public async API consumed by fly_beads actions, refuel_speckit `_chain_epic`,
+and the land/review/brief CLI commands. All functions take explicit
+`cwd: Path` (Guardrail 7 — no `Path.cwd()` defaults) and operate through
+`BeadClient`; all return frozen dataclasses.
+
+## models.py
+
+```python
+class Severity(StrEnum):
+    LOW = "low"; MEDIUM = "medium"; HIGH = "high"
+
+@dataclass(frozen=True, slots=True)
+class AssumptionRecord:
+    bead_id: str
+    question: str
+    adopted_answer: str
+    alternatives: tuple[str, ...]
+    severity: Severity
+    severity_defaulted: bool
+    status: str                      # "open" | "answered" | "waived"
+    owner_spec: str
+    source_bead: str
+    change_ids: tuple[str, ...]      # empty = unstamped
+    is_legacy: bool                  # escalation bead without ledger fields
+
+@dataclass(frozen=True, slots=True)
+class PerSpecAssumptionCounts: ...   # see data-model.md aggregation shape
+```
+
+State-key string constants (`ASSUMPTION_LABEL`, `KEY_SEVERITY`, ...) are
+exported here — no bare string literals at call sites (Constitution VI).
+
+## ledger.py
+
+| Function | Behavior contract |
+|----------|-------------------|
+| `record_assumption(client, *, payload, source_bead_id, epic_id) -> AssumptionRecord \| None` | Creates the entry bead per data-model shape: derives owner spec from epic state, applies the severity rule (see below), wires discovered-from edge, defers low-severity entries, wires next-epic blocks edge for high severity when a next chained epic exists. Dedup: returns the existing record (with a new discovered-from edge appended) instead of creating a duplicate when an open entry with the same normalized question exists under the epic. Never raises for policy reasons; bd failures raise typed `AssumptionLedgerError` for the caller's non-fatal handling. |
+| `next_chained_epic(client, *, epic_id) -> str \| None` | Discovery rule for the high-severity edge target: among open epics with a `speckit_feature` state value, the one with the smallest NNN prefix strictly greater than the owning epic's NNN prefix (the same ordering `_chain_epic` uses). Returns `None` when the owning epic has no `speckit_feature` (flight-plan runs never wire next-epic edges) or no later epic exists — high then degrades to medium behavior. |
+| `stamp_change_id(client, *, entry_ids, change_id) -> StampResult` | Appends `change_id` to `assumption_change_ids` on each entry. Append-only, idempotent per (entry, change_id). Partial failure returns per-entry outcomes; NEVER raises (FR-012 — a commit must not fail because stamping failed). |
+| `answer(client, *, bead_id, answer_text) -> AssumptionRecord` | Requires non-empty text. Sets `assumption_answer`, `assumption_status=answered`, closes the bead (releasing blocks edges). |
+| `waive(client, *, bead_id, reason, waived_by) -> AssumptionRecord` | Requires non-empty reason. Records who/when/why, `assumption_status=waived`, closes the bead. |
+| `open_blocking_entries(client) -> tuple[AssumptionRecord, ...]` | Open entries with severity ∈ {medium, high}, including legacy escalation beads mapped to severity=medium with `is_legacy=True`. Powers the land gate. |
+| `open_high_entries_before(client, *, epic_id) -> tuple[AssumptionRecord, ...]` | Open high-severity entries owned by specs ordered before the given epic; powers `_chain_epic` wiring at refuel. |
+
+## report.py
+
+| Function | Behavior contract |
+|----------|-------------------|
+| `per_spec_counts(client) -> tuple[PerSpecAssumptionCounts, ...]` | Aggregates all `assumption` beads by `assumption_owner_spec`; legacy escalation beads counted in `legacy_open`; every epic in the store yields a row even at zero counts (FR-010); ordered by owner spec identifier. |
+
+## Severity rule (single authority)
+
+The coercion rule — value ∉ {low, medium, high} (or absent) → `medium` +
+defaulted flag — is defined once and applied in two layers with the same
+semantics: `AssumptionPayload`'s validator coerces and exposes
+`severity_defaulted: bool` (agent path), and `record_assumption` re-applies
+the identical rule for direct callers, persisting
+`assumption_severity_defaulted=true` whenever either layer defaulted.
+
+## Error contract
+
+`AssumptionLedgerError(MaverickError)` — single typed error for bd-layer
+failures. Callers decide fatality: `record_assumptions` (workflow action)
+warns and continues (mirrors `create_human_bead` non-fatal pattern);
+CLI commands surface it as a formatted error.

--- a/specs/049-assumption-ledger/contracts/payloads.md
+++ b/specs/049-assumption-ledger/contracts/payloads.md
@@ -1,0 +1,54 @@
+# Contract: Agent Payload Additions
+
+Consumers: OpenCode structured-output tool (schema synthesized from Pydantic),
+fly_beads actions reading step results.
+
+## AssumptionPayload
+
+New model in `maverick.payloads`. JSON shape the model is prompted to emit:
+
+```json
+{
+  "question": "Should the retry limit apply per bead or per run?",
+  "adopted_answer": "Per bead — matches existing MAX_REVIEW_ROUNDS scoping.",
+  "alternatives": ["Per run with a global counter", "Configurable in maverick.yaml"],
+  "severity": "medium"
+}
+```
+
+Rules:
+
+- `question` and `adopted_answer`: required, non-empty strings.
+- `alternatives`: optional list of strings, default `[]`.
+- `severity`: one of `"low" | "medium" | "high"`. Any other value (or absence)
+  is coerced to `"medium"` by the model validator, which also sets a
+  `severity_defaulted: bool` field on the validated payload (excluded from the
+  schema shown to the model); `record_assumption` reads that flag to persist
+  `assumption_severity_defaulted=true`. The payload NEVER fails validation
+  because of severity (FR-011). This is the same rule the ledger re-applies
+  for direct (non-payload) callers — see `ledger-api.md` "Severity rule".
+
+## Extended submit payloads
+
+`SubmitImplementationPayload`, `SubmitReviewPayload`, `SubmitFixResultPayload`
+each gain:
+
+```json
+{ "assumptions": [ AssumptionPayload, ... ] }
+```
+
+- Optional; default `[]`. Existing agent prompts that never mention
+  assumptions keep validating unchanged (backward compatible).
+- Registry keys in `SUPERVISOR_TOOL_PAYLOAD_MODELS` are unchanged
+  (`submit_implementation`, `submit_review`, `submit_fix_result`).
+- Stability: additive-only change; existing fields and their semantics are
+  untouched (Constitution Guardrail 4 — payloads are public interfaces).
+
+## Prompt contract (agents/)
+
+Implementer, reviewer, and fixer prompt builders instruct the model: when you
+adopt an assumption to keep working, report it in `assumptions` with the
+question, your adopted answer, the alternatives you considered, and a severity
+reflecting the blast radius of being wrong (`low` = cosmetic/local, `medium` =
+owning spec's correctness, `high` = decisions later specs will build on).
+Recording is additive — it never replaces implementing/reviewing work.

--- a/specs/049-assumption-ledger/data-model.md
+++ b/specs/049-assumption-ledger/data-model.md
@@ -1,0 +1,161 @@
+# Data Model: Assumption Ledger
+
+**Feature**: 049-assumption-ledger | **Date**: 2026-07-23
+**Sources**: spec.md Key Entities, research.md R1–R3, R5
+
+## Entity: Assumption Ledger Entry (a bead)
+
+One ledger entry = one bd bead. No sidecar store (research R1).
+
+### Bead-level shape
+
+| Bead field | Value |
+|------------|-------|
+| `bead_type` | `TASK` |
+| `category` | `REVIEW` |
+| `priority` | high → `1`, medium → `2`, low → `3` |
+| `assignee` | `"human"` |
+| `parent_id` | owning epic's bead ID |
+| `labels` | `["assumption", "assumption-review", "needs-human-review"]` |
+| `title` | `Assumption: {question truncated to 150 chars}` |
+| `description` | fixed markdown: `## Question`, `## Adopted Answer`, `## Alternatives Considered` (bulleted), `## Context` (source bead id + title) |
+
+The two legacy labels keep the agent-side skip filter
+(`library/actions/beads.py:301`) and `brief --human` working unchanged; the
+new `assumption` label is the ledger discriminator (legacy escalation beads
+have the old labels but not `assumption`).
+
+### State keys (bd `set-state`, all values strings)
+
+| Key | Required | Values / format | Set when |
+|-----|----------|-----------------|----------|
+| `assumption_severity` | yes | `low` \| `medium` \| `high` | creation |
+| `assumption_severity_defaulted` | no | `true` | creation, only if severity was missing/invalid in the payload (FR-011) |
+| `assumption_status` | yes | `open` \| `answered` \| `waived` | creation (`open`); resolution |
+| `assumption_owner_spec` | yes | spec identifier (see below) | creation |
+| `assumption_change_ids` | no | comma-joined jj change IDs, append-only | commit stamping; absent = unstamped (FR-012) |
+| `assumption_answer` | no | answer text | on answer |
+| `assumption_waived_by` | no | git user name | on waive |
+| `assumption_waived_at` | no | ISO-8601 UTC timestamp | on waive |
+| `assumption_waive_reason` | no | stated reason (required input) | on waive |
+| `source_bead` | yes | spawning bead ID | creation (mirrors edge for `brief --human` compat) |
+
+### Owning-spec derivation (clarification #1, research R3)
+
+Resolved at creation from the parent epic's state, first match wins:
+
+1. `speckit_feature` (speckit epics) — e.g. `049-assumption-ledger`
+2. `flight_plan_name` (refuel_maverick epics)
+3. fallback: the epic bead ID itself
+
+### Validation rules
+
+- Severity outside `{low, medium, high}` (or absent) → coerced to `medium` +
+  `assumption_severity_defaulted=true`; never rejected (FR-011).
+- Waive requires a non-empty reason; answer requires non-empty answer text.
+- `assumption_change_ids` is append-only; stamping never overwrites existing
+  IDs (multi-commit assumptions accumulate).
+- Question dedup key: `casefold(collapse_ws(question))` scoped to open
+  `assumption` children of the same epic (FR-014).
+
+## Entity: Discovered-from Edge
+
+| Aspect | Value |
+|--------|-------|
+| Representation | `bd dep add <assumption_bead_id> <source_bead_id> --type discovered-from` |
+| Direction | assumption → discovered-from → spawning work bead (same as existing follow-up edges, `fly_beads/_commit.py:257-268`) |
+| Typed API | `DependencyType.DISCOVERED_FROM` (new enum member) via `BeadClient.add_dependency` |
+| Cardinality | ≥1 per entry; dedup appends extra edges to an existing entry instead of creating duplicates |
+| Blocking? | No — provenance only; readiness is unaffected |
+
+## Entity: Blocking Edge (high severity)
+
+| Aspect | Value |
+|--------|-------|
+| Representation | `bd dep add <next_epic_id> --blocked-by <assumption_bead_id> --type blocks` |
+| Created | at recording (if next epic exists) OR at refuel `_chain_epic` (if entry precedes the next epic) — research R8 |
+| Released | automatically when the entry bead is closed (answer or waive) |
+| High on last spec | no next epic → edge never created → medium behavior (spec US2-S5) |
+
+## Entity: Severity Policy (behavioral mapping)
+
+| Severity | Ready queue | Land gate | Next-epic edge |
+|----------|-------------|-----------|----------------|
+| `low` | created then `bd defer` (open, out of queue) | never blocks | never |
+| `medium` | open, appears in `bd ready` (human-assigned) | blocks while `assumption_status=open` | never |
+| `high` | open, appears in `bd ready` (human-assigned) | blocks while open | `blocks` edge onto next spec's epic |
+
+Legacy escalation beads (no `assumption` label / no severity state) are
+treated as medium by the land gate at read time, without mutation (FR-013).
+
+## State transitions
+
+```
+                    create (record_assumptions)
+                              │
+                              ▼
+                     status=open, bead open
+                    ┌─────────┴──────────┐
+        low: bd defer                medium/high: in bd ready
+                    └─────────┬──────────┘
+              ┌───────────────┼────────────────┐
+              ▼                                ▼
+   answer (maverick review)          waive (maverick review)
+   status=answered                   status=waived (+who/when/why)
+   bead closed                       bead closed
+              └───────────────┬────────────────┘
+                              ▼
+              blocks edges released by bd (close)
+              land gate no longer counts entry
+```
+
+Stamping (`assumption_change_ids`) is orthogonal to status: it happens at each
+successful commit of the source bead's work and an entry may be resolved
+before, after, or without ever being stamped (unstamped = run ended before
+commit, FR-012 / US1-S4).
+
+## Payload models (maverick.payloads)
+
+```
+AssumptionPayload (frozen, extra="allow")
+├── question: str            (min_length 1)
+├── adopted_answer: str      (min_length 1)
+├── alternatives: tuple[str, ...] = ()
+└── severity: str = "medium" (validator coerces unknown → "medium",
+                              records defaulted flag for the workflow)
+
+SubmitImplementationPayload  += assumptions: tuple[AssumptionPayload, ...] = ()
+SubmitReviewPayload          += assumptions: tuple[AssumptionPayload, ...] = ()
+SubmitFixResultPayload       += assumptions: tuple[AssumptionPayload, ...] = ()
+```
+
+Backward compatible: absent field → empty tuple; registry keys in
+`SUPERVISOR_TOOL_PAYLOAD_MODELS` are unchanged.
+
+## Workflow state keys (fly_beads burr graph)
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `pending_assumptions` | list of assumption dicts | accumulated from implement/review/fix payloads within the current bead |
+| `recorded_assumption_ids` | list of bead IDs | entries created for the current bead; consumed by `commit` for stamping |
+| `commit_change_id` | str | jj change ID captured from `jj_commit_bead` (today discarded) |
+
+All three keys are reset in `process_bead_start` so a bead can never stamp or
+re-record the previous bead's entries.
+
+Multi-ID stamps arise from dedup: when a later bead re-records an open
+question, the merged entry gains that bead's discovered-from edge and its
+commit appends a second change ID.
+
+## Aggregation shape (assumptions.report → brief / land gate)
+
+```
+PerSpecAssumptionCounts (frozen dataclass)
+├── owner_spec: str
+├── open: dict[Severity, int]
+├── answered: dict[Severity, int]
+├── waived: dict[Severity, int]
+└── legacy_open: int          (escalation beads without ledger fields)
+```
+
+Specs with epics but zero entries render as explicit zero rows (FR-010).

--- a/specs/049-assumption-ledger/plan.md
+++ b/specs/049-assumption-ledger/plan.md
@@ -1,0 +1,142 @@
+# Implementation Plan: Assumption Ledger
+
+**Branch**: `049-assumption-ledger` | **Date**: 2026-07-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/049-assumption-ledger/spec.md`
+
+## Summary
+
+Extend Maverick's assumption beads into a structured assumption ledger. Agents
+surface adopted assumptions (question, adopted answer, alternatives, severity)
+as new fields in their existing structured result payloads; a new deterministic
+fly action creates one ledger bead per assumption under the owning epic —
+owner spec derived from epic state (`speckit_feature` / `flight_plan_name`),
+discovered-from edge to the spawning bead — and the commit action (fixed to
+stop discarding `jj_commit_bead`'s return) stamps entries with the jj change
+ID(s) embodying them. Severity drives enforcement with zero new pause
+machinery: low entries are `bd defer`red (advisory), medium/high entries block
+`maverick land` via a no-bypass pre-curation gate, and high entries
+additionally gain a `blocks` edge onto the next spec's epic (wired at
+recording time and at refuel `_chain_epic` time) so downstream work never
+becomes `bd ready` until answered or waived through `maverick review`.
+`maverick brief` gains a per-spec assumption-counts section as a spec-quality
+signal. All ledger operations live in a new `maverick.assumptions` package.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (`from __future__ import annotations`)
+**Primary Dependencies**: bd CLI via `maverick.beads.BeadClient` (CommandRunner
+subprocess), Jujutsu via `maverick.jj.client.JjClient` /
+`library/actions/jj.py`, Pydantic (payloads + validation), Click + Rich (CLI),
+burr graph in `workflows/fly_beads/`, structlog, tenacity
+**Storage**: bd bead store (beads + state key/values + labels + dependency
+edges) — no new persistence layer (research R1)
+**Testing**: pytest + pytest-asyncio + xdist via `make test` / `make test-fast`;
+CI gate `make ci`
+**Target Platform**: Linux/macOS developer machines (CLI, single-repo
+jj-colocated checkout per Guardrail 0)
+**Project Type**: single project (existing `src/maverick/` layout)
+**Performance Goals**: interactive CLI latency — land gate and brief section
+add O(assumption beads) `bd` calls (tens of beads, each subprocess ≤30s
+`BD_TIMEOUT`); no hot paths
+**Constraints**: bd state values are `dict[str, str]` (multi-values
+comma-joined); recording/stamping must be non-fatal to fly (FR-012, existing
+`create_human_bead` pattern); payload changes must be additive/backward
+compatible; no `Path.cwd()` below the CLI boundary (Guardrail 7)
+**Scale/Scope**: tens of assumptions per run, a handful of specs per repo;
+~6 source areas touched + 1 new package (~10 modules incl. tests)
+
+## Constitution Check
+
+*GATE: evaluated against constitution v1.10.0 before Phase 0; re-evaluated
+after Phase 1 design.*
+
+| Principle / Guardrail | Verdict | Notes |
+|---|---|---|
+| I. Async-first | PASS | All new ops go through async `BeadClient`/`JjClient`/CommandRunner; no `subprocess.run` in async paths |
+| II. Separation of concerns | PASS | Agents only *report* assumptions in payloads (judgment); the workflow's `record_assumptions` action and CLI own all side effects (clarification #4 codifies this) |
+| III. Dependency injection | PASS | Ledger functions take `client`/`cwd` explicitly; no globals |
+| IV/VIII. Fail gracefully, relentless progress | PASS | Recording and stamping are non-fatal to fly (warn + continue, mirrors `create_human_bead`); land gate failure is an intentional hard stop, not a crash |
+| V. Test-first | PASS (plan) | Test areas enumerated in quickstart; tasks phase orders tests before implementation |
+| VI. Typed contracts | PASS | Frozen dataclasses (`AssumptionRecord`, `PerSpecAssumptionCounts`), StrEnum severity, state-key constants exported — no ad-hoc dict blobs, no magic strings |
+| VII. Simplicity/DRY | PASS | Reuses bd ready/defer/close, existing labels, existing epic chaining; no new pause machinery (clarification #2) |
+| IX. Hardening | PASS | bd calls inherit BeadClient timeouts; typed `AssumptionLedgerError`; no bare except |
+| X.5 One canonical wrapper | PASS (improves) | Adds `DependencyType.DISCOVERED_FROM`; migrates the two raw `bd dep add` call sites in `_commit.py` to `BeadClient` (research R11) |
+| X.7 / Guardrail 7 explicit cwd | PASS | Every ledger function takes explicit `cwd`; CLI resolves once |
+| XI. Modularize early | PASS | New `maverick.assumptions` package instead of growing `fly_beads/actions.py` (1200+ LOC) further |
+| XII. Ownership | PASS | Fixes two found issues in passing: discarded commit change_id; nondeterministic `_chain_epic` tail ordering |
+
+**Post-Phase-1 re-check**: no new violations introduced by the design; the
+Complexity Tracking table remains empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/049-assumption-ledger/
+├── plan.md              # This file
+├── spec.md              # Feature specification (clarified 2026-07-23)
+├── research.md          # Phase 0 — decisions R1–R13
+├── data-model.md        # Phase 1 — bead shape, state keys, transitions
+├── quickstart.md        # Phase 1 — validation scenarios
+├── contracts/
+│   ├── README.md
+│   ├── payloads.md      # AssumptionPayload + submit-payload additions
+│   ├── ledger-api.md    # maverick.assumptions public API
+│   └── cli.md           # land gate, review answer/waive, brief section
+└── tasks.md             # Phase 2 (/speckit-tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/maverick/
+├── assumptions/                    # NEW package (research R13)
+│   ├── __init__.py                 # public re-exports
+│   ├── models.py                   # Severity, AssumptionRecord,
+│   │                               # PerSpecAssumptionCounts, state-key consts
+│   ├── ledger.py                   # record/stamp/answer/waive/query ops
+│   ├── report.py                   # per_spec_counts aggregation
+│   └── errors.py                   # AssumptionLedgerError(MaverickError)
+├── payloads.py                     # + AssumptionPayload; + assumptions field on
+│                                   #   SubmitImplementation/Review/FixResult
+├── beads/models.py                 # + DependencyType.DISCOVERED_FROM
+├── agents/                         # implementer/reviewer/fixer prompt builders:
+│                                   #   assumption-reporting instructions
+├── workflows/
+│   ├── fly_beads/
+│   │   ├── actions.py              # collect payload assumptions →
+│   │   │                           #   pending_assumptions; commit captures
+│   │   │                           #   change_id + stamps entries
+│   │   ├── burr_graph.py           # wire record_assumptions before commit
+│   │   └── _commit.py              # raw `bd dep add` → BeadClient (cleanup)
+│   └── refuel_speckit/workflow.py  # _chain_epic: deterministic NNN ordering +
+│                                   #   wire open high-severity entries → new epic
+└── cli/commands/
+    ├── land.py                     # pre-curation assumption gate (no bypass)
+    ├── review.py                   # answer / waive flows for ledger entries
+    └── brief.py                    # per-spec assumption counts section
+
+tests/
+├── unit/
+│   ├── assumptions/                # NEW: ledger, report, severity coercion,
+│   │                               #   dedup, owner-spec derivation
+│   ├── test_payloads_assumptions.py  # AssumptionPayload validation/back-compat
+│   ├── beads/                      # DependencyType.DISCOVERED_FROM
+│   ├── workflows/fly_beads/        # record_assumptions action, commit stamping
+│   ├── workflows/refuel_speckit/   # _chain_epic high-severity wiring, ordering
+│   ├── library/actions/            # select_next_bead skip regression
+│   └── cli/                        # land gate, review flows, brief section
+└── integration/
+    └── test_assumption_ledger_flow.py  # quickstart scenarios + legacy compat
+```
+
+**Structure Decision**: Single-project layout, existing tree. One new focused
+package (`src/maverick/assumptions/`) holds all ledger domain logic so its
+five consumers (fly, refuel_speckit, land, review, brief) share one
+implementation; all other changes are edits inside existing modules,
+mirrored by tests in the existing `tests/` hierarchy.
+
+## Complexity Tracking
+
+No constitution violations to justify — table intentionally empty.

--- a/specs/049-assumption-ledger/quickstart.md
+++ b/specs/049-assumption-ledger/quickstart.md
@@ -1,0 +1,110 @@
+# Quickstart: Validating the Assumption Ledger
+
+Runnable scenarios proving the feature end-to-end. Shapes and semantics:
+[data-model.md](data-model.md), [contracts/](contracts/).
+
+## Prerequisites
+
+- Repo initialized: `maverick init` (jj colocated + bd store present).
+- A speckit feature ingested: `maverick refuel <feature> --speckit` so an epic
+  with `speckit_feature` state exists.
+- For agent-path scenarios: OpenCode auth configured. Deterministic scenarios
+  (2–6) need no model access.
+
+## Fast checks (no model calls)
+
+```bash
+make test-fast          # unit tests incl. maverick.assumptions, payloads
+make lint typecheck     # ruff + mypy strict
+```
+
+New test areas: `tests/unit/assumptions/` (ledger, report, severity coercion,
+dedup), `tests/unit/workflows/fly_beads/` (record_assumptions, commit
+stamping), `tests/unit/cli/` (land gate, review answer/waive, brief section),
+`tests/unit/workflows/refuel_speckit/` (`_chain_epic` wiring), and
+`tests/integration/test_assumption_ledger_flow.py`.
+
+## Scenario 1 — Record + stamp (US1)
+
+1. Run `maverick fly --epic <id>` on a bead whose prompt/fixture yields an
+   implementation payload containing one `assumptions` entry (integration
+   tests stub the agent; live runs rely on the updated prompts).
+2. After the bead commits, verify the entry:
+
+   ```bash
+   bd list --parent <epic-id> --flat --json | jq '.[] | select(.title | startswith("Assumption:"))'
+   bd show <assumption-id> --json
+   ```
+
+   Expect: labels include `assumption`; state has `assumption_severity`,
+   `assumption_status=open`, `assumption_owner_spec=<feature-dir-name>`,
+   `assumption_change_ids` containing a jj change ID that
+   `jj log -r <change-id>` resolves; `bd dep list <assumption-id> --json`
+   shows a `discovered-from` edge to the source bead (US1-S1/S2/S3).
+3. Kill a run before commit (or use the abandon path in tests): entry exists
+   with no `assumption_change_ids` — unstamped (US1-S4).
+
+## Scenario 2 — Severity policy: low is advisory (US2-S1)
+
+Create a low-severity entry (unit/CLI fixture or a stubbed run), then:
+
+```bash
+bd ready --json            # entry absent (deferred)
+maverick land --dry-run    # gate passes; entry listed nowhere as blocking
+maverick brief             # entry counted under its spec (open, L column)
+```
+
+## Scenario 3 — Medium blocks land until answered/waived (US2-S2, US2-S4)
+
+1. With one open medium entry: `maverick land` → exits non-zero, table names
+   the entry + owning spec + `maverick review <id>` hint. Confirm no bypass
+   flag exists: `maverick land --help` offers none.
+2. `maverick review <id>` → answer flow → `bd show` shows
+   `assumption_status=answered`, bead closed.
+3. `maverick land --dry-run` → gate passes.
+4. Repeat with a second entry using the waive flow (reason required); state
+   records `assumption_waived_by/at/reason` (US2-S4).
+
+## Scenario 4 — High blocks the next spec's epic (US2-S3, FR-007)
+
+1. Spec A epic exists with an open high entry; refuel spec B
+   (`maverick refuel <spec-b> --speckit`).
+2. `bd dep list <spec-b-epic> --json` → `blocks` edge from the assumption
+   entry (wired at chain time or recording time, whichever came second).
+3. `bd ready --json` → no spec-B beads appear.
+4. Resolve the entry via `maverick review` → spec-B work appears in
+   `bd ready` with no manual dependency surgery (SC-006, edge-case
+   "answered mid-run").
+5. High entry on the **last** spec (no spec B): behaves as Scenario 3 only
+   (US2-S5).
+
+## Scenario 5 — Human queue (US3)
+
+```bash
+bd ready --json                 # medium/high entries appear, assignee=human
+maverick brief --human          # entries listed with source-bead context
+maverick review <id>            # full context: question/answer/alternatives/
+                                # severity/spec/stamps/discovered-from
+```
+
+Agent-side check: `select_next_bead` still skips these beads (existing unit
+tests must stay green).
+
+## Scenario 6 — Per-spec counts incl. zero (US4)
+
+With spec A (entries) and spec B (none) both refueled:
+
+```bash
+maverick brief                  # Assumptions table: A with counts, B all-zero
+maverick brief --format json    # assumption_counts array, both specs present
+```
+
+Legacy escalation beads (pre-feature `assumption-review` beads without the
+`assumption` label) appear in the `Legacy` column and cause no errors
+(FR-013).
+
+## Full gate before push
+
+```bash
+make ci
+```

--- a/specs/049-assumption-ledger/research.md
+++ b/specs/049-assumption-ledger/research.md
@@ -1,0 +1,287 @@
+# Research: Assumption Ledger
+
+**Feature**: 049-assumption-ledger | **Date**: 2026-07-23
+
+All Technical Context unknowns resolved. Each decision below records what was
+chosen, why, and what was rejected. File references are to the current tree.
+
+## R1. Ledger storage: extended beads, not a sidecar store
+
+**Decision**: Each ledger entry IS a bead. Structured fields live in bead
+*state* (`bd set-state` key/value, read back via `bd show --json` →
+`BeadDetails.state`), long-form text (question, adopted answer, alternatives)
+lives in the bead description in a fixed markdown shape, and classification
+lives in labels.
+
+**Rationale**: The spec mandates surfacing via `bd ready` and discovered-from
+edges — both are bead-native. Bead state is already the established metadata
+channel (`speckit_feature` on epics at `src/maverick/speckit/build.py:371`,
+`source_bead`/`escalation_type` on today's escalation beads at
+`src/maverick/workflows/fly_beads/actions.py:1130-1137`). A sidecar file would
+need its own sync with bd and would break `bd ready`/dependency semantics.
+
+**Alternatives considered**: (a) JSON ledger file under `.maverick/` — rejected:
+duplicates bd's queue/dependency machinery and drifts from bead status;
+(b) new bd entity type — rejected: bd has no such extension point; beads with
+labels + state are sufficient.
+
+## R2. State-key and label schema
+
+**Decision**: New `assumption` label marks ledger entries (alongside the
+existing `assumption-review` + `needs-human-review` labels so the
+agent-side skip filter at `src/maverick/library/actions/beads.py:301` and
+`brief --human` filter at `src/maverick/cli/commands/brief.py:371` keep
+working unchanged). State keys (all `dict[str, str]`, bd's constraint):
+
+| Key | Values | Purpose |
+|-----|--------|---------|
+| `assumption_severity` | `low` \| `medium` \| `high` | severity policy input |
+| `assumption_severity_defaulted` | `true` (absent otherwise) | FR-011 visibility |
+| `assumption_status` | `open` \| `answered` \| `waived` | resolution lifecycle |
+| `assumption_owner_spec` | e.g. `049-assumption-ledger` | owning spec (see R3) |
+| `assumption_change_ids` | comma-joined jj change IDs | change stamp (see R5) |
+| `assumption_answer` | short answer text | set on answer |
+| `assumption_waived_by` / `assumption_waived_at` / `assumption_waive_reason` | strings | audited waiver |
+| `source_bead` | bead ID | kept for `brief --human` compatibility |
+
+**Rationale**: bd state is string→string; comma-joining change IDs is the
+established pattern for multi-valued state. Reusing existing labels keeps
+FR-013 (legacy compatibility) nearly free.
+
+**Alternatives considered**: severity as a label (`severity:high`) — rejected:
+state is the read-back channel every consumer already uses (`details.state`),
+and labels are currently coarse routing tags only.
+
+## R3. Owning-spec attribution (clarification #1)
+
+**Decision**: At recording time, the workflow reads the owning epic's state:
+`speckit_feature` (speckit epics, set at
+`src/maverick/workflows/refuel_speckit/workflow.py:314`) with fallback to
+`flight_plan_name` (refuel_maverick epics, set at
+`src/maverick/workflows/refuel_maverick/workflow.py:613-615`), and copies the
+value into `assumption_owner_spec` on the entry. If neither key exists
+(legacy/adopted epics), the epic bead ID is used as the owner identifier so
+aggregation still functions.
+
+**Rationale**: Deterministic, agent-free (per clarification), and both epic
+families are cleanly partitioned by which key they populate. Copying onto the
+entry makes per-spec aggregation a single pass over assumption beads without
+per-entry epic lookups.
+
+**Alternatives considered**: resolving owner at read time via `parent_id` →
+epic state — rejected: every report/gate query would need N extra `bd show`
+calls; copy-on-write is stable because a bead never changes epics.
+
+## R4. Recording path (clarification #4)
+
+**Decision**: New frozen Pydantic model `AssumptionPayload` (question,
+adopted_answer, alternatives tuple, severity) added to `maverick.payloads`;
+`SubmitImplementationPayload`, `SubmitReviewPayload`, and
+`SubmitFixResultPayload` gain `assumptions: tuple[AssumptionPayload, ...] = ()`.
+Fly actions (`implement`, `review`, `fix` paths in
+`src/maverick/workflows/fly_beads/actions.py`) accumulate these into a new
+`pending_assumptions` state key. A new deterministic burr action
+`record_assumptions` (wired before `commit` in
+`src/maverick/workflows/fly_beads/burr_graph.py`) creates the ledger beads:
+one bead per deduped assumption, `assignee="human"`, parent = owning epic,
+plus a `discovered-from` edge to the source bead.
+
+**Rationale**: Matches the batch-at-step-end clarification and Guardrail 3
+(agents judge, workflows own side effects). The base payload class is
+`extra="allow"` so older agent prompts that omit the field are unaffected
+(defaults to empty tuple). Placing `record_assumptions` before `commit` lets
+the same bead's commit stamp the entries moments later (R5).
+
+**Alternatives considered**: recording inside the `commit` action — rejected:
+commit already has one job and its failure semantics (non-fatal stamping)
+differ from entry creation; a dedicated action keeps both testable.
+
+## R5. Change-ID capture and stamping
+
+**Decision**: Fix the active `commit` action
+(`src/maverick/workflows/fly_beads/actions.py:1163-1203`) to capture the
+return of `jj_commit_bead` — a dict whose `change_id` is the stable jj change
+ID of the finalized change (`src/maverick/library/actions/jj.py:247-288`,
+`JjClient.commit` → `JjCommitResult.change_id`) — instead of discarding it.
+After a successful commit, the action appends that change ID to
+`assumption_change_ids` on every entry recorded for the current bead
+(`recorded_assumption_ids`, reset per bead). Multi-ID stamps arise via dedup:
+when a later bead re-records an open question, the merged entry is stamped
+again by that bead's commit. Stamping failure logs a warning and never fails
+the commit (FR-012).
+
+**Rationale**: jj change IDs are the stable identity across rewrites (git SHAs
+change under curation in `land`); the return value already exists and is
+merely dropped today. Stamping in `commit` is the only place where both the
+entry IDs and the change ID are simultaneously known.
+
+**Alternatives considered**: git commit SHA — rejected: `land` curation
+rewrites commits, invalidating SHAs; `JjCommitResult` doesn't even expose one.
+
+## R6. Severity policy — low (advisory)
+
+**Decision**: Low-severity entries are created like all others, then
+immediately removed from the ready queue via `bd defer <id>` (existing
+pattern: `defer_bead` at `src/maverick/library/actions/beads.py:408-426`).
+They remain open (countable, answerable if a human seeks them out) but never
+appear in `bd ready`, never block land, and never wire epic dependencies.
+
+**Rationale**: "Advisory only" (FR-005) plus "counts include open entries"
+(FR-010) means low entries must exist but stay out of every queue and gate.
+`bd defer` is exactly that semantic and already has a wrapper.
+
+**Alternatives considered**: creating low entries pre-closed — rejected: they
+would count as "resolved" in reports, misrepresenting an unanswered advisory.
+
+## R7. Severity policy — medium (land gate, clarification #3)
+
+**Decision**: A new pre-land assumption gate runs in
+`src/maverick/cli/commands/land.py` immediately after the existing
+commit-count check / human-review manifest display (land.py:148-151) and
+before curation. It queries open beads labeled `assumption` with
+`assumption_severity` ∈ {medium, high} and `assumption_status == open`,
+grouped by `assumption_owner_spec`. Any hit blocks land with a listing of the
+blocking entries (ID, severity, question, owning spec) and exits non-zero.
+There is **no bypass flag** — the only paths forward are `maverick review`
+answer/waive (R9). Legacy escalation beads without `assumption_severity` are
+listed in the existing human-review manifest as today and treated by the gate
+as medium (severity-defaulting rule FR-011 applied at read time for legacy
+entries, without mutating them).
+
+**Rationale**: land is cwd-scoped with no epic parameter (land.py:130-131), so
+"the owning spec's land" concretely means: the gate blocks the cwd-wide land
+while any spec that would be swept into it has open medium/high entries — and
+identifies them per spec. No-bypass matches the clarification; the waiver is
+the audited escape hatch.
+
+**Alternatives considered**: `--force` flag — rejected per clarification #3;
+scoping the gate to a single epic — rejected: land has no epic identity and
+pushes the whole branch, so a narrower gate would let unanswered assumptions
+ride along.
+
+## R8. Severity policy — high (next-epic dependency, clarification #2)
+
+**Decision**: Dependency-only, wired at two hooks so ordering doesn't matter:
+
+1. **Recording time** (`record_assumptions`): if a next chained epic exists —
+   discovered as the open epic whose `speckit_feature` NNN prefix is the
+   smallest strictly greater than the owning epic's (`next_chained_epic` in
+   the ledger API; flight-plan epics without `speckit_feature` never match) —
+   add `bd dep add <next_epic> --blocked-by <assumption_bead> --type blocks`.
+2. **Refuel time** (`_chain_epic`): when a new speckit epic is created, in
+   addition to chaining behind the tail epic, wire `blocks` edges from every
+   open high-severity assumption entry owned by earlier specs onto the new
+   epic.
+
+Additionally, `_chain_epic`'s "tail" selection is made deterministic by
+sorting open epics by their `speckit_feature` NNN prefix (today it relies on
+unspecified `bd query` ordering — a latent bug this feature would otherwise
+inherit).
+
+**Rationale**: `bd ready` already enforces blocking edges, so work past the
+boundary "simply never becomes ready" with zero new pause machinery — exactly
+the clarified behavior, and it works identically within one run or across
+runs. The dual hook covers both temporal orders (assumption recorded before
+vs. after the next spec is refueled). When no next epic ever appears, the
+entry degrades to medium behavior (land gate only) — matching the spec's
+last-spec rule with no extra code.
+
+**Alternatives considered**: in-run pause state machine — rejected per
+clarification #2; blocking the next epic's *tasks* individually — rejected:
+blocking the epic bead blocks its subtree in `bd ready --parent` traversal
+and needs one edge instead of N. (Verification that a blocked epic suppresses
+its children from `bd ready` is a quickstart scenario; if bd treats epic
+blocking as non-transitive, the fallback is wiring the same edge to the next
+epic's phase-source tasks, computed by the existing `_phase_sources` logic.)
+
+## R9. Answer / waive surface
+
+**Decision**: Extend the existing `maverick review` command
+(`src/maverick/cli/commands/review.py`, already "lightweight human review of
+assumption beads") with explicit resolution flows: answering records
+`assumption_answer`, sets `assumption_status=answered`, and closes the bead;
+waiving requires a reason, records `assumption_waived_by` (git user name) /
+`assumption_waived_at` (ISO timestamp) / `assumption_waive_reason`, sets
+`assumption_status=waived`, and closes the bead. Closing is what releases
+`blocks` edges (bd readiness) and removes the entry from `bd ready`.
+
+**Rationale**: `review` is already the human's resolution surface for these
+beads; closing-on-resolve makes bd itself release the epic dependency (SC-006,
+"no manual dependency surgery"). Status + close state together distinguish
+answered/waived/open for reporting.
+
+**Alternatives considered**: a new `maverick assumptions` command — rejected:
+duplicates an existing surface; `bd close` directly — insufficient: loses the
+audited answer/waiver record.
+
+## R10. Queue surfacing & dedup
+
+**Decision**: Medium/high entries are ordinary open human-assigned beads, so
+they appear in `bd ready` natively (bd is the human's queue per the spec) and
+in `maverick brief --human` (existing label filter). The agent-side
+`select_next_bead` filter already skips them
+(`src/maverick/library/actions/beads.py:295-311`) — no change needed.
+Dedup (FR-014): `record_assumptions` normalizes the question (casefold,
+collapse whitespace) and skips creation when an open `assumption` bead with
+the same normalized question already exists under the same owning epic;
+instead it appends the new source bead's discovered-from edge to the existing
+entry. In-payload duplicates within one step are collapsed the same way.
+
+**Rationale**: Reuses every existing queue mechanism untouched; normalized
+question matching under one epic is cheap (children listing already exists)
+and matches the spec's "same question within one bead" minimum while also
+covering repeat offenders across fix rounds.
+
+**Alternatives considered**: content-hash state key — rejected as premature;
+normalized-text comparison over the epic's open assumption children is
+sufficient at realistic volumes (tens of entries).
+
+## R11. DependencyType enum gap
+
+**Decision**: Add `DISCOVERED_FROM = "discovered-from"` to `DependencyType`
+(`src/maverick/beads/models.py:44-51`) and route all new edge creation through
+`BeadClient.add_dependency`. The two raw `bd dep add ... --type
+discovered-from` call sites in `fly_beads/_commit.py:257-268,365-370` are
+migrated to the typed client as collateral cleanup (Guardrail 5: one canonical
+wrapper; Constitution XII: fix what you find).
+
+**Rationale**: The feature needs discovered-from edges programmatically; the
+enum is the single missing piece blocking typed usage, flagged during
+research as a pre-existing inconsistency.
+
+**Alternatives considered**: keep raw CLI calls — rejected: violates the
+one-canonical-wrapper guardrail and duplicates edge-writing logic in a third
+place.
+
+## R12. Per-spec reporting in brief
+
+**Decision**: `maverick brief` gains an assumption-counts section: aggregate
+all beads labeled `assumption` (plus legacy `assumption-review` beads counted
+in a "legacy" bucket) grouped by `assumption_owner_spec`, showing
+open/answered/waived × severity counts. Epics present in the store whose spec
+has zero entries render as zero rows (FR-010). Shown in the default brief view
+as a compact table and in `--human` view in full; `--format json` includes the
+raw aggregation.
+
+**Rationale**: brief already queries beads globally and has the human filter
+plumbing (`brief.py:98-125,357-407`); a section there matches clarification
+#5. Zero rows require enumerating epics, which `query("type=epic")` provides.
+
+**Alternatives considered**: new subcommand — rejected per clarification #5.
+
+## R13. New package layout
+
+**Decision**: New package `src/maverick/assumptions/` — `models.py` (frozen
+dataclasses: `AssumptionRecord`, `Severity` StrEnum, state-key constants),
+`ledger.py` (async create/stamp/resolve/query operations over `BeadClient`),
+`report.py` (per-spec aggregation used by brief and the land gate). Workflow
+actions, CLI commands, and refuel hooks import from this package; nothing in
+it imports workflow or CLI modules.
+
+**Rationale**: Modularize-early (Constitution XI): the ledger logic is needed
+from four consumers (fly, land, review, brief, refuel) and would otherwise be
+duplicated or dumped into an already-large `actions.py` (1200+ lines).
+
+**Alternatives considered**: putting ledger ops in `library/actions/beads.py`
+— rejected: that module is the generic bead action layer; assumption policy
+(severity, waivers, stamping) is a distinct domain with its own vocabulary.

--- a/specs/049-assumption-ledger/spec.md
+++ b/specs/049-assumption-ledger/spec.md
@@ -1,0 +1,319 @@
+# Feature Specification: Assumption Ledger
+
+**Feature Branch**: `049-assumption-ledger`
+**Created**: 2026-07-23
+**Status**: Draft
+**Input**: User description: "Extend Maverick's assumption beads into an assumption ledger. Each entry records the question, the adopted answer, the alternatives considered, a severity (low, medium, high), the owning spec, and the jj change ID(s) embodying the assumption — stamped when the bead's work is committed. Severity drives escalation: low is advisory only; medium blocks the owning spec's land until answered or waived; high additionally becomes a blocking dependency of the next spec's epic, pausing the run at the spec boundary. The human's queue is surfaced through bd (bd ready), with discovered-from edges linking each assumption to the work that spawned it. Reporting includes per-spec assumption counts as a spec-quality signal. This spec covers the data model, recording path, severity policy wiring, and queue surfacing — not the reconcile mechanics."
+
+## Clarifications
+
+### Session 2026-07-23
+
+- Q: How is the owning spec determined for a recorded assumption? → A: Derived automatically from the bead's parent epic via the epic↔spec mapping created at refuel; agents never state it.
+- Q: How does a high-severity assumption "pause the run at the spec boundary"? → A: Dependency-only — the next spec's epic gets a bd blocking dependency on the assumption, so work past the boundary never becomes ready; no separate in-run pause machinery.
+- Q: Can land bypass an assumption block (e.g., a force flag)? → A: No bypass flag; answering or waiving each blocking entry is the only way past — the waiver is the audited escape hatch.
+- Q: How do assumptions travel from agent to ledger? → A: Batch-at-step-end — assumptions are fields in the agent's structured result payload; the workflow creates the ledger entries deterministically after the step completes.
+- Q: Where do per-spec assumption counts surface? → A: Extend `maverick brief` (the existing bead-status surface) with a per-spec assumption counts section; no new reporting command.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Assumptions become structured ledger entries (Priority: P1)
+
+During an autonomous run, an agent hits a decision it cannot resolve from the spec
+or the code — for example, "should the retry limit apply per bead or per run?" It
+adopts the most defensible answer and keeps working. Instead of that decision
+evaporating into a prose escalation note, the system records a structured ledger
+entry: the question, the adopted answer, the alternatives it considered, a
+severity, and the spec that owns the decision. When the bead's work is committed,
+the entry is stamped with the change identifier(s) that embody the assumption. A
+discovered-from edge links the entry back to the work item that spawned it.
+
+**Why this priority**: The ledger entry is the feature's atom. Every other
+behavior — escalation policy, queue surfacing, reporting — reads from it. Without
+structured entries there is nothing to escalate, surface, or count.
+
+**Independent Test**: Run a workflow where an agent adopts at least one
+assumption, then inspect the resulting work-item store: a ledger entry exists
+with all six fields populated, a discovered-from edge to the spawning work item,
+and (after commit) the change identifier(s) of the commits that embody it.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent implementing a bead adopts an assumption, **When** it
+   records the assumption, **Then** a ledger entry is created containing the
+   question, the adopted answer, at least one alternative considered, a severity
+   of low, medium, or high, and the owning spec.
+2. **Given** a ledger entry recorded against a bead, **When** that bead's work is
+   committed, **Then** the entry is stamped with the change identifier(s) of the
+   commit(s) embodying the assumption.
+3. **Given** a ledger entry, **When** a user inspects it, **Then** a
+   discovered-from edge identifies the work item whose execution spawned the
+   assumption.
+4. **Given** an assumption whose bead's work is never committed (bead fails or
+   run is cancelled), **When** the run ends, **Then** the ledger entry still
+   exists with its question/answer/severity fields but carries no change stamp,
+   and is identifiable as unstamped.
+
+---
+
+### User Story 2 - Severity drives escalation policy (Priority: P2)
+
+A run may adopt many assumptions; not all deserve to stop the line. The recording
+agent assigns a severity, and the workflow enforces a graduated policy: low
+severity is advisory only — visible in the ledger and reports, never blocking.
+Medium severity blocks the owning spec's land step until a human answers or
+waives the assumption. High severity additionally becomes a blocking dependency
+of the next spec's epic, so the run pauses at the spec boundary rather than
+compounding a risky guess across specs.
+
+**Why this priority**: Severity policy is the behavioral payoff of the ledger —
+it converts recorded doubt into proportionate friction. It depends on User
+Story 1's data model existing.
+
+**Independent Test**: Create three assumptions (one per severity) against a spec,
+then attempt to land that spec and start the next one. Land is blocked by the
+medium and high entries but not the low one; the next spec's epic cannot start
+while the high entry is open.
+
+**Acceptance Scenarios**:
+
+1. **Given** a spec with only low-severity open assumptions, **When** the user
+   lands the spec, **Then** the land proceeds and the assumptions are reported as
+   advisories.
+2. **Given** a spec with an open medium-severity assumption, **When** the user
+   attempts to land it, **Then** the land is blocked with a message identifying
+   the blocking assumption(s), and succeeds once each is answered or waived.
+3. **Given** a spec with an open high-severity assumption, **When** the run
+   reaches the boundary to the next spec, **Then** the next spec's epic carries a
+   blocking dependency on the assumption, so none of that spec's work becomes
+   ready until the assumption is answered or waived.
+4. **Given** a medium-severity assumption a human decides is acceptable risk,
+   **When** they waive it, **Then** the waiver (who/when/why) is recorded on the
+   entry and the entry stops blocking land.
+5. **Given** a high-severity assumption recorded against the final spec of a run
+   (no next spec exists), **When** the run completes, **Then** the entry behaves
+   like a medium-severity entry: it blocks that spec's land but there is no
+   next epic to block.
+
+---
+
+### User Story 3 - The human's queue surfaces through the work-item tool (Priority: P3)
+
+The human tending an autonomous run should not need a new inbox. Open assumptions
+addressed to them appear in their existing ready-work queue (`bd ready`), each
+entry navigable to its question, adopted answer, alternatives, severity, and the
+discovered-from work that spawned it — enough context to answer or waive without
+archaeology.
+
+**Why this priority**: Queue surfacing makes the ledger actionable. It builds
+directly on the entries from User Story 1 and gives the escalation policy of
+User Story 2 its resolution path.
+
+**Independent Test**: Record assumptions of each severity, then list the human's
+ready queue: medium and high entries appear as ready human work items; each shows
+enough context (or links to it) to decide; resolving one removes it from the
+queue and unblocks whatever it was blocking.
+
+**Acceptance Scenarios**:
+
+1. **Given** open medium- or high-severity assumptions, **When** the human lists
+   their ready work, **Then** each open assumption appears as a ready work item
+   assigned to them.
+2. **Given** an assumption in the queue, **When** the human opens it, **Then**
+   they can see the question, adopted answer, alternatives considered, severity,
+   owning spec, and follow the discovered-from edge to the spawning work.
+3. **Given** the human answers an assumption from the queue, **When** the answer
+   is recorded, **Then** the entry leaves the ready queue and any land or epic it
+   was blocking becomes unblocked.
+
+---
+
+### User Story 4 - Per-spec assumption counts as a quality signal (Priority: P4)
+
+A spec that generated eleven assumptions was underspecified; one that generated
+zero was either crisp or trivially small. Reporting surfaces per-spec assumption
+counts (total and by severity) so the team can treat assumption volume as a
+spec-quality signal and improve their specification practice over time.
+
+**Why this priority**: Pure read-side value on top of data the earlier stories
+already persist. Useful, but nothing else depends on it.
+
+**Independent Test**: After runs over two specs with differing assumption
+volumes, request the report: each spec shows its assumption count broken down by
+severity and open/resolved status.
+
+**Acceptance Scenarios**:
+
+1. **Given** completed work across multiple specs, **When** the user views the
+   assumption report, **Then** each spec shows its total assumption count and a
+   breakdown by severity.
+2. **Given** a spec with zero assumptions, **When** the report is viewed,
+   **Then** the spec appears with a zero count (absence is itself a signal).
+
+---
+
+### Edge Cases
+
+- **Work spanning multiple commits**: an assumption embodied by several commits
+  is stamped with every relevant change identifier, not just the last one.
+- **Commit succeeds but stamping fails**: stamping must not lose the commit;
+  the entry remains unstamped and the gap is reported rather than silently
+  dropped.
+- **Duplicate recording**: an agent recording the same question twice within one
+  bead should not create two open queue items for the human; re-recording
+  updates or references the existing entry.
+- **Severity omitted or invalid at recording time**: the entry is not rejected
+  (losing the assumption is worse); it defaults to medium — the
+  blocks-owning-spec level — and the defaulting is visible on the entry.
+- **High-severity assumption on the last spec**: no next epic exists to block;
+  degrades to medium behavior (blocks land only) — see US2 scenario 5.
+- **Assumption answered mid-run**: if the human answers a high-severity entry
+  while a run is stopped at the spec boundary, the blocking dependency clears
+  and the next ready-work query serves the next spec's work — no manual
+  dependency surgery or run-state repair is required.
+- **Pre-existing escalation beads**: today's review-exhaustion escalation beads
+  continue to work; entries lacking the new structured fields must not break
+  queue listing or reporting.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST record each adopted assumption as a structured
+  ledger entry containing: the question, the adopted answer, the alternatives
+  considered, a severity (one of low, medium, high), and the owning spec. The
+  owning spec is derived automatically from the bead's parent epic (via the
+  epic↔spec mapping established at refuel); recording agents do not declare it.
+- **FR-002**: The system MUST stamp each ledger entry with the change
+  identifier(s) embodying the assumption at the time the associated bead's work
+  is committed, supporting multiple identifiers per entry.
+- **FR-003**: The system MUST link each ledger entry to the work item that
+  spawned it via a discovered-from edge.
+- **FR-004**: The system MUST allow agents to record assumptions during
+  autonomous execution without interrupting the current bead's work — recording
+  is non-blocking for the recording agent. Assumptions are carried as part of
+  the agent's structured result for the step; the workflow (not the agent)
+  creates the ledger entries deterministically after the step completes.
+- **FR-005**: The system MUST treat low-severity entries as advisory only: they
+  never block land, never block a subsequent spec, and appear in reporting.
+- **FR-006**: The system MUST block the owning spec's land while any
+  medium- or high-severity entry owned by that spec is neither answered nor
+  waived, and MUST identify the blocking entries in the land failure message.
+  No bypass flag exists: answering or waiving each blocking entry is the only
+  way to proceed (the waiver is the audited escape hatch).
+- **FR-007**: For each open high-severity entry, the system MUST additionally
+  register a blocking dependency from the next spec's epic onto the entry in the
+  work-item store. The pause is dependency-only: work past the spec boundary
+  simply never becomes ready while the entry is open — no separate in-run pause
+  state is introduced, and the behavior is identical whether the next spec is
+  worked in the same run or a later one. When no next spec exists, high severity
+  behaves as medium.
+- **FR-008**: The system MUST surface open medium- and high-severity entries as
+  ready work items in the human's existing work queue (`bd ready`), assigned to
+  the human.
+- **FR-009**: The system MUST let a human answer an entry (recording the answer)
+  or waive it (recording who waived, when, and the stated reason), and MUST
+  release any blocks held by that entry upon either resolution.
+- **FR-010**: The system MUST report per-spec assumption counts, broken down by
+  severity and by open/resolved status, including zero counts for specs with no
+  assumptions. The report surfaces as a section of the existing status command
+  (`maverick brief`); no new reporting command is introduced.
+- **FR-011**: The system MUST default an entry with a missing or invalid
+  severity to medium and make the defaulting visible on the entry, rather than
+  rejecting the recording.
+- **FR-012**: The system MUST preserve ledger entries whose work was never
+  committed, identifiable as unstamped, and MUST NOT fail a commit because
+  stamping failed (the gap is surfaced as a warning instead).
+- **FR-013**: The system MUST remain compatible with pre-existing escalation
+  beads that lack the structured fields: listing, queue surfacing, and reporting
+  MUST NOT error on them.
+- **FR-014**: Re-recording a question already open for the same bead MUST NOT
+  create a duplicate open queue item for the human.
+
+### Key Entities
+
+- **Assumption Ledger Entry**: The record of one adopted assumption. Attributes:
+  question, adopted answer, alternatives considered, severity (low | medium |
+  high, defaulted to medium when absent/invalid), owning spec, change
+  identifier stamp(s), resolution state (open | answered | waived), resolution
+  details (answer text, or waiver with who/when/why). Extends today's
+  assumption bead rather than introducing a parallel store.
+- **Discovered-from Edge**: Directed link from a ledger entry to the work item
+  whose execution spawned the assumption; the traceability path from doubt back
+  to work.
+- **Change Stamp**: The set of change identifier(s) embodying the assumption,
+  applied when the bead's work is committed; absence marks an entry as
+  unstamped.
+- **Severity Policy**: The mapping from severity to enforcement — low: advisory;
+  medium: blocks owning spec's land until answered/waived; high: medium plus a
+  blocking dependency from the next spec's epic onto the entry (dependency-only:
+  work past the spec boundary never becomes ready while the entry is open).
+- **Owning Spec**: The specification a ledger entry is attributed to; the unit
+  over which land-blocking applies and report counts aggregate. Attribution is
+  derived from the bead's parent epic (epic↔spec mapping from refuel), never
+  self-declared by the recording agent.
+- **Assumption Report**: Per-spec aggregation of entries — totals and breakdowns
+  by severity and resolution state — used as a spec-quality signal.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of assumptions adopted during an autonomous run exist as
+  ledger entries with question, adopted answer, alternatives, severity, and
+  owning spec populated — zero prose-only escalations for adopted assumptions.
+- **SC-002**: For every assumption whose bead's work was committed, the entry
+  carries at least one change identifier; a reviewer can go from any entry to
+  the embodying change(s) in under a minute without searching history manually.
+- **SC-003**: In no run does a spec with an open (unanswered, unwaived) medium-
+  or high-severity assumption complete its land; in no run does work on a next
+  spec's epic begin while a prior spec's high-severity assumption is open.
+- **SC-004**: Low-severity assumptions cause zero blocked lands and zero run
+  pauses across all runs.
+- **SC-005**: A human can enumerate every assumption awaiting them with a single
+  ready-queue listing, and can reach full decision context (question, answer,
+  alternatives, spawning work) from any queue item without leaving their
+  existing tooling.
+- **SC-006**: Resolving (answering or waiving) a blocking assumption releases
+  the affected land block or epic dependency with no manual dependency surgery;
+  the next land attempt or ready-work query proceeds normally.
+- **SC-007**: Per-spec assumption counts are available for 100% of specs
+  processed after this feature ships, including explicit zero counts.
+
+## Assumptions
+
+- **Ledger entries are extended assumption beads**, not a parallel store: the
+  existing work-item system (beads) already provides identity, assignment,
+  labels, dependencies, and the ready queue, and the user description names
+  `bd ready` as the surfacing mechanism. The "ledger" is the queryable set of
+  these structured entries.
+- **Recording is agent-initiated during execution**: any agent role that adopts
+  an assumption while working a bead (implementer, reviewer, fixer) may record
+  one; the existing review-exhaustion escalation path becomes one producer among
+  several rather than the only one. Agents surface assumptions in their
+  structured step results; ledger-entry creation is the workflow's
+  deterministic responsibility (agents own judgment, workflows own side
+  effects).
+- **"Next spec" means the next spec in the run's execution order** (for
+  multi-spec runs); a high-severity entry blocks the epic of whichever spec
+  follows the owning spec in that order.
+- **Waiving is a human-only action** performed through the existing human
+  review/queue tooling, and is always recorded (who, when, why) — a waiver is an
+  auditable decision, not a silent dismissal.
+- **Severity is assigned by the recording agent** based on blast radius of being
+  wrong; humans can see (and future reconcile work may revise) severities, but
+  initial assignment is autonomous so recording never blocks on a human.
+- **Reconcile mechanics are out of scope** per the user description: this spec
+  covers recording, stamping, severity enforcement, queue surfacing, and
+  counting — not how answered assumptions get folded back into code or specs.
+- **Reporting surfaces through `maverick brief`**, the existing status surface,
+  rather than a new standalone reporting tool.
+
+## Out of Scope
+
+- Reconcile mechanics: applying a human's answer back to the code, revising
+  commits, or re-running affected beads after an assumption is answered.
+- Automatic severity re-classification or severity escalation over time.
+- Cross-run or cross-repository assumption aggregation.
+- Any change to how non-assumption escalations (e.g., generic
+  needs-human-review items) are created or resolved.

--- a/specs/049-assumption-ledger/tasks.md
+++ b/specs/049-assumption-ledger/tasks.md
@@ -1,0 +1,225 @@
+# Tasks: Assumption Ledger
+
+**Input**: Design documents from `/specs/049-assumption-ledger/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included — the project constitution (Principle V, Test-First) mandates
+red-green-refactor; every story writes failing tests before implementation.
+
+**Organization**: Tasks grouped by user story (US1 record+stamp, US2 severity
+policy, US3 queue surfacing, US4 reporting) so each story is independently
+implementable and testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1–US4 from spec.md
+- Run `make test-fast` / `make lint typecheck` while iterating; `make ci` before push
+
+## Phase 1: Setup
+
+**Purpose**: Package skeleton so all subsequent tasks have a home
+
+- [X] T001 Create `src/maverick/assumptions/` package skeleton (`__init__.py`, empty `models.py`, `ledger.py`, `report.py`, `errors.py` with module docstrings) and `tests/unit/assumptions/__init__.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Typed primitives every story depends on — enum member, payload
+models, domain dataclasses, and the one-canonical-wrapper cleanup that
+validates the enum end-to-end.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 [P] Write failing tests for `DependencyType.DISCOVERED_FROM` (enum member value `"discovered-from"`, accepted by `BeadDependency`/`add_dependency` command construction) in `tests/unit/beads/test_models.py` and `tests/unit/beads/test_client.py`
+- [X] T003 [P] Write failing tests for `AssumptionPayload` (required question/adopted_answer, alternatives default, severity coercion unknown/absent→`medium` with defaulted flag exposed, never raising on bad severity) and for the additive `assumptions` field on `SubmitImplementationPayload`/`SubmitReviewPayload`/`SubmitFixResultPayload` (absent field → empty tuple; existing payload dicts still validate; registry keys unchanged) in `tests/unit/test_payloads_assumptions.py` — per `contracts/payloads.md`
+- [X] T004 [P] Write failing tests for `maverick.assumptions.models` (Severity StrEnum; frozen `AssumptionRecord` with `change_ids`/`is_legacy`; `PerSpecAssumptionCounts`; state-key/label constants exported, no magic strings) in `tests/unit/assumptions/test_models.py` — per `contracts/ledger-api.md`
+- [X] T005 Add `DISCOVERED_FROM = "discovered-from"` to `DependencyType` in `src/maverick/beads/models.py` (T002 green)
+- [X] T006 Implement `AssumptionPayload` and add `assumptions: tuple[AssumptionPayload, ...] = ()` to the three submit payloads in `src/maverick/payloads.py` (T003 green)
+- [X] T007 Implement `src/maverick/assumptions/models.py` (Severity, AssumptionRecord, PerSpecAssumptionCounts, `ASSUMPTION_LABEL` + `KEY_*` constants) and `src/maverick/assumptions/errors.py` (`AssumptionLedgerError(MaverickError)`), re-export from `src/maverick/assumptions/__init__.py` (T004 green)
+- [X] T008 Migrate the two raw `bd dep add ... --type discovered-from` call sites in `src/maverick/workflows/fly_beads/_commit.py:257-268,365-370` to `BeadClient.add_dependency` with `DependencyType.DISCOVERED_FROM`; update any affected tests in `tests/unit/workflows/fly_beads/` (research R11 cleanup)
+
+**Checkpoint**: `make test-fast` green — foundation ready; user stories can begin.
+
+---
+
+## Phase 3: User Story 1 - Assumptions become structured ledger entries (Priority: P1) 🎯 MVP
+
+**Goal**: Agent-reported assumptions become structured beads (question, answer,
+alternatives, severity, owner spec, discovered-from edge) and get stamped with
+jj change IDs at commit.
+
+**Independent Test**: quickstart Scenario 1 — run fly with a stubbed
+implementer payload containing an assumption; verify the bead's labels, state
+keys, discovered-from edge, and post-commit `assumption_change_ids`; verify an
+abandoned bead leaves an unstamped entry.
+
+### Tests for User Story 1 (write first, ensure they FAIL)
+
+- [X] T009 [P] [US1] Write failing tests for `record_assumption` — bead shape per data-model (labels/title/description/priority-by-severity/assignee/parent), owner-spec derivation (`speckit_feature` → `flight_plan_name` → epic-ID fallback), severity coercion + `assumption_severity_defaulted`, dedup by normalized question under the same epic (returns existing record, appends discovered-from edge), discovered-from edge wiring, `AssumptionLedgerError` on bd failure — in `tests/unit/assumptions/test_ledger_record.py` (stub BeadClient)
+- [X] T010 [P] [US1] Write failing tests for `stamp_change_id` — appends to comma-joined `assumption_change_ids`, append-only + idempotent per (entry, change_id), partial per-entry failures reported in `StampResult` and NEVER raised — in `tests/unit/assumptions/test_ledger_stamp.py`
+- [X] T011 [P] [US1] Write failing tests for the fly wiring — implement/review/fix actions accumulate payload `assumptions` into `pending_assumptions` (cleared on bead start), `record_assumptions` action creates entries + writes `recorded_assumption_ids` and warns-but-continues on ledger errors, `commit` action captures `commit_change_id` from `jj_commit_bead` and stamps recorded entries non-fatally — in `tests/unit/workflows/fly_beads/test_assumption_actions.py`
+
+### Implementation for User Story 1
+
+- [X] T012 [US1] Implement `record_assumption` (creation, owner-spec derivation, coercion, dedup, discovered-from edge; severity *policy* hooks land in US2) in `src/maverick/assumptions/ledger.py` (T009 green)
+- [X] T013 [US1] Implement `stamp_change_id` + `StampResult` in `src/maverick/assumptions/ledger.py` (T010 green)
+- [X] T014 [US1] Extend `implement`/`review`/fix-result handling in `src/maverick/workflows/fly_beads/actions.py` to append validated payload `assumptions` to a `pending_assumptions` state key; reset `pending_assumptions`, `recorded_assumption_ids`, and `commit_change_id` in `process_bead_start` so no bead stamps or re-records a previous bead's entries
+- [X] T015 [US1] Add `record_assumptions` burr action in `src/maverick/workflows/fly_beads/actions.py` — calls `ledger.record_assumption` per pending assumption (deduped), writes `recorded_assumption_ids`, non-fatal warning path mirrors `create_human_bead`
+- [X] T016 [US1] Wire `record_assumptions` into `src/maverick/workflows/fly_beads/burr_graph.py` between review/create_human_bead and commit (both routes reach commit through it); register new state keys and `.bind` params (cwd, epic_id, events)
+- [X] T017 [US1] Fix `commit` action in `src/maverick/workflows/fly_beads/actions.py:1163-1203` to capture `jj_commit_bead`'s returned `change_id` into `commit_change_id` state and stamp `recorded_assumption_ids` via `stamp_change_id` (warn on stamp failure, never fail the commit) (T011 green)
+- [X] T018 [P] [US1] Update implementer/reviewer/fixer prompt builders in `src/maverick/agents/` (and `src/maverick/agents/system_prompts/` where applicable) with the assumption-reporting instruction from `contracts/payloads.md` (question / adopted answer / alternatives / severity-by-blast-radius)
+- [X] T019 [US1] Add integration test for quickstart Scenario 1 (record → commit → stamped entry with resolvable state; abandoned bead → unstamped entry) in `tests/integration/test_assumption_ledger_flow.py` (stubbed agents, real bd fixture pattern from existing integration tests)
+
+**Checkpoint**: US1 fully functional — entries recorded, linked, and stamped. MVP.
+
+---
+
+## Phase 4: User Story 2 - Severity drives escalation policy (Priority: P2)
+
+**Goal**: low = advisory (deferred), medium/high = land gate with no bypass,
+high = `blocks` edge onto the next spec's epic; answer/waive releases blocks.
+
+**Independent Test**: quickstart Scenarios 2–4 — low entry absent from
+`bd ready` and land passes; medium entry blocks land until answered/waived;
+high entry blocks the next spec's epic in `bd ready` and releases on resolve.
+
+### Tests for User Story 2 (write first, ensure they FAIL)
+
+- [X] T020 [P] [US2] Write failing tests for severity policy in `record_assumption` — low entries deferred (`bd defer`) at creation; high entries wire `blocks` edge onto an existing chained next epic; medium entries do neither — in `tests/unit/assumptions/test_ledger_policy.py`
+- [X] T021 [P] [US2] Write failing tests for `answer` (non-empty text required, sets state, closes bead) and `waive` (reason required, records who/when/why, closes bead) in `tests/unit/assumptions/test_ledger_resolve.py`
+- [X] T022 [P] [US2] Write failing tests for `open_blocking_entries` (open medium/high only; legacy escalation beads surfaced as severity=medium with `is_legacy=True`; answered/waived/closed excluded) and `open_high_entries_before` in `tests/unit/assumptions/test_ledger_query.py`
+- [X] T023 [P] [US2] Write failing CLI tests for the land assumption gate — blocks with per-spec table + `maverick review <id>` hint and non-zero exit; passes when only low/resolved entries exist; `--dry-run` still evaluates; `--help` exposes no bypass flag — in `tests/unit/cli/test_land_command.py`
+- [X] T024 [P] [US2] Write failing tests for `_chain_epic` — deterministic tail selection by `speckit_feature` NNN-prefix sort, and `blocks` edges wired from open high-severity entries of earlier specs onto the newly created epic — in `tests/unit/workflows/refuel_speckit/test_chain_epic.py`
+
+### Implementation for User Story 2
+
+- [X] T025 [US2] Implement severity policy in `src/maverick/assumptions/ledger.py`: defer low entries after creation; implement `next_chained_epic` (open epic with smallest `speckit_feature` NNN prefix strictly greater than the owning epic's; `None` for flight-plan epics) and wire the high-severity `blocks` edge when it returns an epic (T020 green)
+- [X] T026 [US2] Implement `answer` and `waive` in `src/maverick/assumptions/ledger.py` (T021 green)
+- [X] T027 [US2] Implement `open_blocking_entries` and `open_high_entries_before` in `src/maverick/assumptions/ledger.py` (T022 green)
+- [X] T028 [US2] Add the pre-curation assumption gate to `src/maverick/cli/commands/land.py` (after the human-review manifest display at land.py:151, before curation; Rich table grouped by owning spec; exit non-zero; no bypass flag) per `contracts/cli.md` (T023 green)
+- [X] T029 [US2] Extend `src/maverick/cli/commands/review.py` with answer/waive flows for `assumption`-labeled beads (prompt or options; empty answer/reason rejected; delegates to `ledger.answer`/`ledger.waive`; legacy beads keep current behavior)
+- [X] T030 [US2] Update `_chain_epic` in `src/maverick/workflows/refuel_speckit/workflow.py:442-462`: sort open epics deterministically by `speckit_feature` NNN prefix and wire `blocks` edges from `open_high_entries_before` onto the new epic (T024 green)
+- [X] T031 [US2] Add integration test for quickstart Scenarios 3–4 (medium blocks land → answer unblocks; high blocks next epic in `bd ready` → waive releases; high-on-last-spec degrades to medium) in `tests/integration/test_assumption_ledger_flow.py`
+
+**Checkpoint**: Severity policy enforced end-to-end; US1 + US2 both work.
+
+---
+
+## Phase 5: User Story 3 - Human queue surfaces through bd (Priority: P3)
+
+**Goal**: Open medium/high entries appear in `bd ready` as human work with
+full decision context reachable from `maverick review`; agents keep skipping
+them.
+
+**Independent Test**: quickstart Scenario 5 — `bd ready` lists entries,
+`maverick review <id>` shows question/answer/alternatives/severity/spec/
+stamps/source, `select_next_bead` still skips them.
+
+### Tests for User Story 3 (write first, ensure they FAIL)
+
+- [X] T032 [P] [US3] Write failing tests for the review command's ledger display — question, adopted answer, alternatives, severity with `(defaulted)` marker, owning spec, change stamps or `unstamped`, discovered-from source — in `tests/unit/cli/test_review_command.py`
+- [X] T033 [P] [US3] Add regression tests that ledger beads (new `assumption` label set) are skipped by `select_next_bead` in `tests/unit/library/actions/test_beads_actions.py` (existing select-next-bead test module)
+- [X] T034 [P] [US3] Add regression tests that `brief --human` lists ledger entries with their state context in `tests/unit/cli/test_brief_command.py`
+
+### Implementation for User Story 3
+
+- [X] T035 [US3] Implement the full-context ledger display in `src/maverick/cli/commands/review.py` (reads via a `ledger` load helper returning `AssumptionRecord`; Rich formatting per CLI standards) (T032 green)
+- [X] T036 [US3] Verify/adjust `_brief_human` in `src/maverick/cli/commands/brief.py` so ledger entries render alongside legacy escalation beads without error (new state keys shown when present) (T034 green)
+
+**Checkpoint**: Human queue fully navigable; all three enforcement/queue stories done.
+
+---
+
+## Phase 6: User Story 4 - Per-spec assumption counts (Priority: P4)
+
+**Goal**: `maverick brief` reports per-spec assumption counts (severity ×
+open/answered/waived, legacy bucket, explicit zero rows) as a spec-quality
+signal.
+
+**Independent Test**: quickstart Scenario 6 — two specs (one with entries, one
+without) both appear in the brief table and `--format json` output.
+
+### Tests for User Story 4 (write first, ensure they FAIL)
+
+- [X] T037 [P] [US4] Write failing tests for `per_spec_counts` — grouping by `assumption_owner_spec`, severity × status matrix, legacy bucket, zero rows for entry-less epics, deterministic ordering — in `tests/unit/assumptions/test_report.py`
+- [X] T038 [P] [US4] Write failing CLI tests for the brief Assumptions section — default text table incl. zero rows, `--human` inclusion, `--format json` `assumption_counts` array, section omitted when bead store absent — in `tests/unit/cli/test_brief_command.py`
+
+### Implementation for User Story 4
+
+- [X] T039 [US4] Implement `per_spec_counts` in `src/maverick/assumptions/report.py` (T037 green)
+- [X] T040 [US4] Add the Assumptions section to `src/maverick/cli/commands/brief.py` (text table, `--human` view, JSON output) per `contracts/cli.md` (T038 green)
+
+**Checkpoint**: All four user stories independently functional.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T041 [P] Update `CLAUDE.md` (CLI Workflows section: land gate, review answer/waive, brief assumptions section) and add `docs/` notes if a docs page covers fly/land behavior
+- [X] T042 [P] Add FR-013 legacy-compatibility integration coverage: a pre-feature escalation bead (old labels, no ledger state) flows through brief, review, and the land gate without errors in `tests/integration/test_assumption_ledger_flow.py`
+- [X] T043 Execute quickstart.md scenarios end-to-end against a throwaway repo fixture; fix any drift between quickstart and behavior
+- [X] T044 Run `make format-fix && make ci`; fix all failures (tree stays green per Constitution XII)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: none — start immediately
+- **Foundational (Phase 2)**: after T001; **blocks all stories** (enum, payloads, domain models)
+- **US1 (Phase 3)**: after Phase 2 — the MVP; no dependency on other stories
+- **US2 (Phase 4)**: after Phase 2; policy hooks (T025) extend `record_assumption` from T012, so schedule after US1's ledger core (T012–T013) if run sequentially
+- **US3 (Phase 5)**: after Phase 2; display tasks touch `review.py` — coordinate with US2's T029 (same file) if parallelizing
+- **US4 (Phase 6)**: after Phase 2; T040 touches `brief.py` — coordinate with US3's T036 (same file)
+- **Polish (Phase 7)**: after all desired stories
+
+### Key task-level dependencies
+
+- T005–T007 unblock everything downstream; T008 needs T005
+- T012 ← T009; T013 ← T010; T014–T017 ← T011 + T012 + T013; T016 ← T015; T017 ← T016
+- T025 ← T012 + T020; T026 ← T021; T027 ← T022; T028 ← T023 + T027; T029 ← T026; T030 ← T024 + T027
+- T035 ← T032 (+ record loading from T012); T036 ← T034
+- T039 ← T037; T040 ← T038 + T039
+
+### Parallel Opportunities
+
+- Phase 2 test-writing: T002, T003, T004 in parallel (different files)
+- US1 test-writing: T009, T010, T011 in parallel; T018 (prompts) parallel with T012–T017 (different files)
+- US2 test-writing: T020–T024 all parallel (five different files)
+- Cross-story: after Phase 2, US1 and the US2 CLI/refuel test authoring (T023, T024) can proceed concurrently; US3/US4 test authoring likewise
+- Same-file collision watch: `actions.py` (T014, T015, T017 — sequential), `ledger.py` (T012, T013, T025–T027 — sequential), `review.py` (T029, T035), `brief.py` (T036, T040)
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch US1 test authoring together (three different files):
+Task: "record_assumption tests in tests/unit/assumptions/test_ledger_record.py"
+Task: "stamp_change_id tests in tests/unit/assumptions/test_ledger_stamp.py"
+Task: "fly wiring tests in tests/unit/workflows/fly_beads/test_assumption_actions.py"
+
+# Then implement sequentially where files collide (ledger.py, actions.py),
+# with prompt updates in parallel:
+Task: "Prompt-builder updates in src/maverick/agents/"
+```
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+1. Phase 1 + Phase 2 (T001–T008)
+2. Phase 3 (T009–T019)
+3. **STOP and VALIDATE**: quickstart Scenario 1 — entries recorded, linked, stamped
+4. Ship: the ledger records everything even before policy/queue/report exist
+
+### Incremental Delivery
+
+1. + US2 → severity enforcement (land gate, next-epic blocking, answer/waive) → Scenarios 2–4
+2. + US3 → queue navigability → Scenario 5
+3. + US4 → per-spec quality signal → Scenario 6
+4. Polish → legacy coverage, docs, `make ci`
+
+Each increment leaves earlier stories fully working; nothing in a later story
+rewrites an earlier contract.

--- a/src/maverick/agents/system_prompts/maverick.completeness-reviewer.md
+++ b/src/maverick/agents/system_prompts/maverick.completeness-reviewer.md
@@ -66,6 +66,16 @@ it differently" — even when you strongly prefer the alternative. The
 implementer works within single-bead scope; out-of-scope concerns
 should be `minor` at most.
 
+## Reporting Assumptions
+
+If judging completeness forces you to adopt an assumption — e.g. an
+acceptance criterion is ambiguous and you pick an interpretation —
+report it in the `assumptions` field of your structured output: the
+`question`, your `adopted_answer`, the `alternatives` you considered,
+and a `severity` (`low` = cosmetic/local, `medium` = owning spec's
+correctness, `high` = decisions later specs will build on). This is
+additive — most reviews will have none to report.
+
 ## Output Format
 
 Return your output by calling the StructuredOutput tool with the schema

--- a/src/maverick/agents/system_prompts/maverick.correctness-reviewer.md
+++ b/src/maverick/agents/system_prompts/maverick.correctness-reviewer.md
@@ -62,6 +62,16 @@ preferences that have real downside.
 `minor` covers style suggestions, alternative approaches, and "I'd have
 done it differently" — even when you strongly prefer the alternative.
 
+## Reporting Assumptions
+
+If judging correctness forces you to adopt an assumption — e.g. the
+"right" behavior is ambiguous and you pick one to review against —
+report it in the `assumptions` field of your structured output: the
+`question`, your `adopted_answer`, the `alternatives` you considered,
+and a `severity` (`low` = cosmetic/local, `medium` = owning spec's
+correctness, `high` = decisions later specs will build on). This is
+additive — most reviews will have none to report.
+
 ## Output Format
 
 Return your output by calling the StructuredOutput tool with the schema

--- a/src/maverick/agents/system_prompts/maverick.implementer.md
+++ b/src/maverick/agents/system_prompts/maverick.implementer.md
@@ -148,6 +148,21 @@ code.
   existing patterns. Match the style and conventions of surrounding
   code.
 
+## Reporting Assumptions
+
+When you adopt an assumption to keep working — a design or scoping
+decision the bead description doesn't settle — report it in the
+`assumptions` field of your structured output: the `question`, your
+`adopted_answer`, the `alternatives` you considered, and a `severity`
+reflecting the blast radius of being wrong:
+
+- `low` — cosmetic or local; affects only this bead.
+- `medium` — affects the correctness of the owning spec.
+- `high` — a decision later specs will build on.
+
+Recording an assumption is additive — it never replaces implementing
+the bead, and most beads will have none to report.
+
 ## Output Format
 
 Return your output by calling the StructuredOutput tool with the

--- a/src/maverick/assumptions/__init__.py
+++ b/src/maverick/assumptions/__init__.py
@@ -1,0 +1,67 @@
+"""Assumption ledger — structured, bd-native tracking of adopted assumptions.
+
+Public API re-exported here; nothing in this package imports workflow or
+CLI modules (research R13). See ``specs/049-assumption-ledger/contracts/``.
+"""
+
+from __future__ import annotations
+
+from maverick.assumptions.errors import AssumptionLedgerError
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    ASSUMPTION_LABELS,
+    ASSUMPTION_REVIEW_LABEL,
+    DEFAULT_SEVERITY,
+    EPIC_KEY_FLIGHT_PLAN_NAME,
+    EPIC_KEY_SPECKIT_FEATURE,
+    KEY_ANSWER,
+    KEY_CHANGE_IDS,
+    KEY_OWNER_SPEC,
+    KEY_SEVERITY,
+    KEY_SEVERITY_DEFAULTED,
+    KEY_SOURCE_BEAD,
+    KEY_STATUS,
+    KEY_WAIVE_REASON,
+    KEY_WAIVED_AT,
+    KEY_WAIVED_BY,
+    NEEDS_HUMAN_REVIEW_LABEL,
+    STATUS_ANSWERED,
+    STATUS_OPEN,
+    STATUS_WAIVED,
+    AssumptionRecord,
+    PerSpecAssumptionCounts,
+    Severity,
+    StampResult,
+    coerce_severity,
+    nnn_prefix,
+)
+
+__all__ = [
+    "ASSUMPTION_LABEL",
+    "ASSUMPTION_LABELS",
+    "ASSUMPTION_REVIEW_LABEL",
+    "DEFAULT_SEVERITY",
+    "EPIC_KEY_FLIGHT_PLAN_NAME",
+    "EPIC_KEY_SPECKIT_FEATURE",
+    "KEY_ANSWER",
+    "KEY_CHANGE_IDS",
+    "KEY_OWNER_SPEC",
+    "KEY_SEVERITY",
+    "KEY_SEVERITY_DEFAULTED",
+    "KEY_SOURCE_BEAD",
+    "KEY_STATUS",
+    "KEY_WAIVE_REASON",
+    "KEY_WAIVED_AT",
+    "KEY_WAIVED_BY",
+    "NEEDS_HUMAN_REVIEW_LABEL",
+    "STATUS_ANSWERED",
+    "STATUS_OPEN",
+    "STATUS_WAIVED",
+    "AssumptionLedgerError",
+    "AssumptionRecord",
+    "PerSpecAssumptionCounts",
+    "Severity",
+    "StampResult",
+    "coerce_severity",
+    "nnn_prefix",
+]

--- a/src/maverick/assumptions/errors.py
+++ b/src/maverick/assumptions/errors.py
@@ -1,0 +1,13 @@
+"""Exceptions for assumption ledger operations."""
+
+from __future__ import annotations
+
+from maverick.exceptions.base import MaverickError
+
+
+class AssumptionLedgerError(MaverickError):
+    """Raised when a bd-layer operation on a ledger entry fails.
+
+    Attributes:
+        message: Human-readable error message.
+    """

--- a/src/maverick/assumptions/ledger.py
+++ b/src/maverick/assumptions/ledger.py
@@ -1,0 +1,715 @@
+"""Ledger operations: record, stamp, resolve, and query assumption entries.
+
+Every function takes an explicit ``cwd``-scoped ``BeadClient`` (Guardrail 7 —
+no ``Path.cwd()`` defaults) and returns frozen dataclasses from
+``maverick.assumptions.models``. See
+``specs/049-assumption-ledger/contracts/ledger-api.md``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from maverick.assumptions.errors import AssumptionLedgerError
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    ASSUMPTION_LABELS,
+    ASSUMPTION_REVIEW_LABEL,
+    EPIC_KEY_FLIGHT_PLAN_NAME,
+    EPIC_KEY_SPECKIT_FEATURE,
+    KEY_ANSWER,
+    KEY_CHANGE_IDS,
+    KEY_OWNER_SPEC,
+    KEY_SEVERITY,
+    KEY_SEVERITY_DEFAULTED,
+    KEY_SOURCE_BEAD,
+    KEY_STATUS,
+    KEY_WAIVE_REASON,
+    KEY_WAIVED_AT,
+    KEY_WAIVED_BY,
+    STATUS_ANSWERED,
+    STATUS_OPEN,
+    STATUS_WAIVED,
+    AssumptionRecord,
+    Severity,
+    StampResult,
+    coerce_severity,
+    nnn_prefix,
+)
+from maverick.exceptions.beads import BeadError
+from maverick.logging import get_logger
+
+if TYPE_CHECKING:
+    from maverick.beads.client import BeadClient
+    from maverick.payloads import AssumptionPayload
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "answer",
+    "next_chained_epic",
+    "open_blocking_entries",
+    "open_high_entries_before",
+    "parse_description",
+    "record_assumption",
+    "stamp_change_id",
+    "waive",
+]
+
+# Statuses that mean "not open" for dedup / query purposes — bd's own
+# vocabulary includes "closed" and "done" for finished beads.
+_CLOSED_STATUSES = frozenset(("closed", "done"))
+
+_SEVERITY_PRIORITY: dict[Severity, int] = {
+    Severity.HIGH: 1,
+    Severity.MEDIUM: 2,
+    Severity.LOW: 3,
+}
+
+_TITLE_MAX_LEN = 150
+
+
+def _normalize_question(question: str) -> str:
+    """Casefold + collapse-whitespace normalization for dedup matching."""
+    return " ".join(question.split()).casefold()
+
+
+def _section(description: str, marker: str, next_markers: tuple[str, ...]) -> str:
+    """Return the body of one ``## <marker>`` section, bounded by the next heading."""
+    idx = description.find(marker)
+    if idx == -1:
+        return ""
+    rest = description[idx + len(marker) :]
+    end = len(rest)
+    for next_marker in next_markers:
+        pos = rest.find(next_marker)
+        if pos != -1:
+            end = min(end, pos)
+    return rest[:end].strip()
+
+
+def parse_description(description: str) -> tuple[str, str, tuple[str, ...]]:
+    """Parse an entry's fixed markdown description back into its parts.
+
+    Returns ``(question, adopted_answer, alternatives)`` — the inverse of
+    :func:`_build_description`. Used by the ledger's own dedup matching
+    and by ``maverick review``'s full-context display.
+    """
+    question = _section(
+        description,
+        "## Question",
+        ("## Adopted Answer", "## Alternatives Considered", "## Context"),
+    )
+    adopted_answer = _section(
+        description, "## Adopted Answer", ("## Alternatives Considered", "## Context")
+    )
+    alt_body = _section(description, "## Alternatives Considered", ("## Context",))
+    alternatives = (
+        tuple(
+            line.strip()[2:].strip()
+            for line in alt_body.splitlines()
+            if line.strip().startswith("- ")
+        )
+        if alt_body and alt_body != "(none)"
+        else ()
+    )
+    return question, adopted_answer, alternatives
+
+
+def _extract_question(description: str) -> str:
+    """Pull the ``## Question`` section body out of an entry's description."""
+    return parse_description(description)[0]
+
+
+def _build_description(
+    *,
+    question: str,
+    adopted_answer: str,
+    alternatives: Sequence[str],
+    source_bead_id: str,
+    source_title: str,
+) -> str:
+    alt_body = "\n".join(f"- {alt}" for alt in alternatives) if alternatives else "(none)"
+    return (
+        "## Question\n\n"
+        f"{question}\n\n"
+        "## Adopted Answer\n\n"
+        f"{adopted_answer}\n\n"
+        "## Alternatives Considered\n\n"
+        f"{alt_body}\n\n"
+        "## Context\n\n"
+        f"Source bead: {source_bead_id} — {source_title}\n"
+    )
+
+
+async def _derive_owner_spec(client: BeadClient, *, epic_id: str) -> dict[str, str]:
+    """Return the owning epic's state, raising :class:`AssumptionLedgerError` on bd failure.
+
+    Returns an empty mapping when *epic_id* is empty (the global
+    ``maverick fly`` path with no resolvable owning epic) rather than
+    issuing a ``bd show ""`` that would crash and silently drop the entry.
+    """
+    if not epic_id:
+        return {}
+    try:
+        epic_details = await client.show(epic_id)
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to load epic {epic_id}: {exc}") from exc
+    return dict(epic_details.state or {})
+
+
+async def _resolve_owning_epic(client: BeadClient, *, epic_id: str, source_bead_id: str) -> str:
+    """Resolve the epic that should own this assumption entry.
+
+    On the global ``maverick fly`` path (no ``--epic`` filter) *epic_id*
+    is empty; fall back to the source bead's parent epic so the ledger
+    entry is still parented under a real epic and ``owner_spec`` still
+    resolves. Returns ``""`` only when neither is available (best-effort —
+    the entry is still recorded, just unparented).
+    """
+    if epic_id:
+        return epic_id
+    try:
+        source_details = await client.show(source_bead_id)
+    except BeadError:
+        return ""
+    return source_details.parent_id or ""
+
+
+def _owner_spec_from_epic_state(epic_state: dict[str, str], *, epic_id: str) -> str:
+    return (
+        epic_state.get(EPIC_KEY_SPECKIT_FEATURE)
+        or epic_state.get(EPIC_KEY_FLIGHT_PLAN_NAME)
+        or epic_id
+    )
+
+
+async def _find_existing_open_entry(
+    client: BeadClient,
+    *,
+    epic_id: str,
+    normalized_question: str,
+) -> AssumptionRecord | None:
+    """Search open ``assumption`` children of *epic_id* for a question match."""
+    if not epic_id:
+        return None
+    try:
+        children = await client.children(epic_id)
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to list children of {epic_id}: {exc}") from exc
+
+    for child in children:
+        if child.status in _CLOSED_STATUSES:
+            continue
+        try:
+            details = await client.show(child.id)
+        except BeadError as exc:
+            raise AssumptionLedgerError(f"Failed to load bead {child.id}: {exc}") from exc
+        if "assumption" not in (details.labels or []):
+            continue
+        if _normalize_question(_extract_question(details.description)) == normalized_question:
+            return _record_from_details(details)
+    return None
+
+
+def _record_from_details(details: object) -> AssumptionRecord:
+    """Reconstruct an :class:`AssumptionRecord` from a ``BeadDetails``."""
+    state: dict[str, str] = dict(getattr(details, "state", None) or {})
+    severity, _ = coerce_severity(state.get(KEY_SEVERITY))
+    change_ids_raw = state.get(KEY_CHANGE_IDS, "")
+    change_ids = tuple(c for c in change_ids_raw.split(",") if c) if change_ids_raw else ()
+    description = getattr(details, "description", "") or ""
+    question, adopted_answer, alternatives = parse_description(description)
+    return AssumptionRecord(
+        bead_id=getattr(details, "id", ""),
+        question=question,
+        adopted_answer=adopted_answer,
+        alternatives=alternatives,
+        severity=severity,
+        severity_defaulted=state.get(KEY_SEVERITY_DEFAULTED) == "true",
+        status=state.get(KEY_STATUS, STATUS_OPEN),
+        owner_spec=state.get(KEY_OWNER_SPEC, ""),
+        source_bead=state.get(KEY_SOURCE_BEAD, ""),
+        change_ids=change_ids,
+        is_legacy=False,
+    )
+
+
+def _legacy_record_from_details(details: object) -> AssumptionRecord:
+    """Build a synthetic record for a pre-feature escalation bead (FR-013).
+
+    Legacy beads have the ``assumption-review``/``needs-human-review``
+    labels but no ledger state — treated as ``medium`` severity at read
+    time, without mutating the bead.
+    """
+    state: dict[str, str] = dict(getattr(details, "state", None) or {})
+    return AssumptionRecord(
+        bead_id=getattr(details, "id", ""),
+        question=getattr(details, "title", ""),
+        adopted_answer="",
+        alternatives=(),
+        severity=Severity.MEDIUM,
+        severity_defaulted=True,
+        status=STATUS_OPEN,
+        owner_spec=state.get(KEY_OWNER_SPEC) or state.get("flight_plan", ""),
+        source_bead=state.get(KEY_SOURCE_BEAD, ""),
+        change_ids=(),
+        is_legacy=True,
+    )
+
+
+async def next_chained_epic(client: BeadClient, *, epic_id: str) -> str | None:
+    """Discovery rule for the high-severity blocks-edge target.
+
+    Among open epics with a ``speckit_feature`` state value, returns the
+    one with the smallest NNN prefix strictly greater than the owning
+    epic's — the same ordering ``_chain_epic`` uses. Returns ``None``
+    when the owning epic has no ``speckit_feature`` (flight-plan runs
+    never wire next-epic edges) or no later epic exists.
+    """
+    try:
+        epic_details = await client.show(epic_id)
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to load epic {epic_id}: {exc}") from exc
+
+    owning_prefix = nnn_prefix((epic_details.state or {}).get(EPIC_KEY_SPECKIT_FEATURE, ""))
+    if owning_prefix is None:
+        return None
+
+    try:
+        candidates = await client.query("type=epic AND status=open")
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to query open epics: {exc}") from exc
+
+    best_id: str | None = None
+    best_prefix: int | None = None
+    for candidate in candidates:
+        if candidate.id == epic_id:
+            continue
+        try:
+            details = await client.show(candidate.id)
+        except BeadError as exc:
+            raise AssumptionLedgerError(f"Failed to load epic {candidate.id}: {exc}") from exc
+        prefix = nnn_prefix((details.state or {}).get(EPIC_KEY_SPECKIT_FEATURE, ""))
+        if prefix is None or prefix <= owning_prefix:
+            continue
+        if best_prefix is None or prefix < best_prefix:
+            best_prefix = prefix
+            best_id = candidate.id
+    return best_id
+
+
+async def _wire_high_blocks_edge(client: BeadClient, *, entry_id: str, epic_id: str) -> None:
+    """Wire a ``blocks`` edge from a high-severity entry onto the next spec's epic."""
+    from maverick.beads.models import BeadDependency, DependencyType
+
+    next_epic_id = await next_chained_epic(client, epic_id=epic_id)
+    if not next_epic_id:
+        return
+    try:
+        await client.add_dependency(
+            BeadDependency(
+                blocker_id=entry_id,
+                blocked_id=next_epic_id,
+                dep_type=DependencyType.BLOCKS,
+            )
+        )
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to wire blocks edge for {entry_id}: {exc}") from exc
+
+
+async def _maybe_escalate_severity(
+    client: BeadClient,
+    *,
+    existing: AssumptionRecord,
+    new_severity: Severity,
+    new_defaulted: bool,
+    epic_id: str,
+) -> AssumptionRecord:
+    """Raise an existing open entry's severity when a re-report is more severe.
+
+    A later bead re-reporting the same question at a higher severity must
+    strengthen enforcement, not inherit the weaker original: the stored
+    ``assumption_severity`` is bumped so the land gate and ``brief`` reflect
+    the true blast radius, and — when the escalation reaches ``high`` — the
+    ``blocks`` edge onto the next spec's epic is wired. Returns the updated
+    record, or *existing* unchanged when the re-report is no more severe.
+    """
+    if _SEVERITY_PRIORITY[new_severity] >= _SEVERITY_PRIORITY[existing.severity]:
+        return existing
+
+    state: dict[str, str] = {KEY_SEVERITY: new_severity.value}
+    state[KEY_SEVERITY_DEFAULTED] = "true" if new_defaulted else "false"
+    try:
+        await client.set_state(
+            existing.bead_id,
+            state,
+            reason=(f"severity escalated {existing.severity.value} -> {new_severity.value}"),
+        )
+    except BeadError as exc:
+        raise AssumptionLedgerError(
+            f"Failed to escalate severity on {existing.bead_id}: {exc}"
+        ) from exc
+
+    if new_severity is Severity.HIGH and epic_id:
+        await _wire_high_blocks_edge(client, entry_id=existing.bead_id, epic_id=epic_id)
+
+    logger.info(
+        "assumption_severity_escalated",
+        bead_id=existing.bead_id,
+        from_severity=existing.severity.value,
+        to_severity=new_severity.value,
+    )
+    return replace(
+        existing,
+        severity=new_severity,
+        severity_defaulted=new_defaulted,
+    )
+
+
+async def record_assumption(
+    client: BeadClient,
+    *,
+    payload: AssumptionPayload,
+    source_bead_id: str,
+    epic_id: str,
+) -> AssumptionRecord | None:
+    """Create (or merge into) a ledger entry for one reported assumption.
+
+    Derives the owning spec from the epic's state, applies the severity
+    coercion rule, wires a ``discovered-from`` edge to *source_bead_id*, and
+    dedups against open entries with the same normalized question under the
+    same epic (appending a discovered-from edge to the existing entry
+    instead of creating a duplicate).
+
+    Raises:
+        AssumptionLedgerError: On any bd-layer failure.
+    """
+    from maverick.beads.models import (
+        BeadCategory,
+        BeadDefinition,
+        BeadDependency,
+        BeadType,
+        DependencyType,
+    )
+
+    severity, defaulted_here = coerce_severity(payload.severity)
+    defaulted = bool(payload.severity_defaulted) or defaulted_here
+
+    # On the global ``maverick fly`` path epic_id is "" (no --epic filter);
+    # resolve the source bead's real owning epic so the entry is parented
+    # and owner_spec resolves instead of being silently dropped.
+    effective_epic_id = await _resolve_owning_epic(
+        client, epic_id=epic_id, source_bead_id=source_bead_id
+    )
+
+    epic_state = await _derive_owner_spec(client, epic_id=effective_epic_id)
+    owner_spec = _owner_spec_from_epic_state(epic_state, epic_id=effective_epic_id)
+
+    normalized_question = _normalize_question(payload.question)
+    existing = await _find_existing_open_entry(
+        client, epic_id=effective_epic_id, normalized_question=normalized_question
+    )
+    if existing is not None:
+        try:
+            await client.add_dependency(
+                BeadDependency(
+                    blocker_id=source_bead_id,
+                    blocked_id=existing.bead_id,
+                    dep_type=DependencyType.DISCOVERED_FROM,
+                )
+            )
+        except BeadError as exc:
+            raise AssumptionLedgerError(
+                f"Failed to wire discovered-from edge onto {existing.bead_id}: {exc}"
+            ) from exc
+        escalated = await _maybe_escalate_severity(
+            client,
+            existing=existing,
+            new_severity=severity,
+            new_defaulted=defaulted,
+            epic_id=effective_epic_id,
+        )
+        logger.info(
+            "assumption_dedup_merged",
+            bead_id=existing.bead_id,
+            source_bead_id=source_bead_id,
+            escalated_to=escalated.severity.value if escalated is not existing else None,
+        )
+        return escalated
+
+    try:
+        source_title = source_bead_id
+        source_details = await client.show(source_bead_id)
+        source_title = source_details.title or source_bead_id
+    except BeadError:
+        pass  # best-effort context line only
+
+    definition = BeadDefinition(
+        title=f"Assumption: {payload.question[:_TITLE_MAX_LEN]}",
+        bead_type=BeadType.TASK,
+        priority=_SEVERITY_PRIORITY[severity],
+        category=BeadCategory.REVIEW,
+        description=_build_description(
+            question=payload.question,
+            adopted_answer=payload.adopted_answer,
+            alternatives=payload.alternatives,
+            source_bead_id=source_bead_id,
+            source_title=source_title,
+        ),
+        assignee="human",
+        labels=list(ASSUMPTION_LABELS),
+    )
+
+    try:
+        created = await client.create_bead(definition, parent_id=effective_epic_id or None)
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to create assumption bead: {exc}") from exc
+
+    state: dict[str, str] = {
+        KEY_SEVERITY: severity.value,
+        KEY_STATUS: STATUS_OPEN,
+        KEY_OWNER_SPEC: owner_spec,
+        KEY_SOURCE_BEAD: source_bead_id,
+    }
+    if defaulted:
+        state[KEY_SEVERITY_DEFAULTED] = "true"
+
+    try:
+        await client.set_state(
+            created.bd_id, state, reason=f"assumption recorded from {source_bead_id}"
+        )
+    except BeadError as exc:
+        raise AssumptionLedgerError(
+            f"Failed to set state on assumption bead {created.bd_id}: {exc}"
+        ) from exc
+
+    try:
+        await client.add_dependency(
+            BeadDependency(
+                blocker_id=source_bead_id,
+                blocked_id=created.bd_id,
+                dep_type=DependencyType.DISCOVERED_FROM,
+            )
+        )
+    except BeadError as exc:
+        raise AssumptionLedgerError(
+            f"Failed to wire discovered-from edge for {created.bd_id}: {exc}"
+        ) from exc
+
+    if severity is Severity.LOW:
+        from maverick.library.actions.beads import defer_bead
+
+        try:
+            await defer_bead(
+                created.bd_id, cwd=client.cwd, reason="low-severity assumption — advisory only"
+            )
+        except Exception as exc:  # noqa: BLE001 — defer_bead has no typed error hierarchy
+            raise AssumptionLedgerError(
+                f"Failed to defer low-severity entry {created.bd_id}: {exc}"
+            ) from exc
+    elif severity is Severity.HIGH and effective_epic_id:
+        await _wire_high_blocks_edge(client, entry_id=created.bd_id, epic_id=effective_epic_id)
+
+    logger.info(
+        "assumption_recorded",
+        bead_id=created.bd_id,
+        severity=severity.value,
+        owner_spec=owner_spec,
+        source_bead_id=source_bead_id,
+    )
+    return AssumptionRecord(
+        bead_id=created.bd_id,
+        question=payload.question,
+        adopted_answer=payload.adopted_answer,
+        alternatives=tuple(payload.alternatives),
+        severity=severity,
+        severity_defaulted=defaulted,
+        status=STATUS_OPEN,
+        owner_spec=owner_spec,
+        source_bead=source_bead_id,
+        change_ids=(),
+        is_legacy=False,
+    )
+
+
+async def stamp_change_id(
+    client: BeadClient,
+    *,
+    entry_ids: Sequence[str],
+    change_id: str,
+) -> StampResult:
+    """Append *change_id* to each entry's ``assumption_change_ids`` state.
+
+    Append-only and idempotent per ``(entry, change_id)``. Never raises —
+    a commit must not fail because stamping failed (FR-012); per-entry
+    failures are reported in the returned :class:`StampResult`.
+    """
+    stamped: list[str] = []
+    failed: dict[str, str] = {}
+
+    for entry_id in entry_ids:
+        try:
+            details = await client.show(entry_id)
+            existing_raw = (details.state or {}).get(KEY_CHANGE_IDS, "")
+            existing_ids = [c for c in existing_raw.split(",") if c] if existing_raw else []
+            if change_id in existing_ids:
+                stamped.append(entry_id)
+                continue
+            existing_ids.append(change_id)
+            await client.set_state(
+                entry_id,
+                {KEY_CHANGE_IDS: ",".join(existing_ids)},
+                reason=f"stamp {change_id}",
+            )
+            stamped.append(entry_id)
+        except Exception as exc:  # noqa: BLE001 — never raises (FR-012)
+            logger.warning("assumption_stamp_failed", bead_id=entry_id, error=str(exc))
+            failed[entry_id] = str(exc)
+
+    return StampResult(change_id=change_id, stamped=tuple(stamped), failed=failed)
+
+
+async def answer(
+    client: BeadClient,
+    *,
+    bead_id: str,
+    answer_text: str,
+) -> AssumptionRecord:
+    """Record an answer, mark the entry answered, and close it.
+
+    Closing releases any ``blocks`` edges wired for this entry (bd's own
+    dependency-release semantics).
+
+    Raises:
+        AssumptionLedgerError: If *answer_text* is empty, or on bd failure.
+    """
+    if not answer_text or not answer_text.strip():
+        raise AssumptionLedgerError("Answer text must not be empty")
+
+    try:
+        await client.set_state(
+            bead_id,
+            {KEY_ANSWER: answer_text, KEY_STATUS: STATUS_ANSWERED},
+            reason="assumption answered",
+        )
+        await client.close(bead_id, reason="assumption answered")
+        details = await client.show(bead_id)
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to answer {bead_id}: {exc}") from exc
+
+    logger.info("assumption_answered", bead_id=bead_id)
+    return _record_from_details(details)
+
+
+async def waive(
+    client: BeadClient,
+    *,
+    bead_id: str,
+    reason: str,
+    waived_by: str,
+) -> AssumptionRecord:
+    """Record a waiver (who/when/why), mark the entry waived, and close it.
+
+    Closing releases any ``blocks`` edges wired for this entry (bd's own
+    dependency-release semantics).
+
+    Raises:
+        AssumptionLedgerError: If *reason* is empty, or on bd failure.
+    """
+    if not reason or not reason.strip():
+        raise AssumptionLedgerError("Waive reason must not be empty")
+
+    waived_at = datetime.now(UTC).isoformat()
+    try:
+        await client.set_state(
+            bead_id,
+            {
+                KEY_WAIVED_BY: waived_by,
+                KEY_WAIVED_AT: waived_at,
+                KEY_WAIVE_REASON: reason,
+                KEY_STATUS: STATUS_WAIVED,
+            },
+            reason="assumption waived",
+        )
+        await client.close(bead_id, reason=f"waived: {reason[:200]}")
+        details = await client.show(bead_id)
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to waive {bead_id}: {exc}") from exc
+
+    logger.info("assumption_waived", bead_id=bead_id, waived_by=waived_by)
+    return _record_from_details(details)
+
+
+async def open_blocking_entries(client: BeadClient) -> tuple[AssumptionRecord, ...]:
+    """Open entries with severity in {medium, high} — powers the land gate.
+
+    Includes legacy escalation beads (``assumption-review`` label without
+    ``assumption``), surfaced with ``severity=medium``/``is_legacy=True``.
+    """
+    try:
+        candidates = await client.query("type=task AND status=open")
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to query open task beads: {exc}") from exc
+
+    records: list[AssumptionRecord] = []
+    for candidate in candidates:
+        try:
+            details = await client.show(candidate.id)
+        except BeadError as exc:
+            raise AssumptionLedgerError(f"Failed to load bead {candidate.id}: {exc}") from exc
+        labels = details.labels or []
+        if ASSUMPTION_LABEL in labels:
+            record = _record_from_details(details)
+            if record.status == STATUS_OPEN and record.severity in (
+                Severity.MEDIUM,
+                Severity.HIGH,
+            ):
+                records.append(record)
+        elif ASSUMPTION_REVIEW_LABEL in labels:
+            records.append(_legacy_record_from_details(details))
+    return tuple(records)
+
+
+async def open_high_entries_before(
+    client: BeadClient,
+    *,
+    epic_id: str,
+) -> tuple[AssumptionRecord, ...]:
+    """Open high-severity entries owned by specs ordered before *epic_id*.
+
+    Powers ``_chain_epic`` wiring at refuel time (research R8). Returns an
+    empty tuple when *epic_id* has no ``speckit_feature`` NNN prefix.
+    """
+    try:
+        epic_details = await client.show(epic_id)
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to load epic {epic_id}: {exc}") from exc
+
+    target_prefix = nnn_prefix((epic_details.state or {}).get(EPIC_KEY_SPECKIT_FEATURE, ""))
+    if target_prefix is None:
+        return ()
+
+    try:
+        candidates = await client.query("type=task AND status=open")
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to query open task beads: {exc}") from exc
+
+    records: list[AssumptionRecord] = []
+    for candidate in candidates:
+        try:
+            details = await client.show(candidate.id)
+        except BeadError as exc:
+            raise AssumptionLedgerError(f"Failed to load bead {candidate.id}: {exc}") from exc
+        if ASSUMPTION_LABEL not in (details.labels or []):
+            continue
+        record = _record_from_details(details)
+        if record.severity is not Severity.HIGH or record.status != STATUS_OPEN:
+            continue
+        owner_prefix = nnn_prefix(record.owner_spec)
+        if owner_prefix is not None and owner_prefix < target_prefix:
+            records.append(record)
+    return tuple(records)

--- a/src/maverick/assumptions/models.py
+++ b/src/maverick/assumptions/models.py
@@ -1,0 +1,162 @@
+"""Domain models and bead-schema constants for the assumption ledger.
+
+Every ledger entry is a bd bead (research R1) — these constants are the
+single source of truth for the labels/state-keys that shape reads/writes
+across the ledger, fly wiring, refuel chaining, and the land/review/brief
+CLI surfaces (Constitution VI — no magic strings at call sites).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class Severity(StrEnum):
+    """Assumption severity — drives the enforcement policy.
+
+    Attributes:
+        LOW: Advisory only; deferred out of the ready queue.
+        MEDIUM: Blocks ``maverick land`` until answered or waived.
+        HIGH: Blocks land and gains a ``blocks`` edge onto the next spec's epic.
+    """
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+#: Coercion target when a reported/read severity value is missing or
+#: outside {low, medium, high} (FR-011). Applied identically by
+#: ``AssumptionPayload`` (agent path) and ``ledger.record_assumption``
+#: (direct callers) — see contracts/ledger-api.md "Severity rule".
+DEFAULT_SEVERITY: Severity = Severity.MEDIUM
+
+
+def coerce_severity(value: str | None) -> tuple[Severity, bool]:
+    """Coerce a raw severity string, returning ``(severity, defaulted)``.
+
+    ``defaulted`` is True whenever *value* was missing or not one of
+    ``{low, medium, high}`` — the caller persists that as
+    ``assumption_severity_defaulted=true`` (FR-011). Never raises.
+    """
+    if value is not None:
+        try:
+            return Severity(value), False
+        except ValueError:
+            pass
+    return DEFAULT_SEVERITY, True
+
+
+#: Discriminator label for ledger entries. Combined with the two legacy
+#: escalation-bead labels so the existing agent-side skip filter
+#: (``library/actions/beads.py``) and ``brief --human`` keep working
+#: unchanged for ledger entries too (research R2).
+ASSUMPTION_LABEL = "assumption"
+ASSUMPTION_REVIEW_LABEL = "assumption-review"
+NEEDS_HUMAN_REVIEW_LABEL = "needs-human-review"
+ASSUMPTION_LABELS: tuple[str, ...] = (
+    ASSUMPTION_LABEL,
+    ASSUMPTION_REVIEW_LABEL,
+    NEEDS_HUMAN_REVIEW_LABEL,
+)
+
+# bd state keys (data-model.md "State keys").
+KEY_SEVERITY = "assumption_severity"
+KEY_SEVERITY_DEFAULTED = "assumption_severity_defaulted"
+KEY_STATUS = "assumption_status"
+KEY_OWNER_SPEC = "assumption_owner_spec"
+KEY_CHANGE_IDS = "assumption_change_ids"
+KEY_ANSWER = "assumption_answer"
+KEY_WAIVED_BY = "assumption_waived_by"
+KEY_WAIVED_AT = "assumption_waived_at"
+KEY_WAIVE_REASON = "assumption_waive_reason"
+KEY_SOURCE_BEAD = "source_bead"
+
+# Epic-level state keys read to derive ``assumption_owner_spec``
+# (research R3 — first match wins).
+EPIC_KEY_SPECKIT_FEATURE = "speckit_feature"
+EPIC_KEY_FLIGHT_PLAN_NAME = "flight_plan_name"
+
+# assumption_status values.
+STATUS_OPEN = "open"
+STATUS_ANSWERED = "answered"
+STATUS_WAIVED = "waived"
+
+
+def nnn_prefix(feature_name: str) -> int | None:
+    """Extract the leading ``NNN-`` numeric prefix from a spec identifier.
+
+    Returns ``None`` when *feature_name* doesn't start with a 3-digit
+    prefix (e.g. a flight-plan name, or a bare epic-ID fallback). Shared
+    ordering rule for ``ledger.next_chained_epic``/``open_high_entries_before``
+    and ``refuel_speckit._chain_epic`` (research R8).
+    """
+    match = re.match(r"^(\d{3})-", feature_name)
+    return int(match.group(1)) if match else None
+
+
+@dataclass(frozen=True, slots=True)
+class AssumptionRecord:
+    """One assumption ledger entry, read back from its bead.
+
+    Attributes:
+        bead_id: The entry's own bead ID.
+        question: The question the agent (or human) resolved.
+        adopted_answer: The answer that was adopted to keep working.
+        alternatives: Other answers considered.
+        severity: Enforcement severity.
+        severity_defaulted: True when severity was missing/invalid at creation.
+        status: ``"open"`` | ``"answered"`` | ``"waived"``.
+        owner_spec: Owning spec identifier (see ``EPIC_KEY_*`` derivation).
+        source_bead: The bead this entry was discovered from.
+        change_ids: jj change IDs stamping this entry; empty = unstamped.
+        is_legacy: True for pre-feature escalation beads without ledger state.
+    """
+
+    bead_id: str
+    question: str
+    adopted_answer: str
+    alternatives: tuple[str, ...]
+    severity: Severity
+    severity_defaulted: bool
+    status: str
+    owner_spec: str
+    source_bead: str
+    change_ids: tuple[str, ...]
+    is_legacy: bool
+
+
+@dataclass(frozen=True, slots=True)
+class PerSpecAssumptionCounts:
+    """Per-spec assumption counts aggregated for reporting.
+
+    Attributes:
+        owner_spec: Owning spec identifier.
+        open: Open-entry counts keyed by severity.
+        answered: Answered-entry counts keyed by severity.
+        waived: Waived-entry counts keyed by severity.
+        legacy_open: Open pre-feature escalation beads owned by this spec.
+    """
+
+    owner_spec: str
+    open: dict[Severity, int]
+    answered: dict[Severity, int]
+    waived: dict[Severity, int]
+    legacy_open: int
+
+
+@dataclass(frozen=True, slots=True)
+class StampResult:
+    """Outcome of stamping a batch of entries with a jj change ID.
+
+    Attributes:
+        change_id: The jj change ID that was stamped.
+        stamped: Bead IDs successfully stamped.
+        failed: ``{bead_id: error message}`` for entries that failed to stamp.
+    """
+
+    change_id: str
+    stamped: tuple[str, ...]
+    failed: dict[str, str]

--- a/src/maverick/assumptions/report.py
+++ b/src/maverick/assumptions/report.py
@@ -1,0 +1,108 @@
+"""Per-spec assumption aggregation for ``maverick brief`` and the land gate."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from maverick.assumptions.errors import AssumptionLedgerError
+from maverick.assumptions.ledger import _legacy_record_from_details, _record_from_details
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    ASSUMPTION_REVIEW_LABEL,
+    EPIC_KEY_FLIGHT_PLAN_NAME,
+    EPIC_KEY_SPECKIT_FEATURE,
+    STATUS_ANSWERED,
+    STATUS_OPEN,
+    STATUS_WAIVED,
+    PerSpecAssumptionCounts,
+    Severity,
+)
+from maverick.exceptions.beads import BeadError
+from maverick.logging import get_logger
+
+if TYPE_CHECKING:
+    from maverick.beads.client import BeadClient
+
+logger = get_logger(__name__)
+
+__all__ = ["per_spec_counts"]
+
+_CLOSED_STATUSES = frozenset(("closed", "done"))
+
+
+def _empty_severity_counts() -> dict[Severity, int]:
+    return {Severity.LOW: 0, Severity.MEDIUM: 0, Severity.HIGH: 0}
+
+
+async def per_spec_counts(client: BeadClient) -> tuple[PerSpecAssumptionCounts, ...]:
+    """Aggregate all ``assumption`` beads (+ legacy) by owning spec.
+
+    Every epic in the store yields a row even at zero counts (FR-010).
+    Legacy escalation beads (``assumption-review`` without ``assumption``)
+    are counted in a separate ``legacy_open`` bucket. Ordered by owner
+    spec identifier.
+    """
+    try:
+        epic_summaries = await client.query("type=epic")
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to query epics: {exc}") from exc
+
+    owner_specs: dict[str, None] = {}
+    for epic in epic_summaries:
+        try:
+            details = await client.show(epic.id)
+        except BeadError as exc:
+            raise AssumptionLedgerError(f"Failed to load epic {epic.id}: {exc}") from exc
+        spec = (
+            details.state.get(EPIC_KEY_SPECKIT_FEATURE)
+            or details.state.get(EPIC_KEY_FLIGHT_PLAN_NAME)
+            or epic.id
+        )
+        owner_specs.setdefault(spec, None)
+
+    try:
+        task_summaries = await client.query("type=task")
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to query task beads: {exc}") from exc
+
+    open_counts: dict[str, dict[Severity, int]] = {}
+    answered_counts: dict[str, dict[Severity, int]] = {}
+    waived_counts: dict[str, dict[Severity, int]] = {}
+    legacy_counts: dict[str, int] = {}
+
+    for candidate in task_summaries:
+        try:
+            details = await client.show(candidate.id)
+        except BeadError as exc:
+            raise AssumptionLedgerError(f"Failed to load bead {candidate.id}: {exc}") from exc
+        labels = details.labels or []
+
+        if ASSUMPTION_LABEL in labels:
+            record = _record_from_details(details)
+            owner_specs.setdefault(record.owner_spec, None)
+            if record.status == STATUS_OPEN:
+                bucket = open_counts.setdefault(record.owner_spec, _empty_severity_counts())
+            elif record.status == STATUS_ANSWERED:
+                bucket = answered_counts.setdefault(record.owner_spec, _empty_severity_counts())
+            elif record.status == STATUS_WAIVED:
+                bucket = waived_counts.setdefault(record.owner_spec, _empty_severity_counts())
+            else:
+                continue
+            bucket[record.severity] += 1
+        elif ASSUMPTION_REVIEW_LABEL in labels and details.status not in _CLOSED_STATUSES:
+            legacy = _legacy_record_from_details(details)
+            spec = legacy.owner_spec or "(unknown)"
+            owner_specs.setdefault(spec, None)
+            legacy_counts[spec] = legacy_counts.get(spec, 0) + 1
+
+    results = [
+        PerSpecAssumptionCounts(
+            owner_spec=spec,
+            open=open_counts.get(spec, _empty_severity_counts()),
+            answered=answered_counts.get(spec, _empty_severity_counts()),
+            waived=waived_counts.get(spec, _empty_severity_counts()),
+            legacy_open=legacy_counts.get(spec, 0),
+        )
+        for spec in sorted(owner_specs)
+    ]
+    return tuple(results)

--- a/src/maverick/beads/client.py
+++ b/src/maverick/beads/client.py
@@ -75,6 +75,11 @@ class BeadClient:
         self._cwd = cwd
         self._runner = runner or CommandRunner(cwd=cwd, timeout=BD_TIMEOUT)
 
+    @property
+    def cwd(self) -> Path:
+        """Working directory this client operates against."""
+        return self._cwd
+
     async def _run_bd(
         self,
         cmd: list[str],

--- a/src/maverick/beads/models.py
+++ b/src/maverick/beads/models.py
@@ -46,9 +46,12 @@ class DependencyType(StrEnum):
 
     Attributes:
         BLOCKS: The source bead blocks the target bead.
+        DISCOVERED_FROM: The source bead was discovered from the target bead
+            (provenance only — does not affect readiness).
     """
 
     BLOCKS = "blocks"
+    DISCOVERED_FROM = "discovered-from"
 
 
 class BeadDefinition(BaseModel):

--- a/src/maverick/cli/commands/brief.py
+++ b/src/maverick/cli/commands/brief.py
@@ -269,6 +269,68 @@ async def brief(
         await _brief_ready(client, output_format, show_all)
 
 
+# ---------------------------------------------------------------------------
+# Assumption-counts section (FR-010, clarification #5)
+# ---------------------------------------------------------------------------
+
+_ASSUMPTION_TABLE_HEADERS = ["Spec", "Open (L/M/H)", "Answered", "Waived", "Legacy"]
+
+
+async def _assumption_counts_dicts(client: BeadClient) -> list[dict[str, object]]:
+    """Return per-spec assumption counts as JSON-serializable dicts.
+
+    Empty list when the beads store is absent/uninitialized or the
+    aggregation otherwise fails — matches brief's existing degradation
+    behavior rather than crashing the command.
+    """
+    from maverick.assumptions.report import per_spec_counts
+
+    try:
+        counts = await per_spec_counts(client)
+    except Exception:  # noqa: BLE001 — degrade silently, see docstring
+        return []
+
+    return [
+        {
+            "owner_spec": row.owner_spec,
+            "open": {severity.value: n for severity, n in row.open.items()},
+            "answered": {severity.value: n for severity, n in row.answered.items()},
+            "waived": {severity.value: n for severity, n in row.waived.items()},
+            "legacy_open": row.legacy_open,
+        }
+        for row in counts
+    ]
+
+
+async def _display_assumption_counts_section(client: BeadClient) -> None:
+    """Render the compact per-spec Assumptions table, or omit it silently."""
+    from maverick.assumptions.models import Severity
+    from maverick.assumptions.report import per_spec_counts
+
+    try:
+        counts = await per_spec_counts(client)
+    except Exception:  # noqa: BLE001 — beads store absent/uninitialized: omit section
+        return
+    if not counts:
+        return
+
+    rows = [
+        [
+            row.owner_spec,
+            f"{row.open[Severity.LOW]}/{row.open[Severity.MEDIUM]}/{row.open[Severity.HIGH]}",
+            str(sum(row.answered.values())),
+            str(sum(row.waived.values())),
+            str(row.legacy_open),
+        ]
+        for row in counts
+    ]
+
+    console.print()
+    console.print("[bold]Assumptions[/]")
+    console.print()
+    console.print(format_table(_ASSUMPTION_TABLE_HEADERS, rows))
+
+
 async def _brief_ready(
     client: BeadClient,
     output_format: str,
@@ -278,7 +340,11 @@ async def _brief_ready(
     beads = await _fetch_beads_global(client, show_all)
 
     if output_format == "json":
-        console.print_json(json.dumps(_beads_to_dicts(beads)))
+        payload = {
+            "beads": _beads_to_dicts(beads),
+            "assumption_counts": await _assumption_counts_dicts(client),
+        }
+        console.print_json(json.dumps(payload))
         return
 
     count = len(beads)
@@ -286,16 +352,17 @@ async def _brief_ready(
         console.print("[bold]Brief:[/] No beads ready")
         console.print()
         console.print("[dim]All beads are either completed or blocked.[/]")
-        return
+    else:
+        console.print(f"[bold]Brief:[/] {count} bead{'s' if count != 1 else ''} ready")
+        console.print()
+        console.print(format_table(_TABLE_HEADERS, _beads_to_rows(beads)))
+        console.print()
+        console.print(
+            "[dim]Use 'maverick fly' to start executing, "
+            "or 'maverick fly --epic <id>' to focus on one epic.[/]"
+        )
 
-    console.print(f"[bold]Brief:[/] {count} bead{'s' if count != 1 else ''} ready")
-    console.print()
-    console.print(format_table(_TABLE_HEADERS, _beads_to_rows(beads)))
-    console.print()
-    console.print(
-        "[dim]Use 'maverick fly' to start executing, "
-        "or 'maverick fly --epic <id>' to focus on one epic.[/]"
-    )
+    await _display_assumption_counts_section(client)
 
 
 async def _brief_epic(
@@ -387,7 +454,11 @@ async def _brief_human(
             continue
 
     if output_format == "json":
-        console.print_json(json.dumps(human_beads))
+        payload = {
+            "beads": human_beads,
+            "assumption_counts": await _assumption_counts_dicts(client),
+        }
+        console.print_json(json.dumps(payload))
         return
 
     count = len(human_beads)
@@ -395,19 +466,22 @@ async def _brief_human(
         console.print("[bold]Brief:[/] No beads awaiting human review")
         console.print()
         console.print("[dim]All assumption reviews and escalations have been resolved.[/]")
-        return
+    else:
+        console.print(
+            f"[bold]Brief:[/] {count} bead{'s' if count != 1 else ''} awaiting human review"
+        )
+        console.print()
 
-    console.print(f"[bold]Brief:[/] {count} bead{'s' if count != 1 else ''} awaiting human review")
-    console.print()
+        rows = [
+            [b["id"], b["title"], b["priority"], b["source_bead"], b["escalation"]]
+            for b in human_beads
+        ]
+        console.print(format_table(_HUMAN_TABLE_HEADERS, rows))
 
-    rows = [
-        [b["id"], b["title"], b["priority"], b["source_bead"], b["escalation"]]
-        for b in human_beads
-    ]
-    console.print(format_table(_HUMAN_TABLE_HEADERS, rows))
+        console.print()
+        console.print(
+            "[dim]Review each bead and close with: "
+            "bd close <id> --reason 'approved' or 'rejected: <reason>'[/]"
+        )
 
-    console.print()
-    console.print(
-        "[dim]Review each bead and close with: "
-        "bd close <id> --reason 'approved' or 'rejected: <reason>'[/]"
-    )
+    await _display_assumption_counts_section(client)

--- a/src/maverick/cli/commands/land.py
+++ b/src/maverick/cli/commands/land.py
@@ -150,6 +150,15 @@ async def land(
     # ── 1b. Display human review manifest if present ─────────────
     _display_human_review_manifest(cwd)
 
+    # ── 1c. Assumption ledger gate — blocks unless open medium/high
+    # entries have been answered or waived via `maverick review`. No
+    # bypass flag exists. `--dry-run` still evaluates and prints the
+    # table, but only exits non-zero at the end (after the rest of the
+    # preview runs) rather than short-circuiting immediately.
+    gate_blocks = await _check_assumption_gate(cwd)
+    if gate_blocks and not dry_run:
+        raise SystemExit(ExitCode.FAILURE)
+
     # ── 2. Curation ────────────────────────────────────────────────
     if no_curate:
         console.print("Skipping curation (--no-curate).")
@@ -178,6 +187,8 @@ async def land(
 
     if dry_run:
         console.print("Dry run — skipping next-step hint.")
+        if gate_blocks:
+            raise SystemExit(ExitCode.FAILURE)
         return
 
     # ── 3. Runway consolidation (best-effort) ─────────────────────
@@ -373,6 +384,63 @@ def _display_plan(plan: list[dict[str, Any]]) -> None:
         border_style="cyan",
     )
     console.print(panel)
+
+
+# =====================================================================
+# Assumption ledger gate
+# =====================================================================
+
+
+async def _check_assumption_gate(cwd: Path) -> bool:
+    """Return True when open medium/high assumption entries block land.
+
+    Prints the blocking table (grouped by owning spec) as a side effect
+    when the gate blocks. bd-layer failures are non-fatal — the gate
+    passes rather than crashing land (mirrors the "nothing to land"
+    degradation elsewhere in this command).
+    """
+    from maverick.assumptions.ledger import open_blocking_entries
+    from maverick.beads.client import BeadClient
+
+    client = BeadClient(cwd=cwd)
+    if not await client.verify_available():
+        return False
+
+    try:
+        entries = await open_blocking_entries(client)
+    except Exception as exc:  # noqa: BLE001 — non-fatal; gate passes on query failure
+        console.print(format_warning(f"Assumption gate check failed: {exc}"))
+        return False
+
+    if not entries:
+        return False
+
+    _display_assumption_gate_table(entries)
+    return True
+
+
+def _display_assumption_gate_table(entries: Any) -> None:
+    """Render blocking assumption entries grouped by owning spec."""
+    table = Table(show_header=True, header_style="bold red")
+    table.add_column("ID", width=20)
+    table.add_column("Severity", width=10)
+    table.add_column("Spec", width=25)
+    table.add_column("Question")
+
+    for entry in sorted(entries, key=lambda e: (e.owner_spec, e.bead_id)):
+        question = entry.question[:80] + "..." if len(entry.question) > 80 else entry.question
+        table.add_row(entry.bead_id, entry.severity.value, entry.owner_spec, question)
+
+    console.print()
+    panel = Panel(
+        table,
+        title=f"Blocking Assumptions ({len(entries)})",
+        border_style="red",
+    )
+    console.print(panel)
+    console.print()
+    console.print("Resolve with: [bold]maverick review <id>[/bold]")
+    console.print()
 
 
 def _display_human_review_manifest(cwd: Path) -> None:

--- a/src/maverick/cli/commands/review.py
+++ b/src/maverick/cli/commands/review.py
@@ -1,21 +1,32 @@
 """``maverick review`` command — lightweight human review of assumption beads.
 
-Displays the escalation context for a human-assigned bead and captures
-a structured decision: approve, reject (with guidance), or defer.
+Two flavors of "human-assigned bead" share this command:
 
-Rejected beads spawn a correction bead back into the agent pipeline.
+* **Ledger entries** (labeled ``assumption``, from the assumption ledger
+  feature) — full-context display (question / adopted answer /
+  alternatives / severity / owning spec / change stamps / discovered-from
+  source) with an answer/waive resolution flow.
+* **Legacy escalation beads** (``needs-human-review`` / ``assumption-review``
+  without ``assumption``) — the original approve/reject/defer flow.
+  Rejected beads spawn a correction bead back into the agent pipeline.
+
 The human provides judgment and direction, not code.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
 from maverick.cli.console import console
 from maverick.cli.context import ExitCode, async_command
 from maverick.logging import get_logger
+
+if TYPE_CHECKING:
+    from maverick.beads.client import BeadClient
+    from maverick.beads.models import BeadDetails
 
 logger = get_logger(__name__)
 
@@ -26,19 +37,31 @@ logger = get_logger(__name__)
     "--approve",
     is_flag=True,
     default=False,
-    help="Approve without interactive prompt.",
+    help="Approve without interactive prompt (legacy escalation beads).",
 )
 @click.option(
     "--reject",
     "reject_guidance",
     default=None,
-    help="Reject with guidance text (non-interactive).",
+    help="Reject with guidance text (non-interactive, legacy escalation beads).",
 )
 @click.option(
     "--defer",
     is_flag=True,
     default=False,
-    help="Defer without interactive prompt.",
+    help="Defer without interactive prompt (legacy escalation beads).",
+)
+@click.option(
+    "--answer",
+    "answer_text",
+    default=None,
+    help="Answer a ledger entry (non-interactive).",
+)
+@click.option(
+    "--waive",
+    "waive_reason",
+    default=None,
+    help="Waive a ledger entry with a reason (non-interactive).",
 )
 @click.pass_context
 @async_command
@@ -48,15 +71,23 @@ async def review(
     approve: bool,
     reject_guidance: str | None,
     defer: bool,
+    answer_text: str | None,
+    waive_reason: str | None,
 ) -> None:
-    """Review a human-assigned assumption bead.
+    """Review a human-assigned bead.
 
-    Displays the escalation context and captures your decision:
-    approve, reject (with guidance for the correction agent), or defer.
+    For assumption-ledger entries: displays full context and captures
+    answer or waive. For legacy escalation beads: displays the escalation
+    context and captures approve, reject (with guidance for the
+    correction agent), or defer.
 
     Examples:
 
         maverick review dea-ykp.7
+
+        maverick review dea-ykp.7 --answer "Per bead, matches existing scoping."
+
+        maverick review dea-ykp.7 --waive "No longer applicable"
 
         maverick review dea-ykp.7 --approve
 
@@ -64,7 +95,12 @@ async def review(
 
         maverick review dea-ykp.7 --defer
     """
+    from maverick.assumptions.models import ASSUMPTION_LABEL
     from maverick.beads.client import BeadClient
+
+    if answer_text is not None and waive_reason is not None:
+        console.print("[red]Error:[/] --answer and --waive are mutually exclusive")
+        raise SystemExit(ExitCode.FAILURE)
     from maverick.beads.models import (
         BeadCategory,
         BeadDefinition,
@@ -86,6 +122,12 @@ async def review(
 
     state = details.state or {}
     labels = details.labels or []
+
+    if ASSUMPTION_LABEL in labels:
+        await _review_ledger_entry(
+            client, bead_id, details, answer_text=answer_text, waive_reason=waive_reason
+        )
+        return
 
     # Verify this is a human-assigned review bead
     is_human = "needs-human-review" in labels or "assumption-review" in labels
@@ -204,3 +246,101 @@ async def review(
     elif decision == "defer":
         console.print(f"\n[yellow]⏸[/] Bead {bead_id} deferred — no action taken.")
         console.print("Run `maverick review` again when ready.")
+
+
+def _resolve_git_user_name(cwd: Path) -> str:
+    """Resolve the git user name via GitPython config (Guardrail 8)."""
+    try:
+        from git import Repo
+
+        repo = Repo(cwd, search_parent_directories=True)
+        with repo.config_reader() as cfg:
+            name = cfg.get_value("user", "name", default="unknown")
+            return str(name)
+    except Exception:  # noqa: BLE001 — best-effort attribution
+        return "unknown"
+
+
+async def _review_ledger_entry(
+    client: BeadClient,
+    bead_id: str,
+    details: BeadDetails,
+    *,
+    answer_text: str | None,
+    waive_reason: str | None,
+) -> None:
+    """Full-context display + answer/waive flow for an assumption ledger entry."""
+    from maverick.assumptions.errors import AssumptionLedgerError
+    from maverick.assumptions.ledger import answer as ledger_answer
+    from maverick.assumptions.ledger import parse_description
+    from maverick.assumptions.ledger import waive as ledger_waive
+    from maverick.assumptions.models import (
+        KEY_CHANGE_IDS,
+        KEY_OWNER_SPEC,
+        KEY_SEVERITY,
+        KEY_SEVERITY_DEFAULTED,
+        KEY_SOURCE_BEAD,
+    )
+
+    state = details.state or {}
+    question, adopted_answer, alternatives = parse_description(details.description or "")
+    severity = state.get(KEY_SEVERITY, "medium")
+    defaulted = state.get(KEY_SEVERITY_DEFAULTED) == "true"
+    owner_spec = state.get(KEY_OWNER_SPEC, "")
+    source_bead = state.get(KEY_SOURCE_BEAD, "")
+    stamps = state.get(KEY_CHANGE_IDS) or "unstamped"
+
+    console.print()
+    console.print("[bold]━" * 60)
+    console.print(f"[bold] Assumption: {question or details.title}")
+    console.print("[bold]━" * 60)
+    console.print()
+    console.print(f"[dim]Question:[/]        {question}")
+    console.print(f"[dim]Adopted answer:[/]   {adopted_answer}")
+    if alternatives:
+        console.print("[dim]Alternatives:[/]")
+        for alt in alternatives:
+            console.print(f"  - {alt}")
+    severity_display = f"{severity}{' (defaulted)' if defaulted else ''}"
+    console.print(f"[dim]Severity:[/]         {severity_display}")
+    console.print(f"[dim]Owning spec:[/]      {owner_spec}")
+    console.print(f"[dim]Change stamps:[/]    {stamps}")
+    console.print(f"[dim]Discovered from:[/]  {source_bead}")
+    console.print()
+    console.print("[bold]━" * 60)
+    console.print()
+
+    if answer_text is None and waive_reason is None:
+        console.print("[bold]Decision:[/]")
+        console.print()
+        console.print("  [green]1.[/] Answer — record the resolution and close")
+        console.print("  [yellow]2.[/] Waive — record a reason and close")
+        console.print()
+        choice = click.prompt("Choice", type=click.Choice(["1", "2"]))
+        console.print()
+        if choice == "1":
+            answer_text = click.prompt("Answer")
+        else:
+            waive_reason = click.prompt("Waive reason")
+
+    if answer_text is not None:
+        if not answer_text.strip():
+            console.print("[red]Error:[/] Answer text must not be empty")
+            raise SystemExit(ExitCode.FAILURE)
+        try:
+            await ledger_answer(client, bead_id=bead_id, answer_text=answer_text)
+        except AssumptionLedgerError as exc:
+            console.print(f"[red]Error:[/] {exc}")
+            raise SystemExit(ExitCode.FAILURE) from exc
+        console.print(f"\n[green]✓[/] Bead {bead_id} answered and closed.")
+    else:
+        if not waive_reason or not waive_reason.strip():
+            console.print("[red]Error:[/] Waive reason must not be empty")
+            raise SystemExit(ExitCode.FAILURE)
+        waived_by = _resolve_git_user_name(Path.cwd())
+        try:
+            await ledger_waive(client, bead_id=bead_id, reason=waive_reason, waived_by=waived_by)
+        except AssumptionLedgerError as exc:
+            console.print(f"[red]Error:[/] {exc}")
+            raise SystemExit(ExitCode.FAILURE) from exc
+        console.print(f"\n[yellow]⚠[/] Bead {bead_id} waived by {waived_by} and closed.")

--- a/src/maverick/payloads.py
+++ b/src/maverick/payloads.py
@@ -68,6 +68,42 @@ def _first_present(payload: Mapping[str, Any], *keys: str, default: Any = None) 
     return default
 
 
+def _prune_assumptions(data: Any) -> Any:
+    """Drop malformed assumption entries before validating a submit payload.
+
+    ``assumptions`` is additive context on a load-bearing payload
+    (``submit_implementation`` / ``submit_review`` / ``submit_fix_result``).
+    A single entry missing its ``question`` or ``adopted_answer`` must not
+    fail validation of the whole implementation/review result — it is
+    dropped instead. Well-formed entries (and already-parsed
+    :class:`AssumptionPayload` instances from a state round-trip) pass
+    through untouched.
+    """
+    payload = _copy_mapping(data)
+    if not isinstance(payload, dict):
+        return payload
+    raw = payload.get("assumptions")
+    if not isinstance(raw, (list, tuple)):
+        return payload
+    kept: list[Any] = []
+    for item in raw:
+        if isinstance(item, AssumptionPayload):
+            kept.append(item)
+            continue
+        if isinstance(item, Mapping):
+            question = item.get("question")
+            answer = item.get("adopted_answer")
+            if (
+                isinstance(question, str)
+                and question.strip()
+                and isinstance(answer, str)
+                and answer.strip()
+            ):
+                kept.append(item)
+    payload["assumptions"] = kept
+    return payload
+
+
 class FileScopePayload(SupervisorInboxPayload):
     """Mailbox payload for file-scope declarations."""
 
@@ -144,11 +180,47 @@ class SubmitFixPayload(SupervisorInboxPayload):
     details: tuple[WorkUnitDetailPayload, ...]
 
 
+class AssumptionPayload(SupervisorInboxPayload):
+    """An assumption an agent adopted to keep working.
+
+    ``severity`` outside ``{low, medium, high}`` (or absent) is coerced to
+    ``"medium"`` rather than rejected (FR-011); ``severity_defaulted`` records
+    whether that coercion happened so ``record_assumption`` can persist
+    ``assumption_severity_defaulted=true``. It's a derived flag, not
+    something the agent is expected to report — but it's a normal field
+    (not dump-excluded) so it survives the round trip through
+    ``pending_assumptions`` state (dump → burr ``State`` → re-validate).
+    """
+
+    question: str = Field(min_length=1)
+    adopted_answer: str = Field(min_length=1)
+    alternatives: tuple[str, ...] = Field(default_factory=tuple)
+    severity: str = "medium"
+    severity_defaulted: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_severity(cls, data: Any) -> Any:
+        payload = _copy_mapping(data)
+        if isinstance(payload, dict):
+            raw = payload.get("severity")
+            if raw not in ("low", "medium", "high"):
+                payload["severity"] = "medium"
+                payload["severity_defaulted"] = True
+        return payload
+
+
 class SubmitImplementationPayload(SupervisorInboxPayload):
     """Typed payload for ``submit_implementation``."""
 
     summary: str
     files_changed: tuple[str, ...] = Field(default_factory=tuple)
+    assumptions: tuple[AssumptionPayload, ...] = Field(default_factory=tuple)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_malformed_assumptions(cls, data: Any) -> Any:
+        return _prune_assumptions(data)
 
 
 class SubmitFixResultPayload(SupervisorInboxPayload):
@@ -157,6 +229,12 @@ class SubmitFixResultPayload(SupervisorInboxPayload):
     summary: str
     addressed: tuple[str, ...] = Field(default_factory=tuple)
     contested: dict[str, str] = Field(default_factory=dict)
+    assumptions: tuple[AssumptionPayload, ...] = Field(default_factory=tuple)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_malformed_assumptions(cls, data: Any) -> Any:
+        return _prune_assumptions(data)
 
 
 class ReviewFindingPayload(SupervisorInboxPayload):
@@ -190,6 +268,12 @@ class SubmitReviewPayload(SupervisorInboxPayload):
     approved: bool
     findings: tuple[ReviewFindingPayload, ...] = Field(default_factory=tuple)
     findings_count: int | None = None
+    assumptions: tuple[AssumptionPayload, ...] = Field(default_factory=tuple)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_malformed_assumptions(cls, data: Any) -> Any:
+        return _prune_assumptions(data)
 
     @property
     def effective_findings_count(self) -> int:
@@ -489,6 +573,7 @@ def dump_supervisor_payload(payload: SupervisorInboxPayload) -> dict[str, Any]:
 __all__ = [
     "AcceptanceCriterionPayload",
     "ArchitectureDecisionPayload",
+    "AssumptionPayload",
     "ContrarianChallengePayload",
     "ContrarianSimplificationPayload",
     "CurationStepPayload",

--- a/src/maverick/workflows/fly_beads/_commit.py
+++ b/src/maverick/workflows/fly_beads/_commit.py
@@ -226,12 +226,15 @@ async def _create_followup_bead(
     """Tier 1: Create a follow-up task bead for unresolved review findings."""
     import json as _json
 
+    from maverick.beads.client import BeadClient
+    from maverick.beads.models import BeadDependency, DependencyType
     from maverick.runners.command import CommandRunner
 
     followup_description = _build_followup_description(ctx, prior_failures)
 
     try:
-        runner = CommandRunner(cwd=ctx.cwd or Path.cwd())
+        cwd = ctx.cwd or Path.cwd()
+        runner = CommandRunner(cwd=cwd)
         title = f"Address review findings from {ctx.bead_id}: {ctx.title[:80]}"
         result = await runner.run(
             [
@@ -255,16 +258,12 @@ async def _create_followup_bead(
                 followup_id = data.get("id", "")
 
         if followup_id:
-            await runner.run(
-                [
-                    "bd",
-                    "dep",
-                    "add",
-                    followup_id,
-                    ctx.bead_id,
-                    "--type",
-                    "discovered-from",
-                ]
+            await BeadClient(cwd=cwd).add_dependency(
+                BeadDependency(
+                    blocker_id=ctx.bead_id,
+                    blocked_id=followup_id,
+                    dep_type=DependencyType.DISCOVERED_FROM,
+                )
             )
 
         label = f" ({followup_id})" if followup_id else ""
@@ -363,10 +362,18 @@ async def _escalate_to_replan(
                 logger.warning("escalation.replan_parse_failed", error=str(exc))
 
         if replan_id:
+            from maverick.beads.client import BeadClient
+            from maverick.beads.models import BeadDependency, DependencyType
+
+            dep_client = BeadClient(cwd=ctx.cwd or Path.cwd())
             for bid in full_chain:
                 try:
-                    await runner.run(
-                        ["bd", "dep", "add", replan_id, bid, "--type", "discovered-from"]
+                    await dep_client.add_dependency(
+                        BeadDependency(
+                            blocker_id=bid,
+                            blocked_id=replan_id,
+                            dep_type=DependencyType.DISCOVERED_FROM,
+                        )
                     )
                 except Exception as exc:
                     logger.warning(

--- a/src/maverick/workflows/fly_beads/actions.py
+++ b/src/maverick/workflows/fly_beads/actions.py
@@ -53,6 +53,7 @@ __all__ = [
     "implement",
     "init_state",
     "process_bead_start",
+    "record_assumptions",
     "record_outcome",
     "review",
     "select_next_bead",
@@ -71,6 +72,14 @@ AGGREGATE_REVIEW_THRESHOLD: int = 2
 DEFAULT_TIER: str = "_default"
 
 _SOURCE = "fly-burr"
+
+
+def _payload_assumptions(payload: Any) -> list[dict[str, Any]]:
+    """Extract a dumped ``assumptions`` list from a Submit*Payload or its dumped dict."""
+    if payload is None:
+        return []
+    dumped = payload if isinstance(payload, dict) else dump_supervisor_payload(payload)
+    return list(dumped.get("assumptions") or [])
 
 
 async def _put_output(
@@ -242,13 +251,34 @@ async def select_next_bead(
     )
 
 
-@action(reads=["current_bead"], writes=["bead_aborted", "bead_failed", "needs_human_review"])
+@action(
+    reads=["current_bead"],
+    writes=[
+        "bead_aborted",
+        "bead_failed",
+        "needs_human_review",
+        "pending_assumptions",
+        "recorded_assumption_ids",
+        "commit_change_id",
+    ],
+)
 async def process_bead_start(state: State) -> tuple[dict[str, Any], State]:
-    """Reset per-bead state slots before the per-stage pipeline runs."""
+    """Reset per-bead state slots before the per-stage pipeline runs.
+
+    ``pending_assumptions``/``recorded_assumption_ids`` are reset here so a
+    bead can never re-record or re-stamp the previous bead's ledger
+    entries. ``commit_change_id`` is reset alongside them purely as
+    observability — it exposes the landed jj change ID for this bead in the
+    final burr state and feeds nothing downstream (stamping uses the local
+    change ID captured inside ``commit``).
+    """
     return {"bead_id": state["current_bead_id"]}, state.update(
         bead_aborted=False,
         bead_failed=False,
         needs_human_review=False,
+        pending_assumptions=[],
+        recorded_assumption_ids=[],
+        commit_change_id="",
     )
 
 
@@ -258,12 +288,18 @@ async def process_bead_start(state: State) -> tuple[dict[str, Any], State]:
 
 
 @action(
-    reads=["current_bead", "current_bead_id", "implementer_escalation_level"],
+    reads=[
+        "current_bead",
+        "current_bead_id",
+        "implementer_escalation_level",
+        "pending_assumptions",
+    ],
     writes=[
         "implement_ok",
         "implement_summary",
         "bead_aborted",
         "implementer_escalation_level",
+        "pending_assumptions",
     ],
 )
 async def implement(
@@ -298,10 +334,12 @@ async def implement(
         )
 
     summary = dump_supervisor_payload(payload)
+    pending = [*(state.get("pending_assumptions") or ()), *_payload_assumptions(summary)]
     return {"ok": True}, state.update(
         implement_ok=True,
         implement_summary=summary,
         implementer_escalation_level=new_level,
+        pending_assumptions=pending,
     )
 
 
@@ -327,14 +365,15 @@ async def _run_fix(
     round_n: int,
     failure_message: str,
     initial_level: int = 0,
-) -> tuple[bool, int]:
+) -> tuple[bool, int, list[dict[str, Any]]]:
     """Re-prompt the implementer on validation failure.
 
-    Returns ``(ok, new_level)`` where ``ok`` is true when the agent
-    landed a fix payload and ``new_level`` is the implementer
-    escalation level the caller should persist on state. Transient
-    failures bump the tier and retry; non-transient failures (or
-    exhausted escalation) return ``(False, current_level)``.
+    Returns ``(ok, new_level, assumptions)`` where ``ok`` is true when the
+    agent landed a fix payload, ``new_level`` is the implementer escalation
+    level the caller should persist on state, and ``assumptions`` is the
+    dumped ``assumptions`` list from the fix-result payload (empty on
+    failure). Transient failures bump the tier and retry; non-transient
+    failures (or exhausted escalation) return ``(False, current_level, [])``.
     """
     prompt = (
         f"## Fix request — phase: {phase}, round {round_n}\n\n"
@@ -352,12 +391,17 @@ async def _run_fix(
         label=label,
         initial_level=initial_level,
     )
-    return payload is not None, new_level
+    return payload is not None, new_level, _payload_assumptions(payload)
 
 
 @action(
-    reads=["current_bead_id", "implementer_escalation_level"],
-    writes=["gate_passed", "bead_aborted", "implementer_escalation_level"],
+    reads=["current_bead_id", "implementer_escalation_level", "pending_assumptions"],
+    writes=[
+        "gate_passed",
+        "bead_aborted",
+        "implementer_escalation_level",
+        "pending_assumptions",
+    ],
 )
 async def gate(
     state: State,
@@ -372,6 +416,7 @@ async def gate(
 
     bead_id = state["current_bead_id"]
     escalation_level = int(state.get("implementer_escalation_level") or 0)
+    pending = list(state.get("pending_assumptions") or ())
     for attempt in range(MAX_GATE_FIX_ATTEMPTS + 1):
         result = await run_independent_gate(
             stages=["format", "lint", "test"],
@@ -382,6 +427,7 @@ async def gate(
             return {"passed": True, "attempts": attempt + 1}, state.update(
                 gate_passed=True,
                 implementer_escalation_level=escalation_level,
+                pending_assumptions=pending,
             )
         if attempt >= MAX_GATE_FIX_ATTEMPTS:
             summary = result.get("summary") or "gate failed"
@@ -395,6 +441,7 @@ async def gate(
                 gate_passed=False,
                 bead_aborted=True,
                 implementer_escalation_level=escalation_level,
+                pending_assumptions=pending,
             )
         summary = result.get("summary") or "gate failed"
         await _put_output(
@@ -404,7 +451,7 @@ async def gate(
             level="warning",
             metadata={"attempt": attempt + 1},
         )
-        ok, escalation_level = await _run_fix(
+        ok, escalation_level, fix_assumptions = await _run_fix(
             squadron=squadron,
             events=events,
             bead_id=bead_id,
@@ -413,23 +460,31 @@ async def gate(
             failure_message=summary,
             initial_level=escalation_level,
         )
+        pending.extend(fix_assumptions)
         if not ok:
             return {"passed": False, "fix_failed": True}, state.update(
                 gate_passed=False,
                 bead_aborted=True,
                 implementer_escalation_level=escalation_level,
+                pending_assumptions=pending,
             )
     # unreachable but satisfies type checker
     return {"passed": False}, state.update(
         gate_passed=False,
         bead_aborted=True,
         implementer_escalation_level=escalation_level,
+        pending_assumptions=pending,
     )
 
 
 @action(
-    reads=["current_bead", "current_bead_id", "implementer_escalation_level"],
-    writes=["ac_passed", "bead_aborted", "implementer_escalation_level"],
+    reads=[
+        "current_bead",
+        "current_bead_id",
+        "implementer_escalation_level",
+        "pending_assumptions",
+    ],
+    writes=["ac_passed", "bead_aborted", "implementer_escalation_level", "pending_assumptions"],
 )
 async def ac_check(
     state: State,
@@ -449,6 +504,7 @@ async def ac_check(
     bead_id = state["current_bead_id"]
     description = bead.get("description", "") if bead else ""
     escalation_level = int(state.get("implementer_escalation_level") or 0)
+    pending = list(state.get("pending_assumptions") or ())
 
     async def _run_once() -> tuple[bool, str]:
         sections = _parse_work_unit_sections(description)
@@ -474,6 +530,7 @@ async def ac_check(
         return {"passed": True}, state.update(
             ac_passed=True,
             implementer_escalation_level=escalation_level,
+            pending_assumptions=pending,
         )
 
     await _put_output(
@@ -482,7 +539,7 @@ async def ac_check(
         f"AC check failed; requesting fix: {reasons}",
         level="warning",
     )
-    ok, escalation_level = await _run_fix(
+    ok, escalation_level, fix_assumptions = await _run_fix(
         squadron=squadron,
         events=events,
         bead_id=bead_id,
@@ -491,11 +548,13 @@ async def ac_check(
         failure_message=reasons,
         initial_level=escalation_level,
     )
+    pending.extend(fix_assumptions)
     if not ok:
         return {"passed": False}, state.update(
             ac_passed=False,
             bead_aborted=True,
             implementer_escalation_level=escalation_level,
+            pending_assumptions=pending,
         )
 
     passed, reasons = await _run_once()
@@ -505,16 +564,23 @@ async def ac_check(
             ac_passed=False,
             bead_aborted=True,
             implementer_escalation_level=escalation_level,
+            pending_assumptions=pending,
         )
     return {"passed": True}, state.update(
         ac_passed=True,
         implementer_escalation_level=escalation_level,
+        pending_assumptions=pending,
     )
 
 
 @action(
-    reads=["current_bead_id", "implementer_escalation_level"],
-    writes=["spec_passed", "bead_aborted", "implementer_escalation_level"],
+    reads=["current_bead_id", "implementer_escalation_level", "pending_assumptions"],
+    writes=[
+        "spec_passed",
+        "bead_aborted",
+        "implementer_escalation_level",
+        "pending_assumptions",
+    ],
 )
 async def spec_check(
     state: State,
@@ -538,6 +604,7 @@ async def spec_check(
 
     bead_id = state["current_bead_id"]
     escalation_level = int(state.get("implementer_escalation_level") or 0)
+    pending = list(state.get("pending_assumptions") or ())
 
     for attempt in range(MAX_SPEC_FIX_ATTEMPTS + 1):
         result = run_spec_check(cwd=cwd, project_type=project_type)
@@ -552,6 +619,7 @@ async def spec_check(
             return {"passed": True, "attempts": attempt + 1}, state.update(
                 spec_passed=True,
                 implementer_escalation_level=escalation_level,
+                pending_assumptions=pending,
             )
 
         summary = "; ".join(result.findings) or result.details
@@ -567,6 +635,7 @@ async def spec_check(
                 spec_passed=False,
                 bead_aborted=True,
                 implementer_escalation_level=escalation_level,
+                pending_assumptions=pending,
             )
 
         await _put_output(
@@ -576,7 +645,7 @@ async def spec_check(
             level="warning",
             metadata={"findings_count": len(result.findings)},
         )
-        ok, escalation_level = await _run_fix(
+        ok, escalation_level, fix_assumptions = await _run_fix(
             squadron=squadron,
             events=events,
             bead_id=bead_id,
@@ -585,16 +654,19 @@ async def spec_check(
             failure_message=summary,
             initial_level=escalation_level,
         )
+        pending.extend(fix_assumptions)
         if not ok:
             return {"passed": False, "fix_failed": True}, state.update(
                 spec_passed=False,
                 bead_aborted=True,
                 implementer_escalation_level=escalation_level,
+                pending_assumptions=pending,
             )
     return {"passed": False}, state.update(
         spec_passed=False,
         bead_aborted=True,
         implementer_escalation_level=escalation_level,
+        pending_assumptions=pending,
     )
 
 
@@ -604,6 +676,7 @@ async def spec_check(
         "current_bead_id",
         "reviewer_escalation_level",
         "implementer_escalation_level",
+        "pending_assumptions",
     ],
     writes=[
         "approved",
@@ -612,6 +685,7 @@ async def spec_check(
         "last_review_findings",
         "reviewer_escalation_level",
         "implementer_escalation_level",
+        "pending_assumptions",
     ],
 )
 async def review(
@@ -637,12 +711,14 @@ async def review(
     """
     bead = state["current_bead"]
     bead_id = state["current_bead_id"]
+    pending = list(state.get("pending_assumptions") or ())
     if bead is None:
         return {"approved": False}, state.update(
             approved=False,
             review_rounds=0,
             needs_human_review=True,
             last_review_findings=[],
+            pending_assumptions=pending,
         )
 
     description = bead.get("description", "")
@@ -673,6 +749,7 @@ async def review(
                 ],
                 reviewer_escalation_level=escalation_level,
                 implementer_escalation_level=implementer_level,
+                pending_assumptions=pending,
             )
         if results is None:
             # Non-transient reviewer failure — already logged inside
@@ -684,7 +761,11 @@ async def review(
                 last_review_findings=["Review crashed (non-transient)"],
                 reviewer_escalation_level=escalation_level,
                 implementer_escalation_level=implementer_level,
+                pending_assumptions=pending,
             )
+
+        for p in results:
+            pending.extend(_payload_assumptions(p))
 
         approved = all(_payload_approved(p) for p in results)
         if approved:
@@ -694,6 +775,7 @@ async def review(
                 last_review_findings=[],
                 reviewer_escalation_level=escalation_level,
                 implementer_escalation_level=implementer_level,
+                pending_assumptions=pending,
             )
 
         rounds_with_findings += 1
@@ -712,10 +794,11 @@ async def review(
                 last_review_findings=round_findings,
                 reviewer_escalation_level=escalation_level,
                 implementer_escalation_level=implementer_level,
+                pending_assumptions=pending,
             )
 
         # Re-prompt the implementer to address review feedback.
-        ok, implementer_level = await _run_fix(
+        ok, implementer_level, fix_assumptions = await _run_fix(
             squadron=squadron,
             events=events,
             bead_id=bead_id,
@@ -724,6 +807,7 @@ async def review(
             failure_message="\n".join(round_findings) or "(no specific findings)",
             initial_level=implementer_level,
         )
+        pending.extend(fix_assumptions)
         if not ok:
             return {"approved": False, "rounds": rounds_with_findings}, state.update(
                 approved=False,
@@ -732,6 +816,7 @@ async def review(
                 last_review_findings=round_findings,
                 reviewer_escalation_level=escalation_level,
                 implementer_escalation_level=implementer_level,
+                pending_assumptions=pending,
             )
 
     return {"approved": False, "rounds": rounds_with_findings}, state.update(
@@ -741,6 +826,7 @@ async def review(
         last_review_findings=[],
         reviewer_escalation_level=escalation_level,
         implementer_escalation_level=implementer_level,
+        pending_assumptions=pending,
     )
 
 
@@ -1157,8 +1243,82 @@ async def create_human_bead(
 
 
 @action(
-    reads=["current_bead", "current_bead_id", "approved", "needs_human_review", "review_rounds"],
-    writes=["commit_ok"],
+    reads=["current_bead_id", "pending_assumptions"],
+    writes=["recorded_assumption_ids"],
+)
+async def record_assumptions(
+    state: State,
+    *,
+    cwd: str,
+    epic_id: str,
+    events: asyncio.Queue[ProgressEvent | None],
+) -> tuple[dict[str, Any], State]:
+    """Create ledger entries for assumptions accumulated during this bead.
+
+    Non-fatal — mirrors :func:`create_human_bead`'s warn-and-continue
+    pattern (FR-012 / research R4): a ledger write failure never blocks
+    commit. Runs between review/create_human_bead and commit so the
+    same bead's commit can stamp the entries moments later.
+    """
+    from maverick.assumptions.errors import AssumptionLedgerError
+    from maverick.assumptions.ledger import record_assumption
+    from maverick.beads.client import BeadClient
+    from maverick.payloads import AssumptionPayload
+
+    bead_id = state["current_bead_id"]
+    pending: list[dict[str, Any]] = list(state.get("pending_assumptions") or ())
+    if not pending:
+        return {"recorded": 0}, state.update(recorded_assumption_ids=[])
+
+    client = BeadClient(cwd=Path(cwd))
+    recorded_ids: list[str] = []
+    for raw in pending:
+        try:
+            payload = AssumptionPayload.model_validate(raw)
+        except Exception as exc:  # noqa: BLE001 — malformed accumulated entry, skip
+            await _put_output(
+                events,
+                "fly",
+                f"Skipping malformed assumption payload: {exc}",
+                level="warning",
+            )
+            continue
+        try:
+            record = await record_assumption(
+                client, payload=payload, source_bead_id=bead_id, epic_id=epic_id
+            )
+        except AssumptionLedgerError as exc:
+            await _put_output(
+                events,
+                "fly",
+                f"Failed to record assumption for {bead_id}: {exc}",
+                level="warning",
+            )
+            continue
+        if record is not None:
+            recorded_ids.append(record.bead_id)
+
+    if recorded_ids:
+        await _put_output(
+            events,
+            "fly",
+            f"Recorded {len(recorded_ids)} assumption(s) for {bead_id}",
+            metadata={"recorded_assumption_ids": recorded_ids},
+        )
+
+    return {"recorded": len(recorded_ids)}, state.update(recorded_assumption_ids=recorded_ids)
+
+
+@action(
+    reads=[
+        "current_bead",
+        "current_bead_id",
+        "approved",
+        "needs_human_review",
+        "review_rounds",
+        "recorded_assumption_ids",
+    ],
+    writes=["commit_ok", "commit_change_id"],
 )
 async def commit(
     state: State,
@@ -1166,7 +1326,7 @@ async def commit(
     cwd: str,
     events: asyncio.Queue[ProgressEvent | None],
 ) -> tuple[dict[str, Any], State]:
-    """Commit the bead's changes and mark the bead complete."""
+    """Commit the bead's changes, mark it complete, and stamp any ledger entries."""
     from maverick.library.actions.beads import mark_bead_complete
     from maverick.library.actions.jj import jj_commit_bead
 
@@ -1184,10 +1344,12 @@ async def commit(
     message = "\n".join(message_parts)
 
     try:
-        await jj_commit_bead(message, cwd=cwd)
+        commit_result = await jj_commit_bead(message, cwd=cwd)
     except Exception as exc:  # noqa: BLE001
         await _put_output(events, "commit", f"Commit failed: {exc}", level="error")
         return {"committed": False, "error": str(exc)}, state.update(commit_ok=False)
+
+    change_id = commit_result.get("change_id") or ""
 
     try:
         await mark_bead_complete(bead_id, cwd=cwd)
@@ -1199,8 +1361,25 @@ async def commit(
             level="warning",
         )
 
+    recorded_ids = list(state.get("recorded_assumption_ids") or ())
+    if recorded_ids and change_id:
+        from maverick.assumptions.ledger import stamp_change_id
+        from maverick.beads.client import BeadClient
+
+        stamp_result = await stamp_change_id(
+            BeadClient(cwd=Path(cwd)), entry_ids=recorded_ids, change_id=change_id
+        )
+        if stamp_result.failed:
+            await _put_output(
+                events,
+                "commit",
+                f"Failed to stamp {len(stamp_result.failed)} assumption entry(s): "
+                f"{stamp_result.failed}",
+                level="warning",
+            )
+
     await _put_output(events, "commit", f"Committed bead {bead_id}", level="success")
-    return {"committed": True}, state.update(commit_ok=True)
+    return {"committed": True}, state.update(commit_ok=True, commit_change_id=change_id)
 
 
 @action(reads=["current_bead_id"], writes=["bead_aborted", "bead_failed"])

--- a/src/maverick/workflows/fly_beads/burr_graph.py
+++ b/src/maverick/workflows/fly_beads/burr_graph.py
@@ -8,14 +8,22 @@ Shape:
     init_state → select_next_bead
         ├─ loop_done → done
         └─ has bead → process_bead_start → implement
-                ├─ failed → abandon_bead → record_outcome → select_next_bead (cycle)
+                ├─ failed → abandon_bead → record_assumptions → record_outcome (cycle)
                 └─ ok → gate
-                        ├─ failed → abandon_bead → record_outcome → select_next_bead
+                        ├─ failed → abandon_bead → record_assumptions → record_outcome
                         └─ passed → ac_check
-                                ├─ failed → abandon_bead → record_outcome → ...
+                                ├─ failed → abandon_bead → record_assumptions → ...
                                 └─ passed → spec_check
-                                        ├─ failed → abandon_bead → record_outcome → ...
-                                        └─ passed → review → commit → record_outcome → ...
+                                        ├─ failed → abandon_bead → record_assumptions → ...
+                                        └─ passed → review
+                                        ├─ needs_human_review → create_human_bead
+                                        │       → record_assumptions → commit → ...
+                                        └─ approved → record_assumptions → commit → ...
+
+    record_assumptions branches on ``bead_aborted``: aborted beads skip
+    commit and go straight to record_outcome; approved/human-review beads
+    proceed to commit so the same run stamps the entries with the jj
+    change ID.
 
 The recorder cycles back to ``select_next_bead`` until ``loop_done``
 becomes true (no more beads, graceful stop, or max_beads reached).
@@ -53,6 +61,7 @@ FLY_ACTION_LABELS: dict[str, str] = {
     "spec_check": "Spec check",
     "review": "Reviewing",
     "create_human_bead": "Creating human review bead",
+    "record_assumptions": "Recording assumptions",
     "commit": "Committing",
     "abandon_bead": "Abandoning bead",
     "record_outcome": "Recording outcome",
@@ -127,6 +136,11 @@ def build_fly_application(
                 flight_plan_name=flight_plan_name,
                 events=event_queue,
             ),
+            record_assumptions=fly_actions.record_assumptions.bind(
+                cwd=cwd,
+                epic_id=epic_id,
+                events=event_queue,
+            ),
             commit=fly_actions.commit.bind(cwd=cwd, events=event_queue),
             abandon_bead=fly_actions.abandon_bead.bind(events=event_queue),
             record_outcome=fly_actions.record_outcome,
@@ -166,6 +180,11 @@ def build_fly_application(
             commit_ok=False,
             last_review_findings=[],
             human_bead_id="",
+            # Assumption ledger accumulators — reset per bead in
+            # process_bead_start.
+            pending_assumptions=[],
+            recorded_assumption_ids=[],
+            commit_change_id="",
             # Watch mode: count of consecutive empty-poll cycles.
             idle_polls=0,
             # Aggregate (cross-bead) review summary — None until the
@@ -200,15 +219,25 @@ def build_fly_application(
             ("ac_check", "spec_check"),
             ("spec_check", "abandon_bead", expr("not spec_passed")),
             ("spec_check", "review"),
-            # Review either approves → commit, or escalates to
-            # create_human_bead → commit. The bead's work still lands
-            # in either case (commit applies the needs-human-review
-            # trailer when the assumption bead is created).
+            # Review either approves or escalates to create_human_bead;
+            # both routes funnel through record_assumptions so any
+            # entries accumulated this bead are created before commit
+            # stamps them with the jj change ID. The bead's work still
+            # lands in either case (commit applies the
+            # needs-human-review trailer when the assumption bead is
+            # created).
             ("review", "create_human_bead", expr("needs_human_review")),
-            ("review", "commit"),
-            ("create_human_bead", "commit"),
+            ("review", "record_assumptions"),
+            ("create_human_bead", "record_assumptions"),
+            # Abort paths also funnel through record_assumptions so
+            # assumptions accumulated before the abort (e.g. by the
+            # implementer, then a gate/spec failure) still land in the
+            # ledger. record_assumptions branches on ``bead_aborted``:
+            # aborted beads skip commit and go straight to record_outcome.
+            ("abandon_bead", "record_assumptions"),
+            ("record_assumptions", "record_outcome", expr("bead_aborted")),
+            ("record_assumptions", "commit"),
             ("commit", "record_outcome"),
-            ("abandon_bead", "record_outcome"),
             # Cycle back into the loop.
             ("record_outcome", "select_next_bead"),
         )

--- a/src/maverick/workflows/refuel_speckit/workflow.py
+++ b/src/maverick/workflows/refuel_speckit/workflow.py
@@ -440,26 +440,73 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
         return epic_details.id, existing_task_map
 
     async def _chain_epic(self, client: Any, new_epic_id: str) -> str | None:
-        """Chain *new_epic_id* behind the tail of existing open epics."""
-        from maverick.beads.models import BeadDependency
+        """Chain *new_epic_id* behind the tail of existing open epics.
+
+        Tail selection is deterministic: open epics are sorted by their
+        ``speckit_feature`` NNN prefix (epics without one — flight-plan
+        runs — sort after all NNN-prefixed epics, in bd's own query
+        order) instead of relying on unspecified ``bd query`` ordering
+        (research R8). Additionally wires ``blocks`` edges from any open
+        high-severity assumption entries owned by earlier specs onto the
+        new epic, so refuel-time chaining catches entries recorded before
+        this spec existed (the other temporal order is handled at
+        recording time by ``ledger.next_chained_epic``).
+        """
+        from maverick.assumptions.ledger import open_high_entries_before
+        from maverick.assumptions.models import nnn_prefix
+        from maverick.beads.models import BeadDependency, DependencyType
 
         try:
             all_beads = await client.query("type=epic AND status=open")
         except Exception as exc:
             logger.warning("speckit_chain_epic_query_failed", error=str(exc))
-            return None
+            all_beads = []
         existing_epics = [b for b in all_beads if b.id != new_epic_id]
-        if not existing_epics:
-            return None
-        tail_epic = existing_epics[-1]
+
+        tail_epic_id: str | None = None
+        if existing_epics:
+            ordered: list[tuple[tuple[int, int], Any]] = []
+            for idx, epic in enumerate(existing_epics):
+                prefix: int | None = None
+                try:
+                    details = await client.show(epic.id)
+                    prefix = nnn_prefix(details.state.get("speckit_feature", ""))
+                except Exception:
+                    prefix = None
+                sort_key = (0, prefix) if prefix is not None else (1, idx)
+                ordered.append((sort_key, epic))
+            ordered.sort(key=lambda pair: pair[0])
+            tail_epic_id = ordered[-1][1].id
+            try:
+                await client.add_dependency(
+                    BeadDependency(blocker_id=tail_epic_id, blocked_id=new_epic_id)
+                )
+            except Exception as exc:
+                logger.warning("speckit_chain_epic_failed", error=str(exc))
+                tail_epic_id = None
+
         try:
-            await client.add_dependency(
-                BeadDependency(blocker_id=tail_epic.id, blocked_id=new_epic_id)
-            )
+            blocking_entries = await open_high_entries_before(client, epic_id=new_epic_id)
         except Exception as exc:
-            logger.warning("speckit_chain_epic_failed", error=str(exc))
-            return None
-        return tail_epic.id
+            logger.warning("speckit_chain_epic_assumption_query_failed", error=str(exc))
+            blocking_entries = ()
+        for entry in blocking_entries:
+            try:
+                await client.add_dependency(
+                    BeadDependency(
+                        blocker_id=entry.bead_id,
+                        blocked_id=new_epic_id,
+                        dep_type=DependencyType.BLOCKS,
+                    )
+                )
+            except Exception as exc:
+                logger.warning(
+                    "speckit_chain_epic_assumption_block_failed",
+                    entry_id=entry.bead_id,
+                    error=str(exc),
+                )
+
+        return tail_epic_id
 
     async def _record_run(self, cwd: Path, feature_name: str, epic_id: str, status: str) -> None:
         from maverick.runway.run_metadata import RunMetadata, write_metadata

--- a/tests/integration/test_assumption_ledger_flow.py
+++ b/tests/integration/test_assumption_ledger_flow.py
@@ -1,0 +1,345 @@
+"""Integration test: assumption ledger against real ``bd`` + ``jj``.
+
+Automates quickstart.md Scenario 1 (record → commit → stamped entry;
+abandoned bead → unstamped entry), Scenario 3 (medium blocks the land
+gate until answered), Scenario 4 (high blocks the next spec's epic,
+released by waive), and FR-013 legacy compatibility (a pre-feature
+escalation bead flows through brief/review/the land gate without
+errors) against real CLIs rather than stubs. Skips entirely when ``bd``
+isn't on PATH.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from maverick.assumptions.ledger import (
+    answer,
+    open_blocking_entries,
+    open_high_entries_before,
+    record_assumption,
+    stamp_change_id,
+    waive,
+)
+from maverick.assumptions.models import KEY_CHANGE_IDS, KEY_STATUS, STATUS_OPEN
+from maverick.beads.client import BeadClient
+from maverick.beads.models import (
+    BeadCategory,
+    BeadDefinition,
+    BeadDependency,
+    BeadType,
+    DependencyType,
+)
+from maverick.jj.client import JjClient
+from maverick.payloads import AssumptionPayload
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+if shutil.which("bd") is None:
+    pytest.skip("bd CLI not available on PATH", allow_module_level=True)
+
+
+@pytest.fixture
+def bd_jj_repo(tmp_path: Path) -> Path:
+    """A tmp directory with a real, jj-colocated ``bd`` database."""
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["jj", "git", "init", "--colocate"], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["bd", "init", "--non-interactive"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    return tmp_path
+
+
+async def _make_epic(client: BeadClient, cwd: Path, feature: str = "049-assumption-ledger") -> str:
+    epic = await client.create_bead(
+        BeadDefinition(
+            title=f"Integration epic ({feature})",
+            bead_type=BeadType.EPIC,
+            priority=1,
+            category=BeadCategory.FOUNDATION,
+        )
+    )
+    await client.set_state(epic.bd_id, {"speckit_feature": feature})
+    return epic.bd_id
+
+
+async def _make_source_bead(client: BeadClient, epic_id: str) -> str:
+    source = await client.create_bead(
+        BeadDefinition(
+            title="Implement the thing",
+            bead_type=BeadType.TASK,
+            priority=1,
+            category=BeadCategory.USER_STORY,
+        ),
+        parent_id=epic_id,
+    )
+    return source.bd_id
+
+
+@pytest.mark.asyncio
+async def test_record_commit_stamp_flow(bd_jj_repo: Path) -> None:
+    client = BeadClient(cwd=bd_jj_repo)
+    jj_client = JjClient(cwd=bd_jj_repo)
+
+    epic_id = await _make_epic(client, bd_jj_repo)
+    source_bead_id = await _make_source_bead(client, epic_id)
+
+    payload = AssumptionPayload(
+        question="Should retries be scoped per bead?",
+        adopted_answer="Per bead — matches existing scoping.",
+        alternatives=("Per run",),
+        severity="high",
+    )
+    record = await record_assumption(
+        client, payload=payload, source_bead_id=source_bead_id, epic_id=epic_id
+    )
+    assert record is not None
+
+    # Labels + state land as documented in data-model.md.
+    entry_details = await client.show(record.bead_id)
+    assert "assumption" in entry_details.labels
+    assert "assumption-review" in entry_details.labels
+    assert "needs-human-review" in entry_details.labels
+    assert entry_details.state[KEY_STATUS] == STATUS_OPEN
+    assert KEY_CHANGE_IDS not in entry_details.state  # unstamped until commit
+
+    # discovered-from edge to the source bead.
+    dep_list_result = subprocess.run(
+        ["bd", "dep", "list", record.bead_id, "--json"],
+        cwd=bd_jj_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    deps = json.loads(dep_list_result.stdout)
+    assert any(
+        d.get("type") == "discovered-from" and d.get("issue_id") == source_bead_id for d in deps
+    )
+
+    # Commit the (empty) working-copy change, mirroring the fly `commit`
+    # action's jj_commit_bead call, then stamp the entry.
+    (bd_jj_repo / "work.txt").write_text("done", encoding="utf-8")
+    commit_result = await jj_client.commit(f"bead({source_bead_id}): Implement the thing")
+    assert commit_result.change_id
+
+    stamp_result = await stamp_change_id(
+        client, entry_ids=[record.bead_id], change_id=commit_result.change_id
+    )
+    assert stamp_result.stamped == (record.bead_id,)
+    assert stamp_result.failed == {}
+
+    stamped_details = await client.show(record.bead_id)
+    change_ids = stamped_details.state[KEY_CHANGE_IDS].split(",")
+    assert commit_result.change_id in change_ids
+
+    # The stamped change ID resolves via `jj log`.
+    log_result = subprocess.run(
+        ["jj", "log", "-r", commit_result.change_id, "--no-graph"],
+        cwd=bd_jj_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert log_result.returncode == 0
+    assert commit_result.change_id[:8] in log_result.stdout or commit_result.change_id in (
+        log_result.stdout
+    )
+
+
+@pytest.mark.asyncio
+async def test_abandoned_bead_leaves_unstamped_entry(bd_jj_repo: Path) -> None:
+    """A run that ends before commit leaves the entry with no change_ids (US1-S4)."""
+    client = BeadClient(cwd=bd_jj_repo)
+    epic_id = await _make_epic(client, bd_jj_repo)
+    source_bead_id = await _make_source_bead(client, epic_id)
+
+    payload = AssumptionPayload(question="Q?", adopted_answer="A.")
+    record = await record_assumption(
+        client, payload=payload, source_bead_id=source_bead_id, epic_id=epic_id
+    )
+    assert record is not None
+
+    # No commit/stamp call — entry simply stays as created.
+    entry_details = await client.show(record.bead_id)
+    assert KEY_CHANGE_IDS not in entry_details.state
+    assert entry_details.state[KEY_STATUS] == STATUS_OPEN
+
+
+@pytest.mark.asyncio
+async def test_medium_blocks_land_gate_until_answered(bd_jj_repo: Path) -> None:
+    """Quickstart Scenario 3: medium entry blocks the land gate until answered."""
+    client = BeadClient(cwd=bd_jj_repo)
+    epic_id = await _make_epic(client, bd_jj_repo, feature="048-spec-a")
+    source_bead_id = await _make_source_bead(client, epic_id)
+
+    payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="medium")
+    record = await record_assumption(
+        client, payload=payload, source_bead_id=source_bead_id, epic_id=epic_id
+    )
+    assert record is not None
+
+    blocking = await open_blocking_entries(client)
+    assert any(r.bead_id == record.bead_id for r in blocking)
+
+    await answer(client, bead_id=record.bead_id, answer_text="Yes, per bead.")
+
+    blocking_after = await open_blocking_entries(client)
+    assert not any(r.bead_id == record.bead_id for r in blocking_after)
+
+    entry_details = await client.show(record.bead_id)
+    assert entry_details.status in ("closed", "done")
+
+
+@pytest.mark.asyncio
+async def test_high_blocks_next_spec_epic_and_waive_releases(bd_jj_repo: Path) -> None:
+    """Quickstart Scenario 4: high entry blocks the next spec's epic; waive releases it."""
+    client = BeadClient(cwd=bd_jj_repo)
+    epic_a = await _make_epic(client, bd_jj_repo, feature="048-spec-a")
+    source_bead_id = await _make_source_bead(client, epic_a)
+
+    payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="high")
+    record = await record_assumption(
+        client, payload=payload, source_bead_id=source_bead_id, epic_id=epic_a
+    )
+    assert record is not None
+
+    # Spec B is refueled after the entry was recorded — mirrors
+    # refuel_speckit._chain_epic's post-recording wiring hook.
+    epic_b = await _make_epic(client, bd_jj_repo, feature="049-spec-b")
+    entries = await open_high_entries_before(client, epic_id=epic_b)
+    assert any(e.bead_id == record.bead_id for e in entries)
+
+    await client.add_dependency(
+        BeadDependency(
+            blocker_id=record.bead_id, blocked_id=epic_b, dep_type=DependencyType.BLOCKS
+        )
+    )
+
+    dep_list = subprocess.run(
+        ["bd", "dep", "list", epic_b, "--json"],
+        cwd=bd_jj_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    deps = json.loads(dep_list.stdout)
+    assert any(d.get("type") == "blocks" and d.get("issue_id") == record.bead_id for d in deps)
+
+    await waive(client, bead_id=record.bead_id, reason="not applicable", waived_by="tester")
+
+    entry_details = await client.show(record.bead_id)
+    assert entry_details.status in ("closed", "done")
+
+    # No more open high entries for spec A once waived.
+    entries_after = await open_high_entries_before(client, epic_id=epic_b)
+    assert not any(e.bead_id == record.bead_id for e in entries_after)
+
+
+@pytest.mark.asyncio
+async def test_legacy_escalation_bead_flows_through_brief_review_and_land_gate(
+    bd_jj_repo: Path,
+) -> None:
+    """FR-013: a pre-feature escalation bead (old labels, no ledger state)
+    flows through brief, review, and the land gate without errors."""
+    from maverick.cli.commands.brief import brief
+    from maverick.cli.commands.review import review
+
+    client = BeadClient(cwd=bd_jj_repo)
+    epic_id = await _make_epic(client, bd_jj_repo, feature="048-legacy-spec")
+    source_bead_id = await _make_source_bead(client, epic_id)
+
+    # Mirrors create_human_bead's pre-feature shape exactly: no `assumption`
+    # label, no `assumption_*` state keys.
+    legacy = await client.create_bead(
+        BeadDefinition(
+            title="Review: legacy escalation",
+            bead_type=BeadType.TASK,
+            priority=1,
+            category=BeadCategory.REVIEW,
+            description="## Escalation Reason\n\nReview rounds exhausted.",
+            assignee="human",
+            labels=["assumption-review", "needs-human-review"],
+        ),
+        parent_id=epic_id,
+    )
+    await client.set_state(
+        legacy.bd_id,
+        {
+            "source_bead": source_bead_id,
+            "escalation_type": "fix_exhaustion",
+            "flight_plan": "048-legacy-spec",
+        },
+    )
+
+    # --- land gate: legacy bead is surfaced as a medium blocker ---------
+    blocking = await open_blocking_entries(client)
+    matches = [r for r in blocking if r.bead_id == legacy.bd_id]
+    assert len(matches) == 1
+    assert matches[0].is_legacy is True
+    assert matches[0].severity.value == "medium"
+
+    # --- brief: legacy bead counted in the legacy_open bucket -----------
+    runner = CliRunner()
+    cwd = os.getcwd()
+    try:
+        os.chdir(bd_jj_repo)
+        brief_result = runner.invoke(brief, ["--human"])
+        assert brief_result.exit_code == 0, brief_result.output
+        assert legacy.bd_id in brief_result.output
+
+        # --- review: legacy approve/reject/defer flow is unchanged ------
+        review_result = runner.invoke(review, [legacy.bd_id, "--approve"])
+        assert review_result.exit_code == 0, review_result.output
+        assert "closed as approved" in review_result.output
+    finally:
+        os.chdir(cwd)
+
+    closed_details = await client.show(legacy.bd_id)
+    assert closed_details.status in ("closed", "done")
+
+    # Once closed, the land gate no longer counts it.
+    blocking_after = await open_blocking_entries(client)
+    assert not any(r.bead_id == legacy.bd_id for r in blocking_after)
+
+
+@pytest.mark.asyncio
+async def test_low_severity_is_advisory_only(bd_jj_repo: Path) -> None:
+    """Quickstart Scenario 2: low entries are deferred out of `bd ready`,
+    never block land, and still count in `per_spec_counts`."""
+    from maverick.assumptions.report import per_spec_counts
+
+    client = BeadClient(cwd=bd_jj_repo)
+    epic_id = await _make_epic(client, bd_jj_repo, feature="049-assumption-ledger")
+    source_bead_id = await _make_source_bead(client, epic_id)
+
+    payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="low")
+    record = await record_assumption(
+        client, payload=payload, source_bead_id=source_bead_id, epic_id=epic_id
+    )
+    assert record is not None
+
+    # Deferred — absent from `bd ready`.
+    ready = await client.ready(epic_id, limit=50)
+    assert not any(r.id == record.bead_id for r in ready)
+
+    # Never blocks land.
+    blocking = await open_blocking_entries(client)
+    assert not any(r.bead_id == record.bead_id for r in blocking)
+
+    # Still counted (open, low) in per-spec reporting.
+    from maverick.assumptions.models import Severity
+
+    counts = await per_spec_counts(client)
+    row = next(r for r in counts if r.owner_spec == "049-assumption-ledger")
+    assert row.open[Severity.LOW] == 1

--- a/tests/unit/assumptions/test_ledger_policy.py
+++ b/tests/unit/assumptions/test_ledger_policy.py
@@ -1,0 +1,354 @@
+"""Tests for severity policy hooks in record_assumption (US2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from maverick.assumptions.ledger import record_assumption
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    KEY_OWNER_SPEC,
+    KEY_SEVERITY,
+    KEY_STATUS,
+    STATUS_OPEN,
+    Severity,
+)
+from maverick.beads.client import BeadClient
+from maverick.beads.models import BeadDetails, BeadSummary, DependencyType
+from maverick.payloads import AssumptionPayload
+
+
+def _client() -> BeadClient:
+    return BeadClient(cwd=Path("/tmp/repo"))
+
+
+def _epic_details(bead_id: str = "epic-1", **state: str) -> BeadDetails:
+    return BeadDetails(id=bead_id, title="Epic", bead_type="epic", status="open", state=state)
+
+
+def _base_mocks(epic_state: dict[str, str]):
+    async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+        if bead_id == "epic-1":
+            return _epic_details(**epic_state)
+        return _epic_details(bead_id)
+
+    async def fake_children(self: BeadClient, parent_id: str) -> list:
+        return []
+
+    return fake_show, fake_children
+
+
+class TestLowSeverityDeferred:
+    @pytest.mark.asyncio
+    async def test_low_entry_deferred_at_creation(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="low")
+
+        fake_show, fake_children = _base_mocks({"speckit_feature": "049-assumption-ledger"})
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()),
+            patch("maverick.library.actions.beads.defer_bead", new=AsyncMock()) as mock_defer,
+        ):
+            record = await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id="epic-1"
+            )
+
+        assert record is not None
+        mock_defer.assert_awaited_once()
+        assert mock_defer.await_args.args[0] == "dea-1"
+
+
+class TestMediumSeverityNeither:
+    @pytest.mark.asyncio
+    async def test_medium_entry_not_deferred_no_blocks_edge(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="medium")
+
+        fake_show, fake_children = _base_mocks({"speckit_feature": "049-assumption-ledger"})
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()) as mock_add_dep,
+            patch("maverick.library.actions.beads.defer_bead", new=AsyncMock()) as mock_defer,
+        ):
+            await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id="epic-1"
+            )
+
+        mock_defer.assert_not_awaited()
+        # Only the discovered-from edge was wired, no blocks edge.
+        assert mock_add_dep.await_count == 1
+
+
+class TestHighSeverityBlocksEdge:
+    @pytest.mark.asyncio
+    async def test_high_entry_wires_blocks_edge_onto_next_epic(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="high")
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id == "epic-1":
+                return _epic_details("epic-1", speckit_feature="049-assumption-ledger")
+            if bead_id == "epic-2":
+                return _epic_details("epic-2", speckit_feature="050-next-spec")
+            return _epic_details(bead_id)
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list:
+            return []
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(id="epic-1", title="Epic 1", status="open", bead_type="epic"),
+                BeadSummary(id="epic-2", title="Epic 2", status="open", bead_type="epic"),
+            ]
+
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()) as mock_add_dep,
+        ):
+            await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id="epic-1"
+            )
+
+        # discovered-from + blocks edge
+        assert mock_add_dep.await_count == 2
+        from maverick.beads.models import DependencyType
+
+        blocks_calls = [
+            c for c in mock_add_dep.await_args_list if c.args[0].dep_type == DependencyType.BLOCKS
+        ]
+        assert len(blocks_calls) == 1
+        dep = blocks_calls[0].args[0]
+        assert dep.blocker_id == "dea-1"
+        assert dep.blocked_id == "epic-2"
+
+    @pytest.mark.asyncio
+    async def test_high_entry_no_next_epic_no_blocks_edge(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="high")
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id == "epic-1":
+                return _epic_details("epic-1", speckit_feature="049-assumption-ledger")
+            return _epic_details(bead_id)
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list:
+            return []
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            return [BeadSummary(id="epic-1", title="Epic 1", status="open", bead_type="epic")]
+
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()) as mock_add_dep,
+        ):
+            await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id="epic-1"
+            )
+
+        # Only discovered-from edge — no next epic exists.
+        assert mock_add_dep.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_high_entry_flight_plan_epic_no_blocks_edge(self) -> None:
+        """Owning epic has no speckit_feature -> next_chained_epic returns None."""
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="high")
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id == "epic-1":
+                return _epic_details("epic-1", flight_plan_name="my-plan")
+            return _epic_details(bead_id)
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list:
+            return []
+
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()) as mock_add_dep,
+        ):
+            await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id="epic-1"
+            )
+
+        assert mock_add_dep.await_count == 1
+
+
+def _existing_open_entry(severity: str) -> BeadDetails:
+    return BeadDetails(
+        id="dea-existing",
+        title="Assumption: Should retries be per bead?",
+        description=(
+            "## Question\n\nShould retries be per bead?\n\n## Adopted Answer\n\nPer bead.\n\n"
+        ),
+        bead_type="task",
+        status="open",
+        labels=[ASSUMPTION_LABEL, "assumption-review", "needs-human-review"],
+        state={
+            KEY_SEVERITY: severity,
+            KEY_STATUS: STATUS_OPEN,
+            KEY_OWNER_SPEC: "049-earlier-spec",
+        },
+    )
+
+
+class TestSeverityEscalationOnDedup:
+    """A later bead re-reporting the same question at a higher severity must
+    strengthen enforcement rather than inherit the weaker original."""
+
+    @pytest.mark.asyncio
+    async def test_medium_re_report_escalates_low_entry(self) -> None:
+        client = _client()
+        existing = _existing_open_entry("low")
+        payload = AssumptionPayload(
+            question="Should retries be per bead?", adopted_answer="A.", severity="medium"
+        )
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id == "epic-1":
+                return _epic_details("epic-1", speckit_feature="049-earlier-spec")
+            return existing
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(
+                    id="dea-existing", title=existing.title, status="open", bead_type="task"
+                )
+            ]
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=AsyncMock()) as mock_create,
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()),
+        ):
+            record = await record_assumption(
+                client, payload=payload, source_bead_id="new-src", epic_id="epic-1"
+            )
+
+        mock_create.assert_not_awaited()
+        assert record is not None
+        assert record.severity is Severity.MEDIUM
+        # set_state was called to bump the stored severity.
+        state_dict = mock_set_state.await_args.args[1]
+        assert state_dict[KEY_SEVERITY] == Severity.MEDIUM.value
+
+    @pytest.mark.asyncio
+    async def test_high_re_report_escalates_and_wires_blocks_edge(self) -> None:
+        client = _client()
+        existing = _existing_open_entry("medium")
+        payload = AssumptionPayload(
+            question="Should retries be per bead?", adopted_answer="A.", severity="high"
+        )
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id == "epic-1":
+                return _epic_details("epic-1", speckit_feature="049-earlier-spec")
+            if bead_id == "epic-2":
+                return _epic_details("epic-2", speckit_feature="050-next-spec")
+            return existing
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(
+                    id="dea-existing", title=existing.title, status="open", bead_type="task"
+                )
+            ]
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(id="epic-1", title="Epic 1", status="open", bead_type="epic"),
+                BeadSummary(id="epic-2", title="Epic 2", status="open", bead_type="epic"),
+            ]
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "create_bead", new=AsyncMock()) as mock_create,
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()) as mock_add_dep,
+        ):
+            record = await record_assumption(
+                client, payload=payload, source_bead_id="new-src", epic_id="epic-1"
+            )
+
+        mock_create.assert_not_awaited()
+        assert record is not None
+        assert record.severity is Severity.HIGH
+        state_dict = mock_set_state.await_args.args[1]
+        assert state_dict[KEY_SEVERITY] == Severity.HIGH.value
+        blocks = [
+            c for c in mock_add_dep.await_args_list if c.args[0].dep_type == DependencyType.BLOCKS
+        ]
+        assert len(blocks) == 1
+        assert blocks[0].args[0].blocker_id == "dea-existing"
+        assert blocks[0].args[0].blocked_id == "epic-2"
+
+    @pytest.mark.asyncio
+    async def test_lower_re_report_does_not_downgrade(self) -> None:
+        client = _client()
+        existing = _existing_open_entry("high")
+        payload = AssumptionPayload(
+            question="Should retries be per bead?", adopted_answer="A.", severity="low"
+        )
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id == "epic-1":
+                return _epic_details("epic-1", speckit_feature="049-earlier-spec")
+            return existing
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(
+                    id="dea-existing", title=existing.title, status="open", bead_type="task"
+                )
+            ]
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=AsyncMock()),
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()),
+            patch("maverick.library.actions.beads.defer_bead", new=AsyncMock()),
+        ):
+            record = await record_assumption(
+                client, payload=payload, source_bead_id="new-src", epic_id="epic-1"
+            )
+
+        assert record is not None
+        assert record.severity is Severity.HIGH  # unchanged
+        # No severity escalation → set_state not called for the existing entry.
+        mock_set_state.assert_not_awaited()

--- a/tests/unit/assumptions/test_ledger_query.py
+++ b/tests/unit/assumptions/test_ledger_query.py
@@ -1,0 +1,178 @@
+"""Tests for open_blocking_entries / open_high_entries_before."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from maverick.assumptions.ledger import open_blocking_entries, open_high_entries_before
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    ASSUMPTION_REVIEW_LABEL,
+    KEY_OWNER_SPEC,
+    KEY_SEVERITY,
+    KEY_STATUS,
+    NEEDS_HUMAN_REVIEW_LABEL,
+    STATUS_ANSWERED,
+    STATUS_OPEN,
+    Severity,
+)
+from maverick.beads.client import BeadClient
+from maverick.beads.models import BeadDetails, BeadSummary
+
+
+def _client() -> BeadClient:
+    return BeadClient(cwd=Path("/tmp/repo"))
+
+
+def _summary(bead_id: str, status: str = "open") -> BeadSummary:
+    return BeadSummary(id=bead_id, title=bead_id, status=status, bead_type="task")
+
+
+def _entry(
+    bead_id: str, severity: str, status: str = STATUS_OPEN, owner_spec: str = ""
+) -> BeadDetails:
+    return BeadDetails(
+        id=bead_id,
+        title=f"Assumption: {bead_id}",
+        description="## Question\n\nQ?\n\n",
+        bead_type="task",
+        status="closed" if status != STATUS_OPEN else "open",
+        labels=[ASSUMPTION_LABEL, ASSUMPTION_REVIEW_LABEL, NEEDS_HUMAN_REVIEW_LABEL],
+        state={KEY_SEVERITY: severity, KEY_STATUS: status, KEY_OWNER_SPEC: owner_spec},
+    )
+
+
+def _legacy_entry(bead_id: str) -> BeadDetails:
+    return BeadDetails(
+        id=bead_id,
+        title="Review: legacy",
+        description="legacy escalation",
+        bead_type="task",
+        status="open",
+        labels=[ASSUMPTION_REVIEW_LABEL, NEEDS_HUMAN_REVIEW_LABEL],
+        state={"source_bead": "b-1", "flight_plan": "legacy-plan"},
+    )
+
+
+class TestOpenBlockingEntries:
+    @pytest.mark.asyncio
+    async def test_includes_open_medium_and_high_excludes_low(self) -> None:
+        client = _client()
+        entries = {
+            "dea-low": _entry("dea-low", "low"),
+            "dea-med": _entry("dea-med", "medium"),
+            "dea-high": _entry("dea-high", "high"),
+        }
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            return [_summary(k) for k in entries]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return entries[bead_id]
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            result = await open_blocking_entries(client)
+
+        ids = {r.bead_id for r in result}
+        assert ids == {"dea-med", "dea-high"}
+
+    @pytest.mark.asyncio
+    async def test_excludes_answered_and_waived(self) -> None:
+        client = _client()
+        entries = {
+            "dea-open": _entry("dea-open", "medium", status=STATUS_OPEN),
+            "dea-answered": _entry("dea-answered", "medium", status=STATUS_ANSWERED),
+        }
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            return [_summary(k) for k in entries]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return entries[bead_id]
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            result = await open_blocking_entries(client)
+
+        ids = {r.bead_id for r in result}
+        assert ids == {"dea-open"}
+
+    @pytest.mark.asyncio
+    async def test_legacy_escalation_bead_surfaced_as_medium(self) -> None:
+        client = _client()
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            return [_summary("legacy-1")]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return _legacy_entry("legacy-1")
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            result = await open_blocking_entries(client)
+
+        assert len(result) == 1
+        assert result[0].severity == Severity.MEDIUM
+        assert result[0].is_legacy is True
+
+
+class TestOpenHighEntriesBefore:
+    @pytest.mark.asyncio
+    async def test_only_high_entries_owned_by_earlier_specs(self) -> None:
+        client = _client()
+        entries = {
+            "dea-earlier-high": _entry("dea-earlier-high", "high", owner_spec="048-earlier-spec"),
+            "dea-earlier-med": _entry("dea-earlier-med", "medium", owner_spec="048-earlier-spec"),
+            "dea-later-high": _entry("dea-later-high", "high", owner_spec="050-later-spec"),
+        }
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id == "epic-1":
+                return BeadDetails(
+                    id="epic-1",
+                    title="Epic",
+                    bead_type="epic",
+                    status="open",
+                    state={"speckit_feature": "049-assumption-ledger"},
+                )
+            return entries[bead_id]
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            return [_summary(k) for k in entries]
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "query", new=fake_query),
+        ):
+            result = await open_high_entries_before(client, epic_id="epic-1")
+
+        ids = {r.bead_id for r in result}
+        assert ids == {"dea-earlier-high"}
+
+    @pytest.mark.asyncio
+    async def test_flight_plan_epic_returns_empty(self) -> None:
+        client = _client()
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return BeadDetails(
+                id="epic-1",
+                title="Epic",
+                bead_type="epic",
+                status="open",
+                state={"flight_plan_name": "my-plan"},
+            )
+
+        with patch.object(BeadClient, "show", new=fake_show):
+            result = await open_high_entries_before(client, epic_id="epic-1")
+
+        assert result == ()

--- a/tests/unit/assumptions/test_ledger_record.py
+++ b/tests/unit/assumptions/test_ledger_record.py
@@ -1,0 +1,408 @@
+"""Tests for maverick.assumptions.ledger.record_assumption."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from maverick.assumptions.errors import AssumptionLedgerError
+from maverick.assumptions.ledger import record_assumption
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    KEY_OWNER_SPEC,
+    KEY_SEVERITY,
+    KEY_SEVERITY_DEFAULTED,
+    KEY_SOURCE_BEAD,
+    KEY_STATUS,
+    STATUS_OPEN,
+    Severity,
+)
+from maverick.beads.client import BeadClient
+from maverick.beads.models import BeadDetails
+from maverick.payloads import AssumptionPayload
+
+
+def _client() -> BeadClient:
+    return BeadClient(cwd=Path("/tmp/repo"))
+
+
+def _epic_details(**state: str) -> BeadDetails:
+    return BeadDetails(
+        id="epic-1",
+        title="Epic",
+        bead_type="epic",
+        status="open",
+        labels=[],
+        state=state,
+    )
+
+
+class TestOwnerSpecDerivation:
+    @pytest.mark.asyncio
+    async def test_speckit_feature_wins(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.")
+
+        show_calls: list[str] = []
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            show_calls.append(bead_id)
+            return _epic_details(
+                speckit_feature="049-assumption-ledger", flight_plan_name="ignored"
+            )
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list:
+            return []
+
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()) as mock_add_dep,
+        ):
+            record = await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id="epic-1"
+            )
+
+        assert record is not None
+        assert record.owner_spec == "049-assumption-ledger"
+        set_state_kwargs = mock_set_state.await_args
+        state_dict = set_state_kwargs.args[1]
+        assert state_dict[KEY_OWNER_SPEC] == "049-assumption-ledger"
+        mock_add_dep.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_flight_plan_name_fallback(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.")
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return _epic_details(flight_plan_name="my-flight-plan")
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list:
+            return []
+
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()),
+        ):
+            record = await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id="epic-1"
+            )
+
+        assert record is not None
+        assert record.owner_spec == "my-flight-plan"
+
+    @pytest.mark.asyncio
+    async def test_epic_id_fallback_when_neither_key_present(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.")
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return _epic_details()
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list:
+            return []
+
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()),
+        ):
+            record = await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id="epic-1"
+            )
+
+        assert record is not None
+        assert record.owner_spec == "epic-1"
+
+
+class TestBeadShape:
+    @pytest.mark.asyncio
+    async def test_title_priority_assignee_parent(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(
+            question="Should retries be per bead?",
+            adopted_answer="Per bead.",
+            severity="high",
+        )
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return _epic_details(speckit_feature="049-assumption-ledger")
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list:
+            return []
+
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+        create_bead_mock = AsyncMock(return_value=created)
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=create_bead_mock),
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()),
+            patch.object(BeadClient, "query", new=AsyncMock(return_value=[])),
+        ):
+            record = await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id="epic-1"
+            )
+
+        assert record is not None
+        definition = create_bead_mock.await_args.args[0]
+        parent_id = create_bead_mock.await_args.kwargs.get("parent_id")
+        assert definition.title.startswith("Assumption:")
+        assert "Should retries be per bead?" in definition.title
+        assert definition.priority == 1  # high -> 1
+        assert definition.assignee == "human"
+        assert ASSUMPTION_LABEL in definition.labels
+        assert "assumption-review" in definition.labels
+        assert "needs-human-review" in definition.labels
+        assert parent_id == "epic-1"
+
+        state_dict = mock_set_state.await_args.args[1]
+        assert state_dict[KEY_SEVERITY] == Severity.HIGH.value
+        assert state_dict[KEY_STATUS] == STATUS_OPEN
+        assert state_dict[KEY_SOURCE_BEAD] == "src-1"
+        assert KEY_SEVERITY_DEFAULTED not in state_dict
+
+    @pytest.mark.asyncio
+    async def test_severity_defaulted_flag_persisted(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="bogus")
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return _epic_details(speckit_feature="049-assumption-ledger")
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list:
+            return []
+
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()),
+        ):
+            record = await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id="epic-1"
+            )
+
+        assert record is not None
+        assert record.severity_defaulted is True
+        state_dict = mock_set_state.await_args.args[1]
+        assert state_dict[KEY_SEVERITY_DEFAULTED] == "true"
+
+
+class TestDiscoveredFromEdge:
+    @pytest.mark.asyncio
+    async def test_wires_edge_from_source_to_new_entry(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.")
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return _epic_details(speckit_feature="049-assumption-ledger")
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list:
+            return []
+
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()) as mock_add_dep,
+        ):
+            await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id="epic-1"
+            )
+
+        dep = mock_add_dep.await_args.args[0]
+        assert dep.blocker_id == "src-1"
+        assert dep.blocked_id == "dea-1"
+
+
+class TestDedup:
+    @pytest.mark.asyncio
+    async def test_existing_open_entry_with_same_question_appends_edge_only(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(
+            question="  Should retries be   per bead?  ", adopted_answer="A."
+        )
+
+        existing_entry = BeadDetails(
+            id="dea-existing",
+            title="Assumption: Should retries be per bead?",
+            description=(
+                "## Question\n\nShould retries be per bead?\n\n"
+                "## Adopted Answer\n\nPer bead.\n\n"
+                "## Alternatives Considered\n\n(none)\n\n"
+                "## Context\n\nSource bead: other-src — Other\n"
+            ),
+            bead_type="task",
+            status="open",
+            labels=[ASSUMPTION_LABEL, "assumption-review", "needs-human-review"],
+            state={
+                KEY_SEVERITY: "medium",
+                KEY_STATUS: STATUS_OPEN,
+                KEY_OWNER_SPEC: "049-assumption-ledger",
+                KEY_SOURCE_BEAD: "other-src",
+            },
+        )
+
+        from maverick.beads.models import BeadSummary
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(
+                    id="dea-existing",
+                    title=existing_entry.title,
+                    status="open",
+                    bead_type="task",
+                )
+            ]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id == "epic-1":
+                return _epic_details(speckit_feature="049-assumption-ledger")
+            return existing_entry
+
+        create_bead_mock = AsyncMock()
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=create_bead_mock),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()) as mock_add_dep,
+        ):
+            record = await record_assumption(
+                client, payload=payload, source_bead_id="new-src", epic_id="epic-1"
+            )
+
+        create_bead_mock.assert_not_awaited()
+        assert record is not None
+        assert record.bead_id == "dea-existing"
+        dep = mock_add_dep.await_args.args[0]
+        assert dep.blocker_id == "new-src"
+        assert dep.blocked_id == "dea-existing"
+
+
+class TestEmptyEpicResolution:
+    """``maverick fly`` without ``--epic`` passes ``epic_id=''``; the entry
+    must still be recorded under the source bead's real owning epic rather
+    than dropped by a ``bd show ''``."""
+
+    @pytest.mark.asyncio
+    async def test_empty_epic_resolves_source_bead_parent(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.")
+
+        source = BeadDetails(
+            id="src-1",
+            title="Implement thing",
+            bead_type="task",
+            status="open",
+            parent_id="epic-parent",
+        )
+        epic = BeadDetails(
+            id="epic-parent",
+            title="Epic",
+            bead_type="epic",
+            status="open",
+            state={"speckit_feature": "049-assumption-ledger"},
+        )
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id == "src-1":
+                return source
+            if bead_id == "epic-parent":
+                return epic
+            raise LookupError(bead_id)
+
+        async def fake_children(self: BeadClient, parent_id: str) -> list:
+            assert parent_id == "epic-parent"
+            return []
+
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+        create_bead_mock = AsyncMock(return_value=created)
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "children", new=fake_children),
+            patch.object(BeadClient, "create_bead", new=create_bead_mock),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()),
+        ):
+            record = await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id=""
+            )
+
+        assert record is not None
+        assert record.owner_spec == "049-assumption-ledger"
+        assert create_bead_mock.await_args.kwargs.get("parent_id") == "epic-parent"
+
+    @pytest.mark.asyncio
+    async def test_empty_epic_no_parent_records_unparented(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.")
+
+        source = BeadDetails(
+            id="src-1", title="t", bead_type="task", status="open", parent_id=None
+        )
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return source
+
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+        create_bead_mock = AsyncMock(return_value=created)
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "create_bead", new=create_bead_mock),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()),
+        ):
+            record = await record_assumption(
+                client, payload=payload, source_bead_id="src-1", epic_id=""
+            )
+
+        assert record is not None
+        # No resolvable epic → recorded unparented rather than dropped.
+        assert create_bead_mock.await_args.kwargs.get("parent_id") is None
+
+
+class TestErrors:
+    @pytest.mark.asyncio
+    async def test_bd_failure_raises_assumption_ledger_error(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.")
+
+        from maverick.exceptions.beads import BeadQueryError
+
+        async def failing_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            raise BeadQueryError("boom")
+
+        with patch.object(BeadClient, "show", new=failing_show):
+            with pytest.raises(AssumptionLedgerError):
+                await record_assumption(
+                    client, payload=payload, source_bead_id="src-1", epic_id="epic-1"
+                )

--- a/tests/unit/assumptions/test_ledger_resolve.py
+++ b/tests/unit/assumptions/test_ledger_resolve.py
@@ -1,0 +1,118 @@
+"""Tests for maverick.assumptions.ledger.answer / waive."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from maverick.assumptions.errors import AssumptionLedgerError
+from maverick.assumptions.ledger import answer, waive
+from maverick.assumptions.models import (
+    KEY_ANSWER,
+    KEY_STATUS,
+    KEY_WAIVE_REASON,
+    KEY_WAIVED_AT,
+    KEY_WAIVED_BY,
+    STATUS_ANSWERED,
+    STATUS_WAIVED,
+)
+from maverick.beads.client import BeadClient
+from maverick.beads.models import BeadDetails, ClosedBead
+
+
+def _client() -> BeadClient:
+    return BeadClient(cwd=Path("/tmp/repo"))
+
+
+def _details(status: str = "open", **state: str) -> BeadDetails:
+    return BeadDetails(
+        id="dea-1",
+        title="Assumption: Q?",
+        description="## Question\n\nQ?\n\n## Adopted Answer\n\nA.\n",
+        bead_type="task",
+        status=status,
+        state=state,
+    )
+
+
+class TestAnswer:
+    @pytest.mark.asyncio
+    async def test_requires_non_empty_text(self) -> None:
+        client = _client()
+        with pytest.raises(AssumptionLedgerError):
+            await answer(client, bead_id="dea-1", answer_text="")
+
+    @pytest.mark.asyncio
+    async def test_rejects_whitespace_only(self) -> None:
+        client = _client()
+        with pytest.raises(AssumptionLedgerError):
+            await answer(client, bead_id="dea-1", answer_text="   ")
+
+    @pytest.mark.asyncio
+    async def test_sets_state_and_closes_bead(self) -> None:
+        client = _client()
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return _details(status="closed", **{KEY_STATUS: STATUS_ANSWERED, KEY_ANSWER: "Yes."})
+
+        with (
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+            patch.object(
+                BeadClient,
+                "close",
+                new=AsyncMock(return_value=ClosedBead(id="dea-1", status="closed")),
+            ) as mock_close,
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            record = await answer(client, bead_id="dea-1", answer_text="Yes.")
+
+        state_dict = mock_set_state.await_args.args[1]
+        assert state_dict[KEY_ANSWER] == "Yes."
+        assert state_dict[KEY_STATUS] == STATUS_ANSWERED
+        mock_close.assert_awaited_once()
+        assert record.status == STATUS_ANSWERED
+
+
+class TestWaive:
+    @pytest.mark.asyncio
+    async def test_requires_non_empty_reason(self) -> None:
+        client = _client()
+        with pytest.raises(AssumptionLedgerError):
+            await waive(client, bead_id="dea-1", reason="", waived_by="alice")
+
+    @pytest.mark.asyncio
+    async def test_records_who_when_why_and_closes(self) -> None:
+        client = _client()
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return _details(
+                status="closed",
+                **{
+                    KEY_STATUS: STATUS_WAIVED,
+                    KEY_WAIVED_BY: "alice",
+                    KEY_WAIVE_REASON: "not applicable",
+                },
+            )
+
+        with (
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+            patch.object(
+                BeadClient,
+                "close",
+                new=AsyncMock(return_value=ClosedBead(id="dea-1", status="closed")),
+            ) as mock_close,
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            record = await waive(
+                client, bead_id="dea-1", reason="not applicable", waived_by="alice"
+            )
+
+        state_dict = mock_set_state.await_args.args[1]
+        assert state_dict[KEY_WAIVED_BY] == "alice"
+        assert state_dict[KEY_WAIVE_REASON] == "not applicable"
+        assert KEY_WAIVED_AT in state_dict
+        assert state_dict[KEY_STATUS] == STATUS_WAIVED
+        mock_close.assert_awaited_once()
+        assert record.status == STATUS_WAIVED

--- a/tests/unit/assumptions/test_ledger_stamp.py
+++ b/tests/unit/assumptions/test_ledger_stamp.py
@@ -1,0 +1,115 @@
+"""Tests for maverick.assumptions.ledger.stamp_change_id."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from maverick.assumptions.ledger import stamp_change_id
+from maverick.assumptions.models import KEY_CHANGE_IDS
+from maverick.beads.client import BeadClient
+from maverick.beads.models import BeadDetails
+
+
+def _client() -> BeadClient:
+    return BeadClient(cwd=Path("/tmp/repo"))
+
+
+def _details(bead_id: str, change_ids: str = "") -> BeadDetails:
+    state = {KEY_CHANGE_IDS: change_ids} if change_ids else {}
+    return BeadDetails(
+        id=bead_id, title="Assumption", bead_type="task", status="open", state=state
+    )
+
+
+class TestStampChangeId:
+    @pytest.mark.asyncio
+    async def test_appends_to_comma_joined_state(self) -> None:
+        client = _client()
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return _details(bead_id, change_ids="abc123")
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+        ):
+            result = await stamp_change_id(client, entry_ids=["dea-1"], change_id="def456")
+
+        assert result.stamped == ("dea-1",)
+        assert result.failed == {}
+        state_dict = mock_set_state.await_args.args[1]
+        assert state_dict[KEY_CHANGE_IDS] == "abc123,def456"
+
+    @pytest.mark.asyncio
+    async def test_first_stamp_on_unstamped_entry(self) -> None:
+        client = _client()
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return _details(bead_id)
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+        ):
+            result = await stamp_change_id(client, entry_ids=["dea-1"], change_id="abc123")
+
+        assert result.stamped == ("dea-1",)
+        state_dict = mock_set_state.await_args.args[1]
+        assert state_dict[KEY_CHANGE_IDS] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_idempotent_per_entry_and_change_id(self) -> None:
+        client = _client()
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return _details(bead_id, change_ids="abc123")
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+        ):
+            result = await stamp_change_id(client, entry_ids=["dea-1"], change_id="abc123")
+
+        assert result.stamped == ("dea-1",)
+        mock_set_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_reported_never_raises(self) -> None:
+        client = _client()
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id == "dea-bad":
+                raise RuntimeError("bd show failed")
+            return _details(bead_id)
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+        ):
+            result = await stamp_change_id(
+                client, entry_ids=["dea-1", "dea-bad"], change_id="abc123"
+            )
+
+        assert result.stamped == ("dea-1",)
+        assert "dea-bad" in result.failed
+
+    @pytest.mark.asyncio
+    async def test_multiple_entries_all_stamped(self) -> None:
+        client = _client()
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return _details(bead_id)
+
+        with (
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+        ):
+            result = await stamp_change_id(
+                client, entry_ids=["dea-1", "dea-2"], change_id="abc123"
+            )
+
+        assert set(result.stamped) == {"dea-1", "dea-2"}
+        assert result.change_id == "abc123"

--- a/tests/unit/assumptions/test_models.py
+++ b/tests/unit/assumptions/test_models.py
@@ -1,0 +1,124 @@
+"""Tests for maverick.assumptions.models."""
+
+from __future__ import annotations
+
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    ASSUMPTION_LABELS,
+    KEY_ANSWER,
+    KEY_CHANGE_IDS,
+    KEY_OWNER_SPEC,
+    KEY_SEVERITY,
+    KEY_SEVERITY_DEFAULTED,
+    KEY_SOURCE_BEAD,
+    KEY_STATUS,
+    KEY_WAIVE_REASON,
+    KEY_WAIVED_AT,
+    KEY_WAIVED_BY,
+    STATUS_ANSWERED,
+    STATUS_OPEN,
+    STATUS_WAIVED,
+    AssumptionRecord,
+    PerSpecAssumptionCounts,
+    Severity,
+    coerce_severity,
+    nnn_prefix,
+)
+
+
+class TestSeverity:
+    def test_members(self) -> None:
+        assert Severity.LOW == "low"
+        assert Severity.MEDIUM == "medium"
+        assert Severity.HIGH == "high"
+
+
+class TestCoerceSeverity:
+    def test_valid_values_pass_through(self) -> None:
+        for value in ("low", "medium", "high"):
+            severity, defaulted = coerce_severity(value)
+            assert severity == Severity(value)
+            assert defaulted is False
+
+    def test_invalid_value_defaults_to_medium(self) -> None:
+        severity, defaulted = coerce_severity("urgent")
+        assert severity == Severity.MEDIUM
+        assert defaulted is True
+
+    def test_none_defaults_to_medium(self) -> None:
+        severity, defaulted = coerce_severity(None)
+        assert severity == Severity.MEDIUM
+        assert defaulted is True
+
+
+class TestNnnPrefix:
+    def test_extracts_leading_prefix(self) -> None:
+        assert nnn_prefix("049-assumption-ledger") == 49
+        assert nnn_prefix("001-greet-cli") == 1
+
+    def test_none_when_no_prefix(self) -> None:
+        assert nnn_prefix("my-flight-plan") is None
+        assert nnn_prefix("") is None
+
+
+class TestAssumptionRecord:
+    def test_construction(self) -> None:
+        record = AssumptionRecord(
+            bead_id="dea-1",
+            question="Q?",
+            adopted_answer="A.",
+            alternatives=("B.",),
+            severity=Severity.HIGH,
+            severity_defaulted=False,
+            status=STATUS_OPEN,
+            owner_spec="049-assumption-ledger",
+            source_bead="dea-0",
+            change_ids=(),
+            is_legacy=False,
+        )
+        assert record.bead_id == "dea-1"
+        assert record.change_ids == ()
+        assert record.is_legacy is False
+
+
+class TestPerSpecAssumptionCounts:
+    def test_construction(self) -> None:
+        counts = PerSpecAssumptionCounts(
+            owner_spec="049-assumption-ledger",
+            open={Severity.LOW: 1, Severity.MEDIUM: 0, Severity.HIGH: 0},
+            answered={Severity.LOW: 0, Severity.MEDIUM: 1, Severity.HIGH: 0},
+            waived={Severity.LOW: 0, Severity.MEDIUM: 0, Severity.HIGH: 1},
+            legacy_open=2,
+        )
+        assert counts.open[Severity.LOW] == 1
+        assert counts.legacy_open == 2
+
+
+class TestConstants:
+    def test_state_key_constants_are_distinct_strings(self) -> None:
+        keys = {
+            KEY_SEVERITY,
+            KEY_SEVERITY_DEFAULTED,
+            KEY_STATUS,
+            KEY_OWNER_SPEC,
+            KEY_CHANGE_IDS,
+            KEY_ANSWER,
+            KEY_WAIVED_BY,
+            KEY_WAIVED_AT,
+            KEY_WAIVE_REASON,
+            KEY_SOURCE_BEAD,
+        }
+        assert len(keys) == 10
+        assert all(isinstance(k, str) and k for k in keys)
+
+    def test_status_values(self) -> None:
+        assert {STATUS_OPEN, STATUS_ANSWERED, STATUS_WAIVED} == {
+            "open",
+            "answered",
+            "waived",
+        }
+
+    def test_assumption_labels_include_legacy(self) -> None:
+        assert ASSUMPTION_LABEL in ASSUMPTION_LABELS
+        assert "assumption-review" in ASSUMPTION_LABELS
+        assert "needs-human-review" in ASSUMPTION_LABELS

--- a/tests/unit/assumptions/test_report.py
+++ b/tests/unit/assumptions/test_report.py
@@ -1,0 +1,183 @@
+"""Tests for maverick.assumptions.report.per_spec_counts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    ASSUMPTION_REVIEW_LABEL,
+    KEY_OWNER_SPEC,
+    KEY_SEVERITY,
+    KEY_STATUS,
+    NEEDS_HUMAN_REVIEW_LABEL,
+    STATUS_ANSWERED,
+    STATUS_OPEN,
+    STATUS_WAIVED,
+    Severity,
+)
+from maverick.assumptions.report import per_spec_counts
+from maverick.beads.client import BeadClient
+from maverick.beads.models import BeadDetails, BeadSummary
+
+
+def _client() -> BeadClient:
+    return BeadClient(cwd=Path("/tmp/repo"))
+
+
+def _epic_summary(bead_id: str) -> BeadSummary:
+    return BeadSummary(id=bead_id, title=bead_id, status="open", bead_type="epic")
+
+
+def _epic_details(bead_id: str, speckit_feature: str = "") -> BeadDetails:
+    state = {"speckit_feature": speckit_feature} if speckit_feature else {}
+    return BeadDetails(id=bead_id, title=bead_id, bead_type="epic", state=state)
+
+
+def _entry(
+    bead_id: str,
+    severity: str,
+    status: str,
+    owner_spec: str,
+) -> BeadDetails:
+    return BeadDetails(
+        id=bead_id,
+        title=f"Assumption: {bead_id}",
+        description="## Question\n\nQ?\n\n",
+        bead_type="task",
+        status="closed" if status != STATUS_OPEN else "open",
+        labels=[ASSUMPTION_LABEL, ASSUMPTION_REVIEW_LABEL, NEEDS_HUMAN_REVIEW_LABEL],
+        state={KEY_SEVERITY: severity, KEY_STATUS: status, KEY_OWNER_SPEC: owner_spec},
+    )
+
+
+def _legacy(bead_id: str, flight_plan: str = "legacy-plan") -> BeadDetails:
+    return BeadDetails(
+        id=bead_id,
+        title="Review: legacy",
+        bead_type="task",
+        status="open",
+        labels=[ASSUMPTION_REVIEW_LABEL, NEEDS_HUMAN_REVIEW_LABEL],
+        state={"source_bead": "b-1", "flight_plan": flight_plan},
+    )
+
+
+class TestPerSpecCounts:
+    @pytest.mark.asyncio
+    async def test_groups_by_owner_spec_severity_x_status_matrix(self) -> None:
+        client = _client()
+        epics = {"epic-1": _epic_details("epic-1", "049-assumption-ledger")}
+        entries = {
+            "dea-1": _entry("dea-1", "high", STATUS_OPEN, "049-assumption-ledger"),
+            "dea-2": _entry("dea-2", "medium", STATUS_ANSWERED, "049-assumption-ledger"),
+            "dea-3": _entry("dea-3", "low", STATUS_WAIVED, "049-assumption-ledger"),
+        }
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            if filter_expr.startswith("type=epic"):
+                return [_epic_summary(k) for k in epics]
+            return [BeadSummary(id=k, title=k, status="open", bead_type="task") for k in entries]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id in epics:
+                return epics[bead_id]
+            return entries[bead_id]
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            result = await per_spec_counts(client)
+
+        assert len(result) == 1
+        row = result[0]
+        assert row.owner_spec == "049-assumption-ledger"
+        assert row.open[Severity.HIGH] == 1
+        assert row.answered[Severity.MEDIUM] == 1
+        assert row.waived[Severity.LOW] == 1
+        assert row.legacy_open == 0
+
+    @pytest.mark.asyncio
+    async def test_legacy_bucket_counted_separately(self) -> None:
+        client = _client()
+        epics = {"epic-1": _epic_details("epic-1", "049-assumption-ledger")}
+        legacy = {"legacy-1": _legacy("legacy-1", flight_plan="049-assumption-ledger")}
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            if filter_expr.startswith("type=epic"):
+                return [_epic_summary(k) for k in epics]
+            return [BeadSummary(id=k, title=k, status="open", bead_type="task") for k in legacy]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id in epics:
+                return epics[bead_id]
+            return legacy[bead_id]
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            result = await per_spec_counts(client)
+
+        assert len(result) == 1
+        assert result[0].legacy_open == 1
+
+    @pytest.mark.asyncio
+    async def test_epic_with_zero_entries_renders_zero_row(self) -> None:
+        client = _client()
+        epics = {
+            "epic-1": _epic_details("epic-1", "048-has-entries"),
+            "epic-2": _epic_details("epic-2", "049-no-entries"),
+        }
+        entries = {"dea-1": _entry("dea-1", "medium", STATUS_OPEN, "048-has-entries")}
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            if filter_expr.startswith("type=epic"):
+                return [_epic_summary(k) for k in epics]
+            return [BeadSummary(id=k, title=k, status="open", bead_type="task") for k in entries]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            if bead_id in epics:
+                return epics[bead_id]
+            return entries[bead_id]
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            result = await per_spec_counts(client)
+
+        specs = {r.owner_spec for r in result}
+        assert specs == {"048-has-entries", "049-no-entries"}
+        zero_row = next(r for r in result if r.owner_spec == "049-no-entries")
+        assert all(v == 0 for v in zero_row.open.values())
+        assert all(v == 0 for v in zero_row.answered.values())
+        assert all(v == 0 for v in zero_row.waived.values())
+        assert zero_row.legacy_open == 0
+
+    @pytest.mark.asyncio
+    async def test_deterministic_ordering_by_owner_spec(self) -> None:
+        client = _client()
+        epics = {
+            "epic-b": _epic_details("epic-b", "050-b-spec"),
+            "epic-a": _epic_details("epic-a", "010-a-spec"),
+        }
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            if filter_expr.startswith("type=epic"):
+                return [_epic_summary(k) for k in epics]
+            return []
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return epics[bead_id]
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            result = await per_spec_counts(client)
+
+        assert [r.owner_spec for r in result] == ["010-a-spec", "050-b-spec"]

--- a/tests/unit/beads/test_client.py
+++ b/tests/unit/beads/test_client.py
@@ -213,6 +213,40 @@ class TestBeadClientAddDependency:
         ]
 
     @pytest.mark.asyncio
+    async def test_add_dependency_discovered_from(
+        self, mock_runner: AsyncMock, temp_dir: Path
+    ) -> None:
+        from maverick.beads.models import DependencyType
+
+        mock_runner.run.return_value = CommandResult(
+            returncode=0,
+            stdout="",
+            stderr="",
+            duration_ms=50,
+            timed_out=False,
+        )
+        client = BeadClient(cwd=temp_dir, runner=mock_runner)
+        dep = BeadDependency(
+            blocker_id="source-bead",
+            blocked_id="assumption-bead",
+            dep_type=DependencyType.DISCOVERED_FROM,
+        )
+        await client.add_dependency(dep)
+
+        call_args = mock_runner.run.call_args
+        cmd = call_args[0][0]
+        assert cmd == [
+            "bd",
+            "dep",
+            "add",
+            "assumption-bead",
+            "--blocked-by",
+            "source-bead",
+            "--type",
+            "discovered-from",
+        ]
+
+    @pytest.mark.asyncio
     async def test_add_dependency_failure_raises(
         self, mock_runner: AsyncMock, temp_dir: Path
     ) -> None:

--- a/tests/unit/beads/test_models.py
+++ b/tests/unit/beads/test_models.py
@@ -58,6 +58,15 @@ class TestDependencyType:
     def test_blocks_value(self) -> None:
         assert DependencyType.BLOCKS.value == "blocks"
 
+    def test_discovered_from_value(self) -> None:
+        assert DependencyType.DISCOVERED_FROM.value == "discovered-from"
+
+    def test_discovered_from_accepted_by_bead_dependency(self) -> None:
+        dep = BeadDependency(
+            blocker_id="a", blocked_id="b", dep_type=DependencyType.DISCOVERED_FROM
+        )
+        assert dep.dep_type == DependencyType.DISCOVERED_FROM
+
 
 class TestBeadDefinition:
     """Tests for BeadDefinition model."""

--- a/tests/unit/cli/test_brief_command.py
+++ b/tests/unit/cli/test_brief_command.py
@@ -17,6 +17,7 @@ _PATCH_VERIFY = "maverick.cli.commands.brief.BeadClient.verify_available"
 _PATCH_READY = "maverick.cli.commands.brief.BeadClient.ready"
 _PATCH_CHILDREN = "maverick.cli.commands.brief.BeadClient.children"
 _PATCH_QUERY = "maverick.cli.commands.brief.BeadClient.query"
+_PATCH_SHOW = "maverick.cli.commands.brief.BeadClient.show"
 
 
 def _make_ready_bead(
@@ -235,10 +236,12 @@ class TestBriefReady:
         result = cli_runner.invoke(cli, ["brief", "--format", "json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert isinstance(data, list)
-        assert len(data) == 1
-        assert data[0]["id"] == "bead-001"
-        assert data[0]["title"] == "Setup project"
+        assert isinstance(data, dict)
+        assert "assumption_counts" in data
+        beads = data["beads"]
+        assert len(beads) == 1
+        assert beads[0]["id"] == "bead-001"
+        assert beads[0]["title"] == "Setup project"
 
     @patch(_PATCH_QUERY, new_callable=AsyncMock)
     @patch(_PATCH_READY, new_callable=AsyncMock)
@@ -323,9 +326,10 @@ class TestBriefReady:
         result = cli_runner.invoke(cli, ["brief", "--format", "json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert len(data) == 1
+        beads = data["beads"]
+        assert len(beads) == 1
         # Ready takes precedence
-        assert data[0]["status"] == "ready"
+        assert beads[0]["status"] == "ready"
 
 
 class TestBriefEpic:
@@ -519,6 +523,261 @@ class TestBriefEpic:
         )
         data = json.loads(result.output)
         assert data[0]["status"] == "closed"
+
+
+class TestBriefAssumptionsSection:
+    """Tests for the per-spec Assumptions section (T038 / FR-010)."""
+
+    @patch(_PATCH_QUERY, new_callable=AsyncMock, return_value=[])
+    @patch(_PATCH_READY, new_callable=AsyncMock, return_value=[])
+    @patch(_PATCH_VERIFY, new_callable=AsyncMock, return_value=True)
+    def test_default_text_view_shows_zero_row(
+        self,
+        mock_verify: AsyncMock,
+        mock_ready: AsyncMock,
+        mock_query: AsyncMock,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from maverick.assumptions.models import PerSpecAssumptionCounts, Severity
+
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        zero = {Severity.LOW: 0, Severity.MEDIUM: 0, Severity.HIGH: 0}
+        row = PerSpecAssumptionCounts(
+            owner_spec="049-no-entries",
+            open=zero,
+            answered=zero,
+            waived=zero,
+            legacy_open=0,
+        )
+        with patch(
+            "maverick.assumptions.report.per_spec_counts",
+            new=AsyncMock(return_value=(row,)),
+        ):
+            result = cli_runner.invoke(cli, ["brief"])
+        assert result.exit_code == 0
+        assert "Assumptions" in result.output
+        assert "049-no-entries" in result.output
+        assert "0/0/0" in result.output
+
+    @patch(_PATCH_QUERY, new_callable=AsyncMock, return_value=[])
+    @patch(_PATCH_READY, new_callable=AsyncMock, return_value=[])
+    @patch(_PATCH_VERIFY, new_callable=AsyncMock, return_value=True)
+    def test_default_json_view_includes_assumption_counts_array(
+        self,
+        mock_verify: AsyncMock,
+        mock_ready: AsyncMock,
+        mock_query: AsyncMock,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from maverick.assumptions.models import PerSpecAssumptionCounts, Severity
+
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        counts = {Severity.LOW: 1, Severity.MEDIUM: 2, Severity.HIGH: 0}
+        row = PerSpecAssumptionCounts(
+            owner_spec="049-assumption-ledger",
+            open=counts,
+            answered={Severity.LOW: 0, Severity.MEDIUM: 0, Severity.HIGH: 0},
+            waived={Severity.LOW: 0, Severity.MEDIUM: 0, Severity.HIGH: 0},
+            legacy_open=3,
+        )
+        with patch(
+            "maverick.assumptions.report.per_spec_counts",
+            new=AsyncMock(return_value=(row,)),
+        ):
+            result = cli_runner.invoke(cli, ["brief", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["assumption_counts"] == [
+            {
+                "owner_spec": "049-assumption-ledger",
+                "open": {"low": 1, "medium": 2, "high": 0},
+                "answered": {"low": 0, "medium": 0, "high": 0},
+                "waived": {"low": 0, "medium": 0, "high": 0},
+                "legacy_open": 3,
+            }
+        ]
+
+    @patch(_PATCH_QUERY, new_callable=AsyncMock, return_value=[])
+    @patch(_PATCH_READY, new_callable=AsyncMock, return_value=[])
+    @patch(_PATCH_VERIFY, new_callable=AsyncMock, return_value=True)
+    def test_section_omitted_when_beads_store_absent(
+        self,
+        mock_verify: AsyncMock,
+        mock_ready: AsyncMock,
+        mock_query: AsyncMock,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        with patch(
+            "maverick.assumptions.report.per_spec_counts",
+            new=AsyncMock(side_effect=RuntimeError("bd not initialized")),
+        ):
+            result = cli_runner.invoke(cli, ["brief"])
+        assert result.exit_code == 0
+        assert "Assumptions" not in result.output
+
+
+class TestBriefHuman:
+    """Tests for ``brief --human`` — ledger entries alongside legacy
+    escalation beads (T034/T036)."""
+
+    @patch(_PATCH_SHOW, new_callable=AsyncMock)
+    @patch(_PATCH_READY, new_callable=AsyncMock)
+    @patch(_PATCH_VERIFY, new_callable=AsyncMock, return_value=True)
+    def test_lists_ledger_entry_with_state_context(
+        self,
+        mock_verify: AsyncMock,
+        mock_ready: AsyncMock,
+        mock_show: AsyncMock,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from maverick.beads.models import BeadDetails
+
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        mock_ready.return_value = [
+            _make_ready_bead("dea-1", "Assumption: Should retries be per bead?", 2)
+        ]
+        mock_show.return_value = BeadDetails(
+            id="dea-1",
+            title="Assumption: Should retries be per bead?",
+            description="## Question\n\nShould retries be per bead?\n\n",
+            labels=["assumption", "assumption-review", "needs-human-review"],
+            state={
+                "assumption_severity": "medium",
+                "assumption_status": "open",
+                "assumption_owner_spec": "049-assumption-ledger",
+                "source_bead": "src-1",
+            },
+        )
+        result = cli_runner.invoke(cli, ["brief", "--human"])
+        assert result.exit_code == 0
+        assert "dea-1" in result.output
+        assert "src-1" in result.output
+
+    @patch(_PATCH_SHOW, new_callable=AsyncMock)
+    @patch(_PATCH_READY, new_callable=AsyncMock)
+    @patch(_PATCH_VERIFY, new_callable=AsyncMock, return_value=True)
+    def test_ledger_entries_and_legacy_beads_render_together(
+        self,
+        mock_verify: AsyncMock,
+        mock_ready: AsyncMock,
+        mock_show: AsyncMock,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from maverick.beads.models import BeadDetails
+
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        mock_ready.return_value = [
+            _make_ready_bead("dea-1", "Assumption: Q?", 2),
+            _make_ready_bead("dea-legacy", "Review: legacy", 1),
+        ]
+
+        async def _show(bead_id: str) -> BeadDetails:
+            if bead_id == "dea-1":
+                return BeadDetails(
+                    id="dea-1",
+                    title="Assumption: Q?",
+                    labels=["assumption", "assumption-review", "needs-human-review"],
+                    state={"source_bead": "src-1"},
+                )
+            return BeadDetails(
+                id="dea-legacy",
+                title="Review: legacy",
+                labels=["assumption-review", "needs-human-review"],
+                state={"source_bead": "src-2", "escalation_type": "fix_exhaustion"},
+            )
+
+        mock_show.side_effect = _show
+        result = cli_runner.invoke(cli, ["brief", "--human"])
+        assert result.exit_code == 0
+        assert "dea-1" in result.output
+        assert "dea-legacy" in result.output
+
+    @patch(_PATCH_SHOW, new_callable=AsyncMock)
+    @patch(_PATCH_READY, new_callable=AsyncMock)
+    @patch(_PATCH_VERIFY, new_callable=AsyncMock, return_value=True)
+    def test_human_json_format(
+        self,
+        mock_verify: AsyncMock,
+        mock_ready: AsyncMock,
+        mock_show: AsyncMock,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from maverick.beads.models import BeadDetails
+
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        mock_ready.return_value = [_make_ready_bead("dea-1", "Assumption: Q?", 2)]
+        mock_show.return_value = BeadDetails(
+            id="dea-1",
+            title="Assumption: Q?",
+            labels=["assumption", "assumption-review", "needs-human-review"],
+            state={"source_bead": "src-1"},
+        )
+        result = cli_runner.invoke(cli, ["brief", "--human", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "assumption_counts" in data
+        beads = data["beads"]
+        assert beads[0]["id"] == "dea-1"
+        assert beads[0]["source_bead"] == "src-1"
+
+    @patch(_PATCH_SHOW, new_callable=AsyncMock)
+    @patch(_PATCH_READY, new_callable=AsyncMock, return_value=[])
+    @patch(_PATCH_VERIFY, new_callable=AsyncMock, return_value=True)
+    def test_human_view_includes_assumptions_section(
+        self,
+        mock_verify: AsyncMock,
+        mock_ready: AsyncMock,
+        mock_show: AsyncMock,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from maverick.assumptions.models import PerSpecAssumptionCounts, Severity
+
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        zero = {Severity.LOW: 0, Severity.MEDIUM: 0, Severity.HIGH: 0}
+        row = PerSpecAssumptionCounts(
+            owner_spec="049-assumption-ledger",
+            open=zero,
+            answered=zero,
+            waived=zero,
+            legacy_open=0,
+        )
+        with patch(
+            "maverick.assumptions.report.per_spec_counts",
+            new=AsyncMock(return_value=(row,)),
+        ):
+            result = cli_runner.invoke(cli, ["brief", "--human"])
+        assert result.exit_code == 0
+        assert "Assumptions" in result.output
+        assert "049-assumption-ledger" in result.output
 
 
 class TestBriefWatch:

--- a/tests/unit/cli/test_land_command.py
+++ b/tests/unit/cli/test_land_command.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from maverick.assumptions.models import AssumptionRecord, Severity
 from maverick.cli.commands.land import (
     _display_plan,
     land,
@@ -223,6 +224,88 @@ class TestModeHints:
             result = runner.invoke(land, ["--no-curate", "--eject", "--branch", "wip/foo"])
         assert result.exit_code == 0
         assert "wip/foo" in result.output
+
+
+# ── Assumption ledger gate ──────────────────────────────────────────
+
+
+def _blocking_entry(
+    bead_id: str = "dea-1", severity: Severity = Severity.MEDIUM
+) -> AssumptionRecord:
+    return AssumptionRecord(
+        bead_id=bead_id,
+        question="Should retries be per bead?",
+        adopted_answer="Per bead.",
+        alternatives=(),
+        severity=severity,
+        severity_defaulted=False,
+        status="open",
+        owner_spec="049-assumption-ledger",
+        source_bead="src-1",
+        change_ids=(),
+        is_legacy=False,
+    )
+
+
+def _patch_gate(*, entries: list[AssumptionRecord] | None = None, bd_available: bool = True):
+    return (
+        patch(
+            "maverick.beads.client.BeadClient.verify_available",
+            new=AsyncMock(return_value=bd_available),
+        ),
+        patch(
+            "maverick.assumptions.ledger.open_blocking_entries",
+            new=AsyncMock(return_value=entries or []),
+        ),
+    )
+
+
+class TestAssumptionGate:
+    def test_blocks_with_table_and_hint_nonzero_exit(self) -> None:
+        runner = CliRunner()
+        gather, curate, consolidate = _patch_curation()
+        verify, blocking = _patch_gate(entries=[_blocking_entry()])
+        with gather, curate, consolidate, verify, blocking:
+            result = runner.invoke(land, ["--no-curate", "--yes"])
+        assert result.exit_code != 0
+        assert "dea-1" in result.output
+        assert "049-assumption-ledger" in result.output
+        assert "maverick review" in result.output
+
+    def test_passes_when_no_blocking_entries(self) -> None:
+        runner = CliRunner()
+        gather, curate, consolidate = _patch_curation()
+        verify, blocking = _patch_gate(entries=[])
+        with gather, curate, consolidate, verify, blocking:
+            result = runner.invoke(land, ["--no-curate"])
+        assert result.exit_code == 0
+
+    def test_dry_run_still_evaluates_and_exits_nonzero_at_end(self) -> None:
+        runner = CliRunner()
+        gather, curate, consolidate = _patch_curation()
+        verify, blocking = _patch_gate(entries=[_blocking_entry()])
+        with gather, curate, consolidate, verify, blocking:
+            result = runner.invoke(land, ["--no-curate", "--dry-run"])
+        # The rest of the (no-op) preview still runs...
+        assert "Dry run" in result.output
+        assert "dea-1" in result.output
+        # ...but the command exits non-zero because a real land would block.
+        assert result.exit_code != 0
+
+    def test_no_bd_available_gate_passes(self) -> None:
+        runner = CliRunner()
+        gather, curate, consolidate = _patch_curation()
+        verify, blocking = _patch_gate(bd_available=False)
+        with gather, curate, consolidate, verify, blocking:
+            result = runner.invoke(land, ["--no-curate"])
+        assert result.exit_code == 0
+
+    def test_help_exposes_no_bypass_flag(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(land, ["--help"])
+        assert result.exit_code == 0
+        for flag in ("--force", "--skip-gate", "--bypass", "--no-gate"):
+            assert flag not in result.output
 
 
 # ── Display plan ────────────────────────────────────────────────────

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -1,0 +1,188 @@
+"""Unit tests for the ``maverick review`` command's ledger display and
+answer/waive flows (T029/T032). Legacy escalation-bead behavior
+(approve/reject/defer) is exercised implicitly by not setting the
+``assumption`` label.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from click.testing import CliRunner
+
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    ASSUMPTION_REVIEW_LABEL,
+    KEY_CHANGE_IDS,
+    KEY_OWNER_SPEC,
+    KEY_SEVERITY,
+    KEY_SEVERITY_DEFAULTED,
+    KEY_SOURCE_BEAD,
+    NEEDS_HUMAN_REVIEW_LABEL,
+)
+from maverick.beads.models import BeadDetails
+from maverick.cli.commands.review import review
+
+_LEDGER_DESCRIPTION = (
+    "## Question\n\nShould retries be per bead?\n\n"
+    "## Adopted Answer\n\nPer bead — matches existing scoping.\n\n"
+    "## Alternatives Considered\n\n- Per run\n- Configurable\n\n"
+    "## Context\n\nSource bead: src-1 — Implement the thing\n"
+)
+
+
+def _ledger_details(**state: str) -> BeadDetails:
+    return BeadDetails(
+        id="dea-1",
+        title="Assumption: Should retries be per bead?",
+        description=_LEDGER_DESCRIPTION,
+        bead_type="task",
+        status="open",
+        labels=[ASSUMPTION_LABEL, ASSUMPTION_REVIEW_LABEL, NEEDS_HUMAN_REVIEW_LABEL],
+        state=state,
+    )
+
+
+def _patch_client(details: BeadDetails):
+    return (
+        patch(
+            "maverick.beads.client.BeadClient.verify_available",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "maverick.beads.client.BeadClient.show",
+            new=AsyncMock(return_value=details),
+        ),
+    )
+
+
+class TestLedgerDisplay:
+    def test_shows_question_answer_alternatives_severity_spec_stamps_source(self) -> None:
+        runner = CliRunner()
+        details = _ledger_details(
+            **{
+                KEY_SEVERITY: "high",
+                KEY_OWNER_SPEC: "049-assumption-ledger",
+                KEY_SOURCE_BEAD: "src-1",
+                KEY_CHANGE_IDS: "abc123",
+            }
+        )
+        verify, show = _patch_client(details)
+        with verify, show:
+            result = runner.invoke(review, ["dea-1", "--waive", "not needed"])
+        assert "Should retries be per bead?" in result.output
+        assert "Per bead — matches existing scoping." in result.output
+        assert "Per run" in result.output
+        assert "high" in result.output
+        assert "049-assumption-ledger" in result.output
+        assert "abc123" in result.output
+        assert "src-1" in result.output
+
+    def test_defaulted_severity_marker(self) -> None:
+        runner = CliRunner()
+        details = _ledger_details(**{KEY_SEVERITY: "medium", KEY_SEVERITY_DEFAULTED: "true"})
+        verify, show = _patch_client(details)
+        with verify, show:
+            result = runner.invoke(review, ["dea-1", "--waive", "n/a"])
+        assert "(defaulted)" in result.output
+
+    def test_unstamped_entry_shows_unstamped(self) -> None:
+        runner = CliRunner()
+        details = _ledger_details(**{KEY_SEVERITY: "medium"})
+        verify, show = _patch_client(details)
+        with verify, show:
+            result = runner.invoke(review, ["dea-1", "--waive", "n/a"])
+        assert "unstamped" in result.output
+
+
+class TestAnswerFlow:
+    def test_answer_records_and_closes(self) -> None:
+        runner = CliRunner()
+        details = _ledger_details(**{KEY_SEVERITY: "medium"})
+        verify, show = _patch_client(details)
+        with (
+            verify,
+            show,
+            patch("maverick.assumptions.ledger.answer", new=AsyncMock()) as mock_answer,
+        ):
+            result = runner.invoke(review, ["dea-1", "--answer", "Per bead."])
+        assert result.exit_code == 0
+        mock_answer.assert_awaited_once()
+        assert mock_answer.await_args.kwargs["answer_text"] == "Per bead."
+        assert "answered and closed" in result.output
+
+    def test_empty_answer_rejected(self) -> None:
+        runner = CliRunner()
+        details = _ledger_details(**{KEY_SEVERITY: "medium"})
+        verify, show = _patch_client(details)
+        with verify, show:
+            result = runner.invoke(review, ["dea-1", "--answer", "   "])
+        assert result.exit_code != 0
+        assert "must not be empty" in result.output
+
+
+class TestWaiveFlow:
+    def test_waive_records_who_when_why_and_closes(self) -> None:
+        runner = CliRunner()
+        details = _ledger_details(**{KEY_SEVERITY: "medium"})
+        verify, show = _patch_client(details)
+        with (
+            verify,
+            show,
+            patch(
+                "maverick.cli.commands.review._resolve_git_user_name",
+                return_value="alice",
+            ),
+            patch("maverick.assumptions.ledger.waive", new=AsyncMock()) as mock_waive,
+        ):
+            result = runner.invoke(review, ["dea-1", "--waive", "no longer applicable"])
+        assert result.exit_code == 0
+        mock_waive.assert_awaited_once()
+        assert mock_waive.await_args.kwargs["reason"] == "no longer applicable"
+        assert mock_waive.await_args.kwargs["waived_by"] == "alice"
+        assert "waived by alice" in result.output
+
+    def test_empty_reason_rejected(self) -> None:
+        runner = CliRunner()
+        details = _ledger_details(**{KEY_SEVERITY: "medium"})
+        verify, show = _patch_client(details)
+        with verify, show:
+            result = runner.invoke(review, ["dea-1", "--waive", "   "])
+        assert result.exit_code != 0
+        assert "must not be empty" in result.output
+
+
+class TestMutualExclusion:
+    def test_answer_and_waive_together_rejected(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(review, ["dea-1", "--answer", "A.", "--waive", "not needed"])
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+
+class TestLegacyBeadsUnaffected:
+    def test_legacy_escalation_bead_keeps_approve_flow(self) -> None:
+        """A bead without the `assumption` label keeps today's behavior."""
+        runner = CliRunner()
+        legacy_details = BeadDetails(
+            id="dea-legacy",
+            title="Review: legacy",
+            description="legacy escalation",
+            bead_type="task",
+            status="open",
+            labels=[ASSUMPTION_REVIEW_LABEL, NEEDS_HUMAN_REVIEW_LABEL],
+            state={"source_bead": "b-1"},
+        )
+        verify, show = _patch_client(legacy_details)
+        with (
+            verify,
+            show,
+            patch(
+                "maverick.beads.client.BeadClient.close",
+                new=AsyncMock(),
+            ) as mock_close,
+        ):
+            result = runner.invoke(review, ["dea-legacy", "--approve"])
+        assert result.exit_code == 0
+        mock_close.assert_awaited_once()
+        assert "closed as approved" in result.output

--- a/tests/unit/library/actions/test_beads_actions.py
+++ b/tests/unit/library/actions/test_beads_actions.py
@@ -403,6 +403,60 @@ class TestSelectNextBead:
         assert result.flight_plan_name == "my-plan"
 
     @pytest.mark.asyncio
+    async def test_skips_ledger_beads_and_selects_next_ready(self) -> None:
+        """Assumption-ledger beads (assumption + legacy labels) are skipped
+        by the same filter that already skips legacy escalation beads —
+        no code change needed, this locks the behavior in (T033)."""
+        from maverick.beads.models import BeadDetails, ReadyBead
+        from maverick.library.actions.beads import select_next_bead
+
+        mock_client = AsyncMock()
+        mock_client.ready.return_value = [
+            ReadyBead(id="dea-1", title="Assumption: Q?", priority=2, parent_id="epic-1"),
+            ReadyBead(id="b-1", title="Fix lint", priority=5, parent_id="epic-1"),
+        ]
+
+        async def _show_side_effect(bead_id: str) -> BeadDetails:
+            if bead_id == "dea-1":
+                return BeadDetails(
+                    id="dea-1",
+                    title="Assumption: Q?",
+                    labels=["assumption", "assumption-review", "needs-human-review"],
+                )
+            return BeadDetails(id=bead_id, title="Fix lint", labels=[])
+
+        mock_client.show.side_effect = _show_side_effect
+
+        with patch("maverick.beads.client.BeadClient", return_value=mock_client):
+            result = await select_next_bead("epic-1", cwd=Path("/tmp"))
+
+        assert result.found is True
+        assert result.bead_id == "b-1"
+
+    @pytest.mark.asyncio
+    async def test_only_ledger_beads_ready_returns_not_found(self) -> None:
+        """When every ready bead is a ledger entry, select_next_bead reports
+        not-found (agent skips them; the human queue is the only path)."""
+        from maverick.beads.models import BeadDetails, ReadyBead
+        from maverick.library.actions.beads import select_next_bead
+
+        mock_client = AsyncMock()
+        mock_client.ready.return_value = [
+            ReadyBead(id="dea-1", title="Assumption: Q?", priority=2, parent_id="epic-1"),
+        ]
+        mock_client.show.return_value = BeadDetails(
+            id="dea-1",
+            title="Assumption: Q?",
+            labels=["assumption", "assumption-review", "needs-human-review"],
+        )
+
+        with patch("maverick.beads.client.BeadClient", return_value=mock_client):
+            result = await select_next_bead("epic-1", cwd=Path("/tmp"))
+
+        assert result.found is False
+        assert result.done is False
+
+    @pytest.mark.asyncio
     async def test_empty_epic_no_beads_returns_done(self) -> None:
         """When epic_id is empty and no beads found, result is done."""
         from maverick.library.actions.beads import select_next_bead

--- a/tests/unit/test_payloads_assumptions.py
+++ b/tests/unit/test_payloads_assumptions.py
@@ -1,0 +1,121 @@
+"""Tests for AssumptionPayload and the assumptions field on submit payloads."""
+
+from __future__ import annotations
+
+from maverick.payloads import (
+    AssumptionPayload,
+    SubmitFixResultPayload,
+    SubmitImplementationPayload,
+    SubmitReviewPayload,
+)
+
+
+class TestAssumptionPayload:
+    def test_requires_question_and_adopted_answer(self) -> None:
+        payload = AssumptionPayload(
+            question="Should retries be per bead?",
+            adopted_answer="Per bead.",
+        )
+        assert payload.question == "Should retries be per bead?"
+        assert payload.adopted_answer == "Per bead."
+
+    def test_alternatives_default_empty(self) -> None:
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.")
+        assert payload.alternatives == ()
+
+    def test_valid_severity_not_defaulted(self) -> None:
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="high")
+        assert payload.severity == "high"
+        assert payload.severity_defaulted is False
+
+    def test_unknown_severity_coerced_to_medium(self) -> None:
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="critical")
+        assert payload.severity == "medium"
+        assert payload.severity_defaulted is True
+
+    def test_absent_severity_defaults_to_medium(self) -> None:
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.")
+        assert payload.severity == "medium"
+        assert payload.severity_defaulted is True
+
+    def test_never_raises_on_bad_severity(self) -> None:
+        # Should not raise ValidationError for any severity string.
+        payload = AssumptionPayload(
+            question="Q?", adopted_answer="A.", severity="not-a-real-severity"
+        )
+        assert payload.severity == "medium"
+
+
+class TestSubmitPayloadsAssumptionsField:
+    def test_submit_implementation_absent_field_defaults_empty(self) -> None:
+        payload = SubmitImplementationPayload(summary="did stuff")
+        assert payload.assumptions == ()
+
+    def test_submit_implementation_with_assumptions(self) -> None:
+        payload = SubmitImplementationPayload(
+            summary="did stuff",
+            assumptions=[{"question": "Q?", "adopted_answer": "A."}],
+        )
+        assert len(payload.assumptions) == 1
+        assert payload.assumptions[0].question == "Q?"
+
+    def test_submit_review_absent_field_defaults_empty(self) -> None:
+        payload = SubmitReviewPayload(approved=True)
+        assert payload.assumptions == ()
+
+    def test_submit_fix_result_absent_field_defaults_empty(self) -> None:
+        payload = SubmitFixResultPayload(summary="fixed")
+        assert payload.assumptions == ()
+
+    def test_existing_payload_dicts_still_validate(self) -> None:
+        """Older agent prompts that never mention assumptions keep validating."""
+        payload = SubmitImplementationPayload.model_validate(
+            {"summary": "did stuff", "files_changed": ["a.py"]}
+        )
+        assert payload.assumptions == ()
+        assert payload.files_changed == ("a.py",)
+
+    def test_malformed_assumption_dropped_not_fatal(self) -> None:
+        """A partially-filled assumption must not fail the whole load-bearing
+        payload — it is pruned, the rest of the payload validates."""
+        payload = SubmitImplementationPayload.model_validate(
+            {
+                "summary": "did stuff",
+                "files_changed": ["a.py"],
+                "assumptions": [
+                    {"question": "Kept?", "adopted_answer": "Yes."},
+                    {"question": "Missing answer"},  # dropped
+                    {"adopted_answer": "Missing question"},  # dropped
+                    {"question": "  ", "adopted_answer": "blank q"},  # dropped
+                ],
+            }
+        )
+        assert payload.summary == "did stuff"
+        assert len(payload.assumptions) == 1
+        assert payload.assumptions[0].question == "Kept?"
+
+    def test_malformed_assumption_dropped_on_review_and_fix(self) -> None:
+        review = SubmitReviewPayload.model_validate(
+            {"approved": True, "assumptions": [{"question": "Q?"}]}
+        )
+        assert review.assumptions == ()
+        fix = SubmitFixResultPayload.model_validate(
+            {"summary": "fixed", "assumptions": [{"adopted_answer": "A."}]}
+        )
+        assert fix.assumptions == ()
+
+    def test_assumptions_round_trip_through_dump_and_revalidate(self) -> None:
+        """dump -> state dict -> re-validate preserves severity_defaulted."""
+        from maverick.payloads import dump_supervisor_payload
+
+        payload = SubmitImplementationPayload(
+            summary="did stuff",
+            assumptions=[{"question": "Q?", "adopted_answer": "A.", "severity": "bogus"}],
+        )
+        dumped = dump_supervisor_payload(payload)
+        assumption_dict = dumped["assumptions"][0]
+        assert assumption_dict["severity_defaulted"] is True
+
+        rebuilt = AssumptionPayload.model_validate(assumption_dict)
+        assert rebuilt.severity == "medium"
+        assert rebuilt.severity_defaulted is True

--- a/tests/unit/workflows/fly_beads/test_assumption_actions.py
+++ b/tests/unit/workflows/fly_beads/test_assumption_actions.py
@@ -1,0 +1,281 @@
+"""Tests for assumption-ledger wiring in the fly_beads Burr actions.
+
+Covers: implement/review/fix accumulate payload ``assumptions`` into
+``pending_assumptions`` (cleared on bead start), ``record_assumptions``
+creates entries non-fatally, and ``commit`` captures ``commit_change_id``
+and stamps recorded entries non-fatally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from burr.core import State
+
+from maverick.assumptions.errors import AssumptionLedgerError
+from maverick.assumptions.models import AssumptionRecord, Severity, StampResult
+from maverick.events import ProgressEvent
+from maverick.payloads import SubmitFixResultPayload, SubmitImplementationPayload
+from maverick.workflows.fly_beads import actions as fly_actions
+from tests.unit.agents.airframe_stubs import StubCodingAgent
+
+pytestmark = pytest.mark.asyncio
+
+
+class _NullCM:
+    def __enter__(self) -> _NullCM:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+class _StubSquadron:
+    def __init__(self, coder: StubCodingAgent) -> None:
+        self._coder = coder
+
+    def coder_for(self, _tier: str) -> StubCodingAgent:
+        return self._coder
+
+    def bead_context(self, **_kwargs: object) -> _NullCM:
+        return _NullCM()
+
+
+def _queue() -> asyncio.Queue[ProgressEvent | None]:
+    return asyncio.Queue()
+
+
+_ASSUMPTION_DICT = {"question": "Q?", "adopted_answer": "A.", "severity": "medium"}
+
+
+class TestImplementAccumulatesAssumptions:
+    async def test_appends_assumptions_from_payload(self) -> None:
+        squadron = _StubSquadron(
+            StubCodingAgent(
+                implement_payloads=[
+                    SubmitImplementationPayload(
+                        summary="did stuff", assumptions=[_ASSUMPTION_DICT]
+                    )
+                ]
+            )
+        )
+        state = State(
+            {
+                "current_bead": {"bead_id": "b-1", "title": "t", "description": "d"},
+                "current_bead_id": "b-1",
+                "implementer_escalation_level": 0,
+                "pending_assumptions": [],
+            }
+        )
+        _, new_state = await fly_actions.implement(state, squadron=squadron, events=_queue())  # type: ignore[arg-type]
+        pending = new_state["pending_assumptions"]
+        assert len(pending) == 1
+        assert pending[0]["question"] == "Q?"
+
+    async def test_preserves_existing_pending_assumptions(self) -> None:
+        squadron = _StubSquadron(
+            StubCodingAgent(implement_payloads=[SubmitImplementationPayload(summary="did stuff")])
+        )
+        state = State(
+            {
+                "current_bead": {"bead_id": "b-1", "title": "t", "description": "d"},
+                "current_bead_id": "b-1",
+                "implementer_escalation_level": 0,
+                "pending_assumptions": [dict(_ASSUMPTION_DICT)],
+            }
+        )
+        _, new_state = await fly_actions.implement(state, squadron=squadron, events=_queue())  # type: ignore[arg-type]
+        assert len(new_state["pending_assumptions"]) == 1
+
+
+class TestFixAccumulatesAssumptions:
+    async def test_run_fix_returns_assumptions_from_fix_payload(self) -> None:
+        squadron = _StubSquadron(
+            StubCodingAgent(
+                fix_payloads=[
+                    SubmitFixResultPayload(summary="fixed", assumptions=[_ASSUMPTION_DICT])
+                ]
+            )
+        )
+        ok, level, assumptions = await fly_actions._run_fix(
+            squadron=squadron,  # type: ignore[arg-type]
+            events=_queue(),
+            bead_id="b-1",
+            phase="gate",
+            round_n=1,
+            failure_message="boom",
+        )
+        assert ok is True
+        assert level == 0
+        assert len(assumptions) == 1
+        assert assumptions[0]["question"] == "Q?"
+
+
+class TestProcessBeadStartResetsAssumptionState:
+    async def test_resets_all_three_keys(self) -> None:
+        state = State(
+            {
+                "current_bead": {"bead_id": "b-1"},
+                "current_bead_id": "b-1",
+                "pending_assumptions": [dict(_ASSUMPTION_DICT)],
+                "recorded_assumption_ids": ["dea-1"],
+                "commit_change_id": "old-change-id",
+            }
+        )
+        _, new_state = await fly_actions.process_bead_start(state)
+        assert new_state["pending_assumptions"] == []
+        assert new_state["recorded_assumption_ids"] == []
+        assert new_state["commit_change_id"] == ""
+
+
+class TestRecordAssumptionsAction:
+    async def test_no_pending_assumptions_is_a_noop(self) -> None:
+        state = State({"current_bead_id": "b-1", "pending_assumptions": []})
+        _, new_state = await fly_actions.record_assumptions(
+            state, cwd="/tmp/repo", epic_id="epic-1", events=_queue()
+        )
+        assert new_state["recorded_assumption_ids"] == []
+
+    async def test_records_each_pending_assumption(self) -> None:
+        state = State(
+            {
+                "current_bead_id": "b-1",
+                "pending_assumptions": [dict(_ASSUMPTION_DICT)],
+            }
+        )
+        record = AssumptionRecord(
+            bead_id="dea-1",
+            question="Q?",
+            adopted_answer="A.",
+            alternatives=(),
+            severity=Severity.MEDIUM,
+            severity_defaulted=False,
+            status="open",
+            owner_spec="epic-1",
+            source_bead="b-1",
+            change_ids=(),
+            is_legacy=False,
+        )
+        with patch(
+            "maverick.assumptions.ledger.record_assumption",
+            new=AsyncMock(return_value=record),
+        ) as mock_record:
+            _, new_state = await fly_actions.record_assumptions(
+                state, cwd="/tmp/repo", epic_id="epic-1", events=_queue()
+            )
+        mock_record.assert_awaited_once()
+        assert new_state["recorded_assumption_ids"] == ["dea-1"]
+
+    async def test_ledger_error_warns_and_continues(self) -> None:
+        state = State(
+            {
+                "current_bead_id": "b-1",
+                "pending_assumptions": [dict(_ASSUMPTION_DICT)],
+            }
+        )
+        with patch(
+            "maverick.assumptions.ledger.record_assumption",
+            new=AsyncMock(side_effect=AssumptionLedgerError("bd unavailable")),
+        ):
+            _, new_state = await fly_actions.record_assumptions(
+                state, cwd="/tmp/repo", epic_id="epic-1", events=_queue()
+            )
+        # Non-fatal: no exception propagates, entry just isn't recorded.
+        assert new_state["recorded_assumption_ids"] == []
+
+
+class TestCommitCapturesChangeIdAndStamps:
+    async def test_captures_commit_change_id(self) -> None:
+        state = State(
+            {
+                "current_bead": {"bead_id": "b-1", "title": "t"},
+                "current_bead_id": "b-1",
+                "approved": True,
+                "needs_human_review": False,
+                "review_rounds": 0,
+                "recorded_assumption_ids": [],
+            }
+        )
+        with (
+            patch(
+                "maverick.library.actions.jj.jj_commit_bead",
+                new=AsyncMock(return_value={"change_id": "c-123", "success": True}),
+            ),
+            patch(
+                "maverick.library.actions.beads.mark_bead_complete",
+                new=AsyncMock(),
+            ),
+        ):
+            _, new_state = await fly_actions.commit(state, cwd="/tmp/repo", events=_queue())
+        assert new_state["commit_change_id"] == "c-123"
+        assert new_state["commit_ok"] is True
+
+    async def test_stamps_recorded_assumption_ids(self) -> None:
+        state = State(
+            {
+                "current_bead": {"bead_id": "b-1", "title": "t"},
+                "current_bead_id": "b-1",
+                "approved": True,
+                "needs_human_review": False,
+                "review_rounds": 0,
+                "recorded_assumption_ids": ["dea-1", "dea-2"],
+            }
+        )
+        with (
+            patch(
+                "maverick.library.actions.jj.jj_commit_bead",
+                new=AsyncMock(return_value={"change_id": "c-123", "success": True}),
+            ),
+            patch(
+                "maverick.library.actions.beads.mark_bead_complete",
+                new=AsyncMock(),
+            ),
+            patch(
+                "maverick.assumptions.ledger.stamp_change_id",
+                new=AsyncMock(
+                    return_value=StampResult(
+                        change_id="c-123", stamped=("dea-1", "dea-2"), failed={}
+                    )
+                ),
+            ) as mock_stamp,
+        ):
+            await fly_actions.commit(state, cwd="/tmp/repo", events=_queue())
+
+        mock_stamp.assert_awaited_once()
+        assert mock_stamp.await_args.kwargs["entry_ids"] == ["dea-1", "dea-2"]
+        assert mock_stamp.await_args.kwargs["change_id"] == "c-123"
+
+    async def test_stamp_failure_does_not_fail_commit(self) -> None:
+        state = State(
+            {
+                "current_bead": {"bead_id": "b-1", "title": "t"},
+                "current_bead_id": "b-1",
+                "approved": True,
+                "needs_human_review": False,
+                "review_rounds": 0,
+                "recorded_assumption_ids": ["dea-1"],
+            }
+        )
+        with (
+            patch(
+                "maverick.library.actions.jj.jj_commit_bead",
+                new=AsyncMock(return_value={"change_id": "c-123", "success": True}),
+            ),
+            patch(
+                "maverick.library.actions.beads.mark_bead_complete",
+                new=AsyncMock(),
+            ),
+            patch(
+                "maverick.assumptions.ledger.stamp_change_id",
+                new=AsyncMock(
+                    return_value=StampResult(
+                        change_id="c-123", stamped=(), failed={"dea-1": "boom"}
+                    )
+                ),
+            ),
+        ):
+            _, new_state = await fly_actions.commit(state, cwd="/tmp/repo", events=_queue())
+
+        assert new_state["commit_ok"] is True

--- a/tests/unit/workflows/fly_beads/test_burr_graph.py
+++ b/tests/unit/workflows/fly_beads/test_burr_graph.py
@@ -302,6 +302,57 @@ class TestFlyBurrAbandonPath:
         assert state["succeeded_count"] == 0
         assert state["failed_count"] == 1
 
+    async def test_abort_path_records_assumptions_from_implementer(self, tmp_path: Path) -> None:
+        """Assumptions the implementer reported before a gate abort must still
+        reach the ledger — the abort path funnels through record_assumptions."""
+        from maverick.payloads import AssumptionPayload
+        from maverick.workflows.fly_beads.graceful_stop import reset_graceful_stop
+
+        reset_graceful_stop()
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        squadron = StubFlySquadron(
+            coder=StubCodingAgent(
+                implement_payloads=[
+                    SubmitImplementationPayload(
+                        summary="stub impl",
+                        assumptions=(AssumptionPayload(question="Q?", adopted_answer="A."),),
+                    )
+                ],
+                fix_payloads=[SubmitFixResultPayload(summary="stub fix") for _ in range(5)],
+            )
+        )
+
+        record_mock = AsyncMock(return_value=type("Rec", (), {"bead_id": "dea-1"})())
+
+        with (
+            patch(
+                "maverick.library.actions.beads.select_next_bead",
+                new=AsyncMock(side_effect=[_bead("b-1"), _NO_MORE]),
+            ),
+            patch(
+                "maverick.library.actions.validation.run_independent_gate",
+                new=AsyncMock(return_value=_gate_failed()),
+            ),
+            patch("maverick.assumptions.ledger.record_assumption", new=record_mock),
+        ):
+            app = build_fly_application(
+                squadron=squadron,  # type: ignore[arg-type]
+                event_queue=queue,
+                epic_id="e-1",
+                cwd=str(tmp_path),
+                max_beads=10,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=FLY_TERMINAL_ACTIONS, event_queue=queue)
+            events = await _collect(driver)
+
+        sequence = _action_sequence(events)
+        assert "abandon_bead" in sequence
+        assert "record_assumptions" in sequence
+        assert "commit" not in sequence
+        # The implementer's assumption was recorded despite the abort.
+        record_mock.assert_awaited_once()
+
 
 class TestFlyBurrReviewLoop:
     async def test_review_fix_then_approve(self, tmp_path: Path) -> None:

--- a/tests/unit/workflows/fly_beads/test_commit_dep_wiring.py
+++ b/tests/unit/workflows/fly_beads/test_commit_dep_wiring.py
@@ -1,0 +1,102 @@
+"""Regression tests for the discovered-from dependency wiring in _commit.py.
+
+Locks in the migration from raw ``bd dep add`` CommandRunner calls to
+``BeadClient.add_dependency`` (research R11 / task T008).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from maverick.beads.models import BeadDependency, DependencyType
+from maverick.workflows.fly_beads._commit import (
+    _create_followup_bead,
+    _escalate_to_replan,
+)
+from maverick.workflows.fly_beads.models import BeadContext
+
+
+def _make_ctx(**overrides: object) -> BeadContext:
+    defaults: dict[str, object] = {
+        "bead_id": "bead-1",
+        "title": "Do the thing",
+        "description": "desc",
+        "epic_id": "epic-1",
+        "cwd": Path("/tmp/repo"),
+        "discovered_from_chain": [],
+    }
+    defaults.update(overrides)
+    return BeadContext(**defaults)  # type: ignore[arg-type]
+
+
+class _FakeRunnerResult:
+    def __init__(self, stdout: str = "") -> None:
+        self.stdout = stdout
+
+
+class TestCreateFollowupBeadDepWiring:
+    @pytest.mark.asyncio
+    async def test_wires_discovered_from_via_bead_client(self) -> None:
+        ctx = _make_ctx()
+        wf = AsyncMock()
+
+        with (
+            patch(
+                "maverick.runners.command.CommandRunner.run",
+                new=AsyncMock(return_value=_FakeRunnerResult('{"id": "followup-1"}')),
+            ),
+            patch(
+                "maverick.beads.client.BeadClient.add_dependency",
+                new=AsyncMock(),
+            ) as mock_add_dep,
+        ):
+            await _create_followup_bead(wf, ctx, ["review failed"])
+
+        mock_add_dep.assert_awaited_once()
+        dep = mock_add_dep.await_args.args[0]
+        assert isinstance(dep, BeadDependency)
+        assert dep.blocker_id == "bead-1"
+        assert dep.blocked_id == "followup-1"
+        assert dep.dep_type == DependencyType.DISCOVERED_FROM
+
+
+class TestEscalateToReplanDepWiring:
+    @pytest.mark.asyncio
+    async def test_wires_discovered_from_for_each_chain_member(self) -> None:
+        ctx = _make_ctx(discovered_from_chain=["root-1", "mid-1"])
+        wf = AsyncMock()
+
+        async def _fake_run(cmd: list[str], *_a: object, **_kw: object) -> _FakeRunnerResult:
+            if cmd[:2] == ["bd", "create"]:
+                return _FakeRunnerResult('{"id": "replan-1"}')
+            return _FakeRunnerResult("")
+
+        with (
+            patch(
+                "maverick.runners.command.CommandRunner.run",
+                new=AsyncMock(side_effect=_fake_run),
+            ),
+            patch(
+                "maverick.beads.client.BeadClient.add_dependency",
+                new=AsyncMock(),
+            ) as mock_add_dep,
+            patch(
+                "maverick.workflows.fly_beads._commit._defer_dependent_beads",
+                new=AsyncMock(),
+            ),
+        ):
+            await _escalate_to_replan(wf, ctx, ["review failed"])
+
+        assert mock_add_dep.await_count == 3  # root-1, mid-1, bead-1
+        wired = {
+            (call.args[0].blocker_id, call.args[0].blocked_id, call.args[0].dep_type)
+            for call in mock_add_dep.await_args_list
+        }
+        assert wired == {
+            ("root-1", "replan-1", DependencyType.DISCOVERED_FROM),
+            ("mid-1", "replan-1", DependencyType.DISCOVERED_FROM),
+            ("bead-1", "replan-1", DependencyType.DISCOVERED_FROM),
+        }

--- a/tests/unit/workflows/refuel_speckit/test_chain_epic.py
+++ b/tests/unit/workflows/refuel_speckit/test_chain_epic.py
@@ -1,0 +1,152 @@
+"""Tests for SpeckitRefuelWorkflow._chain_epic — deterministic tail
+selection by speckit_feature NNN prefix, and assumption blocks-edge
+wiring (research R8 / T024).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    KEY_OWNER_SPEC,
+    KEY_SEVERITY,
+    KEY_STATUS,
+    STATUS_OPEN,
+)
+from maverick.beads.models import BeadDependency, BeadDetails, BeadSummary, DependencyType
+from maverick.workflows.refuel_speckit.workflow import SpeckitRefuelWorkflow
+from tests.unit.workflows.refuel_speckit.conftest import make_mock_bead_client
+
+
+def _epic_summary(bead_id: str) -> BeadSummary:
+    return BeadSummary(id=bead_id, title=bead_id, status="open", priority=1, bead_type="epic")
+
+
+def _epic_details(bead_id: str, speckit_feature: str = "") -> BeadDetails:
+    state = {"speckit_feature": speckit_feature} if speckit_feature else {}
+    return BeadDetails(id=bead_id, title=bead_id, bead_type="epic", state=state)
+
+
+class TestDeterministicTailSelection:
+    @pytest.mark.asyncio
+    async def test_sorts_by_nnn_prefix_not_query_order(self) -> None:
+        """Existing epics come back in an arbitrary bd order; the tail must
+        still be the highest NNN prefix, not the last list element."""
+        workflow = SpeckitRefuelWorkflow(config=MagicMock())
+        client = make_mock_bead_client(
+            existing_epics=[_epic_summary("epic-050"), _epic_summary("epic-010")],
+            epic_details_by_id={
+                "epic-050": _epic_details("epic-050", "050-later-spec"),
+                "epic-010": _epic_details("epic-010", "010-earlier-spec"),
+                "new-epic": _epic_details("new-epic", "051-new-spec"),
+            },
+        )
+
+        tail = await workflow._chain_epic(client, "new-epic")
+
+        assert tail == "epic-050"
+        chain_calls = [
+            c for c in client.add_dependency.call_args_list if c.args[0].blocked_id == "new-epic"
+        ]
+        blocks_only = [c for c in chain_calls if c.args[0].dep_type == DependencyType.BLOCKS]
+        # One is the tail-chain edge (default BLOCKS dep_type).
+        assert any(c.args[0].blocker_id == "epic-050" for c in blocks_only)
+
+    @pytest.mark.asyncio
+    async def test_unprefixed_epics_sort_after_prefixed(self) -> None:
+        workflow = SpeckitRefuelWorkflow(config=MagicMock())
+        client = make_mock_bead_client(
+            existing_epics=[_epic_summary("flight-epic"), _epic_summary("epic-010")],
+            epic_details_by_id={
+                "flight-epic": _epic_details("flight-epic"),  # no speckit_feature
+                "epic-010": _epic_details("epic-010", "010-spec"),
+                "new-epic": _epic_details("new-epic", "011-new-spec"),
+            },
+        )
+
+        tail = await workflow._chain_epic(client, "new-epic")
+
+        assert tail == "flight-epic"
+
+    @pytest.mark.asyncio
+    async def test_no_existing_epics_returns_none_tail(self) -> None:
+        workflow = SpeckitRefuelWorkflow(config=MagicMock())
+        client = make_mock_bead_client(
+            existing_epics=[],
+            epic_details_by_id={"new-epic": _epic_details("new-epic", "001-new-spec")},
+        )
+
+        tail = await workflow._chain_epic(client, "new-epic")
+
+        assert tail is None
+
+
+class TestAssumptionBlocksEdgeWiring:
+    @pytest.mark.asyncio
+    async def test_wires_blocks_edge_from_open_high_entry_of_earlier_spec(self) -> None:
+        workflow = SpeckitRefuelWorkflow(config=MagicMock())
+        earlier_entry = BeadDetails(
+            id="dea-1",
+            title="Assumption: earlier",
+            description="## Question\n\nQ?\n\n",
+            bead_type="task",
+            status="open",
+            labels=[ASSUMPTION_LABEL],
+            state={
+                KEY_SEVERITY: "high",
+                KEY_STATUS: STATUS_OPEN,
+                KEY_OWNER_SPEC: "010-earlier-spec",
+            },
+        )
+        client = make_mock_bead_client(
+            existing_epics=[],
+            epic_details_by_id={"new-epic": _epic_details("new-epic", "011-new-spec")},
+        )
+
+        async def _query(filter_expr: str) -> list[BeadSummary]:
+            if filter_expr.startswith("type=task"):
+                return [BeadSummary(id="dea-1", title="dea-1", status="open", bead_type="task")]
+            return []
+
+        client.query.side_effect = _query
+
+        async def _show(bead_id: str) -> BeadDetails:
+            if bead_id == "new-epic":
+                return _epic_details("new-epic", "011-new-spec")
+            if bead_id == "dea-1":
+                return earlier_entry
+            raise LookupError(bead_id)
+
+        client.show.side_effect = _show
+
+        await workflow._chain_epic(client, "new-epic")
+
+        blocks_calls = [
+            c
+            for c in client.add_dependency.call_args_list
+            if c.args[0].dep_type == DependencyType.BLOCKS and c.args[0].blocked_id == "new-epic"
+        ]
+        assert len(blocks_calls) == 1
+        assert blocks_calls[0].args[0].blocker_id == "dea-1"
+
+    @pytest.mark.asyncio
+    async def test_no_open_high_entries_no_blocks_edge(self) -> None:
+        workflow = SpeckitRefuelWorkflow(config=MagicMock())
+        client = make_mock_bead_client(
+            existing_epics=[],
+            epic_details_by_id={"new-epic": _epic_details("new-epic", "011-new-spec")},
+        )
+        client.query.side_effect = lambda filter_expr: []
+
+        await workflow._chain_epic(client, "new-epic")
+
+        assert client.add_dependency.call_count == 0
+
+
+class TestBeadDependencyDefaultType:
+    def test_default_dep_type_is_blocks(self) -> None:
+        dep = BeadDependency(blocker_id="a", blocked_id="b")
+        assert dep.dep_type == DependencyType.BLOCKS


### PR DESCRIPTION
## Summary

Implements the **Assumption Ledger** feature (`specs/049-assumption-ledger/`) — all 44 tasks across 4 user stories. Extends Maverick's assumption beads into a structured ledger:

- Agents report adopted assumptions (question / adopted answer / alternatives / severity) in `submit_implementation` / `submit_review` / `submit_fix_result` payloads.
- The fly workflow's `record_assumptions` action creates one ledger bead per assumption under the owning epic with a `discovered-from` edge; `commit` stamps entries with the jj change ID.
- **Severity drives enforcement**: `low` is deferred (advisory, never blocks); `medium`/`high` block `maverick land` via a no-bypass gate; `high` additionally wires a `blocks` edge onto the next spec's epic (at record time and at `refuel --speckit` epic-chaining).
- `maverick review` gains `--answer`/`--waive` resolution flows; `maverick brief` reports per-spec assumption counts.

New package `maverick.assumptions` (`models` / `ledger` / `report` / `errors`).

## Code-review hardening (from `/code-review xhigh`)

- `record_assumption` resolves the source bead's owning epic when `fly` runs without `--epic` (`epic_id=""`) instead of silently dropping every assumption.
- Dedup **escalates** an existing entry's severity when a later re-report is more severe (and wires the high blocks-edge); never downgrades.
- The **abort path** funnels through `record_assumptions`, so assumptions reported before a gate/spec failure still reach the ledger.
- **Malformed nested assumptions** are pruned rather than failing the whole load-bearing submit payload.
- `maverick review --answer`/`--waive` are mutually exclusive.

## Notable design decision

`brief --format json` output shape changed from a bare array to `{"beads": [...], "assumption_counts": [...]}` to accommodate the new per-spec counts — a deliberate, documented break (existing tests updated).

## Testing

`make ci` green: **3604 passed, 2 skipped**. The 2 skips are `tests/integration/test_assumption_ledger_flow.py`, which requires the `bd` CLI (not installed in the sandbox; runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)