### PR TITLE
feat(spec): add headless Spec Kit chain (maverick spec)

### DIFF
--- a/.claude/skills/speckit-analyze/SKILL.md
+++ b/.claude/skills/speckit-analyze/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: "speckit-analyze"
+description: "Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation."
+argument-hint: "Optional focus areas for analysis"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/analyze.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before analysis)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Goal.
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Goal
+
+Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/speckit-tasks` has successfully produced a complete `tasks.md`.
+
+## Operating Constraints
+
+**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/speckit-analyze`.
+
+## Execution Steps
+
+### 1. Initialize Analysis Context
+
+Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- TASKS = FEATURE_DIR/tasks.md
+
+Abort with an error message if any required file is missing (instruct the user to run missing prerequisite command).
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+### 2. Load Artifacts (Progressive Disclosure)
+
+Load only the minimal necessary context from each artifact:
+
+**From spec.md:**
+
+- Overview/Context
+- Functional Requirements
+- Success Criteria (measurable outcomes — e.g., performance, security, availability, user success, business impact)
+- User Stories
+- Edge Cases (if present)
+
+**From plan.md:**
+
+- Architecture/stack choices
+- Data Model references
+- Phases
+- Technical constraints
+
+**From tasks.md:**
+
+- Task IDs
+- Descriptions
+- Phase grouping
+- Parallel markers [P]
+- Referenced file paths
+
+**From constitution:**
+
+- Load `.specify/memory/constitution.md` for principle validation
+
+### 3. Build Semantic Models
+
+Create internal representations (do not include raw artifacts in output):
+
+- **Requirements inventory**: For each Functional Requirement (FR-###) and Success Criterion (SC-###), record a stable key. Use the explicit FR-/SC- identifier as the primary key when present, and optionally also derive an imperative-phrase slug for readability (e.g., "User can upload file" → `user-can-upload-file`). Include only Success Criteria items that require buildable work (e.g., load-testing infrastructure, security audit tooling), and exclude post-launch outcome metrics and business KPIs (e.g., "Reduce support tickets by 50%").
+- **User story/action inventory**: Discrete user actions with acceptance criteria
+- **Task coverage mapping**: Map each task to one or more requirements or stories (inference by keyword / explicit reference patterns like IDs or key phrases)
+- **Constitution rule set**: Extract principle names and MUST/SHOULD normative statements
+
+### 4. Detection Passes (Token-Efficient Analysis)
+
+Focus on high-signal findings. Limit to 50 findings total; aggregate remainder in overflow summary.
+
+#### A. Duplication Detection
+
+- Identify near-duplicate requirements
+- Mark lower-quality phrasing for consolidation
+
+#### B. Ambiguity Detection
+
+- Flag vague adjectives (fast, scalable, secure, intuitive, robust) lacking measurable criteria
+- Flag unresolved placeholders (TODO, TKTK, ???, `<placeholder>`, etc.)
+
+#### C. Underspecification
+
+- Requirements with verbs but missing object or measurable outcome
+- User stories missing acceptance criteria alignment
+- Tasks referencing files or components not defined in spec/plan
+
+#### D. Constitution Alignment
+
+- Any requirement or plan element conflicting with a MUST principle
+- Missing mandated sections or quality gates from constitution
+
+#### E. Coverage Gaps
+
+- Requirements with zero associated tasks
+- Tasks with no mapped requirement/story
+- Success Criteria requiring buildable work (performance, security, availability) not reflected in tasks
+
+#### F. Inconsistency
+
+- Terminology drift (same concept named differently across files)
+- Data entities referenced in plan but absent in spec (or vice versa)
+- Task ordering contradictions (e.g., integration tasks before foundational setup tasks without dependency note)
+- Conflicting requirements (e.g., one requires Next.js while other specifies Vue)
+
+### 5. Severity Assignment
+
+Use this heuristic to prioritize findings:
+
+- **CRITICAL**: Violates constitution MUST, missing core spec artifact, or requirement with zero coverage that blocks baseline functionality
+- **HIGH**: Duplicate or conflicting requirement, ambiguous security/performance attribute, untestable acceptance criterion
+- **MEDIUM**: Terminology drift, missing non-functional task coverage, underspecified edge case
+- **LOW**: Style/wording improvements, minor redundancy not affecting execution order
+
+### 6. Produce Compact Analysis Report
+
+Output a Markdown report (no file writes) with the following structure:
+
+## Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|----|----------|----------|-------------|---------|----------------|
+| A1 | Duplication | HIGH | spec.md:L120-134 | Two similar requirements ... | Merge phrasing; keep clearer version |
+
+(Add one row per finding; generate stable IDs prefixed by category initial.)
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|-----------------|-----------|----------|-------|
+
+**Constitution Alignment Issues:** (if any)
+
+**Unmapped Tasks:** (if any)
+
+**Metrics:**
+
+- Total Requirements
+- Total Tasks
+- Coverage % (requirements with >=1 task)
+- Ambiguity Count
+- Duplication Count
+- Critical Issues Count
+
+### 7. Provide Next Actions
+
+At end of report, output a concise Next Actions block:
+
+- If CRITICAL issues exist: Recommend resolving before `/speckit-implement`
+- If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
+- Provide explicit command suggestions: e.g., "Run /speckit-specify with refinement", "Run /speckit-plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+
+### 8. Offer Remediation
+
+Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+### 9. Check for extension hooks
+
+After reporting, check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Operating Principles
+
+### Context Efficiency
+
+- **Minimal high-signal tokens**: Focus on actionable findings, not exhaustive documentation
+- **Progressive disclosure**: Load artifacts incrementally; don't dump all content into analysis
+- **Token-efficient output**: Limit findings table to 50 rows; summarize overflow
+- **Deterministic results**: Rerunning without changes should produce consistent IDs and counts
+
+### Analysis Guidelines
+
+- **NEVER modify files** (this is read-only analysis)
+- **NEVER hallucinate missing sections** (if absent, report them accurately)
+- **Prioritize constitution violations** (these are always CRITICAL)
+- **Use examples over exhaustive rules** (cite specific instances, not generic patterns)
+- **Report zero issues gracefully** (emit success report with coverage statistics)
+
+## Context
+
+$ARGUMENTS

--- a/.claude/skills/speckit-checklist/SKILL.md
+++ b/.claude/skills/speckit-checklist/SKILL.md
@@ -1,0 +1,376 @@
+---
+name: "speckit-checklist"
+description: "Generate a custom checklist for the current feature based on user requirements."
+argument-hint: "Domain or focus area for the checklist"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/checklist.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## Checklist Purpose: "Unit Tests for English"
+
+**CRITICAL CONCEPT**: Checklists are **UNIT TESTS FOR REQUIREMENTS WRITING** - they validate the quality, clarity, and completeness of requirements in a given domain.
+
+**NOT for verification/testing**:
+
+- ❌ NOT "Verify the button clicks correctly"
+- ❌ NOT "Test error handling works"
+- ❌ NOT "Confirm the API returns 200"
+- ❌ NOT checking if code/implementation matches the spec
+
+**FOR requirements quality validation**:
+
+- ✅ "Are visual hierarchy requirements defined for all card types?" (completeness)
+- ✅ "Is 'prominent display' quantified with specific sizing/positioning?" (clarity)
+- ✅ "Are hover state requirements consistent across all interactive elements?" (consistency)
+- ✅ "Are accessibility requirements defined for keyboard navigation?" (coverage)
+- ✅ "Does the spec define what happens when logo image fails to load?" (edge cases)
+
+**Metaphor**: If your spec is code written in English, the checklist is its unit test suite. You're testing whether the requirements are well-written, complete, unambiguous, and ready for implementation - NOT whether the implementation works.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before checklist generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Execution Steps.
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Execution Steps
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
+   - All file paths must be absolute.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **IF EXISTS**: Load `.specify/memory/constitution.md` for project principles and governance constraints.
+
+3. **Clarify intent (dynamic)**: Derive up to THREE initial contextual clarifying questions (no pre-baked catalog). They MUST:
+   - Be generated from the user's phrasing + extracted signals from spec/plan/tasks
+   - Only ask about information that materially changes checklist content
+   - Be skipped individually if already unambiguous in `$ARGUMENTS`
+   - Prefer precision over breadth
+
+   Generation algorithm:
+   1. Extract signals: feature domain keywords (e.g., auth, latency, UX, API), risk indicators ("critical", "must", "compliance"), stakeholder hints ("QA", "review", "security team"), and explicit deliverables ("a11y", "rollback", "contracts").
+   2. Cluster signals into candidate focus areas (max 4) ranked by relevance.
+   3. Identify probable audience & timing (author, reviewer, QA, release) if not explicit.
+   4. Detect missing dimensions: scope breadth, depth/rigor, risk emphasis, exclusion boundaries, measurable acceptance criteria.
+   5. Formulate questions chosen from these archetypes:
+      - Scope refinement (e.g., "Should this include integration touchpoints with X and Y or stay limited to local module correctness?")
+      - Risk prioritization (e.g., "Which of these potential risk areas should receive mandatory gating checks?")
+      - Depth calibration (e.g., "Is this a lightweight pre-commit sanity list or a formal release gate?")
+      - Audience framing (e.g., "Will this be used by the author only or peers during PR review?")
+      - Boundary exclusion (e.g., "Should we explicitly exclude performance tuning items this round?")
+      - Scenario class gap (e.g., "No recovery flows detected—are rollback / partial failure paths in scope?")
+
+   Question formatting rules:
+   - If presenting options, generate a compact table with columns: Option | Candidate | Why It Matters
+   - Limit to A–E options maximum; omit table if a free-form answer is clearer
+   - Never ask the user to restate what they already said
+   - Avoid speculative categories (no hallucination). If uncertain, ask explicitly: "Confirm whether X belongs in scope."
+
+   Defaults when interaction impossible:
+   - Depth: Standard
+   - Audience: Reviewer (PR) if code-related; Author otherwise
+   - Focus: Top 2 relevance clusters
+
+   Output the questions (label Q1/Q2/Q3). After answers: if ≥2 scenario classes (Alternate / Exception / Recovery / Non-Functional domain) remain unclear, you MAY ask up to TWO more targeted follow‑ups (Q4/Q5) with a one-line justification each (e.g., "Unresolved recovery path risk"). Do not exceed five total questions. Skip escalation if user explicitly declines more.
+
+4. **Understand user request**: Combine `$ARGUMENTS` + clarifying answers:
+   - Derive checklist theme (e.g., security, review, deploy, ux)
+   - Consolidate explicit must-have items mentioned by user
+   - Map focus selections to category scaffolding
+   - Infer any missing context from spec/plan/tasks (do NOT hallucinate)
+
+5. **Load feature context**: Read from FEATURE_DIR:
+   - spec.md: Feature requirements and scope
+   - plan.md (if exists): Technical details, dependencies
+   - tasks.md (if exists): Implementation tasks
+
+   **Context Loading Strategy**:
+   - Load only necessary portions relevant to active focus areas (avoid full-file dumping)
+   - Prefer summarizing long sections into concise scenario/requirement bullets
+   - Use progressive disclosure: add follow-on retrieval only if gaps detected
+   - If source docs are large, generate interim summary items instead of embedding raw text
+
+6. **Generate checklist** - Create "Unit Tests for Requirements":
+   - Create `FEATURE_DIR/checklists/` directory if it doesn't exist
+   - Generate unique checklist filename:
+     - Use short, descriptive name based on domain (e.g., `ux.md`, `api.md`, `security.md`)
+     - Format: `[domain].md`
+   - File handling behavior:
+     - If file does NOT exist: Create new file and number items starting from CHK001
+     - If file exists: Append new items to existing file, continuing from the last CHK ID (e.g., if last item is CHK015, start new items at CHK016)
+   - Never delete or replace existing checklist content - always preserve and append
+
+   **CORE PRINCIPLE - Test the Requirements, Not the Implementation**:
+   Every checklist item MUST evaluate the REQUIREMENTS THEMSELVES for:
+   - **Completeness**: Are all necessary requirements present?
+   - **Clarity**: Are requirements unambiguous and specific?
+   - **Consistency**: Do requirements align with each other?
+   - **Measurability**: Can requirements be objectively verified?
+   - **Coverage**: Are all scenarios/edge cases addressed?
+
+   **Category Structure** - Group items by requirement quality dimensions:
+   - **Requirement Completeness** (Are all necessary requirements documented?)
+   - **Requirement Clarity** (Are requirements specific and unambiguous?)
+   - **Requirement Consistency** (Do requirements align without conflicts?)
+   - **Acceptance Criteria Quality** (Are success criteria measurable?)
+   - **Scenario Coverage** (Are all flows/cases addressed?)
+   - **Edge Case Coverage** (Are boundary conditions defined?)
+   - **Non-Functional Requirements** (Performance, Security, Accessibility, etc. - are they specified?)
+   - **Dependencies & Assumptions** (Are they documented and validated?)
+   - **Ambiguities & Conflicts** (What needs clarification?)
+
+   **HOW TO WRITE CHECKLIST ITEMS - "Unit Tests for English"**:
+
+   ❌ **WRONG** (Testing implementation):
+   - "Verify landing page displays 3 episode cards"
+   - "Test hover states work on desktop"
+   - "Confirm logo click navigates home"
+
+   ✅ **CORRECT** (Testing requirements quality):
+   - "Are the exact number and layout of featured episodes specified?" [Completeness]
+   - "Is 'prominent display' quantified with specific sizing/positioning?" [Clarity]
+   - "Are hover state requirements consistent across all interactive elements?" [Consistency]
+   - "Are keyboard navigation requirements defined for all interactive UI?" [Coverage]
+   - "Is the fallback behavior specified when logo image fails to load?" [Edge Cases]
+   - "Are loading states defined for asynchronous episode data?" [Completeness]
+   - "Does the spec define visual hierarchy for competing UI elements?" [Clarity]
+
+   **ITEM STRUCTURE**:
+   Each item should follow this pattern:
+   - Question format asking about requirement quality
+   - Focus on what's WRITTEN (or not written) in the spec/plan
+   - Include quality dimension in brackets [Completeness/Clarity/Consistency/etc.]
+   - Reference spec section `[Spec §X.Y]` when checking existing requirements
+   - Use `[Gap]` marker when checking for missing requirements
+
+   **EXAMPLES BY QUALITY DIMENSION**:
+
+   Completeness:
+   - "Are error handling requirements defined for all API failure modes? [Gap]"
+   - "Are accessibility requirements specified for all interactive elements? [Completeness]"
+   - "Are mobile breakpoint requirements defined for responsive layouts? [Gap]"
+
+   Clarity:
+   - "Is 'fast loading' quantified with specific timing thresholds? [Clarity, Spec §NFR-2]"
+   - "Are 'related episodes' selection criteria explicitly defined? [Clarity, Spec §FR-5]"
+   - "Is 'prominent' defined with measurable visual properties? [Ambiguity, Spec §FR-4]"
+
+   Consistency:
+   - "Do navigation requirements align across all pages? [Consistency, Spec §FR-10]"
+   - "Are card component requirements consistent between landing and detail pages? [Consistency]"
+
+   Coverage:
+   - "Are requirements defined for zero-state scenarios (no episodes)? [Coverage, Edge Case]"
+   - "Are concurrent user interaction scenarios addressed? [Coverage, Gap]"
+   - "Are requirements specified for partial data loading failures? [Coverage, Exception Flow]"
+
+   Measurability:
+   - "Are visual hierarchy requirements measurable/testable? [Acceptance Criteria, Spec §FR-1]"
+   - "Can 'balanced visual weight' be objectively verified? [Measurability, Spec §FR-2]"
+
+   **Scenario Classification & Coverage** (Requirements Quality Focus):
+   - Check if requirements exist for: Primary, Alternate, Exception/Error, Recovery, Non-Functional scenarios
+   - For each scenario class, ask: "Are [scenario type] requirements complete, clear, and consistent?"
+   - If scenario class missing: "Are [scenario type] requirements intentionally excluded or missing? [Gap]"
+   - Include resilience/rollback when state mutation occurs: "Are rollback requirements defined for migration failures? [Gap]"
+
+   **Traceability Requirements**:
+   - MINIMUM: ≥80% of items MUST include at least one traceability reference
+   - Each item should reference: spec section `[Spec §X.Y]`, or use markers: `[Gap]`, `[Ambiguity]`, `[Conflict]`, `[Assumption]`
+   - If no ID system exists: "Is a requirement & acceptance criteria ID scheme established? [Traceability]"
+
+   **Surface & Resolve Issues** (Requirements Quality Problems):
+   Ask questions about the requirements themselves:
+   - Ambiguities: "Is the term 'fast' quantified with specific metrics? [Ambiguity, Spec §NFR-1]"
+   - Conflicts: "Do navigation requirements conflict between §FR-10 and §FR-10a? [Conflict]"
+   - Assumptions: "Is the assumption of 'always available podcast API' validated? [Assumption]"
+   - Dependencies: "Are external podcast API requirements documented? [Dependency, Gap]"
+   - Missing definitions: "Is 'visual hierarchy' defined with measurable criteria? [Gap]"
+
+   **Content Consolidation**:
+   - Soft cap: If raw candidate items > 40, prioritize by risk/impact
+   - Merge near-duplicates checking the same requirement aspect
+   - If >5 low-impact edge cases, create one item: "Are edge cases X, Y, Z addressed in requirements? [Coverage]"
+
+   **🚫 ABSOLUTELY PROHIBITED** - These make it an implementation test, not a requirements test:
+   - ❌ Any item starting with "Verify", "Test", "Confirm", "Check" + implementation behavior
+   - ❌ References to code execution, user actions, system behavior
+   - ❌ "Displays correctly", "works properly", "functions as expected"
+   - ❌ "Click", "navigate", "render", "load", "execute"
+   - ❌ Test cases, test plans, QA procedures
+   - ❌ Implementation details (frameworks, APIs, algorithms)
+
+   **✅ REQUIRED PATTERNS** - These test requirements quality:
+   - ✅ "Are [requirement type] defined/specified/documented for [scenario]?"
+   - ✅ "Is [vague term] quantified/clarified with specific criteria?"
+   - ✅ "Are requirements consistent between [section A] and [section B]?"
+   - ✅ "Can [requirement] be objectively measured/verified?"
+   - ✅ "Are [edge cases/scenarios] addressed in requirements?"
+   - ✅ "Does the spec define [missing aspect]?"
+
+7. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
+
+8. **Report**: Output full path to checklist file, item count, and summarize whether the run created a new file or appended to an existing one. Summarize:
+   - Focus areas selected
+   - Depth level
+   - Actor/timing
+   - Any explicit user-specified must-have items incorporated
+
+**Important**: Each `/speckit-checklist` command invocation uses a short, descriptive checklist filename and either creates a new file or appends to an existing one. This allows:
+
+- Multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`)
+- Simple, memorable filenames that indicate checklist purpose
+- Easy identification and navigation in the `checklists/` folder
+
+To avoid clutter, use descriptive types and clean up obsolete checklists when done.
+
+## Example Checklist Types & Sample Items
+
+**UX Requirements Quality:** `ux.md`
+
+Sample items (testing the requirements, NOT the implementation):
+
+- "Are visual hierarchy requirements defined with measurable criteria? [Clarity, Spec §FR-1]"
+- "Is the number and positioning of UI elements explicitly specified? [Completeness, Spec §FR-1]"
+- "Are interaction state requirements (hover, focus, active) consistently defined? [Consistency]"
+- "Are accessibility requirements specified for all interactive elements? [Coverage, Gap]"
+- "Is fallback behavior defined when images fail to load? [Edge Case, Gap]"
+- "Can 'prominent display' be objectively measured? [Measurability, Spec §FR-4]"
+
+**API Requirements Quality:** `api.md`
+
+Sample items:
+
+- "Are error response formats specified for all failure scenarios? [Completeness]"
+- "Are rate limiting requirements quantified with specific thresholds? [Clarity]"
+- "Are authentication requirements consistent across all endpoints? [Consistency]"
+- "Are retry/timeout requirements defined for external dependencies? [Coverage, Gap]"
+- "Is versioning strategy documented in requirements? [Gap]"
+
+**Performance Requirements Quality:** `performance.md`
+
+Sample items:
+
+- "Are performance requirements quantified with specific metrics? [Clarity]"
+- "Are performance targets defined for all critical user journeys? [Coverage]"
+- "Are performance requirements under different load conditions specified? [Completeness]"
+- "Can performance requirements be objectively measured? [Measurability]"
+- "Are degradation requirements defined for high-load scenarios? [Edge Case, Gap]"
+
+**Security Requirements Quality:** `security.md`
+
+Sample items:
+
+- "Are authentication requirements specified for all protected resources? [Coverage]"
+- "Are data protection requirements defined for sensitive information? [Completeness]"
+- "Is the threat model documented and requirements aligned to it? [Traceability]"
+- "Are security requirements consistent with compliance obligations? [Consistency]"
+- "Are security failure/breach response requirements defined? [Gap, Exception Flow]"
+
+## Anti-Examples: What NOT To Do
+
+**❌ WRONG - These test implementation, not requirements:**
+
+```markdown
+- [ ] CHK001 - Verify landing page displays 3 episode cards [Spec §FR-001]
+- [ ] CHK002 - Test hover states work correctly on desktop [Spec §FR-003]
+- [ ] CHK003 - Confirm logo click navigates to home page [Spec §FR-010]
+- [ ] CHK004 - Check that related episodes section shows 3-5 items [Spec §FR-005]
+```
+
+**✅ CORRECT - These test requirements quality:**
+
+```markdown
+- [ ] CHK001 - Are the number and layout of featured episodes explicitly specified? [Completeness, Spec §FR-001]
+- [ ] CHK002 - Are hover state requirements consistently defined for all interactive elements? [Consistency, Spec §FR-003]
+- [ ] CHK003 - Are navigation requirements clear for all clickable brand elements? [Clarity, Spec §FR-010]
+- [ ] CHK004 - Is the selection criteria for related episodes documented? [Gap, Spec §FR-005]
+- [ ] CHK005 - Are loading state requirements defined for asynchronous episode data? [Gap]
+- [ ] CHK006 - Can "visual hierarchy" requirements be objectively measured? [Measurability, Spec §FR-001]
+```
+
+**Key Differences:**
+
+- Wrong: Tests if the system works correctly
+- Correct: Tests if the requirements are written correctly
+- Wrong: Verification of behavior
+- Correct: Validation of requirement quality
+- Wrong: "Does it do X?"
+- Correct: "Is X clearly specified?"
+
+## Post-Execution Checks
+
+**Check for extension hooks (after checklist generation)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.claude/skills/speckit-clarify/SKILL.md
+++ b/.claude/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: "speckit-clarify"
+description: "Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec."
+argument-hint: "Optional areas to clarify in the spec"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/clarify.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before clarification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_clarify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+Goal: Detect and reduce ambiguity or missing decision points in the active feature specification and record the clarifications directly in the spec file.
+
+Note: This clarification workflow is expected to run (and be completed) BEFORE invoking `/speckit-plan`. If the user explicitly states they are skipping clarification (e.g., exploratory spike), you may proceed, but must warn that downstream rework risk increases.
+
+Execution steps:
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` from repo root **once** (combined `--json --paths-only` mode / `-Json -PathsOnly`). Parse minimal JSON payload fields:
+   - `FEATURE_DIR`
+   - `FEATURE_SPEC`
+   - (Optionally capture `IMPL_PLAN`, `TASKS` for future chained flows.)
+   - If JSON parsing fails, abort and instruct user to re-run `/speckit-specify` or verify feature branch environment.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **IF EXISTS**: Load `.specify/memory/constitution.md` for project principles and governance constraints.
+
+3. Load the current spec file. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
+
+   Functional Scope & Behavior:
+   - Core user goals & success criteria
+   - Explicit out-of-scope declarations
+   - User roles / personas differentiation
+
+   Domain & Data Model:
+   - Entities, attributes, relationships
+   - Identity & uniqueness rules
+   - Lifecycle/state transitions
+   - Data volume / scale assumptions
+
+   Interaction & UX Flow:
+   - Critical user journeys / sequences
+   - Error/empty/loading states
+   - Accessibility or localization notes
+
+   Non-Functional Quality Attributes:
+   - Performance (latency, throughput targets)
+   - Scalability (horizontal/vertical, limits)
+   - Reliability & availability (uptime, recovery expectations)
+   - Observability (logging, metrics, tracing signals)
+   - Security & privacy (authN/Z, data protection, threat assumptions)
+   - Compliance / regulatory constraints (if any)
+
+   Integration & External Dependencies:
+   - External services/APIs and failure modes
+   - Data import/export formats
+   - Protocol/versioning assumptions
+
+   Edge Cases & Failure Handling:
+   - Negative scenarios
+   - Rate limiting / throttling
+   - Conflict resolution (e.g., concurrent edits)
+
+   Constraints & Tradeoffs:
+   - Technical constraints (language, storage, hosting)
+   - Explicit tradeoffs or rejected alternatives
+
+   Terminology & Consistency:
+   - Canonical glossary terms
+   - Avoided synonyms / deprecated terms
+
+   Completion Signals:
+   - Acceptance criteria testability
+   - Measurable Definition of Done style indicators
+
+   Misc / Placeholders:
+   - TODO markers / unresolved decisions
+   - Ambiguous adjectives ("robust", "intuitive") lacking quantification
+
+   For each category with Partial or Missing status, add a candidate question opportunity unless:
+   - Clarification would not materially change implementation or validation strategy
+   - Information is better deferred to planning phase (note internally)
+
+4. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
+    - Maximum of 5 total questions across the whole session.
+    - Each question must be answerable with EITHER:
+       - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
+       - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").
+    - Only include questions whose answers materially impact architecture, data modeling, task decomposition, test design, UX behavior, operational readiness, or compliance validation.
+    - Ensure category coverage balance: attempt to cover the highest impact unresolved categories first; avoid asking two low-impact questions when a single high-impact area (e.g., security posture) is unresolved.
+    - Exclude questions already answered, trivial stylistic preferences, or plan-level execution details (unless blocking correctness).
+    - Favor clarifications that reduce downstream rework risk or prevent misaligned acceptance tests.
+    - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
+
+5. Sequential questioning loop (interactive):
+    - Present EXACTLY ONE question at a time.
+    - For multiple‑choice questions:
+       - **Analyze all options** and determine the **most suitable option** based on:
+          - Best practices for the project type
+          - Common patterns in similar implementations
+          - Risk reduction (security, performance, maintainability)
+          - Alignment with any explicit project goals or constraints visible in the spec
+       - Present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
+       - Format as: `**Recommended:** Option [X] - <reasoning>`
+       - Then render all options as a Markdown table:
+
+       | Option | Description |
+       |--------|-------------|
+       | A | <Option A description> |
+       | B | <Option B description> |
+       | C | <Option C description> (add D/E as needed up to 5) |
+       | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
+
+       - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
+    - For short‑answer style (no meaningful discrete options):
+       - Provide your **suggested answer** based on best practices and context.
+       - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
+       - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
+    - After the user answers:
+       - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
+       - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
+       - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
+       - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
+    - Stop asking further questions when:
+       - All critical ambiguities resolved early (remaining queued items become unnecessary), OR
+       - User signals completion ("done", "good", "no more"), OR
+       - You reach 5 asked questions.
+    - Never reveal future queued questions in advance.
+    - If no valid questions exist at start, immediately report no critical ambiguities.
+
+6. Integration after EACH accepted answer (incremental update approach):
+    - Maintain in-memory representation of the spec (loaded once at start) plus the raw file contents.
+    - For the first integrated answer in this session:
+       - Ensure a `## Clarifications` section exists (create it just after the highest-level contextual/overview section per the spec template if missing).
+       - Under it, create (if not present) a `### Session YYYY-MM-DD` subheading for today.
+    - Append a bullet line immediately after acceptance: `- Q: <question> → A: <final answer>`.
+    - Then immediately apply the clarification to the most appropriate section(s):
+       - Functional ambiguity → Update or add a bullet in Functional Requirements.
+       - User interaction / actor distinction → Update User Stories or Actors subsection (if present) with clarified role, constraint, or scenario.
+       - Data shape / entities → Update Data Model (add fields, types, relationships) preserving ordering; note added constraints succinctly.
+       - Non-functional constraint → Add/modify measurable criteria in Success Criteria > Measurable Outcomes (convert vague adjective to metric or explicit target).
+       - Edge case / negative flow → Add a new bullet under Edge Cases / Error Handling (or create such subsection if template provides placeholder for it).
+       - Terminology conflict → Normalize term across spec; retain original only if necessary by adding `(formerly referred to as "X")` once.
+    - If the clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.
+    - Save the spec file AFTER each integration to minimize risk of context loss (atomic overwrite).
+    - Preserve formatting: do not reorder unrelated sections; keep heading hierarchy intact.
+    - Keep each inserted clarification minimal and testable (avoid narrative drift).
+
+7. Validation (performed after EACH write plus final pass):
+   - Clarifications session contains exactly one bullet per accepted answer (no duplicates).
+   - Total asked (accepted) questions ≤ 5.
+   - Updated sections contain no lingering vague placeholders the new answer was meant to resolve.
+   - No contradictory earlier statement remains (scan for now-invalid alternative choices removed).
+   - Markdown structure valid; only allowed new headings: `## Clarifications`, `### Session YYYY-MM-DD`.
+   - Terminology consistency: same canonical term used across all updated sections.
+
+8. Write the updated spec back to `FEATURE_SPEC`.
+
+9. **Re-validate Spec Quality Checklist** (if it exists):
+   - Check if `FEATURE_DIR/checklists/requirements.md` exists.
+   - If it does NOT exist, skip this step silently.
+   - If it exists:
+     1. Read the checklist file.
+     2. Identify all GitHub task-list checkbox lines — lines matching `- [ ]`, `- [x]`, or `- [X]` (case-insensitive, tolerant of leading whitespace for nested items) outside of code fences. Ignore all other content (headings, notes, non-checkbox bullets, metadata).
+     3. For each checkbox line, record its current marker state (checked or unchecked) and item text into a before-snapshot list.
+     4. Re-evaluate each checkbox item against the **updated** spec (the version just saved in step 7).
+     5. For each checkbox item, update only if the checked/unchecked state actually changes:
+        - If the item now passes and was unchecked: change `[ ]` to `[x]`.
+        - If the item now fails and was checked: change `[x]`/`[X]` to `[ ]`.
+        - If the state is unchanged: leave the marker as-is (preserve existing case to avoid cosmetic diffs).
+     6. Save the updated checklist file. **Only toggle the `[ ]`/`[x]` marker portion of checkbox lines whose state changed.** All other file content — headings, metadata, notes, line ordering, whitespace — must remain unchanged to avoid noisy diffs.
+     7. Compare the before-snapshot with the current state to compute three lists for the Completion Report:
+        - **Newly passing**: items that changed from unchecked to checked.
+        - **Regressions**: items that changed from checked to unchecked.
+        - **Still unchecked**: items that remain unchecked.
+     8. Record the before/after pass counts as checked/total checkbox items (e.g., "12/16 → 15/16 items passing").
+
+Behavior rules:
+
+- If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
+- If spec file missing, instruct user to run `/speckit-specify` first (do not create a new spec here).
+- Never exceed 5 total asked questions (clarification retries for a single question do not count as new questions).
+- Avoid speculative tech stack questions unless the absence blocks functional clarity.
+- Respect user early termination signals ("stop", "done", "proceed").
+- If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
+- If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
+
+Context for prioritization: $ARGUMENTS
+
+## Mandatory Post-Execution Hooks
+
+**You MUST complete this section before reporting completion to the user.**
+
+Check if `.specify/extensions.yml` exists in the project root.
+- If it does not exist, or no hooks are registered under `hooks.after_clarify`, skip to the Completion Report.
+- If it exists, read it and look for entries under the `hooks.after_clarify` key.
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue to the Completion Report.
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Mandatory hook** (`optional: false`) — **You MUST emit `EXECUTE_COMMAND:` for each mandatory hook**:
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+## Completion Report
+
+Report completion (after questioning loop ends or early termination):
+- Number of questions asked & answered.
+- Path to updated spec.
+- Sections touched (list names).
+- Spec quality checklist status (if `FEATURE_DIR/checklists/requirements.md` was re-validated): show before/after pass counts (e.g., "Spec Quality Checklist: 12/16 → 15/16 items passing") and list any items that changed state — both newly checked (unchecked → checked) and any regressions (checked → unchecked). If any items remain unchecked, list them as areas needing attention.
+- Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
+- If any Outstanding or Deferred remain, recommend whether to proceed to `/speckit-plan` or run `/speckit-clarify` again later post-plan.
+- Suggested next command.
+
+## Done When
+
+- [ ] Spec ambiguities identified and clarifications integrated into spec file
+- [ ] Spec quality checklist re-validated against updated spec (if `FEATURE_DIR/checklists/requirements.md` exists)
+- [ ] Extension hooks dispatched or skipped according to the rules in Mandatory Post-Execution Hooks above
+- [ ] Completion reported to user with questions answered, sections touched, checklist status, and coverage summary

--- a/.claude/skills/speckit-constitution/SKILL.md
+++ b/.claude/skills/speckit-constitution/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: "speckit-constitution"
+description: "Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync."
+argument-hint: "Principles or values for the project constitution"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/constitution.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Scope Guard
+
+This command's own work is limited to updating the project constitution and propagating
+constitution-driven changes to the dependent artifacts identified in this command.
+
+- Classify every part of the user input as either constitution content or a separate,
+  non-governance intent.
+- If the input includes feature implementation, code generation, refactoring, building, or
+  deployment requests, you **MUST NOT** execute them. Extract them as deferred intents instead.
+- You **MUST NOT** create, modify, or delete application source files, feature routes,
+  components, tests, deployment files, or other artifacts unrelated to the constitution
+  workflow and its required propagation.
+- If it is unclear whether an instruction is constitution content, ask for clarification before
+  making changes.
+- After completing the constitution update, include a `Next Actions` section for each deferred
+  intent. List the original intent and suggest the appropriate follow-up Spec Kit command, such
+  as `/speckit-specify`, without invoking it.
+- If there are no non-governance intents, omit the `Next Actions` section.
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before constitution update)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+
+**Note**: If `.specify/memory/constitution.md` does not exist yet, it should have been initialized from `.specify/templates/constitution-template.md` during project setup. If it's missing, copy the template first.
+
+Follow this execution flow:
+
+1. Load the existing constitution at `.specify/memory/constitution.md`.
+   - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
+   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+
+2. Collect/derive values for placeholders:
+   - If user input (conversation) supplies a value, use it.
+   - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
+   - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+   - If version bump type ambiguous, propose reasoning before finalizing.
+
+3. Draft the updated constitution content:
+   - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
+   - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
+   - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non‑negotiable rules, explicit rationale if not obvious.
+   - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
+
+4. Consistency propagation checklist (convert prior checklist into active validations):
+   - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each installed Spec Kit command file for your agent (including this one) — named `speckit.*` or `speckit-*` (dot or hyphen depending on the agent), or laid out as `speckit-<name>/SKILL.md` for skills-based integrations, e.g. in `.github/agents/`, `.github/skills/`, `.claude/skills/`, or your agent's equivalent commands directory — to verify no outdated references (CLAUDE-only or other agent-specific names) remain when generic guidance is required.
+   - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
+
+5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+   - Version change: old → new
+   - List of modified principles (old title → new title if renamed)
+   - Added sections
+   - Removed sections
+   - Templates requiring updates (✅ updated / ⚠ pending) with file paths
+   - Follow-up TODOs if any placeholders intentionally deferred.
+
+6. Validation before final output:
+   - No remaining unexplained bracket tokens.
+   - Version line matches report.
+   - Dates ISO format YYYY-MM-DD.
+   - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
+
+7. Write the completed constitution back to `.specify/memory/constitution.md` (overwrite).
+
+8. Output a final summary to the user with:
+   - New version and bump rationale.
+   - Any files flagged for manual follow-up.
+   - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+   - A `Next Actions` section for any deferred non-governance intents.
+
+Formatting & Style Requirements:
+
+- Use Markdown headings exactly as in the template (do not demote/promote levels).
+- Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
+- Keep a single blank line between sections.
+- Avoid trailing whitespace.
+
+If the user supplies partial updates (e.g., only one principle revision), still perform validation and version decision steps.
+
+If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
+
+Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.
+
+## Post-Execution Checks
+
+**Check for extension hooks (after constitution update)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.claude/skills/speckit-converge/SKILL.md
+++ b/.claude/skills/speckit-converge/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: "speckit-converge"
+description: "Assess the current codebase against the feature's spec, plan, and tasks, then append any remaining unbuilt work as new tasks to tasks.md so implement can complete it."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/converge.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before convergence)**:
+
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_converge` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+
+    ```text
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+  - **Mandatory hook** (`optional: false`):
+
+    ```text
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Goal.
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Goal
+
+Close the gap between what a feature's specification, plan, and tasks call for and what the
+codebase currently implements. Read `spec.md`, `plan.md`, and `tasks.md` as the **sole
+source of intent** (with the constitution as governing constraints), assess the current
+state of the code, determine which requirements, acceptance criteria, plan decisions, and
+existing tasks are unmet, incomplete, or only partially satisfied, and **append each piece
+of remaining work as a new, traceable task** at the bottom of `tasks.md` so that
+`/speckit-implement` can complete it. This command MUST run only after
+`/speckit-implement` has run on the current `tasks.md`, and after `/speckit-tasks` has produced a complete `tasks.md`.
+
+This is **not** a diff tool and does **not** track changes. It assesses the present state
+of the code relative to the feature's artifacts — no git, no branch comparison, no history.
+
+## Operating Constraints
+
+**APPEND-ONLY, NEVER REWRITE**: The command's **only** write is appending a new
+`## Phase N: Convergence` section to `tasks.md`. It MUST NOT:
+
+- modify `spec.md` or `plan.md` in any way;
+- rewrite, renumber, reorder, or delete any existing task (including tasks from a prior
+  Convergence phase);
+- modify, create, or delete any application code — completing the appended tasks is the
+  job of `/speckit-implement`.
+
+When the codebase already satisfies everything, the command MUST leave `tasks.md`
+**byte-for-byte unchanged** (no empty Convergence header) and report a clean result.
+
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is
+**non-negotiable**. Code that violates a MUST principle is the highest-severity finding and
+produces a corresponding remediation task. If the constitution is an unfilled template,
+skip constitution checks gracefully rather than failing.
+
+## Execution Steps
+
+### 1. Initialize Convergence Context
+
+Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- TASKS = FEATURE_DIR/tasks.md
+- CONSTITUTION = `.specify/memory/constitution.md` (if present)
+If `spec.md`, `plan.md`, or `tasks.md` is missing, STOP with a clear, actionable message naming the
+prerequisite command to run (`/speckit-specify` for a missing spec, `/speckit-plan` for a missing plan,
+`/speckit-tasks` for missing tasks). Do not produce partial output.
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+### 2. Load Artifacts (Progressive Disclosure)
+
+Load only the minimal necessary context from each artifact:
+
+**From spec.md:**
+
+- Functional Requirements (FR-###)
+- Success Criteria (SC-###) — include only items requiring buildable work; exclude
+  post-launch outcome metrics and business KPIs
+- User Stories and their Acceptance Scenarios
+- Edge Cases (if present)
+
+**From plan.md:**
+
+- Architecture/stack choices and technical decisions
+- Data Model references
+- Phases and named touch-points (files/components the plan says will be created or edited)
+- Technical constraints
+
+**From tasks.md:**
+
+- Task IDs (to compute the next ID and next phase number)
+- Descriptions, phase grouping, and referenced file paths
+
+**From constitution (if not an unfilled template):**
+
+- Principle names and MUST/SHOULD normative statements
+
+### 3. Build the Intent Inventory
+
+Create an internal model (do not echo raw artifacts):
+
+- **Requirements inventory**: one stable key per FR-### / SC-### / user-story acceptance
+  scenario (e.g. `US1/AC2`), plus the plan decisions and constitution principles that
+  impose buildable obligations.
+- **Code-scope map**: from the file paths named in `plan.md` and `tasks.md`, plus a keyword
+  search for the concepts each requirement describes, derive the set of source files and
+  components in scope for assessment. Bound the assessment to these — do **not** infer
+  scope beyond what the artifacts define.
+
+### 4. Assess the Codebase and Classify Findings
+
+For each item in the intent inventory, inspect the current code in scope and produce a
+`Finding` only where there is a gap. Classify every finding by **gap type**:
+
+- **`missing`**: the required work is absent from the code entirely.
+- **`partial`**: the work exists but does not yet fully satisfy the requirement /
+  acceptance criterion / plan decision.
+- **`contradicts`**: the code does something that conflicts with stated intent or a
+  constitution MUST principle.
+- **`unrequested`**: the code contains work not called for by the spec, plan, or tasks
+  (surfaced for awareness — converge does **not** delete code, it only appends a task to
+  review/justify or remove it).
+
+Each `Finding` records: a stable id, the `source-ref` it traces to, the `gap-type`, a
+severity, and a short human-readable description with the evidence (the file/area observed).
+
+**Edge cases:**
+
+- **Little or no code yet**: treat the entire specified scope as `missing` remaining work
+  rather than failing.
+- **Nothing remains**: produce zero findings and follow the converged branch in Step 7.
+
+### 5. Assign Severity
+
+- **CRITICAL**: violates a constitution MUST principle, or a `missing`/`contradicts` gap
+  that blocks baseline functionality of a P1 user story.
+- **HIGH**: a `missing` or `partial` gap on a core functional requirement or acceptance
+  criterion.
+- **MEDIUM**: a `partial` gap on a secondary requirement, or an `unrequested` addition with
+  unclear justification.
+- **LOW**: minor partial gaps, polish, or low-risk `unrequested` additions.
+
+### 6. Present the In-Session Findings Summary
+
+Before appending anything, output a compact, severity-graded summary (no file writes yet):
+
+## Convergence Findings
+
+| ID | Gap Type | Severity | Source | Evidence | Remaining Work |
+|----|----------|----------|--------|----------|----------------|
+| F1 | missing  | HIGH     | FR-008 | Example: no append-only guard detected in path/to/module.py when writing tasks.md | Add append-only enforcement |
+
+**Summary metrics:**
+
+- Requirements / acceptance criteria checked
+- Plan decisions checked
+- Constitution principles checked (or "skipped — template")
+- Findings by gap type (missing / partial / contradicts / unrequested)
+- Findings by severity
+
+### 7. Append Convergence Tasks (or report converged)
+
+**If there are one or more actionable findings** (`tasks_appended` outcome):
+
+Append to the **end** of `tasks.md`, per the append contract:
+
+1. Scan all existing task IDs; let `M` be the maximum. Determine the next phase number `N`
+   (highest existing phase + 1).
+2. Write a single new section header `## Phase N: Convergence`.
+3. Emit one checklist item per actionable finding, ordered CRITICAL/HIGH first, assigning
+   zero-padded IDs `T{M+1:03d}, T{M+2:03d}, …`:
+
+   ```markdown
+   - [ ] T042 <imperative description> per <source-ref> (<gap-type>)
+   ```
+
+   `<source-ref>` traces the task to its origin: e.g. `FR-003`, `SC-002`,
+   `US1/AC2`, `plan: storage decision`, `Constitution II`.
+
+   `<gap-type>` is one of `missing`, `partial`, `contradicts`, `unrequested`.
+
+   Constitution-violation tasks MUST be emitted first and described as
+   `CRITICAL`.
+4. Never reuse or renumber existing IDs. If a prior Convergence phase exists, add a new,
+   separately-numbered one below it — do not touch the old one.
+
+**If there are no actionable findings** (`converged` outcome):
+
+- Do **not** modify `tasks.md` at all — no empty phase header.
+- Report: **"✅ Converged — the implementation satisfies the spec, plan, and tasks."**
+- Include the summary counts of what was checked.
+
+### 8. Provide Next Actions (Handoff)
+
+- On `tasks_appended`: state how many tasks were appended under which phase, and recommend
+  running `/speckit-implement` to complete them; note that a follow-up converge
+  run will find fewer or no remaining items.
+- On `converged`: recommend proceeding to review / opening a PR. No further implement pass
+  is needed for this feature's specified scope.
+
+### 9. Check for extension hooks
+
+After producing the result, check if `.specify/extensions.yml` exists in the project root.
+
+- If it exists, read it and look for entries under the `hooks.after_converge` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- Report the convergence outcome (`converged` or `tasks_appended`) in-session before listing
+  any hooks, so users can decide whether to run optional follow-up commands.
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+
+    ```text
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+  - **Mandatory hook** (`optional: false`):
+
+    ```text
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.claude/skills/speckit-implement/SKILL.md
+++ b/.claude/skills/speckit-implement/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: "speckit-implement"
+description: "Execute the implementation plan by processing and executing all tasks defined in tasks.md"
+argument-hint: "Optional implementation guidance or task filter"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/implement.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before implementation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_implement` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
+   - Scan all checklist files in the checklists/ directory
+   - For each checklist, count:
+     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
+     - Completed items: Lines matching `- [X]` or `- [x]`
+     - Incomplete items: Lines matching `- [ ]`
+   - Create a status table:
+
+     ```text
+     | Checklist | Total | Completed | Incomplete | Status |
+     |-----------|-------|-----------|------------|--------|
+     | ux.md     | 12    | 12        | 0          | ✓ PASS |
+     | test.md   | 8     | 5         | 3          | ✗ FAIL |
+     | security.md | 6   | 6         | 0          | ✓ PASS |
+     ```
+
+   - Calculate overall status:
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
+
+   - **If any checklist is incomplete**:
+     - Display the table with incomplete item counts
+     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", proceed to step 3
+
+   - **If all checklists are complete**:
+     - Display the table showing all checklists passed
+     - Automatically proceed to step 3
+
+3. Load and analyze the implementation context:
+   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
+   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **IF EXISTS**: Read data-model.md for entities and relationships
+   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
+   - **IF EXISTS**: Read research.md for technical decisions and constraints
+   - **IF EXISTS**: Read .specify/memory/constitution.md for governance constraints
+   - **IF EXISTS**: Read quickstart.md for integration scenarios
+
+4. **Project Setup Verification**:
+   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+   **Detection & Creation Logic**:
+   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+     ```sh
+     git rev-parse --git-dir 2>/dev/null
+     ```
+
+   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+   - Check if .eslintrc* exists → create/verify .eslintignore
+   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
+   - Check if .prettierrc* exists → create/verify .prettierignore
+   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+   - Check if terraform files (*.tf) exist → create/verify .terraformignore
+   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+   **If ignore file missing**: Create with full pattern set for detected technology
+
+   **Common Patterns by Technology** (from plan.md tech stack):
+   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
+   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
+   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
+   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+   **Tool-Specific Patterns**:
+   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
+   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
+   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
+   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+
+5. Parse tasks.md structure and extract:
+   - **Task phases**: Setup, Tests, Core, Integration, Polish
+   - **Task dependencies**: Sequential vs parallel execution rules
+   - **Task details**: ID, description, file paths, parallel markers [P]
+   - **Execution flow**: Order and dependency requirements
+
+6. Execute implementation following the task plan:
+   - **Phase-by-phase execution**: Complete each phase before moving to the next
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together
+   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
+   - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Validation checkpoints**: Verify each phase completion before proceeding
+
+7. Implementation execution rules:
+   - **Setup first**: Initialize project structure, dependencies, configuration
+   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
+   - **Core development**: Implement models, services, CLI commands, endpoints
+   - **Integration work**: Database connections, middleware, logging, external services
+   - **Polish and validation**: Unit tests, performance optimization, documentation
+
+8. Progress tracking and error handling:
+   - Report progress after each completed task
+   - Halt execution if any non-parallel task fails
+   - For parallel tasks [P], continue with successful tasks, report failed ones
+   - Provide clear error messages with context for debugging
+   - Suggest next steps if implementation cannot proceed
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+
+9. Completion validation:
+   - Verify all required tasks are completed
+   - Check that implemented features match the original specification
+   - Validate that tests pass and coverage meets requirements
+   - Confirm the implementation follows the technical plan
+
+Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit-tasks` first to regenerate the task list.
+
+## Mandatory Post-Execution Hooks
+
+**You MUST complete this section before reporting completion to the user.**
+
+Check if `.specify/extensions.yml` exists in the project root.
+- If it does not exist, or no hooks are registered under `hooks.after_implement`, skip to the Completion Report.
+- If it exists, read it and look for entries under the `hooks.after_implement` key.
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue to the Completion Report.
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Mandatory hook** (`optional: false`) — **You MUST emit `EXECUTE_COMMAND:` for each mandatory hook**:
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+## Completion Report
+
+Report final status with summary of completed work.
+
+## Done When
+
+- [ ] All tasks in tasks.md completed and marked `[X]`
+- [ ] Implementation validated against specification, plan, and test coverage
+- [ ] Extension hooks dispatched or skipped according to the rules in Mandatory Post-Execution Hooks above
+- [ ] Completion reported to user with summary of completed work

--- a/.claude/skills/speckit-plan/SKILL.md
+++ b/.claude/skills/speckit-plan/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: "speckit-plan"
+description: "Execute the implementation planning workflow using the plan template to generate design artifacts."
+argument-hint: "Optional guidance for the planning phase"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/plan.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before planning)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_plan` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+
+3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+   - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
+   - Fill Constitution Check section from constitution
+   - Evaluate gates (ERROR if violations unjustified)
+   - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md
+   - Re-evaluate Constitution Check post-design
+
+## Mandatory Post-Execution Hooks
+
+**You MUST complete this section before reporting completion to the user.**
+
+Check if `.specify/extensions.yml` exists in the project root.
+- If it does not exist, or no hooks are registered under `hooks.after_plan`, skip to the Completion Report.
+- If it exists, read it and look for entries under the `hooks.after_plan` key.
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue to the Completion Report.
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Mandatory hook** (`optional: false`) — **You MUST emit `EXECUTE_COMMAND:` for each mandatory hook**:
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+## Completion Report
+
+Command ends after Phase 1 design. Report branch, IMPL_PLAN path, and generated artifacts.
+
+## Phases
+
+### Phase 0: Outline & Research
+
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+
+   ```text
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+### Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Define interface contracts** (if project has external interfaces) → `/contracts/`:
+   - Identify what interfaces the project exposes to users or other systems
+   - Document the contract format appropriate for the project type
+   - Examples: public APIs for libraries, command schemas for CLI tools, endpoints for web services, grammars for parsers, UI contracts for applications
+   - Skip if project is purely internal (build scripts, one-off tools, etc.)
+
+3. **Create quickstart validation guide** → `quickstart.md`:
+   - Document runnable validation scenarios that prove the feature works end-to-end
+   - Include prerequisites, setup commands, test/run commands, and expected outcomes
+   - Use links or references to contracts and data model details instead of duplicating them
+   - Do not include full implementation code, model/service/controller bodies, migrations, or complete test suites
+   - Keep this artifact as a validation/run guide; implementation details belong in `tasks.md` and the implementation phase
+
+**Output**: data-model.md, /contracts/*, quickstart.md
+
+## Key rules
+
+- Use absolute paths for filesystem operations; use project-relative paths for references in documentation
+- ERROR on gate failures or unresolved clarifications
+
+## Done When
+
+- [ ] Plan workflow executed and design artifacts generated
+- [ ] Extension hooks dispatched or skipped according to the rules in Mandatory Post-Execution Hooks above
+- [ ] Completion reported to user with branch, plan path, and generated artifacts

--- a/.claude/skills/speckit-specify/SKILL.md
+++ b/.claude/skills/speckit-specify/SKILL.md
@@ -1,0 +1,348 @@
+---
+name: "speckit-specify"
+description: "Create or update the feature specification from a natural language feature description."
+argument-hint: "Describe the feature you want to specify"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/specify.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before specification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_specify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+The text the user typed after `/speckit-specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the feature:
+   - Analyze the feature description and extract the most meaningful keywords
+   - Create a 2-4 word short name that captures the essence of the feature
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+   - Keep it concise but descriptive enough to understand the feature at a glance
+   - Examples:
+     - "I want to add user authentication" → "user-auth"
+     - "Implement OAuth2 integration for the API" → "oauth2-api-integration"
+     - "Create a dashboard for analytics" → "analytics-dashboard"
+     - "Fix payment processing timeout bug" → "fix-payment-timeout"
+
+2. **Branch creation** (optional, via hook):
+
+   If a `before_specify` hook ran successfully in the Pre-Execution Checks above, it will have created/switched to a git branch and output JSON containing `BRANCH_NAME` and `FEATURE_NUM`. Note these values for reference, but the branch name does **not** dictate the spec directory name.
+
+   If the user explicitly provided `GIT_BRANCH_NAME`, pass it through to the hook so the branch script uses the exact value as the branch name (bypassing all prefix/suffix generation).
+
+3. **Create the spec feature directory**:
+
+   Specs live under the default `specs/` directory unless the user explicitly provides `SPECIFY_FEATURE_DIRECTORY`.
+
+   **Resolution order for `SPECIFY_FEATURE_DIRECTORY`**:
+   1. If the user explicitly provided `SPECIFY_FEATURE_DIRECTORY` (e.g., via environment variable, argument, or configuration), use it as-is
+   2. Otherwise, auto-generate it under `specs/`:
+      - Check `.specify/init-options.json` for `feature_numbering` (preferred) or `branch_numbering` (deprecated, migration only — will be removed in a future release)
+      - If `"timestamp"`: prefix is `YYYYMMDD-HHMMSS` (current timestamp)
+      - If `"sequential"` or absent: prefix is `NNN` (next available 3-digit number after scanning existing directories in `specs/`)
+      - Construct the directory name: `<prefix>-<short-name>` (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+      - Set `SPECIFY_FEATURE_DIRECTORY` to `specs/<directory-name>`
+      - If `branch_numbering` was used (and `feature_numbering` was absent), emit a one-line warning: "⚠️ `branch_numbering` in init-options.json is deprecated. Rename to `feature_numbering`."
+
+   **Create the directory and spec file**:
+   - `mkdir -p SPECIFY_FEATURE_DIRECTORY`
+   - Resolve the active `spec-template` through the Spec Kit preset/template resolution stack (equivalent to `specify preset resolve spec-template`)
+   - Copy the resolved `spec-template` file to `SPECIFY_FEATURE_DIRECTORY/spec.md` as the starting point
+   - Set `SPEC_FILE` to `SPECIFY_FEATURE_DIRECTORY/spec.md`
+   - Persist the resolved path to `.specify/feature.json`:
+     ```json
+     {
+       "feature_directory": "<resolved feature dir>"
+     }
+     ```
+     Write the actual resolved directory path value (for example, `specs/003-user-auth`), not the literal string `SPECIFY_FEATURE_DIRECTORY`.
+     This allows downstream commands (`/speckit-plan`, `/speckit-tasks`, etc.) to locate the feature directory without relying on git branch name conventions.
+
+   **IMPORTANT**:
+   - You must only create one feature per `/speckit-specify` invocation
+   - The spec directory name and the git branch name are independent — they may be the same but that is the user's choice
+   - The spec directory and file are always created by this command, never by the hook
+
+4. Load the resolved active `spec-template` file to understand required sections.
+
+5. **IF EXISTS**: Load `.specify/memory/constitution.md` for project principles and governance constraints.
+
+6. Follow this execution flow:
+    1. Parse user description from arguments
+       If empty: ERROR "No feature description provided"
+    2. Extract key concepts from description
+       Identify: actors, actions, data, constraints
+    3. For unclear aspects:
+       - Make informed guesses based on context and industry standards
+       - Only mark with [NEEDS CLARIFICATION: specific question] if:
+         - The choice significantly impacts feature scope or user experience
+         - Multiple reasonable interpretations exist with different implications
+         - No reasonable default exists
+       - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
+       - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
+    4. Fill User Scenarios & Testing section
+       If no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements
+       Each requirement must be testable
+       Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
+    6. Define Success Criteria
+       Create measurable, technology-agnostic outcomes
+       Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
+       Each criterion must be verifiable without implementation details
+    7. Identify Key Entities (if data involved)
+    8. Return: SUCCESS (spec ready for planning)
+
+7. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+8. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+
+   a. **Create Spec Quality Checklist**: Generate a checklist file at `SPECIFY_FEATURE_DIRECTORY/checklists/requirements.md` using the checklist template structure with these validation items:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+
+      **Purpose**: Validate specification completeness and quality before proceeding to planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+
+      ## Content Quality
+
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] Written for non-technical stakeholders
+      - [ ] All mandatory sections completed
+
+      ## Requirement Completeness
+
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable
+      - [ ] Success criteria are technology-agnostic (no implementation details)
+      - [ ] All acceptance scenarios are defined
+      - [ ] Edge cases are identified
+      - [ ] Scope is clearly bounded
+      - [ ] Dependencies and assumptions identified
+
+      ## Feature Readiness
+
+      - [ ] All functional requirements have clear acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] Feature meets measurable outcomes defined in Success Criteria
+      - [ ] No implementation details leak into specification
+
+      ## Notes
+
+      - Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+      ```
+
+   b. **Run Validation Check**: Review the spec against each checklist item:
+      - For each item, determine if it passes or fails
+      - Document specific issues found (quote relevant spec sections)
+
+   c. **Handle Validation Results**:
+
+      - **If all items pass**: Mark checklist complete and proceed to the Mandatory Post-Execution Hooks section
+
+      - **If items fail (excluding [NEEDS CLARIFICATION])**:
+        1. List the failing items and specific issues
+        2. Update the spec to address each issue
+        3. Re-run validation until all items pass (max 3 iterations)
+        4. If still failing after 3 iterations, document remaining issues in checklist notes and warn user
+
+      - **If [NEEDS CLARIFICATION] markers remain**:
+        1. Extract all [NEEDS CLARIFICATION: ...] markers from the spec
+        2. **LIMIT CHECK**: If more than 3 markers exist, keep only the 3 most critical (by scope/security/UX impact) and make informed guesses for the rest
+        3. For each clarification needed (max 3), present options to user in this format:
+
+           ```markdown
+           ## Question [N]: [Topic]
+
+           **Context**: [Quote relevant spec section]
+
+           **What we need to know**: [Specific question from NEEDS CLARIFICATION marker]
+
+           **Suggested Answers**:
+
+           | Option | Answer | Implications |
+           |--------|--------|--------------|
+           | A      | [First suggested answer] | [What this means for the feature] |
+           | B      | [Second suggested answer] | [What this means for the feature] |
+           | C      | [Third suggested answer] | [What this means for the feature] |
+           | Custom | Provide your own answer | [Explain how to provide custom input] |
+
+           **Your choice**: _[Wait for user response]_
+           ```
+
+        4. **CRITICAL - Table Formatting**: Ensure markdown tables are properly formatted:
+           - Use consistent spacing with pipes aligned
+           - Each cell should have spaces around content: `| Content |` not `|Content|`
+           - Header separator must have at least 3 dashes: `|--------|`
+           - Test that the table renders correctly in markdown preview
+        5. Number questions sequentially (Q1, Q2, Q3 - max 3 total)
+        6. Present all questions together before waiting for responses
+        7. Wait for user to respond with their choices for all questions (e.g., "Q1: A, Q2: Custom - [details], Q3: B")
+        8. Update the spec by replacing each [NEEDS CLARIFICATION] marker with the user's selected or provided answer
+        9. Re-run validation after all clarifications are resolved
+
+   d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
+
+## Mandatory Post-Execution Hooks
+
+**You MUST complete this section before reporting completion to the user.**
+
+Check if `.specify/extensions.yml` exists in the project root.
+- If it does not exist, or no hooks are registered under `hooks.after_specify`, skip to the Completion Report.
+- If it exists, read it and look for entries under the `hooks.after_specify` key.
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue to the Completion Report.
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Mandatory hook** (`optional: false`) — **You MUST emit `EXECUTE_COMMAND:` for each mandatory hook**:
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+## Completion Report
+
+Report completion to the user with:
+- `SPECIFY_FEATURE_DIRECTORY` — the feature directory path
+- `SPEC_FILE` — the spec file path
+- Checklist results summary
+- Readiness for the next phase (`/speckit-clarify` or `/speckit-plan`)
+
+**NOTE:** Branch creation is handled by the `before_specify` hook (git extension). Spec directory and file creation are always handled by this core command.
+
+## Quick Guidelines
+
+- Focus on **WHAT** users need and **WHY**.
+- Avoid HOW to implement (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- DO NOT create any checklists that are embedded in the spec. That will be a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+
+When creating this spec from a user prompt:
+
+1. **Make informed guesses**: Use context, industry standards, and common patterns to fill gaps
+2. **Document assumptions**: Record reasonable defaults in the Assumptions section
+3. **Limit clarifications**: Maximum 3 [NEEDS CLARIFICATION] markers - use only for critical decisions that:
+   - Significantly impact feature scope or user experience
+   - Have multiple reasonable interpretations with different implications
+   - Lack any reasonable default
+4. **Prioritize clarifications**: scope > security/privacy > user experience > technical details
+5. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+6. **Common areas needing clarification** (only if no reasonable default exists):
+   - Feature scope and boundaries (include/exclude specific use cases)
+   - User types and permissions (if multiple conflicting interpretations possible)
+   - Security/compliance requirements (when legally/financially significant)
+
+**Examples of reasonable defaults** (don't ask about these):
+
+- Data retention: Industry-standard practices for the domain
+- Performance targets: Standard web/mobile app expectations unless specified
+- Error handling: User-friendly messages with appropriate fallbacks
+- Authentication method: Standard session-based or OAuth2 for web apps
+- Integration patterns: Use project-appropriate patterns (REST/GraphQL for web services, function calls for libraries, CLI args for tools, etc.)
+
+### Success Criteria Guidelines
+
+Success criteria must be:
+
+1. **Measurable**: Include specific metrics (time, percentage, count, rate)
+2. **Technology-agnostic**: No mention of frameworks, languages, databases, or tools
+3. **User-focused**: Describe outcomes from user/business perspective, not system internals
+4. **Verifiable**: Can be tested/validated without knowing implementation details
+
+**Good examples**:
+
+- "Users can complete checkout in under 3 minutes"
+- "System supports 10,000 concurrent users"
+- "95% of searches return results in under 1 second"
+- "Task completion rate improves by 40%"
+
+**Bad examples** (implementation-focused):
+
+- "API response time is under 200ms" (too technical, use "Users see results instantly")
+- "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
+- "React components render efficiently" (framework-specific)
+- "Redis cache hit rate above 80%" (technology-specific)
+
+## Done When
+
+- [ ] Specification written to `SPEC_FILE` and validated against quality checklist
+- [ ] Extension hooks dispatched or skipped according to the rules in Mandatory Post-Execution Hooks above
+- [ ] Completion reported to user with feature directory, spec file path, and checklist results

--- a/.claude/skills/speckit-tasks/SKILL.md
+++ b/.claude/skills/speckit-tasks/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: "speckit-tasks"
+description: "Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts."
+argument-hint: "Optional task generation constraints"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/tasks.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_tasks` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/setup-tasks.sh --json` from repo root and parse FEATURE_DIR, TASKS_TEMPLATE, and AVAILABLE_DOCS list. `FEATURE_DIR` and `TASKS_TEMPLATE` must be absolute paths when provided. `AVAILABLE_DOCS` is a list of document names/relative paths available under `FEATURE_DIR` (for example `research.md` or `contracts/`). For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load design documents**: Read from FEATURE_DIR:
+   - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Optional**: data-model.md (entities), contracts/ (interface contracts), research.md (decisions), quickstart.md (test scenarios)
+   - **IF EXISTS**: Load `.specify/memory/constitution.md` for project principles and governance constraints
+   - Note: Not all projects have all documents. Generate tasks based on what's available.
+
+3. **Execute task generation workflow**:
+   - Load plan.md and extract tech stack, libraries, project structure
+   - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
+   - If data-model.md exists: Extract entities and map to user stories
+   - If contracts/ exists: Map interface contracts to user stories
+   - If research.md exists: Extract decisions for setup tasks
+   - Generate tasks organized by user story (see Task Generation Rules below)
+   - Generate dependency graph showing user story completion order
+   - Create parallel execution examples per user story
+   - Validate task completeness (each user story has all needed tasks, independently testable)
+
+4. **Generate tasks.md**: Read the tasks template from TASKS_TEMPLATE (from the JSON output above) and use it as structure. If TASKS_TEMPLATE is empty, fall back to `.specify/templates/tasks-template.md`. Fill with:
+   - Correct feature name from plan.md
+   - Phase 1: Setup tasks (project initialization)
+   - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
+   - Phase 3+: One phase per user story (in priority order from spec.md)
+   - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
+   - Final Phase: Polish & cross-cutting concerns
+   - All tasks must follow the strict checklist format (see Task Generation Rules below)
+   - Clear file paths for each task
+   - Dependencies section showing story completion order
+   - Parallel execution examples per story
+   - Implementation strategy section (MVP first, incremental delivery)
+
+## Mandatory Post-Execution Hooks
+
+**You MUST complete this section before reporting completion to the user.**
+
+Check if `.specify/extensions.yml` exists in the project root.
+- If it does not exist, or no hooks are registered under `hooks.after_tasks`, skip to the Completion Report.
+- If it exists, read it and look for entries under the `hooks.after_tasks` key.
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue to the Completion Report.
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Mandatory hook** (`optional: false`) — **You MUST emit `EXECUTE_COMMAND:` for each mandatory hook**:
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+## Completion Report
+
+Output path to generated tasks.md and summary:
+- Total task count
+- Task count per user story
+- Parallel opportunities identified
+- Independent test criteria for each story
+- Suggested MVP scope (typically just User Story 1)
+- Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+Context for task generation: $ARGUMENTS
+
+The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+## Task Generation Rules
+
+**CRITICAL**: Tasks MUST be organized by user story to enable independent implementation and testing.
+
+**Tests are OPTIONAL**: Only generate test tasks if explicitly requested in the feature specification or if user requests TDD approach.
+
+### Checklist Format (REQUIRED)
+
+Every task MUST strictly follow this format:
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+**Format Components**:
+
+1. **Checkbox**: ALWAYS start with `- [ ]` (markdown checkbox)
+2. **Task ID**: Sequential number (T001, T002, T003...) in execution order
+3. **[P] marker**: Include ONLY if task is parallelizable (different files, no dependencies on incomplete tasks)
+4. **[Story] label**: REQUIRED for user story phase tasks only
+   - Format: [US1], [US2], [US3], etc. (maps to user stories from spec.md)
+   - Setup phase: NO story label
+   - Foundational phase: NO story label
+   - User Story phases: MUST have story label
+   - Polish phase: NO story label
+5. **Description**: Clear action with exact file path
+
+**Examples**:
+
+- ✅ CORRECT: `- [ ] T001 Create project structure per implementation plan`
+- ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
+- ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
+- ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
+- ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
+- ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
+- ❌ WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+
+### Task Organization
+
+1. **From User Stories (spec.md)** - PRIMARY ORGANIZATION:
+   - Each user story (P1, P2, P3...) gets its own phase
+   - Map all related components to their story:
+     - Models needed for that story
+     - Services needed for that story
+     - Interfaces/UI needed for that story
+     - If tests requested: Tests specific to that story
+   - Mark story dependencies (most stories should be independent)
+
+2. **From Contracts**:
+   - Map each interface contract → to the user story it serves
+   - If tests requested: Each interface contract → contract test task [P] before implementation in that story's phase
+
+3. **From Data Model**:
+   - Map each entity to the user story(ies) that need it
+   - If entity serves multiple stories: Put in earliest story or Setup phase
+   - Relationships → service layer tasks in appropriate story phase
+
+4. **From Setup/Infrastructure**:
+   - Shared infrastructure → Setup phase (Phase 1)
+   - Foundational/blocking tasks → Foundational phase (Phase 2)
+   - Story-specific setup → within that story's phase
+
+### Phase Structure
+
+- **Phase 1**: Setup (project initialization)
+- **Phase 2**: Foundational (blocking prerequisites - MUST complete before user stories)
+- **Phase 3+**: User Stories in priority order (P1, P2, P3...)
+  - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
+  - Each phase should be a complete, independently testable increment
+- **Final Phase**: Polish & Cross-Cutting Concerns
+
+## Done When
+
+- [ ] tasks.md generated with all phases, task IDs, and file paths
+- [ ] Extension hooks dispatched or skipped according to the rules in Mandatory Post-Execution Hooks above
+- [ ] Completion reported to user with task count, story breakdown, and MVP scope

--- a/.claude/skills/speckit-taskstoissues/SKILL.md
+++ b/.claude/skills/speckit-taskstoissues/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: "speckit-taskstoissues"
+description: "Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts."
+argument-hint: "Optional filter or label for GitHub issues"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/taskstoissues.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks-to-issues conversion)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. **IF EXISTS**: Load `.specify/memory/constitution.md` for project principles and governance constraints.
+1. From the executed script, extract the path to **tasks**.
+1. Get the Git remote by running:
+
+```bash
+git config --get remote.origin.url
+```
+
+> [!CAUTION]
+> ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
+
+1. **Fetch existing issues for deduplication**: Before creating anything, build the set of task IDs you are about to process from `tasks.md` (each is a `T` followed by three digits, e.g. `T001`). Then use the GitHub MCP server's `list_issues` tool to look for issues that already cover those IDs. Do not pass a `state` value, since omitting it makes the tool return both open and closed issues. Request `perPage: 100` to keep the number of calls down, and since the tool uses cursor-based pagination, request pages with the `after` parameter (using the `endCursor` from the previous response). For each issue title, match it against the task ID pattern `\bT\d{3}\b` (word boundaries so tokens like `ST001` or `T0010` are not matched by mistake; this also recognises titles written as `T001 ...`, `T001: ...` or `[T001] ...`) and, when it matches one of your task IDs, mark that ID as already having an issue. Stop paginating as soon as every task ID has been matched, or when there are no more pages, so you do not keep fetching the whole repository's issue history once all task IDs are accounted for. This bounds the number of calls on repos with large issue histories and still prevents duplicates when the command is re-run after `tasks.md` is regenerated or the skill is re-invoked.
+1. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote. Task lines in `tasks.md` start with a markdown checkbox, so first strip the leading `- [ ]` (and any `[P]` / `[US#]` markers) to recover the task ID and its description. Create the issue with a single canonical title of the form `T001: <description>`, with the ID written once followed by the task description (for example, the line `- [ ] T001 Create project structure` becomes the title `T001: Create project structure`).
+   - **Skip** any task whose ID is already present in the set of existing issues from the previous step, and report it (for example, `T001 already has an issue, skipping`).
+   - Only create issues for tasks that do not yet have a matching issue.
+
+> [!CAUTION]
+> UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL
+
+## Post-Execution Checks
+
+**Check for extension hooks (after tasks-to-issues conversion)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+    After emitting the block above you MUST actually invoke the hook and wait for it to finish before continuing. Run it the same way you would run the command yourself in this agent/session (the invocation may differ from the literal `{command}` id shown above, e.g. a skills-mode agent runs it as `/skill:speckit-...` or `$speckit-...`). Emitting the block alone does not run the hook.
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/050-headless-spec-chain"
+}

--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,0 +1,9 @@
+{
+  "ai": "claude",
+  "ai_skills": true,
+  "feature_numbering": "sequential",
+  "here": true,
+  "integration": "claude",
+  "script": "sh",
+  "speckit_version": "0.14.0"
+}

--- a/.specify/integration.json
+++ b/.specify/integration.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.14.0",
+  "integration_state_schema": 1,
+  "installed_integrations": [
+    "claude"
+  ],
+  "integration_settings": {
+    "claude": {
+      "script": "sh",
+      "invoke_separator": "-"
+    }
+  },
+  "integration": "claude",
+  "default_integration": "claude"
+}

--- a/.specify/integrations/claude.manifest.json
+++ b/.specify/integrations/claude.manifest.json
@@ -1,0 +1,17 @@
+{
+  "integration": "claude",
+  "version": "0.14.0",
+  "installed_at": "2026-07-23T15:49:39.174747+00:00",
+  "files": {
+    ".claude/skills/speckit-analyze/SKILL.md": "fecd4bf113c3dda58c75d387473c0106fc2dfea97a27bb7c65af94f3f916c188",
+    ".claude/skills/speckit-clarify/SKILL.md": "c1c2098756ca407530cca11c5b608f517d769962215ddafa013951b81e3e19c5",
+    ".claude/skills/speckit-constitution/SKILL.md": "70a37fbeeb741ac4ecd5d9a73860ecc7d397ec61d665d304b5212e9c06749481",
+    ".claude/skills/speckit-implement/SKILL.md": "c36b1326054c66ca23e17b00d6c12b1d2af8f7eee69656cefd38459210552cfe",
+    ".claude/skills/speckit-converge/SKILL.md": "04226b8443797337624983111546d5e5a48d9993a176c4e6d72a4099a0af50d4",
+    ".claude/skills/speckit-plan/SKILL.md": "7c2af71208f4358b54c58a60508362aa24a82ec2f24f7fc2213f50c10e5d7563",
+    ".claude/skills/speckit-checklist/SKILL.md": "946c6bc808891436972a11a423f89f0fbd272a79809bb8fd1d29f481ebe02613",
+    ".claude/skills/speckit-specify/SKILL.md": "333e492196f033890734161a16e93639080956f7e74f8a64b0d4f2a7a0aff3fe",
+    ".claude/skills/speckit-tasks/SKILL.md": "f2e56011107c53edf9a3b7cad987ce8fef73d50cb8a6aa26baa4628950d743f7",
+    ".claude/skills/speckit-taskstoissues/SKILL.md": "dfe23aaca349cd76e98505dafa9aae1ef4616a0c35a5c79122b9bd881e16b62f"
+  }
+}

--- a/.specify/integrations/speckit.manifest.json
+++ b/.specify/integrations/speckit.manifest.json
@@ -1,0 +1,27 @@
+{
+  "integration": "speckit",
+  "version": "0.14.0",
+  "installed_at": "2026-07-23T15:49:39.214059+00:00",
+  "files": {
+    ".specify/scripts/bash/setup-plan.sh": "079dee34382af0ae320c8d97eee396ae0056ea0ff360e55a997adfddf81cdf9f",
+    ".specify/scripts/bash/common.sh": "e58fe0b681121b172ddb79e68bec8171511430de71e5899c56ec4d77c256e1f3",
+    ".specify/scripts/bash/create-new-feature.sh": "9b376cf23e970cae7107c75bcff24c758e0135297c436b895b75373e21bab852",
+    ".specify/scripts/bash/check-prerequisites.sh": "b8784dd9bdce038955ac69955074c819229b1619931a094ec3810f7394722eba",
+    ".specify/templates/tasks-template.md": "5da92ac1fbf5be2f9018a5064497995bf3592761ccb6b3951503c63d851297e8",
+    ".specify/templates/spec-template.md": "bd529dda1cccaaee34fce4355100c5bfcf56d3811698c6aa7dbab5f6b5476c60",
+    ".specify/templates/checklist-template.md": "312eee8291dfa984b21f95ddd0ca778e7a1f0b3a64bfc470d79762a3e3f5d7b8",
+    ".specify/templates/plan-template.md": "5098a72779163f8549858018be4d4e3283861529b152461e28226eed6b4e24ec",
+    ".specify/scripts/bash/setup-tasks.sh": "cf21ba2212b4dd5b435c5ea8527500cfd27768b86c0bbc7ebc3207759f118d27",
+    ".specify/templates/constitution-template.md": "ce7549540fa45543cca797a150201d868e64495fdff39dc38246fb17bd4024b3"
+  },
+  "recovered_files": [
+    ".specify/scripts/bash/check-prerequisites.sh",
+    ".specify/scripts/bash/common.sh",
+    ".specify/scripts/bash/create-new-feature.sh",
+    ".specify/scripts/bash/setup-plan.sh",
+    ".specify/templates/checklist-template.md",
+    ".specify/templates/plan-template.md",
+    ".specify/templates/spec-template.md",
+    ".specify/templates/tasks-template.md"
+  ]
+}

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,22 +1,18 @@
 <!--
 Sync Impact Report
 ==================
-Version change: 1.9.0 → 1.10.0
+Version change: 1.10.0 to 1.11.0
 Modified principles: None
-Removed sections:
-  - Guardrail #11: Workspace Isolation (was DSL-specific cwd threading — now Appendix E covers Python workflows)
-  - Guardrail #12: DSL Expression Type Safety (was YAML DSL-specific — maverick.dsl package removed)
-  - Appendix A: DSL execution split pattern row (maverick.dsl package removed)
+Removed sections: None
 Updated sections:
-  - Principle I: Removed "DSL PythonStep" reference, generalized to "Python steps"
-  - Guardrail #2: Removed "DSL PythonStep" reference, generalized to "Python steps"
-  - Guardrail #5: Removed "DSL/workflow definition" reference
-  - Appendix C: Updated import from maverick.dsl.events to maverick.events
-  - Appendix E: Reframed for Python workflows (removed YAML DSL specifics)
-  - Compliance Review: Removed Guardrail #11 and #12 references
+  - Appendix E: Replaced the stale "fly hidden workspace" narrative (that model was
+    retired when the single-repo CWD model, Guardrail 0, became the default) with a
+    pointer to Guardrail 0 as the default model plus the spec-chain's hidden jj
+    workspace as the one documented, scoped exception (spec 050-headless-spec-chain).
 Templates requiring updates: None
-Source: Feature 041-remove-yaml-dsl — deleted maverick.dsl package entirely in favour of
-Python-native workflow authoring. YAML DSL content in constitution was dead/misleading.
+Source: Feature 050-headless-spec-chain -- maverick spec introduces the first
+hidden-workspace exception to Guardrail 0 since the single-repo model was adopted;
+Appendix E's prior content predated that model and no longer matched any running code.
 -->
 
 # Maverick Constitution
@@ -489,7 +485,7 @@ MUST comply with these principles.
 - Branch naming conventions (Guardrail #10, Appendix D) MUST be verified before pushing
 - Workspace cwd threading (Appendix E) MUST be verified for all new workflow steps
 
-**Version**: 1.10.0 | **Ratified**: 2025-12-12 | **Last Amended**: 2026-03-03
+**Version**: 1.11.0 | **Ratified**: 2025-12-12 | **Last Amended**: 2026-07-24
 
 ## Appendix B: Canonical Third-Party Libraries
 
@@ -687,72 +683,74 @@ and verification procedures prevent wasted effort and repository pollution.
 
 ## Appendix E: Workspace Isolation Architecture
 
-The `fly` command creates a hidden jj workspace at `~/.maverick/workspaces/<project>/`
-where all agent work happens. The user's working directory is never modified during fly.
-After fly completes, `land` curates and pushes commits from the workspace.
+**Default: single-repo CWD model (Guardrail 0).** `fly`, `refuel`, `land`, and every
+other long-running command operate directly in the user's checkout under `Path.cwd()`
+(resolved once at the CLI boundary and threaded explicitly through every layer beneath
+it — see Guardrail 0 and Guardrail 7 in CLAUDE.md). There is no hidden workspace, no
+clone bridge, and no `WorkspaceManager` for these commands. Two implementations of a
+general-purpose hidden-workspace model were tried and retired before this model was
+adopted (`jj git clone` — drifted on bd state, gone in `cf11db4`; `jj workspace add` —
+bd's gitignored `embeddeddolt/` didn't travel into the workspace, gone in the slice that
+introduced the single-repo model). See CLAUDE.md Guardrail 0 for the full history and
+the CWD contract every command in this model follows: CLI resolves `cwd`, passes it
+explicitly to the workflow, which threads it to every action/agent step — no
+`Path.cwd()` defaults inside `src/maverick/workflows/` or `src/maverick/actors/`.
 
-### The CWD Contract
+### The scoped exception: spec-chain's hidden jj workspace
 
-Every workflow step that operates inside the workspace MUST receive the workspace path as
-its working directory. The workspace path is returned by `create_workspace` and must be
-threaded explicitly to all subsequent steps:
+`maverick spec` (spec 050-headless-spec-chain) is a **documented exception** to the
+single-repo model. Each chain step (specify → clarify → plan → tasks → analyze) mutates
+`specs/`, `.specify/feature.json`, and agent scratch state over a multi-minute model
+call; the user's checkout must stay untouched until each step's artifacts are verified
+complete, and only completed-step artifacts may land. Running steps directly in the
+user's checkout would expose half-written spec artifacts mid-run and make atomic landing
+impossible without ad-hoc staging.
 
-```
-create_workspace step
-  └── workspace_path (e.g. "/home/user/.maverick/workspaces/my-project")
-        │
-        ├── implement (agent step)
-        │     context["cwd"] = workspace_path
-        │
-        ├── validate_and_fix (sub-workflow/fragment)
-        │     inputs["cwd"] = workspace_path
-        │     └── (fragment wires cwd to its internal validate + fix_loop steps)
-        │
-        ├── gather_review_context (python step)
-        │     kwargs["cwd"] = workspace_path
-        │
-        └── git_commit (python step)
-              kwargs["cwd"] = workspace_path
-```
+The historic reason general-purpose workspaces were retired — bd's gitignored
+`embeddeddolt/` not traveling into `jj workspace add` — does **not** apply here: the
+spec chain never runs `bd` inside the workspace. All bead/ledger writes (assumption
+ledger entries from clarify, remediation beads from analyze) happen in the user's
+checkout via the workflow (`src/maverick/workflows/spec_chain/workflow.py`), never the
+agent and never the workspace. This keeps Guardrail X.3 (agents never own deterministic
+side effects) and Guardrail X.8 (canonical wrappers) intact even inside the exception.
 
-### Why Explicit CWD Is Required
+**Mechanism** (`src/maverick/workspace/spec_chain.py`, `research.md` R3):
 
-- **Agent steps**: The Claude agent's tool server resolves file paths relative to `cwd`.
-  Without explicit cwd, the agent reads/writes the user's repo instead of the workspace.
-- **Validate steps**: `ValidationRunner` runs `ruff`, `pytest`, etc. in a subprocess.
-  Without cwd, these run against the user's repo (which may not have the workspace's changes).
-- **Review actions**: `AsyncGitRepository(cwd)` computes diffs against the workspace.
-  Without cwd, diffs show nothing because the user repo hasn't changed.
-- **jj actions**: `JjClient(cwd=Path(workspace_path))` operates on the workspace's
-  `.jj/` store. The `_make_client` helper accepts `str | Path | None` and coerces with
-  `Path(cwd)`.
+- Location: `~/.maverick/workspaces/<project-slug>/spec-chain/<feature>/` — per-feature,
+  so two features' chains never share (and one can never destroy the other's resumable
+  state).
+- Creation: `JjClient.workspace_add`, from the user's colocated checkout — the shared
+  backing store materializes committed files (`.claude/commands/speckit.*.md`,
+  `.specify/**`, existing `specs/**`) into the workspace. The PRD file (often untracked)
+  is copied in explicitly.
+- Reuse & cleanup: a resumable chain (`status` `halted`/`running`) reuses its workspace
+  on resume; a fresh or completed chain forgets + recreates it, so runs start clean.
+- Landing: after each step succeeds (verified against the filesystem, never the agent's
+  self-report — research.md R9), `src/maverick/workflows/spec_chain/landing.py` syncs
+  `specs/<feature-dir>/**` from the workspace into the user's checkout via an atomic
+  staged copy (temp sibling + rename). This is what makes "only completed artifacts
+  land" and "resume never regenerates a landed step" both hold.
 
-### Path Coercion at Step Boundaries
+### CWD contract inside the exception
 
-Workspace paths flow as Python `str` or `Path` objects between workflow steps. Step
-handlers MUST coerce to `Path` before use:
+Within the spec-chain workflow itself, the ordinary Guardrail 7 rules still apply one
+level down: `SpecChainWorkflow._run()` resolves the workspace path once (via
+`prepare_workspace`) and threads it explicitly to every step (`build_step_prompt`,
+`verify_step_artifacts`, `land_step_artifacts`) and to `SpecChainSquadron` — no step
+re-derives or defaults it. The one deliberate deviation is `SpecChainAgent.run_step`,
+which binds the OS process working directory via a locked `os.chdir()`/restore pair for
+the duration of a single airframe `execute()` call — a workaround for airframe 0.9.0rc1
+exposing no `cwd`/`working_directory` parameter on the `claude` provider's runtime
+(research.md R1; the field exists on `CopilotOptions`/`KimiOptions`/
+`OpenCodeServerOptions` but not `ClaudeOptions`, an adapter gap worth upstreaming later).
+Because chain steps run strictly sequentially and one Maverick CLI invocation runs one
+workflow per process, the exposure window is a single in-process critical section, not
+cross-workflow concurrency.
 
-```python
-# In action code or step handler:
-from pathlib import Path
-
-def _make_client(cwd: str | Path | None = None) -> JjClient:
-    return JjClient(cwd=Path(cwd) if cwd else Path.cwd())
-
-# In validate step handler:
-input_cwd = context.inputs.get("cwd")
-cwd = Path(input_cwd) if input_cwd else Path.cwd()
-```
-
-### Preflight Tool Availability
-
-Preflight checks for validation tools (`ruff`, `pytest`, `mypy`) MUST be deferred when
-running in workspace mode. The workspace's `.venv` doesn't exist until bootstrap runs
-(after `create_workspace`). Use `check_validation_tools: false` in preflight kwargs and
-rely on the `sync_deps` step to install tools before validation runs.
-
-**Rationale**: The workspace isolation debugging session (2026-02-20) revealed that the
-implementer agent was silently writing files to the user's repo instead of the hidden
-workspace because no step passed `cwd`. The bug was invisible — fly "succeeded" but
-`land` found nothing to push. Explicit cwd threading is the only reliable way to ensure
-workspace isolation.
+**Rationale**: The workspace isolation debugging session (2026-02-20) that originally
+motivated this appendix revealed that an implementer agent can silently write to the
+wrong directory when no step passes `cwd` explicitly — the bug is invisible until
+downstream steps find nothing to work with. That lesson generalizes to both models
+above: whether the working directory is the user's checkout (the default) or a hidden
+workspace (this scoped exception), every step must receive it explicitly, and nothing
+in `workflows/` or `actors/` may default to `Path.cwd()`.

--- a/.specify/scripts/bash/setup-tasks.sh
+++ b/.specify/scripts/bash/setup-tasks.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Parse command line arguments
+JSON_MODE=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --json) JSON_MODE=true ;;
+        --help|-h)
+            echo "Usage: $0 [--json]"
+            echo "  --json    Output results in JSON format"
+            echo "  --help    Show this help message"
+            exit 0
+            ;;
+        *) echo "ERROR: Unknown option '$arg'" >&2; exit 1 ;;
+    esac
+done
+
+# Source common functions
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# Get feature paths
+_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+eval "$_paths_output"
+unset _paths_output
+
+# Validate required files
+if [[ ! -f "$IMPL_PLAN" ]]; then
+    echo "ERROR: plan.md not found in $FEATURE_DIR" >&2
+    echo "Run /speckit-plan first to create the implementation plan." >&2
+    exit 1
+fi
+
+if [[ ! -f "$FEATURE_SPEC" ]]; then
+    echo "ERROR: spec.md not found in $FEATURE_DIR" >&2
+    echo "Run /speckit-specify first to create the feature structure." >&2
+    exit 1
+fi
+
+# Build available docs list
+docs=()
+[[ -f "$RESEARCH" ]] && docs+=("research.md")
+[[ -f "$DATA_MODEL" ]] && docs+=("data-model.md")
+if [[ -d "$CONTRACTS_DIR" ]] && [[ -n "$(ls -A "$CONTRACTS_DIR" 2>/dev/null)" ]]; then
+    docs+=("contracts/")
+fi
+[[ -f "$QUICKSTART" ]] && docs+=("quickstart.md")
+
+# Resolve tasks template through override stack
+TASKS_TEMPLATE=$(resolve_template "tasks-template" "$REPO_ROOT") || true
+if [[ -z "$TASKS_TEMPLATE" ]] || [[ ! -f "$TASKS_TEMPLATE" ]]; then
+    echo "ERROR: Could not resolve required tasks-template from the template override stack for $REPO_ROOT" >&2
+    echo "Template 'tasks-template' was not found in any supported location (overrides, presets, extensions, or shared core). Add an override at .specify/templates/overrides/tasks-template.md, or run 'specify init' / reinstall shared infra to restore the core .specify/templates/tasks-template.md template." >&2
+    exit 1
+fi
+
+# Output results
+if $JSON_MODE; then
+    if has_jq; then
+        if [[ ${#docs[@]} -eq 0 ]]; then
+            json_docs="[]"
+        else
+            json_docs=$(printf '%s\n' "${docs[@]}" | jq -R . | jq -s .)
+        fi
+        jq -cn \
+            --arg feature_dir "$FEATURE_DIR" \
+            --argjson docs "$json_docs" \
+            --arg tasks_template "${TASKS_TEMPLATE:-}" \
+            '{FEATURE_DIR:$feature_dir,AVAILABLE_DOCS:$docs,TASKS_TEMPLATE:$tasks_template}'
+    else
+        if [[ ${#docs[@]} -eq 0 ]]; then
+            json_docs="[]"
+        else
+            json_docs=$(for d in "${docs[@]}"; do printf '"%s",' "$(json_escape "$d")"; done)
+            json_docs="[${json_docs%,}]"
+        fi
+        printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s,"TASKS_TEMPLATE":"%s"}\n' \
+            "$(json_escape "$FEATURE_DIR")" "$json_docs" "$(json_escape "${TASKS_TEMPLATE:-}")"
+    fi
+else
+    echo "FEATURE_DIR: $FEATURE_DIR"
+    echo "TASKS_TEMPLATE: ${TASKS_TEMPLATE:-not found}"
+    echo "AVAILABLE_DOCS:"
+    check_file "$RESEARCH" "research.md"
+    check_file "$DATA_MODEL" "data-model.md"
+    check_dir "$CONTRACTS_DIR" "contracts/"
+    check_file "$QUICKSTART" "quickstart.md"
+fi

--- a/.specify/templates/constitution-template.md
+++ b/.specify/templates/constitution-template.md
@@ -1,0 +1,50 @@
+# [PROJECT_NAME] Constitution
+<!-- Example: Spec Constitution, TaskFlow Constitution, etc. -->
+
+## Core Principles
+
+### [PRINCIPLE_1_NAME]
+<!-- Example: I. Library-First -->
+[PRINCIPLE_1_DESCRIPTION]
+<!-- Example: Every feature starts as a standalone library; Libraries must be self-contained, independently testable, documented; Clear purpose required - no organizational-only libraries -->
+
+### [PRINCIPLE_2_NAME]
+<!-- Example: II. CLI Interface -->
+[PRINCIPLE_2_DESCRIPTION]
+<!-- Example: Every library exposes functionality via CLI; Text in/out protocol: stdin/args → stdout, errors → stderr; Support JSON + human-readable formats -->
+
+### [PRINCIPLE_3_NAME]
+<!-- Example: III. Test-First (NON-NEGOTIABLE) -->
+[PRINCIPLE_3_DESCRIPTION]
+<!-- Example: TDD mandatory: Tests written → User approved → Tests fail → Then implement; Red-Green-Refactor cycle strictly enforced -->
+
+### [PRINCIPLE_4_NAME]
+<!-- Example: IV. Integration Testing -->
+[PRINCIPLE_4_DESCRIPTION]
+<!-- Example: Focus areas requiring integration tests: New library contract tests, Contract changes, Inter-service communication, Shared schemas -->
+
+### [PRINCIPLE_5_NAME]
+<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
+[PRINCIPLE_5_DESCRIPTION]
+<!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
+
+## [SECTION_2_NAME]
+<!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->
+
+[SECTION_2_CONTENT]
+<!-- Example: Technology stack requirements, compliance standards, deployment policies, etc. -->
+
+## [SECTION_3_NAME]
+<!-- Example: Development Workflow, Review Process, Quality Gates, etc. -->
+
+[SECTION_3_CONTENT]
+<!-- Example: Code review requirements, testing gates, deployment approval process, etc. -->
+
+## Governance
+<!-- Example: Constitution supersedes all other practices; Amendments require documentation, approval, migration plan -->
+
+[GOVERNANCE_RULES]
+<!-- Example: All PRs/reviews must verify compliance; Complexity must be justified; Use [GUIDANCE_FILE] for runtime development guidance -->
+
+**Version**: [CONSTITUTION_VERSION] | **Ratified**: [RATIFICATION_DATE] | **Last Amended**: [LAST_AMENDED_DATE]
+<!-- Example: Version: 2.1.1 | Ratified: 2025-06-13 | Last Amended: 2025-07-16 -->

--- a/.specify/workflows/speckit/workflow.yml
+++ b/.specify/workflows/speckit/workflow.yml
@@ -1,0 +1,77 @@
+schema_version: "1.0"
+workflow:
+  id: "speckit"
+  name: "Full SDD Cycle"
+  version: "1.0.0"
+  author: "GitHub"
+  description: "Runs specify → plan → tasks → implement with review gates"
+
+requires:
+  # 0.8.5 is the first release with engine-side resolution of the
+  # ``integration: "auto"`` default. Older versions would treat "auto"
+  # as a literal integration key and fail at dispatch.
+  speckit_version: ">=0.8.5"
+  integrations:
+    # The four commands below (specify, plan, tasks, implement) are core
+    # spec-kit commands provided by every integration. The list here is an
+    # advisory, non-exhaustive compatibility hint following the documented
+    # ``any: [...]`` schema -- it is NOT a closed set. The workflow runs
+    # against any integration the project was initialized with, including
+    # ones not listed below, as long as that integration provides the four
+    # core commands referenced in ``steps``.
+    any:
+      - "claude"
+      - "copilot"
+      - "gemini"
+      - "opencode"
+
+inputs:
+  spec:
+    type: string
+    required: true
+    prompt: "Describe what you want to build"
+  integration:
+    type: string
+    default: "auto"
+    prompt: "Integration to use (e.g. claude, copilot, gemini; 'auto' uses the project's initialized integration)"
+  scope:
+    type: string
+    default: "full"
+    enum: ["full", "backend-only", "frontend-only"]
+
+steps:
+  - id: specify
+    command: speckit.specify
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: review-spec
+    type: gate
+    message: "Review the generated spec before planning."
+    options: [approve, reject]
+    on_reject: abort
+
+  - id: plan
+    command: speckit.plan
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: review-plan
+    type: gate
+    message: "Review the plan before generating tasks."
+    options: [approve, reject]
+    on_reject: abort
+
+  - id: tasks
+    command: speckit.tasks
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: implement
+    command: speckit.implement
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"

--- a/.specify/workflows/workflow-registry.json
+++ b/.specify/workflows/workflow-registry.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "1.0",
+  "workflows": {
+    "speckit": {
+      "name": "Full SDD Cycle",
+      "version": "1.0.0",
+      "description": "Runs specify \u2192 plan \u2192 tasks \u2192 implement with review gates",
+      "source": "bundled",
+      "installed_at": "2026-07-23T15:49:39.241750+00:00",
+      "updated_at": "2026-07-23T15:49:39.241761+00:00"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,6 +461,24 @@ The full pull-work-push architecture in
 `.claude/scratchpads/architecture-pull-work-push.md` solves it via bd
 federation; until that lands, single-repo is the contract.
 
+**Scoped exception — `maverick spec` (spec 050-headless-spec-chain)**:
+the headless Spec Kit chain (`specify → clarify → plan → tasks →
+analyze`) runs inside a hidden jj workspace at
+`~/.maverick/workspaces/<project-slug>/spec-chain/<feature>/`
+(`src/maverick/workspace/spec_chain.py`), one exception to the model
+above. Rationale: each step mutates `specs/` and `.specify/` state over
+a multi-minute model call, and only a completed step's artifacts may
+land in the user's checkout — running in-checkout would expose
+half-written files mid-run. The bd/`embeddeddolt/` impedance mismatch
+that retired the general-purpose workspace above does **not** apply
+here: the chain never runs `bd` inside the workspace — all bead/ledger
+writes (assumption-ledger entries, remediation beads) happen in the
+user's checkout via the workflow, never the agent. Landing is per-step
+and atomic (`src/maverick/workflows/spec_chain/landing.py`); see
+`.specify/memory/constitution.md` Appendix E and
+`specs/050-headless-spec-chain/research.md` R3 for the full mechanism.
+Every other command still follows the single-repo model unchanged.
+
 ### 1. Async-first means no blocking on the event loop
 
 - Never call `subprocess.run` from an `async def` path.
@@ -521,6 +539,7 @@ Beads-only workflow model. All development is driven by beads (`bd` CLI).
 | Command                                              | Purpose                              |
 | ---------------------------------------------------- | ------------------------------------ |
 | `maverick plan generate <name> --from-prd <file>`    | Flight plan from PRD                 |
+| `maverick spec <feature> --from-prd <file>`          | Headless Spec Kit chain from a PRD   |
 | `maverick refuel <plan-name>`                        | Decompose plan into beads            |
 | `maverick refuel <feature> --speckit [--dry-run\|--enrich]` | Deterministic Spec Kit ingestion |
 | `maverick fly --epic <id>`                           | Implement beads (actor-mailbox)      |
@@ -530,6 +549,34 @@ Beads-only workflow model. All development is driven by beads (`bd` CLI).
 | `maverick brief [--watch\|--human]`                  | Bead status + assumption counts      |
 | `maverick review <bead-id> [--answer\|--waive]`      | Resolve a human-assigned bead         |
 | `maverick runway seed\|consolidate`                  | Manage knowledge store               |
+
+### spec (headless Spec Kit chain)
+
+`maverick spec <feature> --from-prd <file>` runs the target repository's
+own Spec Kit chain — specify → clarify → plan → tasks → analyze —
+headlessly, inside a hidden jj workspace (the one documented exception to
+Guardrail 0; see above), invoking the repo's own `/speckit.*` commands
+via an airframe `SpecChainAgent`. Clarify never blocks: adopted answers
+are filed as standalone assumption-ledger entries
+(`assumptions.ledger.record_standalone_assumption`, no epic yet) via
+question interception where the provider supports it, else by parsing
+Spec Kit's non-interactive `## Clarifications` convention out of the
+updated `spec.md`. A failed or blocked clarify halts the chain (exit 1);
+any other mid-chain failure halts the same way; an analyze failure
+degrades to a `[yellow]Warning:[/yellow]` and the chain still completes
+(exit 0) — analyze findings become standalone `spec-remediation` beads
+that `refuel --speckit` later adopts under the epic it creates. Chain
+state is checkpointed after every step transition
+(`.maverick/runs/<run-id>/spec-chain.json`); re-running `maverick spec
+<feature>` (no `--from-prd` needed) auto-resumes a halted or still-running
+chain from the first incomplete step, re-verifying that already-landed
+artifacts still exist before trusting them. Completed-step artifacts land
+in the user's `specs/NNN-<feature>/` tree as ordinary markdown, one step
+at a time. `maverick init` advisory-checks Spec Kit presence and offers
+to install it (`uvx --from specify-cli==<pin> specify init --here`) on
+interactive TTYs. See `src/maverick/workflows/spec_chain/` (workflow,
+steps, landing, clarify policy, state) and
+`specs/050-headless-spec-chain/` (spec/plan/research/contracts).
 
 ### refuel (Spec Kit ingestion mode)
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,23 @@ maverick plan generate my-feature --from-prd spec.md
 maverick plan generate my-feature --from-prd spec.md --skip-briefing
 ```
 
+### `maverick spec` — Headless Spec Kit Chain
+
+For Spec Kit-managed repositories, runs the repo's own Spec Kit chain —
+specify → clarify → plan → tasks → analyze — end to end with zero
+interactive prompts, invoking the repository's own `/speckit.*` commands
+inside an isolated hidden workspace. Clarify questions are answered
+automatically and filed as auditable assumption-ledger entries; a failed
+or blocked clarify halts the chain rather than producing plans from an
+unvetted spec. Analyze findings become remediation beads instead of
+blocking the run. Completed artifacts land in `specs/NNN-<feature>/` as
+ordinary markdown, one step at a time.
+
+```bash
+maverick spec my-feature --from-prd docs/prd.md
+maverick spec my-feature   # re-run with no --from-prd: resumes a halted/running chain
+```
+
 ### `maverick refuel` — Decompose into Beads
 
 Decomposes a flight plan into work units with acceptance criteria, file scope,

--- a/specs/050-headless-spec-chain/checklists/requirements.md
+++ b/specs/050-headless-spec-chain/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Headless Spec Kit Chain (`maverick spec`)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- References to git-native markdown artifacts, CLI command shape, and the
+  assumption ledger are retained deliberately: they are user-facing product
+  requirements stated in the feature description (artifact reviewability,
+  command surface, and the spec-049 audit contract), not implementation
+  choices made by this spec.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/050-headless-spec-chain/contracts/chain-state.md
+++ b/specs/050-headless-spec-chain/contracts/chain-state.md
@@ -1,0 +1,34 @@
+# Contract: Persisted chain state & resume
+
+**File**: `.maverick/runs/<run-id>/spec-chain.json` (Pydantic `ChainState`,
+`schema_version: 1`), beside a standard `metadata.json` written via
+`runway.run_metadata` helpers. Treated as a public interface (Guardrail X.4): fields
+are additive-only within schema_version 1.
+
+## Write discipline
+
+- Atomic writes only (temp file + `rename`), after **every** transition:
+  step start, step success, landing success, halt, completion.
+- Checkpoint ordering: workspace artifact write → landing sync → `landed=true` →
+  checkpoint. Resume logic trusts only `landed` steps' artifacts.
+
+## Resume resolution (`maverick spec <feature>`)
+
+1. Scan `.maverick/runs/*/spec-chain.json` (newest `updated_at` first).
+2. First state with `feature == FEATURE` and `status in {"halted", "running"}` → resume.
+   (`"running"` covers crash/kill: staleness is assumed, not probed — single-user CLI.)
+3. Resume behavior: recreate/reuse workspace; verify landed artifacts exist in the user
+   checkout (missing → re-run that step); continue from the first step whose status is
+   not `succeeded`. PRD digest mismatch → proceed with warning (spec artifacts already
+   derive from the old PRD; specify is not re-run unless it never succeeded).
+4. No matching resumable state → fresh run (new run-id, workspace recreated).
+
+## Guarantees (traceability)
+
+- FR-016/SC-007: user's `specs/` tree only ever receives complete, atomically-synced
+  step artifact sets (landing contract above).
+- FR-020: halted/interrupted chains resume from the first non-succeeded step with zero
+  regeneration of landed steps.
+- FR-009: `steps[CLARIFY].status == "failed"` ⇒ `status == "halted"` and
+  plan/tasks/analyze remain `pending`/`skipped` — enforced in `workflow.py`, visible in
+  persisted state for post-mortem.

--- a/specs/050-headless-spec-chain/contracts/cli-spec.md
+++ b/specs/050-headless-spec-chain/contracts/cli-spec.md
@@ -1,0 +1,55 @@
+# Contract: CLI surface
+
+## `maverick spec <FEATURE> --from-prd <FILE>`
+
+New lazy-registered command (`cli/commands/spec.py`; `_LAZY_COMMANDS["spec"]`).
+Note: the existing `plan` command group is unaffected; `spec` is a sibling top-level command.
+
+### Arguments & options
+
+| Surface | Type | Required | Meaning |
+|---------|------|----------|---------|
+| `FEATURE` | arg, str | yes | Feature name (slug); resume key |
+| `--from-prd FILE` | path | yes for fresh runs; optional on resume (state has the digest) | PRD input |
+| `--session-log FILE` | path | no | same semantics as refuel/fly |
+
+### Preflight (fail-fast, before workspace creation)
+
+1. `verify_bd_ready()` — bd installed + `.beads/` present (ledger/finding writes need it).
+   Reuses the existing shared preflight helper (`maverick.cli.common.verify_bd_ready`,
+   Guardrail 5 one-canonical-wrapper) exactly as `refuel`/`fly` do — it exits with
+   `ExitCode.FAILURE` (1), **not** 2, on failure. This is a deliberate deviation from
+   the general "preflight → exit 2" framing below: changing `verify_bd_ready`'s exit
+   code would change behavior for every other command that shares it. The checks
+   below (2–4), which are specific to `maverick spec`, use exit 2 as originally
+   specified.
+2. Spec Kit installed in target repo (R7 check) — else exit 2 with install guidance (FR-018).
+3. PRD exists/readable/non-empty (fresh runs) — else exit 2 (FR-001).
+4. Feature-name collision rules (FR-015/FR-020): halted chain for FEATURE → resume;
+   completed chain / foreign `specs/` dir conflict → exit 2 with explanation.
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Chain completed (analyze ran; findings recorded — findings never affect exit code) |
+| 1 | Chain halted at a step (clarify failure included), **or** the shared bd preflight failed; state persisted (chain case); resume hint printed (chain case) |
+| 2 | `maverick spec`-specific preflight/usage error (checks 2–4 above) — nothing started, no state written |
+| 130 | Interrupted (Ctrl-C); state persisted; resume hint printed |
+
+### Output (Rich, per CLI output rules — human-readable phases, no emoji)
+
+- One sequential completion line per step: `✓ Specify (142.3s)` / `✗ Clarify (88.1s)`.
+- Final summary (FR-019): feature dir, steps completed, clarify questions answered
+  (ledger entry count), remediation beads created, and on halt:
+  `Resume: maverick spec <feature>`.
+- Warnings (analyze failure, PRD digest mismatch on resume) via `[yellow]Warning:[/yellow]`.
+
+## `maverick init` (extension)
+
+- New advisory prerequisite: Spec Kit presence (`.specify/` + supported `speckit_version`).
+- Interactive TTY + missing → Click confirm offer; accept runs the pinned installer via
+  `CommandRunner`; decline → notice, init still exits 0 (FR-017).
+- Non-interactive → notice only. Re-init idempotent: present+compatible → silent pass;
+  present+incompatible version → warning with supported range.
+- `InitResult` gains `speckit_installed: bool | None` (None = not applicable/declined).

--- a/specs/050-headless-spec-chain/contracts/ledger-and-beads.md
+++ b/specs/050-headless-spec-chain/contracts/ledger-and-beads.md
@@ -1,0 +1,49 @@
+# Contract: Ledger extension & remediation-bead adoption
+
+## `record_standalone_assumption` (new, `assumptions/ledger.py`)
+
+```python
+async def record_standalone_assumption(
+    client: BeadClient,
+    *,
+    payload: AssumptionPayload,     # question, adopted_answer, alternatives, severity, severity_defaulted
+    owner_spec: str,                # "NNN-<feature>" directory name
+    source_ref: str,                # e.g. "spec-chain:clarify"
+) -> AssumptionRecord | None:      # None on dedup-merge, same as record_assumption
+```
+
+Bead shape: identical to `record_assumption` output (TASK/REVIEW, assignee "human",
+labels `assumption` + `assumption-review` + `needs-human-review`, state keys
+`assumption_severity`, `assumption_severity_defaulted`, `assumption_status="open"`,
+`assumption_owner_spec=owner_spec`) with two differences: **no parent epic**, and state
+key `source_ref` replaces `source_bead`. Dedup: normalized-question match against open
+entries with the same `owner_spec` (escalate severity on merge, as today).
+
+**Compatibility invariant** (FR-007, verified against current readers): `maverick brief`
+(`per_spec_counts`), `maverick review` (label lookup), and the land gate
+(`open_blocking_entries`) key on labels + state keys only — standalone entries flow
+through all three unchanged. A regression test pins this.
+
+## Remediation beads (created by spec-chain analyze step)
+
+`BeadType.TASK`, unparented, label `spec-remediation`, state keys:
+`speckit_feature=<NNN-feature>`, `remediation_source="spec-chain:analyze"`,
+`finding_fingerprint=sha256(normalized title + location)`. Creation is idempotent per
+fingerprint (re-run of analyze never duplicates). Severity hint goes in the description,
+not the priority (findings are advisory — FR-012).
+
+## Adoption (extension to `workflows/refuel_speckit`)
+
+After epic create/find (fresh or delta), a new post-ingest step:
+
+1. `client.query("status=open")`-based lookup of beads with
+   `state["speckit_feature"] == feature` and no parent, label `spec-remediation`.
+2. Preferred primitive: `BeadClient.update_parent(bead_id, parent_id)` — **implementation
+   gate**: verify `bd update --parent` support at build start; if unsupported, fallback is
+   `add_dependency(parent-child)` + state stamp `adopted_by_epic=<epic-id>`.
+3. Adoption is idempotent (skip beads already parented / already stamped) and best-effort
+   per bead (one failure does not abort ingestion — Principle IV).
+
+Ledger beads are **not** adopted — they stay standalone with `owner_spec` linkage,
+matching spec-049's epic-derivation-by-state, and remain governed by their own
+answer/waive lifecycle.

--- a/specs/050-headless-spec-chain/data-model.md
+++ b/specs/050-headless-spec-chain/data-model.md
@@ -1,0 +1,111 @@
+# Data Model: Headless Spec Kit Chain
+
+All models are Pydantic `BaseModel` (persisted) or frozen dataclasses (in-memory
+results), per constitution Principle VI. Module homes are shown per entity.
+
+## ChainStep (enum) — `workflows/spec_chain/constants.py`
+
+Ordered: `SPECIFY → CLARIFY → PLAN → TASKS → ANALYZE`. The order is the single source
+of truth for FR-002/FR-008 gating; `next_step(state)` derives from it.
+
+## ChainState — `workflows/spec_chain/models.py`, persisted to `.maverick/runs/<run-id>/spec-chain.json`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `schema_version` | `int` | starts at 1; guards future migrations |
+| `run_id` | `str` | matches the `.maverick/runs/` directory |
+| `feature` | `str` | user-supplied feature name (resolution key for resume) |
+| `feature_dir` | `str \| None` | `specs/NNN-<feature>` allocated by specify (R8); `None` until specify lands |
+| `prd_path` | `str` | user-supplied PRD path (original, user-checkout relative) |
+| `prd_digest` | `str` | sha256 of PRD content at chain start; resume warns on mismatch |
+| `workspace_path` | `str` | hidden workspace root (per-feature: `~/.maverick/workspaces/<project-slug>/spec-chain/<feature>/`) |
+| `status` | `Literal["running","halted","completed","failed"]` | terminal: `completed`/`failed`; `halted` is resumable |
+| `steps` | `dict[ChainStep, StepRecord]` | one record per attempted step |
+| `clarify_decisions` | `list[ClarifyDecision]` | filed decisions (audit copy; ledger beads are canonical) |
+| `remediation_bead_ids` | `list[str]` | created finding beads |
+| `started_at` / `updated_at` | `datetime` | ISO-8601 |
+
+**State transitions**: `running → halted` (step failure/interrupt after checkpoint);
+`running → completed` (analyze step finished, findings recorded); `halted → running`
+(resume); `running → failed` (unrecoverable, e.g. workspace creation impossible).
+Invariant: a step may be `in_progress` only if all prior steps are `succeeded`.
+
+## StepRecord — nested in ChainState
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `step` | `ChainStep` | |
+| `status` | `Literal["pending","in_progress","succeeded","failed","skipped"]` | `skipped` only for analyze-after-halt reporting |
+| `attempts` | `int` | tenacity-visible count |
+| `artifacts` | `list[str]` | feature-dir-relative paths landed by this step |
+| `landed` | `bool` | artifacts synced to user checkout (FR-016/FR-020 gate) |
+| `error` | `str \| None` | classified failure summary |
+| `started_at` / `finished_at` | `datetime \| None` | |
+
+## ClarifyDecision — frozen dataclass, `workflows/spec_chain/models.py`
+
+The convergence type for both answering paths (R2).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `question` | `str` | verbatim question text |
+| `adopted_answer` | `str` | recommended option or informed default |
+| `alternatives` | `tuple[str, ...]` | options not chosen (may be empty on fallback path) |
+| `severity` | `Severity` (spec 049) | harness-assessed; default `LOW` (FR-007a) |
+| `severity_defaulted` | `bool` | true when no clear signal |
+| `path` | `Literal["interception","non_interactive"]` | provenance |
+| `ledger_bead_id` | `str \| None` | filled after filing |
+
+Maps 1:1 onto the existing `AssumptionPayload` (question, adopted_answer, alternatives,
+severity, severity_defaulted) when filed via `record_standalone_assumption` (R5).
+
+## StepReport — Pydantic, structured-output schema for `SpecChainAgent` (R9)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `status` | `Literal["completed","blocked","failed"]` | agent's claim; filesystem is ground truth |
+| `artifacts` | `list[str]` | paths the agent believes it wrote |
+| `questions` | `list[ReportedQuestion]` | clarify only: question/adopted/alternatives |
+| `findings` | `list[ReportedFinding]` | analyze only |
+| `detail` | `str` | free-text summary / failure reason |
+
+`ReportedQuestion`: `question, adopted_answer, alternatives`. `ReportedFinding`:
+`title, category, severity_hint, location, summary`.
+
+## AnalyzeFinding → remediation bead — `workflows/spec_chain/models.py` + bead state
+
+Bead shape (R6): `BeadType.TASK`, no parent, label `spec-remediation`.
+
+| Bead state key | Value |
+|----------------|-------|
+| `speckit_feature` | `<NNN-feature>` directory name (adoption key, matches refuel delta key) |
+| `remediation_source` | `"spec-chain:analyze"` |
+| `finding_fingerprint` | sha256 of normalized `title + location` (idempotency) |
+
+Adoption (refuel --speckit post-ingest step): query open beads where
+`speckit_feature == feature` and unparented → `update_parent(bead, epic)` or
+dependency-edge fallback + `adopted_by_epic` state stamp.
+
+## Standalone ledger entry — extension of spec-049 bead shape (R5)
+
+Identical to `record_assumption` output except: no parent epic;
+`source_bead` state key replaced by `source_ref = "spec-chain:clarify"`;
+`assumption_owner_spec` set directly to the feature dir name. All existing readers
+(`per_spec_counts`, `open_blocking_entries`, `maverick review`) operate on
+labels/state keys and remain unchanged.
+
+## SpecChainReport — frozen dataclass returned to the CLI (FR-019)
+
+`feature_dir, status, steps (per-step outcome + timing), ledger_entry_count,
+remediation_bead_count, resume_hint (str | None)`. Rendered by `cli/commands/spec.py`
+via Rich (sequential completion lines per CLI output rules).
+
+## Validation rules (from requirements)
+
+- PRD: must exist, be readable, non-empty (FR-001) — validated before workspace creation.
+- Feature name: non-empty, filesystem-safe slug; collision with an existing *completed*
+  spec dir or a foreign directory → error (FR-015); matching *halted* chain → resume (FR-020).
+- Step gating: `plan` requires `clarify.status == succeeded`; `tasks` requires `plan`;
+  `analyze` requires `tasks` (FR-008). Enforced by the workflow, not prompts.
+- Landing: a step's `landed=True` only after atomic sync succeeds; `ChainState` is
+  checkpointed after landing (ordering guarantees resume never trusts unlanded work).

--- a/specs/050-headless-spec-chain/plan.md
+++ b/specs/050-headless-spec-chain/plan.md
@@ -1,0 +1,123 @@
+# Implementation Plan: Headless Spec Kit Chain (`maverick spec`)
+
+**Branch**: `050-headless-spec-chain` | **Date**: 2026-07-24 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/050-headless-spec-chain/spec.md`
+
+## Summary
+
+Add `maverick spec <feature> --from-prd <file>`: a deterministic workflow that runs the
+target repository's own Spec Kit chain — specify → clarify → plan → tasks → analyze —
+headlessly inside a hidden jj workspace, with each step executed by an airframe
+`AgentRuntime` prompting the repo's `/speckit.*` command surface. Clarify never blocks:
+adopted answers are filed as assumption-ledger entries (via question interception where
+the provider supports it, else Spec Kit's non-interactive convention upgraded into ledger
+entries). Analyze findings become standalone remediation beads that `refuel --speckit`
+later adopts. Chain state is checkpointed per step for auto-resume; completed-step
+artifacts land in the user's `specs/NNN-<feature>/` tree as ordinary markdown.
+`maverick init` gains a Spec Kit prerequisite check with an offer to install.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (`from __future__ import annotations`)
+**Primary Dependencies**: airframe-agents (>=0.9.0rc1,<0.10) for agent execution; Click + Rich (CLI); Pydantic (models/state); structlog; tenacity; jj CLI via `maverick.jj.client.JjClient` (workspace add/forget, colocated); `bd` CLI via `maverick.beads.client.BeadClient`; GitPython (read-only)
+**Storage**: Files — chain state under `.maverick/runs/<run-id>/spec-chain.json` (+ `metadata.json` per existing `run_metadata` conventions); artifacts as markdown in `specs/NNN-<feature>/`; ledger entries and remediation findings as bd beads (labels + state keys, per spec 049 conventions)
+**Testing**: pytest + pytest-asyncio + xdist (`make test`, `make ci`); airframe runtimes stubbed via injected fakes (same pattern as existing `Agent` tests)
+**Target Platform**: Linux/macOS developer CLI (same as all Maverick commands)
+**Project Type**: Single project (existing `src/maverick/` package)
+**Performance Goals**: N/A latency-wise — chain duration is model-bound (minutes per step); the deterministic overhead (workspace setup, state I/O, landing) must stay negligible (<2s per step)
+**Constraints**: Fully headless (no step may block on stdin/interactive input); resumable after halt/interrupt (per-step checkpointing); user's working checkout never modified while steps run; only completed-step artifacts land
+**Scale/Scope**: 5 chain steps per run; ≤ ~5 clarify questions per spec; one feature per invocation
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | Principle / Guardrail | Status | Notes |
+|---|----------------------|--------|-------|
+| I | Async-first | PASS | Chain workflow is async end-to-end; subprocess work (jj, bd, artifact sync) goes through `CommandRunner` / existing async clients; no `subprocess.run` on async paths. |
+| II | Separation of concerns | PASS | Chain step *content* (spec writing, clarify answers, analysis) is agent judgment via airframe; the workflow owns all deterministic effects — workspace lifecycle, ordering, checkpointing, artifact landing, ledger/bead writes. Agents never commit or write beads. |
+| III | Dependency injection | PASS | `SpecChainWorkflow` receives `cwd`, config, `BeadClient`, `JjClient`, and a step-runner (airframe-backed) as injectable deps; tests inject fakes. |
+| IV | Fail gracefully, recover aggressively | PASS | Per-step retries via tenacity for transient runtime errors; halt-on-failed-clarify is a *specified* stop (FR-009), not a crash — state is checkpointed and the report names the failed step and resume path. Analyze failure degrades to a warning (FR-012). |
+| V | Test-first | PASS | TDD: state/model/parsing units first, then workflow scenarios with stubbed runtimes; contract tests for CLI surface. |
+| VI | Type safety & typed contracts | PASS | Chain state, step results, clarify decisions, and analyze findings are frozen dataclasses / Pydantic models (see data-model.md); no `dict[str, Any]` blobs cross boundaries. |
+| VII | Simplicity & DRY | PASS | Reuses existing primitives: `JjClient.workspace_add/forget`, `run_metadata`, assumption ledger, `BeadClient`, `CommandRunner`. New code is one workflow package + one thin CLI command + small extensions to existing modules. |
+| VIII | Relentless progress | PASS | Checkpoint after every step; auto-resume (FR-020); partial artifacts preserved; analyze findings recorded even when analyze partially fails. |
+| IX | Hardening by default | PASS | Every runtime call has explicit timeouts; tenacity for transient errors; specific exception types under a new `SpecChainError` hierarchy branch. |
+| X.3 | Deterministic ops not owned by agents | PASS | See II — landing, state, beads, ledger writes all live in the workflow. |
+| X.8 | Canonical wrappers | PASS | jj via `JjClient`, beads via `BeadClient`, git reads via GitPython, logging via `maverick.logging`, retries via tenacity. |
+| Guardrail 0 (CLAUDE.md single-repo model) / Appendix E | **EXCEPTION — justified** | Spec clarification (2026-07-24) mandates a hidden workspace for the chain. See Complexity Tracking. Constitution/CLAUDE.md amendment is in scope (spec Assumptions). |
+
+**Post-design re-check (after Phase 1)**: PASS — design artifacts introduce no new
+violations; the single tracked exception is the hidden workspace, documented below and
+carried into the governance-amendment work item.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/050-headless-spec-chain/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   ├── cli-spec.md      # `maverick spec` + `maverick init` surface contract
+│   ├── chain-state.md   # persisted chain-state contract (resume semantics)
+│   └── ledger-and-beads.md  # standalone ledger entries + remediation-bead adoption
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created by plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/maverick/
+├── cli/
+│   ├── main-registered lazy command: "spec"
+│   └── commands/spec.py                 # NEW: thin Click command (arg/option parsing,
+│                                        #      preflight, dispatch to workflow, report)
+├── workflows/spec_chain/                # NEW: package-per-workflow (Appendix A pattern)
+│   ├── __init__.py
+│   ├── constants.py                     # step names/order, labels, state keys, timeouts
+│   ├── models.py                        # ChainState, StepResult, ClarifyDecision,
+│   │                                    # AnalyzeFinding, SpecChainReport (typed contracts)
+│   ├── state.py                         # load/save/discover chain state (.maverick/runs/)
+│   ├── steps.py                         # per-step prompt builders + step output parsing
+│   ├── clarify.py                       # interception + non-interactive upgrade paths
+│   ├── landing.py                       # per-step artifact sync workspace → user checkout
+│   └── workflow.py                      # SpecChainWorkflow orchestration (async)
+├── workspace/                           # NEW (small): hidden jj workspace lifecycle
+│   └── spec_chain.py                    # create/reuse/forget via JjClient.workspace_add
+├── agents/spec_chain.py                 # NEW: SpecChainAgent (airframe runtime, persona,
+│                                        #      structured step-report schema)
+├── squadron/                            # SpecChainSquadron (one runtime, role "generate")
+├── init/
+│   ├── prereqs.py                       # + check_speckit_installed (advisory)
+│   └── __init__.py                      # + offer-to-install step (Click confirm)
+├── assumptions/ledger.py                # + record_standalone_assumption (no-epic path)
+├── beads/client.py                      # + update_parent (adoption primitive, if bd
+│                                        #   supports; else dependency-edge fallback)
+└── workflows/refuel_speckit/workflow.py # + adopt standalone spec-labeled beads on ingest
+
+tests/
+├── unit/
+│   ├── workflows/spec_chain/            # state, models, steps, clarify, landing units
+│   ├── workspace/                       # hidden-workspace lifecycle (jj stubbed)
+│   ├── assumptions/                     # standalone-entry ledger path
+│   └── cli/                             # spec command contract, init speckit check
+└── integration/
+    └── spec_chain/                      # full chain against stubbed runtimes + tmp repo
+```
+
+**Structure Decision**: Single project; new code follows the constitution's Appendix A
+package-per-workflow split (`workflows/spec_chain/` with `models.py`, `constants.py`,
+`workflow.py` plus chain-specific `state.py`/`steps.py`/`clarify.py`/`landing.py`).
+Extensions to `init`, `assumptions`, `beads`, and `refuel_speckit` are made in place in
+their owning modules — no parallel wrappers (Guardrail X.8).
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Hidden jj workspace for chain execution (exception to CLAUDE.md Guardrail 0 single-repo CWD model) | Clarified requirement (Session 2026-07-24): chain steps mutate `specs/`, `.specify/feature.json`, and agent scratch state over multi-minute model calls; the user's checkout must stay untouched until each step's artifacts are complete (FR-014, FR-016, SC-007). | Running in the user's checkout (current contract) exposes half-written spec artifacts and `.specify` state churn to the user mid-run and makes atomic "only completed artifacts land" impossible without ad-hoc staging. The historic reason workspaces were retired — bd's `embeddeddolt/` not traveling into `jj workspace add` — does not apply: the chain never runs bd inside the workspace (ledger + remediation beads are written by the workflow in the user's checkout). Governance docs (CLAUDE.md Guardrail 0, constitution Appendix E) are amended as part of this feature to record the scoped exception. |
+| New `workspace/spec_chain.py` module despite prior `WorkspaceManager` retirement | The retired `WorkspaceManager` (clone-based) no longer exists; the chain needs a minimal, purpose-scoped lifecycle helper over `JjClient.workspace_add/forget`. | Resurrecting a general-purpose WorkspaceManager would rebuild the abstraction that was deliberately deleted; inlining jj calls in the workflow would violate DRY once resume + cleanup both need them. The helper is ~1 file, spec-chain-only, and composes the existing canonical `JjClient`. |

--- a/specs/050-headless-spec-chain/quickstart.md
+++ b/specs/050-headless-spec-chain/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart Validation: Headless Spec Kit Chain
+
+Runnable scenarios proving the feature end-to-end. Contracts:
+[cli-spec.md](contracts/cli-spec.md), [chain-state.md](contracts/chain-state.md),
+[ledger-and-beads.md](contracts/ledger-and-beads.md); entities in
+[data-model.md](data-model.md).
+
+## Prerequisites
+
+- A Spec Kit-initialized target repo (e.g. `/workspaces/sample-maverick-project`) with
+  `maverick init` run (jj colocated, `.beads/` present) and a configured `generate`
+  provider binding in `maverick.yaml`.
+- A sample PRD, e.g. `docs/sample-prd.md` (any non-empty markdown works; a deliberately
+  vague PRD exercises clarify).
+
+## Scenario 1 — Full chain, hands-off (US1, SC-001)
+
+```bash
+cd /workspaces/sample-maverick-project
+maverick spec demo-feature --from-prd docs/sample-prd.md
+echo $?          # expect 0
+```
+
+Expected: five sequential step-completion lines, no interactive prompt at any point;
+`specs/NNN-demo-feature/` exists in the checkout containing `spec.md`, `plan.md`,
+`tasks.md` (plain markdown, `git status` shows them as ordinary untracked files);
+summary reports ledger-entry and remediation-bead counts.
+
+## Scenario 2 — Clarify decisions on the record (US2, SC-002)
+
+```bash
+maverick brief            # per-spec assumption counts include NNN-demo-feature
+bd list --label assumption --json | jq '.[].state.assumption_owner_spec'
+maverick review <entry-id>   # answer/waive flow works on a chain-filed entry
+```
+
+Expected: every clarify question from Scenario 1 has one open ledger entry
+(question/adopted/alternatives/severity in the bead description+state); severities are
+`low` unless the question was scope/security-impacting.
+
+## Scenario 3 — Halt on failed clarify + resume (US3, FR-009/FR-020)
+
+```bash
+# Induce failure: run with the clarify step forced to fail (test hook / invalid
+# provider binding swap after specify), or Ctrl-C during clarify.
+maverick spec demo-two --from-prd docs/sample-prd.md   # exits 1 (or 130 on Ctrl-C)
+test -f specs/*demo-two*/spec.md && ls specs/*demo-two*/plan.md 2>&1  # spec.md yes, plan.md absent
+cat .maverick/runs/*/spec-chain.json | jq 'select(.feature=="demo-two") | .status, .steps'
+maverick spec demo-two --from-prd docs/sample-prd.md   # resumes at clarify, no re-specify
+```
+
+Expected: halt report names clarify; plan/tasks/analyze never ran; resume skips specify
+(no regeneration) and continues.
+
+## Scenario 4 — Analyze findings become beads, never blockers (US4, SC-004)
+
+```bash
+bd list --label spec-remediation --json | jq '.[].state.speckit_feature'
+maverick refuel demo-feature --speckit
+bd show <remediation-id>    # now parented/adopted under the demo-feature epic
+```
+
+Expected: chain exit was 0 regardless of findings; each finding is one bead keyed
+`speckit_feature=NNN-demo-feature`; refuel adopts them under the new epic.
+
+## Scenario 5 — Init verification (US5)
+
+```bash
+cd <repo-without-speckit> && maverick init      # offers Spec Kit install
+# decline → init exits 0 with notice; then:
+maverick spec x --from-prd README.md            # exits 2 with install guidance
+```
+
+## Automated coverage
+
+- `make test-fast` — unit suites for state/models/clarify/landing/ledger extension.
+- `make test-integration` — full-chain scenario against stubbed airframe runtimes in a
+  tmp jj+git repo fixture (asserts Scenarios 1–4 invariants without live models).
+- `make ci` — pre-push gate, includes format check.

--- a/specs/050-headless-spec-chain/research.md
+++ b/specs/050-headless-spec-chain/research.md
@@ -1,0 +1,273 @@
+# Phase 0 Research: Headless Spec Kit Chain
+
+All NEEDS CLARIFICATION items from Technical Context are resolved below. Codebase facts
+were verified against the tree on 2026-07-24 (branch `main`, post-airframe migration).
+
+## R1. Executing the target repo's `/speckit.*` commands through airframe
+
+**Decision**: Each chain step is one `AgentRuntime.execute()` call whose prompt instructs
+the agent to run the corresponding slash command (e.g. `/speckit.specify <description>`)
+in the workspace cwd, and to finish by returning a typed step report against a JSON
+schema (`schema=` parameter, same structured-output path as existing `Agent` subclasses).
+A new `SpecChainAgent` (`agents/spec_chain.py`) subclasses the existing `Agent` base and
+uses `_execute_via_runtime`. Slash-command support is a provider capability: agent-CLI
+providers (`claude`, `github-copilot`, `opencode`) execute repo-local commands
+(`.claude/commands/speckit.*.md` or equivalent) natively when the prompt invokes them;
+for providers without a command surface, the step runner falls back to inlining the
+command file's body into the prompt (the command definitions are plain markdown
+instructions, readable from the target repo).
+
+**Rationale**: Maverick has no slash-command execution path today (verified — nothing in
+`src/` references `/speckit.*`); airframe's `execute(prompt, schema, persona, system,
+timeout)` is the only agent surface, and it is sufficient: slash commands are prompt
+conventions of the underlying agent CLIs. Inline-body fallback keeps FR-003's "the
+repo's own command governs the output" property because the instructions still come from
+the target repo's files, not from Maverick.
+
+**Alternatives considered**: (a) Maverick re-implementing the Spec Kit steps natively —
+rejected, violates FR-003 and duplicates Spec Kit; (b) shelling out to `claude -p
+"/speckit.X"` directly via `CommandRunner` — rejected, bypasses airframe (the canonical
+agent wrapper), loses cost telemetry/tier handling, and violates Guardrail X.8; (c) a
+per-provider command API — premature; the prompt convention works uniformly.
+
+**Verification task carried to implementation — RESOLVED (2026-07-24)**: airframe-agents
+0.9.0rc1's `AgentRuntime.execute()`/`session()` expose no `cwd`/`workdir`/`directory`
+parameter (`airframe/protocol.py`), and no runtime constructor accepts one either
+(`ClaudeCodeRuntime.__init__`, `OpenCodeServerRuntime.__init__`). `ProviderOptions` does
+carry a `working_directory` field, but only for `CopilotOptions`/`KimiOptions`/
+`OpenCodeServerOptions` — **not** `ClaudeOptions`, the default `generate`-role provider
+(`maverick.yaml` → `config.py`). The underlying `claude_agent_sdk.ClaudeAgentOptions` does
+support `cwd`, but airframe's `ClaudeCodeRuntime.session()` never threads it through — an
+adapter gap, not an SDK limitation. Maverick's existing `Agent.__init__` already stores
+`self._cwd` but nothing ever reads it (verified: no call site passes cwd to
+`self._runtime.execute()`).
+
+**Revised decision**: "one runtime per squadron" does not by itself bind cwd (the
+constructor has no cwd slot). `SpecChainSquadron`/`SpecChainAgent` instead bind the
+working directory via a process-wide `os.chdir()` scoped around each step's
+`execute()` call, serialized by a dedicated `asyncio.Lock` (spec-chain runs execute
+their five steps strictly sequentially per FR-002, and Maverick's CLI runs one workflow
+per process invocation, so the exposure window is a single in-process critical section,
+not cross-workflow concurrency). The lock + restore-on-exit is implemented as a small
+context manager in `agents/spec_chain.py`, documented as a workaround for the airframe
+adapter gap above (worth upstreaming a `cwd`/`working_directory` field on `ClaudeOptions`
+later, out of scope here).
+
+## R2. Clarify question interception vs. non-interactive fallback
+
+**Decision**: Two paths behind one `ClarifyPolicy` seam (`workflows/spec_chain/clarify.py`):
+
+1. **Interception path** — used when the provider runtime exposes a tool-permission /
+   question callback (probed via an airframe capability check at squadron startup, e.g.
+   the runtime advertising an AskUserQuestion-style hook). The harness's callback answers
+   each question by selecting the recommended option and captures a `ClarifyDecision`
+   (question, adopted, alternatives, severity assessment) synchronously.
+2. **Non-interactive path** — default whenever interception is unavailable. The clarify
+   step prompt invokes `/speckit.clarify` with Spec Kit's documented non-interactive
+   convention (agent adopts informed defaults and records them in the spec's
+   `## Assumptions` / `## Clarifications` sections). After the step, the workflow parses
+   the updated `spec.md` (reusing `maverick.speckit.parser` extension) and upgrades each
+   recorded default into a `ClarifyDecision`.
+
+   **Implementation correction (2026-07-24)**: verified against this repository's own
+   Spec Kit output (every `spec.md` under `specs/`), the actual recorded-default format
+   is `## Clarifications` → `### Session <date>` → `- Q: <question> → A: <answer>`
+   bullets — not the `## Assumptions` section (that section holds narrative prose
+   assumptions, not question/answer pairs). `workflows/spec_chain/clarify.py`'s
+   `decisions_from_spec_md()` parses the `## Clarifications` bullet format directly
+   (regex over `- Q: ... → A: ...` lines) rather than adding a speckit.parser
+   extension — the grammar is a single regex, not worth a new parser module function.
+
+Both paths converge: every `ClarifyDecision` is filed as an assumption-ledger entry by
+the *workflow* (never the agent) after the clarify step completes. Severity is assessed
+per question by the harness and defaults to `low` per the spec clarification (FR-007a) —
+the chain passes severity explicitly, deliberately not relying on the ledger's
+`DEFAULT_SEVERITY = MEDIUM`. Escalation signals are a defined constant list (in
+`workflows/spec_chain/constants.py`), by category: **scope** (feature boundaries,
+in/out-of-scope, user roles/permissions), **security/privacy** (auth, credentials, data
+protection, retention, PII), **compliance** (regulatory/legal), **data integrity**
+(irreversible migrations, deletion semantics) — a question matching any category is at
+least `medium`. A question with no recommended option still gets an adopted informed
+default recorded identically (never skipped, per the spec edge case); if the harness
+cannot form a defensible default, the clarify step is treated as blocked and the chain
+halts (FR-009).
+
+**Rationale**: Matches FR-005/FR-006 exactly; the policy seam makes each path
+independently testable and keeps the "no decision off the record" invariant (SC-002) in
+one place. Filing from the workflow (not the agent) preserves Guardrail X.3.
+
+**Alternatives considered**: interception-only (rejected: not all providers support it —
+FR-006 mandates the fallback); having the agent file ledger entries itself via a tool
+(rejected: agents must not own deterministic side effects).
+
+## R3. Hidden workspace mechanism
+
+**Decision**: A minimal spec-chain workspace helper (`workspace/spec_chain.py`) built on
+the canonical `JjClient`:
+
+- Location: `~/.maverick/workspaces/<project-slug>/spec-chain/<feature>/` (outside the
+  repo, so nothing pollutes the user's tree or gitignore). The path is **per-feature**:
+  chains for different features never share a workspace, so a fresh run for feature B
+  cannot destroy a halted feature A's resumable workspace. `<project-slug>` is the
+  sanitized repository directory name (stable across runs from the same checkout).
+- Creation: `JjClient.workspace_add` from the user's colocated checkout (init guarantees
+  `.jj/` exists). Shared backing store means committed files — including
+  `.claude/commands/speckit.*.md`, `.specify/**`, and existing `specs/**` — are
+  materialized in the workspace.
+- Uncommitted inputs: the PRD file may be untracked in the user's checkout; the workflow
+  copies it into the workspace under a scratch path before the specify step.
+- Reuse & cleanup: an active chain (persisted state, R4) reuses its workspace on resume;
+  a completed or freshly-started chain forgets/recreates it (`workspace_forget` + delete)
+  so runs start clean.
+- bd never runs inside the workspace. All bead/ledger writes happen in the user's
+  checkout via the workflow — this is precisely why the historic bd/workspace impedance
+  mismatch (gitignored `embeddeddolt/` not traveling) does not apply.
+
+**Artifact landing**: after each successful step, `landing.py` syncs the feature's
+artifact set (`specs/NNN-<feature>/**` plus nothing else) from workspace → user checkout
+via an atomic staged copy (write to temp sibling, rename into place). Per-step landing
+is what makes FR-016 (no partial artifacts) and FR-020 (resume reuses completed-step
+artifacts) compose.
+
+**Rationale**: `jj workspace add` is the cheapest isolation the repo already supports;
+the clarified requirement mandates hidden-workspace execution; per-step atomic landing
+gives "only completed artifacts land" without a final big-bang merge.
+
+**Alternatives considered**: full `jj git clone` (rejected: the drift problems that
+retired the clone-based WorkspaceManager); running in-checkout with staging dirs
+(rejected by clarification Q1); landing only at chain end (rejected: a crash before the
+end would discard completed-step work, violating FR-020's reuse guarantee).
+
+## R4. Chain state persistence and resume discovery
+
+**Decision**: Chain state lives at `.maverick/runs/<run-id>/spec-chain.json` (Pydantic
+`ChainState`, see data-model.md), beside a standard `metadata.json` written through the
+existing `run_metadata` helpers (`plan_name` = feature name, `status` ∈ existing values).
+Resume discovery: `maverick spec <feature>` scans `.maverick/runs/*/spec-chain.json` for
+the newest non-terminal state matching the feature (same scan pattern as
+`find_latest_run`). If found → resume from `next_step`; else → fresh run. State is
+written atomically (temp + rename) after every step transition, including step-start
+(so an interrupt mid-step resumes *at* that step, not after it).
+
+**Rationale**: Reuses the established `.maverick/runs/` convention (already gitignored
+by init) instead of inventing a new state root; feature-keyed discovery is exactly how
+`find_latest_run` already works for refuel.
+
+**Alternatives considered**: the generic `checkpoint/` store (viable, but its
+abstraction adds nothing over one small Pydantic file for a linear 5-step chain);
+`.maverick/spec-chains/<feature>/` (a second state root to document and gitignore — not
+worth it).
+
+## R5. Standalone assumption-ledger entries (no epic yet)
+
+**Decision**: Extend `assumptions/ledger.py` with a standalone-entry path:
+`record_standalone_assumption(client, *, payload, owner_spec, source_ref)` that creates
+the same bead shape as `record_assumption` (labels `assumption` + legacy pair, state
+keys `assumption_severity/status/owner_spec`, description built by the existing
+`_build_description`) but with no parent epic and `source_ref` recording the chain step
+(e.g. `spec-chain:clarify`) in place of a spawning bead id. Dedup-by-question runs
+against open standalone entries with the same `owner_spec`. `owner_spec` is set to the
+`NNN-<feature>` directory name, which `per_spec_counts` and the land gate already key on.
+
+**Rationale**: `record_assumption` requires `epic_id` + `source_bead_id`, neither of
+which exists at chain time (epic arrives with `refuel --speckit`). Reusing the bead
+shape and state keys means `brief`, `review`, and the land gate work unchanged
+(FR-007) — verified: they read labels/state keys, not the parent edge.
+
+**Alternatives considered**: creating the epic early to satisfy the current API
+(rejected by clarification Q3); a file-based ledger sidecar (rejected: diverges from the
+spec-049 storage contract and would need parallel brief/review/land support).
+
+## R6. Remediation beads and later adoption by `refuel --speckit`
+
+**Decision**: Analyze findings become standalone task beads (label
+`spec-remediation` + state keys `speckit_feature=<feature-dir>`,
+`remediation_source=spec-chain:analyze`, finding fingerprint for idempotency). Adoption:
+`refuel --speckit` gains a post-ingest step that queries open beads with
+`speckit_feature == <feature>` lacking a parent and adopts them under the epic it
+created/found. Primitive: add `BeadClient.update_parent(bead_id, parent_id)` if the
+`bd` CLI supports parent update (verify `bd update --parent` at implementation start);
+if it does not, adoption falls back to wiring a `parent-child` dependency edge via the
+existing `add_dependency` plus stamping `adopted_by_epic` state — functionally
+equivalent for `bd ready`/traversal purposes.
+
+**Rationale**: Matches clarification Q3 (standalone now, adopted at refuel). Keying on
+`speckit_feature` state reuses the exact mechanism `_find_existing_epic` already uses
+for delta detection, so adoption slots into the existing delta path. Fingerprinting
+findings keeps re-runs of analyze idempotent (spec assumption: dedup within a run;
+fingerprints also make cross-run re-analysis safe).
+
+**Verification task carried to implementation — RESOLVED (2026-07-24)**: `bd` is not
+installed in the implementation sandbox, so `bd update --parent` could not be exercised
+directly. `src/maverick/beads/client.py`'s `BeadClient` confirms no parent-update
+primitive exists today — only `add_dependency()` (`bd dep add <blocked> --blocked-by
+<blocker> --type <dep_type>`) and `set_state()` (`bd set-state <id> key=value`), exactly
+matching the documented fallback. Proceeding with the fallback as the implementation:
+`add_dependency` for the `parent-child` edge plus `set_state(adopted_by_epic=<epic-id>)`.
+`BeadClient.update_parent` may be added later if a live `bd` install confirms
+`--parent` support; the adoption call site is isolated to one helper so swapping the
+primitive later is a one-file change.
+
+**Alternatives considered**: findings-as-file converted at refuel (rejected by Q3);
+immediate epic creation (rejected by Q3).
+
+## R7. `maverick init` Spec Kit verification and install offer
+
+**Decision**: Add `check_speckit_installed(cwd)` to `init/prereqs.py` as an *advisory*
+check (never hard-fails init): "installed" means the repo has the `.specify/` marker
+with a compatible `speckit_version` — the same signal `check_template_compatibility`
+already gates on (`>=0.14,<0.15`). When missing and the session is interactive, init
+offers installation via Click confirm and runs the Spec Kit installer (`uvx --from
+specify-cli specify init --here`, pinned to the supported range) through
+`CommandRunner`; decline records a notice on `InitResult` and init still succeeds
+(FR-017, US5 scenario 3). Non-interactive init (`--yes`-style or no TTY) skips the offer
+and prints the notice. `maverick spec` independently fail-fasts on the same check
+(FR-018) so a skipped init can't cause a mid-chain failure.
+
+**Rationale**: Init currently has no interactive prompts; an advisory + confirm keeps it
+non-blocking and idempotent (re-init already re-runs best-effort steps). Reusing the
+`.specify/` version gate keeps one definition of "Spec Kit installed."
+
+**Alternatives considered**: hard prerequisite (rejected: Spec Kit is only needed for
+`maverick spec`/`refuel --speckit`, and US5 scenario 3 requires init to succeed on
+decline); checking for a global `specify` binary (rejected: Spec Kit is per-repo
+template state, not a machine-level tool).
+
+## R8. Spec directory numbering (NNN allocation)
+
+**Decision**: Delegated entirely to the target repo's `/speckit.specify` command, which
+already allocates the next number per the repo's `feature_numbering` convention.
+Maverick reads the allocated directory back from the workspace after the specify step
+(diff of `specs/` before/after, cross-checked against `.specify/feature.json`) and
+records it in `ChainState.feature_dir`. Maverick never allocates numbers (verified: no
+allocation logic exists in `maverick.speckit`, by design).
+
+**Rationale**: FR-003/FR-013 — the repo's own conventions govern; duplicating the
+allocator invites divergence.
+
+## R9. Structured step reports from slash-command runs
+
+**Decision**: Every step prompt ends with an instruction to report completion via the
+structured-output schema (`StepReport`: status, artifacts touched, questions asked/
+answered, findings list for analyze, failure reason). The workflow treats the *filesystem*
+as ground truth (artifact existence/content decides step success) and the report as
+telemetry + parse accelerator; a well-formed report with missing artifacts is a step
+failure, not a success.
+
+**Rationale**: Agent self-reports are not trustworthy enough to gate ordering (FR-008);
+artifacts are. This mirrors how fly gates on validation rather than agent claims.
+
+## R10. Provider role/tier for the chain agent
+
+**Decision**: The chain agent binds to the existing `"generate"` role in
+`KNOWN_ROLES` (used today for flight-plan generation — the closest semantic match:
+long-form document synthesis). A `SpecChainSquadron` owns the single runtime for the
+run, constructed via `runtime_for_agent("generate", agents_config=config.agents)` with
+per-run cwd binding (R1). No new role is added to `KNOWN_ROLES` unless implementation
+surfaces a real need for independent model selection per chain step.
+
+**Rationale**: Smallest configuration surface; users already know how to override the
+`generate` binding. Per-step tiering is a premature optimization for v1.
+
+**Alternatives considered**: a new `"spec"` role (deferred — additive later without
+breaking config); reusing `"decompose"` (worse semantic fit).

--- a/specs/050-headless-spec-chain/spec.md
+++ b/specs/050-headless-spec-chain/spec.md
@@ -1,0 +1,170 @@
+# Feature Specification: Headless Spec Kit Chain (`maverick spec`)
+
+**Feature Branch**: `050-headless-spec-chain`
+**Created**: 2026-07-24
+**Status**: Draft
+**Input**: User description: "Add maverick spec <feature> --from-prd <file>, which runs the Spec Kit chain — specify, clarify, plan, tasks, analyze — headlessly in the hidden workspace, each step invoking the target repo's own /speckit.* command through airframe. Clarify questions never block: where the agent surface supports AskUserQuestion interception, the harness answers programmatically by adopting the recommended option and filing an assumption-ledger entry (question, adopted, alternatives, severity); otherwise it uses Spec Kit's documented non-interactive convention (informed defaults recorded in the spec's Assumptions section) and upgrades those into ledger entries. Ordering is strict: clarify completes before plan and tasks; a failed or blocked clarify halts that spec's chain rather than falling through. Analyze runs read-only and its findings become remediation beads, not blockers. Artifacts land in specs/NNN/ as ordinary git-native markdown. maverick init verifies Spec Kit is installed in the target repo and offers to install it."
+
+## Clarifications
+
+### Session 2026-07-24
+
+- Q: Where should the Spec Kit chain execute, given the tension between the described "hidden workspace" and Guardrail 0's single-repo CWD model? → A: Hidden workspace — the chain runs in an isolated hidden workspace and only completed artifacts land in the repo's `specs/` tree; Guardrail 0 gains a documented exception for this markdown-only flow (the bd impedance mismatch that retired workspaces does not apply).
+- Q: How does re-running `maverick spec <feature>` behave after a halted chain? → A: Auto-resume — a re-run detects the halted chain for that feature and continues from the failed step, reusing artifacts from completed steps; per-run chain state is persisted to make this possible.
+- Q: Where do analyze remediation beads live, given the feature's epic doesn't exist until `refuel --speckit`? → A: Standalone at creation — beads are created immediately, labeled/linked with the spec ID but parentless; when `refuel --speckit` later creates the epic, its delta logic adopts them under it.
+- Q: What severity do clarify-derived ledger entries default to when the harness has no clear signal? → A: Assessed per question, default low — impactful questions (scope, security) escalate to medium/high and gate `maverick land`; unclear cases default to low (advisory), keeping headless runs unobstructed.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - PRD to complete spec artifacts, hands-off (Priority: P1)
+
+A developer has a product requirements document for a new feature. They run `maverick spec <feature> --from-prd <file>` and walk away. Maverick runs the full Spec Kit chain — specify, clarify, plan, tasks, analyze — end to end with no interactive prompts, using the target repository's own Spec Kit commands and templates so the output matches what the developer would have produced by running each step by hand. When they return, a new numbered spec directory (`specs/NNN-<feature>/`) contains the specification, plan, and task list as ordinary markdown files reviewable with normal git tooling.
+
+**Why this priority**: This is the core value proposition — turning a PRD into implementation-ready Spec Kit artifacts without a human babysitting five sequential interactive steps. Everything else in this feature qualifies or hardens this flow.
+
+**Independent Test**: In a Spec Kit-initialized repository, run the command against a sample PRD and verify a new `specs/NNN-<feature>/` directory appears containing spec, plan, and tasks artifacts, with no interactive prompt having been shown at any point.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Spec Kit-initialized repository and a readable PRD file, **When** the user runs `maverick spec <feature> --from-prd <file>`, **Then** the chain runs specify, clarify, plan, tasks, and analyze in that order and produces spec, plan, and tasks artifacts in a new `specs/NNN-<feature>/` directory without requesting any user input.
+2. **Given** a completed run, **When** the user inspects the artifacts, **Then** they are plain markdown files tracked like any other repository content (diffable, committable, reviewable in a PR) with no proprietary or binary formats.
+3. **Given** a completed run, **When** the user compares the artifacts to those produced by manually running the repository's own Spec Kit commands, **Then** the structure and conventions match, because each chain step invoked the target repository's own Spec Kit command rather than a Maverick reimplementation.
+4. **Given** the chain runs, **When** steps execute, **Then** they execute in Maverick's isolated (hidden) workspace so the user's working checkout is not disturbed mid-run, and the finished artifacts land in the repository's `specs/` tree.
+
+---
+
+### User Story 2 - Clarify questions answered programmatically, on the record (Priority: P2)
+
+During the clarify step, Spec Kit generates targeted questions about underspecified areas. Instead of blocking on a human, the harness answers each question by adopting the recommended option, and files an assumption-ledger entry recording the question, the adopted answer, the alternatives that were not chosen, and a severity. Where programmatic question interception is not available on the agent surface, the chain falls back to Spec Kit's documented non-interactive convention — informed defaults recorded in the spec's Assumptions section — and then upgrades each of those recorded defaults into an equivalent assumption-ledger entry. Either way, every automated decision is durable, attributable, and visible to the existing review workflow (`maverick brief`, `maverick review`, the land gate).
+
+**Why this priority**: Headless operation is only safe if no decision is silently made. The assumption ledger (established in spec 049) is the existing contract for "an agent adopted an answer a human should be able to audit"; clarify decisions must flow into it or the hands-off chain trades away trust for convenience.
+
+**Independent Test**: Run the chain against a deliberately vague PRD that provokes clarify questions; verify the chain completes without prompting and that each clarify question appears as an assumption-ledger entry with question, adopted answer, alternatives, and severity populated.
+
+**Acceptance Scenarios**:
+
+1. **Given** the clarify step asks a question and question interception is available, **When** the harness answers it, **Then** it adopts the recommended option and files an assumption-ledger entry containing the question, the adopted answer, the alternatives, and a severity.
+2. **Given** question interception is not available on the agent surface in use, **When** the clarify step runs, **Then** it runs under Spec Kit's documented non-interactive convention, defaults are recorded in the spec's Assumptions section, and each recorded default is subsequently upgraded into an assumption-ledger entry.
+3. **Given** a completed run that answered N clarify questions, **When** the user runs `maverick brief`, **Then** the assumption counts for the new spec reflect those N entries, and each is resolvable via the existing `maverick review <id>` answer/waive flow.
+4. **Given** the chain answered clarify questions, **When** any question was answered, **Then** at no point did the run pause waiting for human input.
+
+---
+
+### User Story 3 - Strict ordering with halt-on-failed-clarify (Priority: P2)
+
+The chain enforces strict step ordering: clarify must complete successfully before plan and tasks run. If clarify fails or is blocked, the chain for that spec halts with a clear error — it never "falls through" to planning against an unclarified spec. The user gets an unambiguous report of which step failed, why, and what artifacts (if any) were produced up to that point.
+
+**Why this priority**: Falling through a failed clarify would produce plans and tasks built on an unvetted spec — worse than no output, because it looks complete. Halting preserves the integrity guarantee that makes the headless chain trustworthy. It shares P2 with the ledger story because both are the safety half of the P1 flow.
+
+**Independent Test**: Force the clarify step to fail (e.g., unusable spec input or induced step error) and verify the run exits non-zero, reports clarify as the failed step, and no plan or tasks artifacts exist for that spec.
+
+**Acceptance Scenarios**:
+
+1. **Given** the specify step succeeded, **When** clarify fails or is blocked, **Then** the chain halts, exits with a failure status identifying clarify as the failed step, and does not run plan, tasks, or analyze for that spec.
+2. **Given** a halted chain, **When** the user inspects the spec directory, **Then** artifacts produced by completed steps are present and the report states which steps did not run.
+3. **Given** any run, **When** steps execute, **Then** plan never starts before clarify has completed successfully, and tasks never starts before plan has completed successfully.
+
+---
+
+### User Story 4 - Analyze findings become remediation beads (Priority: P3)
+
+After tasks are generated, the analyze step runs as a read-only cross-artifact consistency check. Its findings never block the chain or fail the run; instead each finding is captured as a remediation bead so the issues enter the normal beads workflow and can be picked up by `maverick fly` or reviewed by a human later.
+
+**Why this priority**: Analyze adds quality assurance on top of an already-useful chain. The chain delivers its core value without it, but converting findings into actionable, tracked work items (rather than a report nobody reads or a blocker nobody wants) closes the loop with Maverick's existing bead-driven workflow.
+
+**Independent Test**: Run the chain on a PRD engineered to produce artifact inconsistencies; verify the run still completes successfully and each analyze finding exists as a bead associated with the new spec.
+
+**Acceptance Scenarios**:
+
+1. **Given** tasks were generated, **When** analyze runs, **Then** it makes no modifications to the spec, plan, or tasks artifacts.
+2. **Given** analyze reports findings, **When** the chain finishes, **Then** the run is reported as successful and each finding has been recorded as a remediation bead linked to the spec that produced it.
+3. **Given** analyze itself errors, **When** the chain finishes, **Then** the spec, plan, and tasks artifacts are intact and the run reports the analyze failure as a warning rather than failing the chain.
+
+---
+
+### User Story 5 - `maverick init` verifies Spec Kit availability (Priority: P3)
+
+When a user initializes a Maverick project, init checks whether Spec Kit is installed in the target repository. If it is missing, init offers to install it. This ensures `maverick spec` has its prerequisite in place before anyone attempts a chain run, with a clear path to remediation instead of a mid-run failure.
+
+**Why this priority**: A prerequisite check improves first-run experience but the chain can also detect the missing prerequisite itself; init integration is a convenience layer.
+
+**Independent Test**: Run `maverick init` in a repository without Spec Kit; verify the missing installation is detected and an install offer is presented. Accept it and verify Spec Kit is then present.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository without Spec Kit installed, **When** the user runs `maverick init`, **Then** init reports Spec Kit as missing and offers to install it.
+2. **Given** the user accepts the install offer, **When** init completes, **Then** Spec Kit is installed in the target repository and a subsequent `maverick spec` run can proceed.
+3. **Given** the user declines the install offer, **When** init completes, **Then** init succeeds with a notice that `maverick spec` will be unavailable until Spec Kit is installed.
+4. **Given** a repository with Spec Kit already installed, **When** the user runs `maverick init`, **Then** no install offer is shown.
+
+### Edge Cases
+
+- PRD file does not exist, is unreadable, or is empty: the command fails fast with a clear error before any chain step runs.
+- Spec Kit is not installed in the target repository at `maverick spec` time (init was skipped or declined): the command fails fast with guidance to install, rather than failing mid-chain.
+- Clarify asks zero questions: the chain proceeds normally with no ledger entries filed.
+- Clarify produces a question with no recommended option: the harness must still make a recorded choice (adopting an informed default) or treat the question as blocking and halt — it must never silently skip the question.
+- A mid-chain step (plan or tasks) fails: the chain halts at that step; earlier artifacts remain; the failure report identifies the step, and analyze does not run.
+- The feature name collides with an existing spec directory that is not a halted run of the same feature: the run must not overwrite it; it reports the conflict (numbering allocation follows the repository's existing Spec Kit convention).
+- The isolated workspace cannot be created or the target repository state prevents landing artifacts: the run fails with a report and does not leave partial artifacts in the user's `specs/` tree.
+- Interrupted run (user cancellation or crash): no half-written artifacts land in `specs/`; a re-run resumes from the first step that did not complete, exactly as with a halted chain.
+- Analyze produces zero findings: no remediation beads are created; the run reports a clean analysis.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a `maverick spec <feature> --from-prd <file>` command that accepts a feature name and a path to a PRD file, and validates both (readable, non-empty PRD; usable feature name) before starting any chain step.
+- **FR-002**: The system MUST execute the Spec Kit chain in the strict order specify → clarify → plan → tasks → analyze, exactly once per invocation, for exactly one feature.
+- **FR-003**: Each chain step MUST invoke the target repository's own corresponding Spec Kit command (its `/speckit.*` surface), so that the repository's installed Spec Kit version, templates, and conventions govern the output — the chain orchestrates, it does not reimplement.
+- **FR-004**: The chain MUST run headlessly end to end: no step may block on interactive human input under any circumstance.
+- **FR-005**: When the agent surface supports programmatic interception of interactive questions, the system MUST answer each clarify question by adopting the recommended option and MUST file an assumption-ledger entry recording the question, the adopted answer, the alternatives presented, and a severity.
+- **FR-006**: When programmatic question interception is not available, the system MUST run clarify under Spec Kit's documented non-interactive convention (informed defaults recorded in the spec's Assumptions section) and MUST afterwards upgrade each recorded default into an assumption-ledger entry equivalent to those filed under FR-005.
+- **FR-007**: Assumption-ledger entries filed by the chain MUST participate in the existing assumption workflows: counted by `maverick brief`, resolvable via `maverick review <id>` (answer or waive), and subject to the existing severity-based `maverick land` gate.
+- **FR-007a**: The harness MUST assess severity per question based on its impact (scope- or security-affecting adoptions escalate to medium or high); when no clear signal exists, severity defaults to low (advisory, never blocking).
+- **FR-008**: The system MUST NOT start plan before clarify has completed successfully, and MUST NOT start tasks before plan has completed successfully.
+- **FR-009**: If clarify fails or is blocked, the system MUST halt that spec's chain with a non-zero exit and a report identifying the failed step; it MUST NOT proceed to plan or tasks for that spec.
+- **FR-010**: If any other chain step fails, the system MUST halt at that step, preserve artifacts from completed steps, and report which steps ran, which failed, and which were skipped.
+- **FR-011**: The analyze step MUST run read-only: it MUST NOT modify the spec, plan, or tasks artifacts.
+- **FR-012**: Each analyze finding MUST be recorded as a remediation bead associated with the spec that produced it; analyze findings (or an analyze failure) MUST NOT cause the run to fail.
+- **FR-012a**: Remediation beads are created standalone (no parent epic), carrying a label/link identifying the originating spec; a later `refuel --speckit` run for that spec MUST adopt them under the epic it creates.
+- **FR-013**: All chain artifacts MUST land in the repository's `specs/` tree under a numbered feature directory (`specs/NNN-<feature>/`), as plain git-native markdown files, following the repository's existing Spec Kit numbering and layout conventions.
+- **FR-014**: The chain MUST execute in Maverick's isolated (hidden) workspace so the user's working checkout is not modified while steps run; only completed artifacts land in the repository.
+- **FR-015**: The system MUST NOT overwrite an existing completed spec directory; a feature-name or numbering collision with unrelated content is reported as an error.
+- **FR-016**: An interrupted or failed run MUST NOT leave partially written artifacts in the repository's `specs/` tree; artifacts from fully completed steps are preserved.
+- **FR-020**: The system MUST persist per-run chain state such that re-running `maverick spec <feature>` after a halted or interrupted chain automatically resumes from the first step that did not complete, reusing artifacts from completed steps rather than regenerating them.
+- **FR-017**: `maverick init` MUST verify that Spec Kit is installed in the target repository; when missing, it MUST offer to install it, honor the user's acceptance or decline, and succeed either way (with a notice when declined).
+- **FR-018**: `maverick spec` MUST fail fast with actionable guidance when Spec Kit is not installed in the target repository.
+- **FR-019**: The command MUST report progress per step as it runs and finish with a summary: steps completed, artifacts produced, clarify questions answered (ledger entry count), and remediation beads created.
+
+### Key Entities
+
+- **Spec chain run**: One invocation of `maverick spec` for one feature — the ordered sequence of five steps, its per-step outcomes, and its final status (completed, or halted at a named step).
+- **Chain step**: A single stage (specify, clarify, plan, tasks, analyze) delegating to the target repository's own Spec Kit command; has a strict position, a success/failure outcome, and produced artifacts.
+- **PRD (input document)**: The user-supplied requirements document that seeds the specify step.
+- **Spec artifact set**: The markdown outputs landing in `specs/NNN-<feature>/` — specification, plan, tasks, and any supporting files the repository's Spec Kit templates produce.
+- **Clarify decision**: A question raised during clarify plus the answer adopted on the user's behalf — question text, adopted answer, alternatives, severity — persisted as an assumption-ledger entry regardless of which answering path (interception or non-interactive convention) produced it.
+- **Remediation bead**: A work item created from one analyze finding, linked to the originating spec, entering the normal beads workflow. Created standalone (parentless) at chain time; adopted under the feature's epic when `refuel --speckit` runs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can go from a PRD file to a complete, reviewable spec artifact set (specification, plan, tasks) with a single command and zero interactive inputs.
+- **SC-002**: 100% of clarify questions raised during a chain run have a corresponding assumption-ledger entry with question, adopted answer, alternatives, and severity — no decision is made off the record, on either answering path.
+- **SC-003**: Zero plans or task lists are ever produced from a spec whose clarify step failed or was blocked.
+- **SC-004**: 100% of analyze findings from a completed run exist as remediation beads linked to the spec, and no analyze outcome ever causes an otherwise-successful run to fail.
+- **SC-005**: All produced artifacts are reviewable with standard git tooling (diff, blame, PR review) with no extra tooling required.
+- **SC-006**: After `maverick init` on a repository without Spec Kit, the user has either a working Spec Kit installation or an explicit recorded notice — no user first discovers the missing prerequisite via a mid-chain failure.
+- **SC-007**: A failed run leaves the repository's `specs/` tree either untouched or containing only complete artifacts from successfully finished steps — never half-written files.
+
+## Assumptions
+
+- **Numbering and layout**: The `NNN` spec-directory number is allocated by the target repository's existing Spec Kit convention (next sequential number), matching how manually created specs are numbered today.
+- **One feature per invocation**: `maverick spec` processes exactly one feature per run; batch/multi-spec orchestration is out of scope for this feature.
+- **Assumption ledger contract**: The ledger established by spec 049 (entry shape, severity semantics, `brief`/`review`/`land` integration) is the destination for clarify decisions; this feature files entries into it rather than defining a new mechanism.
+- **Severity assignment**: The severity on a clarify-derived ledger entry is assigned by the answering harness based on the question's apparent impact; absent a clear signal, severity defaults to low (advisory) so headless runs stay unobstructed, with scope- and security-impacting questions escalated to medium/high (clarified 2026-07-24).
+- **Recommended option exists**: Spec Kit clarify questions conventionally present a recommended/first option; when none exists, the harness adopts an informed default and records it identically (see edge case) rather than skipping.
+- **Isolated workspace**: The chain runs in a hidden isolated workspace (clarified 2026-07-24). This is a documented exception to the single-repo CWD guardrail: the spec chain produces only markdown artifacts, so the bd state-portability mismatch that retired the general workspace model does not apply. The constitution's Guardrail 0 must be amended with this exception as part of the feature.
+- **Spec Kit installation check**: "Installed in the target repo" means the repository has been initialized with Spec Kit (its command surface and templates are present), not merely that a Spec Kit binary exists on the machine.
+- **Remediation bead granularity**: One bead per analyze finding, deduplicated within a single run if analyze reports the same finding twice.
+- **PRD format**: The PRD is a text/markdown document; no specific internal structure is required beyond what the specify step can consume.

--- a/specs/050-headless-spec-chain/tasks.md
+++ b/specs/050-headless-spec-chain/tasks.md
@@ -1,0 +1,225 @@
+# Tasks: Headless Spec Kit Chain (`maverick spec`)
+
+**Input**: Design documents from `/specs/050-headless-spec-chain/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included — the project constitution (Principle V, Test-First) mandates TDD; tests are written before implementation within every story.
+
+**Organization**: Tasks are grouped by user story. US1 delivers the full chain running headlessly (clarify uses the non-interactive convention, analyze is report-only); US2 adds the ledger contract, US3 halt/resume hardening, US4 remediation beads + adoption, US5 init verification.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1–US5 from spec.md
+- Include exact file paths in descriptions
+
+## Phase 1: Setup
+
+**Purpose**: Package skeletons and verification of the two implementation gates flagged in research.md
+
+- [ ] T001 Verify implementation gates and record findings in specs/050-headless-spec-chain/research.md: (a) whether the pinned airframe `AgentRuntime` supports per-run working-directory binding (R1 — constructor or `execute()` parameter); (b) whether the `bd` CLI supports re-parenting an existing bead, e.g. `bd update --parent` (R6). Update the affected design decisions in place if either answer differs from the plan's assumption.
+- [ ] T002 Create package skeletons with empty `__init__.py` and module stubs: src/maverick/workflows/spec_chain/{__init__.py,constants.py,models.py,state.py,steps.py,clarify.py,landing.py,workflow.py}, src/maverick/workspace/{__init__.py,spec_chain.py}, src/maverick/agents/spec_chain.py, plus test directories tests/unit/workflows/spec_chain/, tests/unit/workspace/, tests/integration/spec_chain/ with directory-scoped conftest.py placeholders.
+- [ ] T003 [P] Add `SpecChainError` hierarchy (SpecChainError, SpecChainPreflightError, SpecChainStepError, SpecChainWorkspaceError, SpecChainStateError) in src/maverick/exceptions/spec_chain.py and export from src/maverick/exceptions/__init__.py.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Typed models, chain-state persistence, hidden workspace lifecycle, and the airframe-backed agent — everything every story builds on
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T004 [P] Write failing unit tests for ChainStep ordering + ChainState/StepRecord/ClarifyDecision/StepReport validation and state-transition invariants (per data-model.md) in tests/unit/workflows/spec_chain/test_models.py.
+- [ ] T005 [P] Write failing unit tests for atomic state save/load and feature-keyed discovery (newest non-terminal match, per contracts/chain-state.md) in tests/unit/workflows/spec_chain/test_state.py.
+- [ ] T006 [P] Write failing unit tests for hidden-workspace lifecycle (per-feature path `~/.maverick/workspaces/<project-slug>/spec-chain/<feature>/`, create via `JjClient.workspace_add`, reuse when state active, forget+recreate on fresh run, isolation between concurrent features, PRD copy-in) with a stubbed JjClient in tests/unit/workspace/test_spec_chain_workspace.py.
+- [ ] T007 Implement `ChainStep` enum, step order, labels (`spec-remediation`), state keys (`speckit_feature`, `remediation_source`, `finding_fingerprint`, `source_ref`), and timeout constants in src/maverick/workflows/spec_chain/constants.py.
+- [ ] T008 Implement ChainState, StepRecord, ClarifyDecision, StepReport (+ ReportedQuestion/ReportedFinding), AnalyzeFinding, and SpecChainReport models per data-model.md in src/maverick/workflows/spec_chain/models.py (make T004 pass).
+- [ ] T009 Implement atomic chain-state persistence (temp+rename), `metadata.json` integration via `runway.run_metadata`, and `discover_resumable(feature, base)` scan in src/maverick/workflows/spec_chain/state.py (make T005 pass).
+- [ ] T010 Implement hidden-workspace helper (create/reuse/forget under `~/.maverick/workspaces/<project-slug>/spec-chain/`, PRD copy-in, all jj ops through `JjClient`) in src/maverick/workspace/spec_chain.py (make T006 pass).
+- [ ] T011 Implement `SpecChainAgent` (subclass of `maverick.agents.base.Agent`; `provider_tier="generate"`, `result_model=StepReport`, per-run cwd binding per T001 findings) in src/maverick/agents/spec_chain.py, and `SpecChainSquadron` owning its single runtime in src/maverick/squadron/ (following existing squadron module layout); add unit tests with a fake runtime in tests/unit/workflows/spec_chain/test_agent.py.
+
+**Checkpoint**: Foundation ready — user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 — PRD to complete spec artifacts, hands-off (Priority: P1) 🎯 MVP
+
+**Goal**: `maverick spec <feature> --from-prd <file>` runs specify → clarify → plan → tasks → analyze headlessly in the hidden workspace via the repo's own `/speckit.*` commands; completed-step artifacts land atomically in `specs/NNN-<feature>/`. (Clarify runs the non-interactive convention without ledger filing; analyze is executed read-only with findings reported but not yet persisted as beads.)
+
+**Independent Test**: Quickstart Scenario 1 — run against a sample PRD in a Spec Kit repo (stubbed runtimes in CI); a new `specs/NNN-<feature>/` appears with spec/plan/tasks markdown, zero interactive prompts, exit 0.
+
+### Tests for User Story 1 (write first, ensure they FAIL)
+
+- [ ] T012 [P] [US1] Write failing unit tests for per-step prompt builders (slash-command invocation, inline-body fallback when the provider lacks a command surface, structured-report instruction, PRD injection for specify) in tests/unit/workflows/spec_chain/test_steps.py.
+- [ ] T013 [P] [US1] Write failing unit tests for atomic per-step artifact landing (workspace → checkout staged copy+rename, feature-dir readback after specify via specs/ diff + `.specify/feature.json` cross-check, filesystem-as-ground-truth step verification) in tests/unit/workflows/spec_chain/test_landing.py.
+- [ ] T014 [P] [US1] Write failing integration test for the full five-step happy path (tmp jj+git repo fixture with `.claude/commands/speckit.*.md` and `.specify/` markers, stubbed airframe runtime writing canned artifacts) asserting strict ordering, artifact landing, final report counts, that no interactive input is ever requested (FR-004), and that spec/plan/tasks artifact content is byte-identical before and after the analyze step (FR-011) in tests/integration/spec_chain/test_full_chain.py.
+- [ ] T015 [P] [US1] Write failing CLI contract tests for `maverick spec` (argument/option parsing, preflight failures → exit 2 per contracts/cli-spec.md: missing PRD, missing Spec Kit, missing bd) in tests/unit/cli/test_spec_command.py.
+
+### Implementation for User Story 1
+
+- [ ] T016 [US1] Implement per-step prompt builders and step-output handling (five steps; specify consumes the copied PRD; each prompt ends with the StepReport structured-output instruction) in src/maverick/workflows/spec_chain/steps.py (make T012 pass).
+- [ ] T017 [US1] Implement per-step artifact landing and feature-dir readback in src/maverick/workflows/spec_chain/landing.py (make T013 pass).
+- [ ] T018 [US1] Implement `SpecChainWorkflow` (async orchestration: preflight → workspace → sequential steps with tenacity retries and explicit timeouts → land → checkpoint after every transition → SpecChainReport; step success gated on artifacts, not agent claims) in src/maverick/workflows/spec_chain/workflow.py (make T014 pass).
+- [ ] T019 [US1] Implement the `maverick spec` Click command (async_command, `cli_error_handler`, preflight per contracts/cli-spec.md, Rich sequential step lines + final summary per CLI output rules) in src/maverick/cli/commands/spec.py, and register `"spec"` in `_LAZY_COMMANDS` in src/maverick/main.py (make T015 pass).
+- [ ] T020 [US1] Wire structured logging (`maverick.logging.get_logger`) for chain lifecycle events (step start/finish, landing, checkpoint) across src/maverick/workflows/spec_chain/workflow.py and landing.py, keeping raw structlog out of CLI output.
+
+**Checkpoint**: US1 fully functional — MVP: PRD in, reviewable artifacts out, hands-off
+
+---
+
+## Phase 4: User Story 2 — Clarify decisions on the record (Priority: P2)
+
+**Goal**: Every clarify question becomes an assumption-ledger entry (question/adopted/alternatives/severity) via interception where the runtime supports it, else via parsing the non-interactive defaults out of the spec — filed by the workflow, never the agent.
+
+**Independent Test**: Quickstart Scenario 2 — run clarify against a vague PRD (stubbed runtime emitting questions); every question appears as an open ledger bead with `assumption_owner_spec=NNN-<feature>`; `maverick brief` counts them; `maverick review` can answer/waive one.
+
+### Tests for User Story 2 (write first, ensure they FAIL)
+
+- [ ] T021 [P] [US2] Write failing unit tests for `record_standalone_assumption` (epic-less bead shape, `source_ref` state key, dedup-by-question within `owner_spec`, severity escalation on merge, per contracts/ledger-and-beads.md) in tests/unit/assumptions/test_standalone_ledger.py.
+- [ ] T022 [P] [US2] Write failing unit tests for the clarify policy seam (capability probe selects interception vs non-interactive; interception callback adopts recommended option and captures ClarifyDecision; question with no recommended option → adopted informed default recorded identically, or clarify blocked/halted when no defensible default exists — never silently skipped; non-interactive path parses Assumptions/Clarifications sections from an updated spec.md into ClarifyDecisions; severity defaults low and escalates per the R2 signal-category list) in tests/unit/workflows/spec_chain/test_clarify.py.
+- [ ] T023 [P] [US2] Write failing regression test proving standalone ledger entries flow through existing readers unchanged (`per_spec_counts`, `open_blocking_entries`, `maverick review` label lookup) in tests/unit/assumptions/test_standalone_compat.py.
+
+### Implementation for User Story 2
+
+- [ ] T024 [US2] Implement `record_standalone_assumption` in src/maverick/assumptions/ledger.py, reusing `_build_description` and the existing label/state-key constants (make T021 and T023 pass).
+- [ ] T025 [US2] Implement the clarify policy seam (`ClarifyPolicy` with interception + non-interactive paths, runtime capability probe, spec.md defaults parser, severity heuristic per FR-007a) in src/maverick/workflows/spec_chain/clarify.py (make T022 pass).
+- [ ] T026 [US2] Wire clarify into the workflow: after the clarify step succeeds, file each ClarifyDecision via `record_standalone_assumption` (bd runs in the user checkout, never the workspace), record `ledger_bead_id` back onto ChainState, and surface the count in SpecChainReport — in src/maverick/workflows/spec_chain/workflow.py; extend tests/integration/spec_chain/test_full_chain.py to assert ledger filing on both paths.
+
+**Checkpoint**: US1 + US2 — headless runs leave a complete, auditable decision trail
+
+---
+
+## Phase 5: User Story 3 — Strict ordering, halt, and resume (Priority: P2)
+
+**Goal**: A failed/blocked clarify halts the chain (exit 1, plan/tasks/analyze never run); interrupts checkpoint cleanly (exit 130); re-running auto-resumes from the first non-succeeded step, never regenerating landed artifacts; collision rules per FR-015.
+
+**Independent Test**: Quickstart Scenario 3 — force a clarify failure: exit 1, spec.md landed, no plan.md, persisted state shows halted-at-clarify; re-run resumes at clarify without re-running specify.
+
+### Tests for User Story 3 (write first, ensure they FAIL)
+
+- [ ] T027 [P] [US3] Write failing integration tests for halt semantics (clarify failure → status halted, downstream steps pending/skipped, exit 1, resume hint printed; mid-chain plan failure → same shape; analyze failure → warning + exit 0 per FR-012) in tests/integration/spec_chain/test_halt.py.
+- [ ] T028 [P] [US3] Write failing integration tests for resume (halted chain re-run continues from failed step; landed-artifact verification re-runs a step whose artifacts were deleted from the checkout; PRD digest mismatch warns without re-running specify; completed chain + same feature → collision error, exit 2) in tests/integration/spec_chain/test_resume.py.
+- [ ] T029 [P] [US3] Write failing unit tests for interrupt handling (graceful SIGINT during a step → state checkpointed with status `halted`, exit 130, workspace preserved for resume; only a hard crash leaves status `running`, which resume treats as stale-resumable per contracts/chain-state.md) in tests/unit/workflows/spec_chain/test_interrupt.py.
+
+### Implementation for User Story 3
+
+- [ ] T030 [US3] Implement resume resolution in the workflow + CLI (discovery via `state.discover_resumable`, `--from-prd` optional on resume, landed-artifact verification, PRD-digest warning, collision rules) across src/maverick/workflows/spec_chain/workflow.py and src/maverick/cli/commands/spec.py (make T028 pass).
+- [ ] T031 [US3] Implement halt classification and exit-code mapping (clarify/step failure → halted + exit 1; preflight → exit 2; analyze failure → `[yellow]Warning:[/yellow]` + exit 0) in src/maverick/workflows/spec_chain/workflow.py and src/maverick/cli/commands/spec.py (make T027 pass).
+- [ ] T032 [US3] Implement graceful SIGINT handling (checkpoint current state, mark step failed-by-interrupt, print resume hint, exit 130 — mirroring fly's two-stage Ctrl-C pattern where applicable) in src/maverick/cli/commands/spec.py (make T029 pass).
+
+**Checkpoint**: The chain is trustworthy under failure — halt/resume verified end-to-end
+
+---
+
+## Phase 6: User Story 4 — Analyze findings become remediation beads (Priority: P3)
+
+**Goal**: Each analyze finding is persisted as a standalone fingerprinted `spec-remediation` bead; `refuel --speckit` adopts them under the epic it creates; findings never block or fail the run.
+
+**Independent Test**: Quickstart Scenario 4 — chain run with stubbed findings exits 0 and creates one bead per finding keyed `speckit_feature=NNN-<feature>`; a subsequent `refuel --speckit` parents them under the new epic.
+
+### Tests for User Story 4 (write first, ensure they FAIL)
+
+- [ ] T033 [P] [US4] Write failing unit tests for remediation-bead creation (bead shape/labels/state keys per contracts/ledger-and-beads.md, fingerprint idempotency across re-runs, per-bead best-effort error isolation) in tests/unit/workflows/spec_chain/test_remediation.py.
+- [ ] T034 [P] [US4] Write failing unit tests for the adoption primitive (preferred `BeadClient.update_parent`, or the dependency-edge + `adopted_by_epic` stamp fallback per T001's finding) in tests/unit/beads/test_update_parent.py, and for the refuel adoption step (query unparented `spec-remediation` beads by `speckit_feature`, idempotent skip of already-adopted) in tests/unit/workflows/refuel_speckit/test_adoption.py.
+
+### Implementation for User Story 4
+
+- [ ] T035 [US4] Implement remediation-bead creation from analyze findings (parse ReportedFindings, fingerprint, create via `BeadClient` in the user checkout, record ids on ChainState, count in SpecChainReport) in src/maverick/workflows/spec_chain/workflow.py plus a `create_remediation_beads` helper in src/maverick/library/actions/beads.py (make T033 pass).
+- [ ] T036 [US4] Implement the adoption primitive per T001's finding (`update_parent` in src/maverick/beads/client.py, or dependency-edge fallback) (make the T034 client tests pass).
+- [ ] T037 [US4] Add the post-ingest adoption step to `SpeckitRefuelWorkflow` in src/maverick/workflows/refuel_speckit/workflow.py (fresh and delta paths, best-effort per bead) and extend the workflow's existing test module to cover it (make the T034 adoption tests pass).
+
+**Checkpoint**: Analyze closes the loop into the beads workflow without ever blocking
+
+---
+
+## Phase 7: User Story 5 — `maverick init` verifies Spec Kit (Priority: P3)
+
+**Goal**: Init detects Spec Kit presence (`.specify/` + supported version), offers installation on interactive TTYs, succeeds either way; `maverick spec` independently fail-fasts with guidance.
+
+**Independent Test**: Quickstart Scenario 5 — init in a repo without `.specify/` offers install; decline → exit 0 with notice; `maverick spec` then exits 2 with install guidance.
+
+### Tests for User Story 5 (write first, ensure they FAIL)
+
+- [ ] T038 [P] [US5] Write failing unit tests for `check_speckit_installed` (missing `.specify/`, missing/unsupported `speckit_version`, supported → pass; advisory never hard-fails init) in tests/unit/init/test_speckit_prereq.py.
+- [ ] T039 [P] [US5] Write failing unit tests for the init offer flow (interactive accept → installer invoked via `CommandRunner`; decline → notice + exit 0; non-interactive → notice only; idempotent re-init silent when compatible) in tests/unit/init/test_speckit_offer.py.
+
+### Implementation for User Story 5
+
+- [ ] T040 [US5] Implement `check_speckit_installed(cwd)` in src/maverick/init/prereqs.py, reusing the `.specify/init-options.json` version gate from `maverick.speckit.detect` (make T038 pass).
+- [ ] T041 [US5] Implement the offer-to-install step (Click confirm; installer invoked via `CommandRunner` as `uvx --from 'specify-cli==<pin>' specify init --here` with `<pin>` a named constant selecting the newest release whose templates satisfy `SUPPORTED_SPECKIT_RANGE` (>=0.14,<0.15); `InitResult.speckit_installed` field; notices per contracts/cli-spec.md) in src/maverick/init/__init__.py and src/maverick/cli/commands/init.py (make T039 pass).
+
+**Checkpoint**: All five user stories independently functional
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+- [ ] T042 [P] Amend governance docs for the scoped hidden-workspace exception: CLAUDE.md Guardrail 0 (single-repo model exception for the spec chain) and .specify/memory/constitution.md Appendix E (replace the stale WorkspaceManager narrative with the spec-chain jj-workspace mechanism), bumping the constitution's Sync Impact Report.
+- [ ] T043 [P] Update user-facing docs: add `maverick spec` to the CLI Workflows table in CLAUDE.md and the README command reference, including resume and ledger behavior.
+- [ ] T044 [P] Add module docstrings and Google-style docstrings across the new public surface (workflows/spec_chain/*, workspace/spec_chain.py, agents/spec_chain.py, new ledger/beads functions); verify no `Path.cwd()` defaults inside src/maverick/workflows/ (Guardrail 7 grep).
+- [ ] T045 Run quickstart.md Scenarios 1–5 against /workspaces/sample-maverick-project with a live provider binding; record outcomes (and any deviations as fixes or new tasks) in specs/050-headless-spec-chain/quickstart.md.
+- [ ] T046 Run `make format-fix && make ci` and fix all lint/type/test failures across the branch (pre-push gate).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: T001 has no dependencies; T002/T003 immediately after. T001's findings gate T011 (cwd binding) and T036 (adoption primitive) — surface them early.
+- **Foundational (Phase 2)**: Depends on Setup. Tests T004–T006 first (parallel), then T007 → T008 → T009/T010 (parallel) → T011. BLOCKS all user stories.
+- **US1 (Phase 3)**: After Phase 2. Delivers the MVP.
+- **US2 (Phase 4)**: After Phase 2; T026 (workflow wiring) touches workflow.py and therefore lands after T018. T021/T023/T024 (ledger extension) are independent of US1.
+- **US3 (Phase 5)**: After US1 (halting/resume harden the US1 workflow); independent of US2/US4.
+- **US4 (Phase 6)**: T033/T035 after US1 (analyze step exists); T034/T036/T037 (adoption) are independent of the chain and only need Phase 1–2.
+- **US5 (Phase 7)**: Only needs Phase 1 (touches init, not the chain). Can run any time after Setup.
+- **Polish (Phase 8)**: After all desired stories; T042/T043/T044 parallel; T045 → T046 last.
+
+### Within Each User Story
+
+- Tests are written first and MUST fail before implementation (Constitution Principle V).
+- Models → services/helpers → workflow wiring → CLI.
+- Same-file tasks are sequential (workflow.py: T018 → T026 → T030/T031 → T035).
+
+### Parallel Opportunities
+
+- Phase 2: T004, T005, T006 together; then T009 + T010 together.
+- US1: T012–T015 (all four test files) together.
+- US2 ledger track (T021→T024) parallel to clarify track (T022→T025).
+- US3: T027–T029 together.
+- US4 adoption track (T034/T036/T037) parallel to remediation track (T033/T035).
+- US5 is fully parallel to US2–US4 once Setup is done.
+- Polish: T042, T043, T044 together.
+
+## Parallel Example: User Story 1
+
+```bash
+# Write all US1 test files together (different files, no deps):
+Task: "T012 prompt-builder tests in tests/unit/workflows/spec_chain/test_steps.py"
+Task: "T013 landing tests in tests/unit/workflows/spec_chain/test_landing.py"
+Task: "T014 full-chain integration test in tests/integration/spec_chain/test_full_chain.py"
+Task: "T015 CLI contract tests in tests/unit/cli/test_spec_command.py"
+
+# Then implement sequentially where files converge:
+Task: "T016 steps.py" ; Task: "T017 landing.py"   # parallel (different files)
+Task: "T018 workflow.py"                            # after T016+T017
+Task: "T019 cli/commands/spec.py + main.py"         # after T018
+```
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+1. Phase 1 (gates verified) → Phase 2 (foundation) → Phase 3 (US1).
+2. **STOP and VALIDATE**: quickstart Scenario 1 with stubbed runtimes, then a live smoke run in sample-maverick-project.
+3. US1 alone is a demoable product: PRD → reviewable spec/plan/tasks, hands-off.
+
+### Incremental Delivery
+
+- US1 (MVP) → US2 (audit trail — the safety half of headless) → US3 (halt/resume hardening) → US4 (beads loop) → US5 (init convenience) → Polish.
+- US2 and US3 are both P2: prefer US2 first (no decision off the record) if delivering to users between increments; they touch mostly disjoint files and can proceed in parallel otherwise.
+
+### Notes
+
+- Every task that shells out uses the canonical wrappers (JjClient, BeadClient, CommandRunner, GitPython) — no new subprocess wrappers.
+- Commit after each task or logical group; keep `make test-fast` green throughout; `make ci` before push (T046).

--- a/src/maverick/agents/spec_chain.py
+++ b/src/maverick/agents/spec_chain.py
@@ -1,0 +1,75 @@
+"""``SpecChainAgent`` — runs one Spec Kit chain step (`maverick spec`)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+from maverick.agents.base import Agent
+from maverick.workflows.spec_chain.constants import STEP_TIMEOUT_SECONDS
+from maverick.workflows.spec_chain.models import StepReport
+
+if TYPE_CHECKING:
+    from airframe.protocol import AgentRuntime
+
+    from maverick.executor.config import StepConfig
+    from maverick.runtime.registry import CostSink
+
+__all__ = ["SpecChainAgent"]
+
+#: Serializes the `os.chdir()`-scoped step execution below across every
+#: `SpecChainAgent` instance in this process. airframe-agents 0.9.0rc1 has
+#: no per-call (or per-runtime) cwd parameter for the `claude` provider —
+#: `ClaudeOptions` carries no `working_directory` field, unlike
+#: Copilot/Kimi/OpenCodeServer (research.md R1, an adapter gap, not an SDK
+#: limitation). `os.chdir()` is process-wide state; this lock keeps two
+#: chain-step calls from racing on it. Safe in practice because chain
+#: steps already run strictly sequentially (FR-002) and one Maverick CLI
+#: invocation runs exactly one workflow per process.
+_CWD_BIND_LOCK = asyncio.Lock()
+
+
+class SpecChainAgent(Agent):
+    """Executes one Spec Kit chain step against the target repository's own
+    ``/speckit.*`` command surface, inside the hidden workspace.
+    """
+
+    result_model: ClassVar[type[StepReport]] = StepReport
+    provider_tier: ClassVar[str] = "generate"
+    persona_name: ClassVar[str | None] = "maverick.spec-chain"
+
+    def __init__(
+        self,
+        *,
+        runtime: AgentRuntime,
+        cwd: str,
+        step_config: StepConfig | dict[str, object] | None = None,
+        cost_sink: CostSink | None = None,
+        tag: str | None = None,
+    ) -> None:
+        super().__init__(
+            runtime=runtime,
+            cwd=cwd,
+            step_config=step_config,
+            cost_sink=cost_sink,
+            tag=tag,
+        )
+
+    async def run_step(self, prompt: str) -> StepReport:
+        """Run one chain-step prompt and return its structured report.
+
+        Binds the process working directory to this agent's ``cwd`` (the
+        hidden workspace) for the duration of the call — see
+        ``_CWD_BIND_LOCK`` for why this is necessary and how it stays safe.
+        """
+        async with _CWD_BIND_LOCK:
+            previous = Path.cwd()
+            os.chdir(self._cwd)
+            try:
+                report = await self._execute_via_runtime(prompt, timeout=STEP_TIMEOUT_SECONDS)
+            finally:
+                os.chdir(previous)
+        assert isinstance(report, StepReport)
+        return report

--- a/src/maverick/agents/system_prompts/maverick.spec-chain.md
+++ b/src/maverick/agents/system_prompts/maverick.spec-chain.md
@@ -1,0 +1,28 @@
+You are executing one step of a headless Spec Kit chain (specify, clarify,
+plan, tasks, or analyze) inside an isolated working copy of the target
+repository. The user prompt names the exact `/speckit.*` slash command to
+run (or, when your provider has no slash-command surface, inlines that
+command's own instructions verbatim) — follow the target repository's own
+Spec Kit templates and conventions exactly. Do not invent or reimplement
+Spec Kit behavior; the repository's installed command governs the output.
+
+Ground rules:
+
+- Never wait for or request interactive input. If the step conventionally
+  prompts a human (clarify), follow the non-interactive convention the
+  prompt describes instead.
+- Only touch files inside the current working directory (the isolated
+  workspace) — never reach outside it.
+- The analyze step is read-only: do not modify spec.md, plan.md, or
+  tasks.md while analyzing them.
+
+## Output Format
+
+Finish by calling the StructuredOutput tool with the schema provided by
+the runtime. Report `status` (`completed`, `blocked`, or `failed`), the
+artifact paths you wrote or updated, any clarify `questions` you answered
+(with your adopted answer and the alternatives you didn't choose), any
+analyze `findings`, and a short `detail` summary. The orchestrator treats
+the filesystem as the source of truth for whether a step succeeded — your
+report is telemetry, not the final word — so report accurately rather than
+optimistically.

--- a/src/maverick/assumptions/ledger.py
+++ b/src/maverick/assumptions/ledger.py
@@ -26,6 +26,7 @@ from maverick.assumptions.models import (
     KEY_SEVERITY,
     KEY_SEVERITY_DEFAULTED,
     KEY_SOURCE_BEAD,
+    KEY_SOURCE_REF,
     KEY_STATUS,
     KEY_WAIVE_REASON,
     KEY_WAIVED_AT,
@@ -55,6 +56,7 @@ __all__ = [
     "open_high_entries_before",
     "parse_description",
     "record_assumption",
+    "record_standalone_assumption",
     "stamp_change_id",
     "waive",
 ]
@@ -531,6 +533,163 @@ async def record_assumption(
         status=STATUS_OPEN,
         owner_spec=owner_spec,
         source_bead=source_bead_id,
+        change_ids=(),
+        is_legacy=False,
+    )
+
+
+async def _find_existing_standalone_entry(
+    client: BeadClient,
+    *,
+    owner_spec: str,
+    normalized_question: str,
+) -> AssumptionRecord | None:
+    """Search open, unparented ``assumption`` beads sharing *owner_spec*.
+
+    Standalone entries have no epic to search via ``children()`` (R5), so
+    dedup instead scans open task beads for the label + matching
+    ``assumption_owner_spec`` + normalized-question triple.
+    """
+    try:
+        candidates = await client.query("type=task AND status=open")
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to query open task beads: {exc}") from exc
+
+    for candidate in candidates:
+        try:
+            details = await client.show(candidate.id)
+        except BeadError as exc:
+            raise AssumptionLedgerError(f"Failed to load bead {candidate.id}: {exc}") from exc
+        if ASSUMPTION_LABEL not in (details.labels or []):
+            continue
+        state = details.state or {}
+        if state.get(KEY_OWNER_SPEC) != owner_spec:
+            continue
+        if _normalize_question(_extract_question(details.description)) == normalized_question:
+            return _record_from_details(details)
+    return None
+
+
+async def record_standalone_assumption(
+    client: BeadClient,
+    *,
+    payload: AssumptionPayload,
+    owner_spec: str,
+    source_ref: str,
+) -> AssumptionRecord | None:
+    """Create (or merge into) a standalone ledger entry — no owning epic yet.
+
+    Used when a decision must be recorded before any epic exists (R5) —
+    e.g. the spec-chain's clarify step, recorded before ``refuel
+    --speckit`` creates the feature's epic. The bead shape matches
+    :func:`record_assumption`'s output exactly except: no parent epic,
+    and state key ``source_ref`` (the originating step, e.g.
+    ``"spec-chain:clarify"``) replaces ``source_bead``. Dedup runs
+    against open standalone entries sharing the same *owner_spec*,
+    escalating severity on merge exactly like :func:`record_assumption`.
+
+    Returns:
+        The created or merged :class:`AssumptionRecord`.
+
+    Raises:
+        AssumptionLedgerError: On any bd-layer failure.
+    """
+    from maverick.beads.models import BeadCategory, BeadDefinition, BeadType
+
+    severity, defaulted_here = coerce_severity(payload.severity)
+    defaulted = bool(payload.severity_defaulted) or defaulted_here
+
+    normalized_question = _normalize_question(payload.question)
+    existing = await _find_existing_standalone_entry(
+        client, owner_spec=owner_spec, normalized_question=normalized_question
+    )
+    if existing is not None:
+        escalated = await _maybe_escalate_severity(
+            client,
+            existing=existing,
+            new_severity=severity,
+            new_defaulted=defaulted,
+            # No epic to wire a high-blocks edge onto yet — refuel
+            # --speckit's epic-chaining step wires it once the epic exists
+            # (contracts/ledger-and-beads.md).
+            epic_id="",
+        )
+        logger.info(
+            "assumption_standalone_dedup_merged",
+            bead_id=existing.bead_id,
+            source_ref=source_ref,
+            escalated_to=escalated.severity.value if escalated is not existing else None,
+        )
+        return escalated
+
+    definition = BeadDefinition(
+        title=f"Assumption: {payload.question[:_TITLE_MAX_LEN]}",
+        bead_type=BeadType.TASK,
+        priority=_SEVERITY_PRIORITY[severity],
+        category=BeadCategory.REVIEW,
+        description=_build_description(
+            question=payload.question,
+            adopted_answer=payload.adopted_answer,
+            alternatives=payload.alternatives,
+            source_bead_id=source_ref,
+            source_title=source_ref,
+        ),
+        assignee="human",
+        labels=list(ASSUMPTION_LABELS),
+    )
+
+    try:
+        created = await client.create_bead(definition, parent_id=None)
+    except BeadError as exc:
+        raise AssumptionLedgerError(f"Failed to create standalone assumption bead: {exc}") from exc
+
+    state: dict[str, str] = {
+        KEY_SEVERITY: severity.value,
+        KEY_STATUS: STATUS_OPEN,
+        KEY_OWNER_SPEC: owner_spec,
+        KEY_SOURCE_REF: source_ref,
+    }
+    if defaulted:
+        state[KEY_SEVERITY_DEFAULTED] = "true"
+
+    try:
+        await client.set_state(
+            created.bd_id, state, reason=f"standalone assumption recorded from {source_ref}"
+        )
+    except BeadError as exc:
+        raise AssumptionLedgerError(
+            f"Failed to set state on standalone assumption bead {created.bd_id}: {exc}"
+        ) from exc
+
+    if severity is Severity.LOW:
+        from maverick.library.actions.beads import defer_bead
+
+        try:
+            await defer_bead(
+                created.bd_id, cwd=client.cwd, reason="low-severity assumption — advisory only"
+            )
+        except Exception as exc:  # noqa: BLE001 — defer_bead has no typed error hierarchy
+            raise AssumptionLedgerError(
+                f"Failed to defer low-severity entry {created.bd_id}: {exc}"
+            ) from exc
+
+    logger.info(
+        "assumption_standalone_recorded",
+        bead_id=created.bd_id,
+        severity=severity.value,
+        owner_spec=owner_spec,
+        source_ref=source_ref,
+    )
+    return AssumptionRecord(
+        bead_id=created.bd_id,
+        question=payload.question,
+        adopted_answer=payload.adopted_answer,
+        alternatives=tuple(payload.alternatives),
+        severity=severity,
+        severity_defaulted=defaulted,
+        status=STATUS_OPEN,
+        owner_spec=owner_spec,
+        source_bead="",
         change_ids=(),
         is_legacy=False,
     )

--- a/src/maverick/assumptions/ledger.py
+++ b/src/maverick/assumptions/ledger.py
@@ -547,15 +547,21 @@ async def _find_existing_standalone_entry(
     """Search open, unparented ``assumption`` beads sharing *owner_spec*.
 
     Standalone entries have no epic to search via ``children()`` (R5), so
-    dedup instead scans open task beads for the label + matching
-    ``assumption_owner_spec`` + normalized-question triple.
+    dedup instead scans non-closed task beads for the label + matching
+    ``assumption_owner_spec`` + normalized-question triple. Queries all
+    tasks and skips only ``_CLOSED_STATUSES`` — matching
+    :func:`_find_existing_open_entry`'s semantics — so a low-severity
+    entry that was ``bd defer``\\ ed out of the ready queue (its status is
+    no longer ``open``) is still found and deduped, not duplicated.
     """
     try:
-        candidates = await client.query("type=task AND status=open")
+        candidates = await client.query("type=task")
     except BeadError as exc:
-        raise AssumptionLedgerError(f"Failed to query open task beads: {exc}") from exc
+        raise AssumptionLedgerError(f"Failed to query task beads: {exc}") from exc
 
     for candidate in candidates:
+        if candidate.status in _CLOSED_STATUSES:
+            continue
         try:
             details = await client.show(candidate.id)
         except BeadError as exc:

--- a/src/maverick/assumptions/models.py
+++ b/src/maverick/assumptions/models.py
@@ -73,6 +73,10 @@ KEY_WAIVED_BY = "assumption_waived_by"
 KEY_WAIVED_AT = "assumption_waived_at"
 KEY_WAIVE_REASON = "assumption_waive_reason"
 KEY_SOURCE_BEAD = "source_bead"
+#: Standalone-entry variant of ``source_bead`` (R5) — set instead of
+#: ``source_bead`` when no spawning bead exists yet (e.g. the spec-chain's
+#: clarify step, recorded before its epic is created by ``refuel --speckit``).
+KEY_SOURCE_REF = "source_ref"
 
 # Epic-level state keys read to derive ``assumption_owner_spec``
 # (research R3 — first match wins).

--- a/src/maverick/cli/commands/init.py
+++ b/src/maverick/cli/commands/init.py
@@ -147,6 +147,37 @@ def _format_git_output(
     return lines
 
 
+def _format_speckit_output(result: InitResult) -> list[str]:
+    """Format the Spec Kit install-offer notice (R7/US5).
+
+    Silent (no output) when Spec Kit was already installed and compatible
+    — ``speckit_installed`` is only ``None`` in that case *or* when the
+    offer was skipped/declined, so a check against the live prerequisite
+    result decides which of those it was.
+    """
+    if result.speckit_installed is True:
+        return ["[green]✓[/] Spec Kit installed.", ""]
+    if result.speckit_installed is False:
+        return [
+            "[yellow]Warning:[/yellow] Spec Kit install failed — "
+            "`maverick spec` will be unavailable until it's installed manually.",
+            "",
+        ]
+
+    # speckit_installed is None: either already fine, or the offer was
+    # skipped/declined — only the latter needs a user-visible notice.
+    from maverick.init.prereqs import check_speckit_installed
+
+    check = check_speckit_installed(Path(result.config_path).parent)
+    if check.status != PreflightStatus.PASS:
+        return [
+            f"[yellow]Notice:[/yellow] {check.message} — "
+            "`maverick spec` will be unavailable until Spec Kit is installed.",
+            "",
+        ]
+    return []
+
+
 def _format_config_output(
     result: InitResult,
     verbose: bool = False,
@@ -297,6 +328,7 @@ async def init(
             lines.extend(_format_detection_output(result, verbose))
             lines.extend(_format_provider_output(result.provider_discovery))
             lines.extend(_format_git_output(result, verbose))
+            lines.extend(_format_speckit_output(result))
             lines.extend(_format_config_output(result, verbose))
 
             for line in lines:

--- a/src/maverick/cli/commands/spec.py
+++ b/src/maverick/cli/commands/spec.py
@@ -1,0 +1,187 @@
+"""``maverick spec`` — headless Spec Kit chain (`maverick spec`).
+
+Runs the target repository's own Spec Kit chain — specify, clarify,
+plan, tasks, analyze — headlessly inside a hidden workspace. See
+specs/050-headless-spec-chain/contracts/cli-spec.md for the full
+contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+
+import click
+
+from maverick.cli.common import cli_error_handler, verify_bd_ready
+from maverick.cli.console import console, err_console
+from maverick.cli.context import ExitCode, async_command
+from maverick.init.models import PreflightStatus
+from maverick.init.prereqs import check_speckit_installed
+
+__all__ = ["spec"]
+
+
+def _exit_partial(message: str, *, remediation: str | None = None) -> None:
+    err_console.print(f"[red]Error:[/red] {message}")
+    if remediation:
+        err_console.print(f"[yellow]Remediation:[/yellow] {remediation}")
+    raise SystemExit(ExitCode.PARTIAL)
+
+
+def _check_speckit_or_exit(cwd: Path) -> None:
+    check = check_speckit_installed(cwd)
+    if check.status != PreflightStatus.PASS:
+        _exit_partial(check.message, remediation=check.remediation)
+
+
+def _check_prd_or_exit(prd_path: Path) -> None:
+    try:
+        content = prd_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        _exit_partial(f"cannot read PRD file {prd_path}: {exc}")
+        return
+    if not content.strip():
+        _exit_partial(f"PRD file {prd_path} is empty")
+
+
+def _check_feature_collision_or_exit(cwd: Path, feature: str) -> None:
+    """FR-015: refuse to overwrite an existing spec directory for *feature*.
+
+    Only reached once ``discover_resumable`` has already ruled out an
+    auto-resumable (halted/running) chain — a completed/foreign
+    ``specs/`` dir for this feature is a genuine collision (FR-020).
+    """
+    specs_dir = cwd / "specs"
+    if not specs_dir.is_dir():
+        return
+    for candidate in specs_dir.iterdir():
+        if candidate.is_dir() and candidate.name.endswith(f"-{feature}"):
+            _exit_partial(
+                f"a spec directory already exists for '{feature}': {candidate}",
+                remediation="Remove or rename it, or choose a different feature name.",
+            )
+
+
+def _render_summary_and_exit(state: object, feature: str) -> None:
+    from maverick.workflows.spec_chain.models import ChainState
+
+    if not isinstance(state, ChainState):
+        err_console.print(
+            "[red]Error:[/red] no chain state found after the run — this "
+            "indicates an internal error."
+        )
+        raise SystemExit(ExitCode.FAILURE)
+
+    console.print()
+    console.print("[bold]Summary[/]")
+    console.print(f"  Feature dir: [bold]{state.feature_dir or '(none)'}[/]")
+    console.print(f"  Clarify questions answered: {len(state.clarify_decisions)}")
+    console.print(f"  Remediation beads created: {len(state.remediation_bead_ids)}")
+
+    if state.status == "completed":
+        console.print()
+        console.print("[green]✓[/] Chain completed.")
+        raise SystemExit(ExitCode.SUCCESS)
+
+    console.print()
+    console.print("[red]✗[/] Chain halted.")
+    console.print(f"[dim]Resume:[/] [bold]maverick spec {feature}[/]")
+    raise SystemExit(ExitCode.FAILURE)
+
+
+@click.command("spec")
+@click.argument("feature")
+@click.option(
+    "--from-prd",
+    "prd_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Path to the PRD file that seeds the chain (required unless resuming).",
+)
+@click.option(
+    "--session-log",
+    "session_log",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write a session journal (JSONL) to this file path.",
+)
+@click.pass_context
+@async_command
+async def spec(
+    ctx: click.Context,
+    feature: str,
+    prd_path: Path | None,
+    session_log: Path | None,
+) -> None:
+    """Run the headless Spec Kit chain for FEATURE from a PRD.
+
+    Runs specify -> clarify -> plan -> tasks -> analyze inside an
+    isolated hidden workspace, invoking the target repository's own
+    /speckit.* commands. No step ever blocks on interactive input;
+    completed-step artifacts land in specs/NNN-FEATURE/. Re-running for a
+    feature with a halted or still-running chain auto-resumes it from the
+    first incomplete step instead of requiring --from-prd again.
+    """
+    cwd = Path.cwd().resolve()
+
+    with cli_error_handler():
+        verify_bd_ready(cwd)
+        _check_speckit_or_exit(cwd)
+
+    from maverick.workflows.spec_chain.state import discover_resumable, load_chain_state
+
+    resumable = await discover_resumable(feature, cwd)
+
+    if resumable is not None:
+        run_id = resumable.run_id
+        console.print(
+            f"[dim]Resuming '{feature}' (run {run_id}, status: {resumable.status}) — "
+            "continuing from the first incomplete step.[/]"
+        )
+    else:
+        with cli_error_handler():
+            if prd_path is None:
+                _exit_partial(
+                    f"--from-prd is required to start a new chain for '{feature}'",
+                    remediation=(
+                        "Pass --from-prd <file>, or omit it if you meant to resume "
+                        "an existing halted/running chain for this feature."
+                    ),
+                )
+            assert prd_path is not None  # _exit_partial always raises above
+            _check_prd_or_exit(prd_path)
+            _check_feature_collision_or_exit(cwd, feature)
+        run_id = uuid.uuid4().hex[:8]
+
+    from maverick.cli.workflow_executor import PythonWorkflowRunConfig, execute_python_workflow
+    from maverick.workflows.spec_chain.workflow import SpecChainWorkflow
+
+    try:
+        await execute_python_workflow(
+            ctx,
+            PythonWorkflowRunConfig(
+                workflow_class=SpecChainWorkflow,
+                inputs={
+                    "run_id": run_id,
+                    "feature": feature,
+                    "prd_path": str(prd_path) if prd_path else "",
+                    "cwd": str(cwd),
+                },
+                session_log_path=session_log,
+            ),
+        )
+    except asyncio.CancelledError:
+        # Graceful Ctrl-C (T032): the workflow's own rollback already
+        # checkpointed status=halted on the freshest on-disk state before
+        # this propagates here — print the resume hint before the outer
+        # async_command wrapper converts this into exit 130.
+        interrupted_state = await load_chain_state(run_id, cwd)
+        if interrupted_state is not None:
+            err_console.print()
+            err_console.print(f"[dim]Resume:[/] [bold]maverick spec {feature}[/]")
+        raise
+
+    final_state = await load_chain_state(run_id, cwd)
+    _render_summary_and_exit(final_state, feature)

--- a/src/maverick/cli/commands/spec.py
+++ b/src/maverick/cli/commands/spec.py
@@ -126,7 +126,15 @@ async def spec(
     """
     cwd = Path.cwd().resolve()
 
+    from maverick.workflows.spec_chain.models import is_valid_feature_slug
+
     with cli_error_handler():
+        if not is_valid_feature_slug(feature):
+            _exit_partial(
+                f"invalid feature name '{feature}' — must be a filesystem-safe "
+                "slug (letters, digits, hyphen, underscore; no path separators "
+                "or leading dots)"
+            )
         verify_bd_ready(cwd)
         _check_speckit_or_exit(cwd)
 

--- a/src/maverick/exceptions/__init__.py
+++ b/src/maverick/exceptions/__init__.py
@@ -116,6 +116,15 @@ from maverick.exceptions.runway import (
     RunwayNotInitializedError,
 )
 
+# Spec-chain-related exceptions
+from maverick.exceptions.spec_chain import (
+    SpecChainError,
+    SpecChainPreflightError,
+    SpecChainStateError,
+    SpecChainStepError,
+    SpecChainWorkspaceError,
+)
+
 # Validation-related exceptions
 from maverick.exceptions.validation import (
     MaverickValidationError,
@@ -220,6 +229,12 @@ __all__ = [
     "RunwayCorruptedError",
     "RunwayError",
     "RunwayNotInitializedError",
+    # Spec chain
+    "SpecChainError",
+    "SpecChainPreflightError",
+    "SpecChainStateError",
+    "SpecChainStepError",
+    "SpecChainWorkspaceError",
     # Flight
     "FlightError",
     "FlightPlanNotFoundError",

--- a/src/maverick/exceptions/spec_chain.py
+++ b/src/maverick/exceptions/spec_chain.py
@@ -1,0 +1,41 @@
+"""Spec-chain workflow exceptions (`maverick spec`)."""
+
+from __future__ import annotations
+
+from maverick.exceptions.base import MaverickError
+
+
+class SpecChainError(MaverickError):
+    """Base exception for spec-chain operations."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+class SpecChainPreflightError(SpecChainError):
+    """A preflight check failed before any chain step ran."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+class SpecChainStepError(SpecChainError):
+    """A chain step (specify/clarify/plan/tasks/analyze) failed."""
+
+    def __init__(self, step: str, message: str) -> None:
+        self.step = step
+        super().__init__(f"Step '{step}' failed: {message}")
+
+
+class SpecChainWorkspaceError(SpecChainError):
+    """The hidden jj workspace could not be created, reused, or torn down."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+class SpecChainStateError(SpecChainError):
+    """Chain state could not be persisted, loaded, or resolved for resume."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)

--- a/src/maverick/init/__init__.py
+++ b/src/maverick/init/__init__.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import sys
 from pathlib import Path
+
+import click
 
 from maverick.exceptions.init import InitError, PrerequisiteError
 from maverick.init.config_generator import generate_config, write_config
@@ -53,6 +56,7 @@ from maverick.logging import get_logger
 __all__ = [
     # Functions
     "run_init",
+    "install_speckit",
     "parse_git_remote",
     "resolve_model_id",
     "discover_providers",
@@ -64,6 +68,7 @@ __all__ = [
     "MARKER_FILE_MAP",
     "VALIDATION_DEFAULTS",
     "PYTHON_DEFAULTS",
+    "SPECKIT_CLI_PIN",
     # Dataclasses
     "ProjectMarker",
     "ValidationCommands",
@@ -496,6 +501,87 @@ async def _maybe_init_runway(project_path: Path, verbose: bool) -> bool:
 
 
 # =============================================================================
+# Spec Kit prerequisite + install offer (R7/US5)
+# =============================================================================
+
+#: Pinned `specify-cli` version for the install offer's `uvx --from`
+#: invocation. Chosen as the supported range's floor
+#: (`SUPPORTED_SPECKIT_RANGE = ">=0.14,<0.15"`) rather than a guessed
+#: "latest patch" — this sandbox has no way to query PyPI for the true
+#: newest compatible release, and the floor is the one version guaranteed
+#: to satisfy the range. Bump when a newer 0.14.x release is verified
+#: compatible.
+SPECKIT_CLI_PIN = "0.14.0"
+
+#: Timeout for the `uvx --from specify-cli==<pin> specify init --here`
+#: installer subprocess.
+_SPECKIT_INSTALL_TIMEOUT_SECONDS = 120.0
+
+
+async def install_speckit(project_path: Path) -> bool:
+    """Run the pinned Spec Kit installer via `CommandRunner`.
+
+    Args:
+        project_path: Target repository root to install into.
+
+    Returns:
+        True if the installer exited successfully.
+    """
+    from maverick.runners.command import CommandRunner
+
+    runner = CommandRunner(cwd=project_path, timeout=_SPECKIT_INSTALL_TIMEOUT_SECONDS)
+    result = await runner.run(
+        ["uvx", "--from", f"specify-cli=={SPECKIT_CLI_PIN}", "specify", "init", "--here"]
+    )
+    if not result.success:
+        logger.warning(
+            "speckit_install_failed",
+            path=str(project_path),
+            returncode=result.returncode,
+            stderr=result.stderr[:500],
+        )
+    return result.success
+
+
+async def _maybe_offer_speckit_install(project_path: Path, verbose: bool) -> bool | None:
+    """Advisory Spec Kit prerequisite check + interactive install offer (R7).
+
+    Never hard-fails init — this is purely informational/offer logic;
+    :func:`check_speckit_installed` itself never raises.
+
+    Args:
+        project_path: Project root directory.
+        verbose: Whether to log the "already installed" pass case.
+
+    Returns:
+        ``True`` installed this run; ``False`` the offer was accepted but
+        the installer failed; ``None`` not applicable (already installed)
+        or the offer was skipped/declined.
+    """
+    from maverick.init.prereqs import check_speckit_installed
+
+    check = check_speckit_installed(project_path)
+    if check.status.value == "pass":
+        if verbose:
+            logger.debug("speckit_already_installed", message=check.message)
+        return None
+
+    if not sys.stdin.isatty():
+        logger.info("speckit_not_installed_notice", message=check.message)
+        return None
+
+    accepted = click.confirm(
+        f"Spec Kit is not installed ({check.message}). Install it now?",
+        default=True,
+    )
+    if not accepted:
+        logger.info("speckit_install_declined", message=check.message)
+        return None
+
+    return await install_speckit(project_path)
+
+
+# =============================================================================
 # .gitignore maintenance (best-effort)
 # =============================================================================
 
@@ -819,6 +905,7 @@ async def run_init(
         runway_initialized = await _maybe_init_runway(effective_path, verbose)
         await _ensure_gitignore_entries(effective_path, verbose)
         await _untrack_bd_local_state(effective_path, verbose)
+        speckit_installed = await _maybe_offer_speckit_install(effective_path, verbose)
         return InitResult(
             success=True,
             config_path=str(config_path),
@@ -831,6 +918,7 @@ async def run_init(
             runway_initialized=runway_initialized,
             provider_discovery=None,
             config_existed=True,
+            speckit_installed=speckit_installed,
         )
 
     # Step 3: Detect project type
@@ -901,6 +989,9 @@ async def run_init(
     await _ensure_gitignore_entries(effective_path, verbose)
     await _untrack_bd_local_state(effective_path, verbose)
 
+    # Step 9: Advisory Spec Kit prerequisite check + install offer (R7/US5).
+    speckit_installed = await _maybe_offer_speckit_install(effective_path, verbose)
+
     # Build and return result
     return InitResult(
         success=True,
@@ -913,4 +1004,5 @@ async def run_init(
         beads_initialized=beads_initialized,
         runway_initialized=runway_initialized,
         provider_discovery=provider_discovery,
+        speckit_installed=speckit_installed,
     )

--- a/src/maverick/init/models.py
+++ b/src/maverick/init/models.py
@@ -679,6 +679,11 @@ class InitResult:
             target path AND the run was not invoked with ``--force``. In this
             mode init re-runs only the idempotent steps (prereqs, beads,
             runway) and leaves the existing config untouched. (FUTURE.md §4.3)
+        speckit_installed: Spec Kit install-offer outcome (R7/US5):
+            ``True`` installed this run, ``False`` the offer was accepted
+            but the installer failed, ``None`` not applicable (already
+            installed) or the offer was skipped/declined (non-interactive
+            session, or the user said no).
     """
 
     success: bool
@@ -692,6 +697,7 @@ class InitResult:
     runway_initialized: bool = False
     provider_discovery: ProviderDiscoveryResult | None = None
     config_existed: bool = False
+    speckit_installed: bool | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization.
@@ -713,6 +719,7 @@ class InitResult:
                 self.provider_discovery.to_dict() if self.provider_discovery else None
             ),
             "config_existed": self.config_existed,
+            "speckit_installed": self.speckit_installed,
         }
 
 

--- a/src/maverick/init/prereqs.py
+++ b/src/maverick/init/prereqs.py
@@ -20,10 +20,11 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 __all__ = [
+    "check_gh_authenticated",
+    "check_gh_installed",
     "check_git_installed",
     "check_in_git_repo",
-    "check_gh_installed",
-    "check_gh_authenticated",
+    "check_speckit_installed",
     "verify_prerequisites",
 ]
 
@@ -108,6 +109,68 @@ async def _run_command(
         return 127, "", f"Command not found: {command[0]}"
     except PermissionError:
         return 126, "", f"Permission denied: {command[0]}"
+
+
+def check_speckit_installed(cwd: Path) -> PrerequisiteCheck:
+    """Check whether Spec Kit is installed in the target repository (R7).
+
+    Advisory only — never hard-fails ``maverick init`` (the check is a
+    :class:`PrerequisiteCheck`, not an exception). "Installed" means the
+    repository has the ``.specify/`` marker with a compatible (or
+    unknown-but-present) ``speckit_version``, reusing the same version
+    gate :func:`maverick.speckit.detect.check_template_compatibility`
+    already applies to ``refuel --speckit``. An explicitly *unsupported*
+    version, or a missing ``.specify/`` directory entirely, is reported
+    as ``FAIL`` so callers (``maverick init``'s install offer,
+    ``maverick spec``'s own fail-fast preflight) can act on it.
+
+    Args:
+        cwd: Target repository root.
+
+    Returns:
+        A :class:`PrerequisiteCheck` named ``"speckit_installed"``.
+    """
+    from maverick.speckit.detect import SUPPORTED_SPECKIT_RANGE, check_template_compatibility
+
+    if not (cwd / ".specify").is_dir():
+        return PrerequisiteCheck(
+            name="speckit_installed",
+            display_name="Spec Kit",
+            status=PreflightStatus.FAIL,
+            message="Spec Kit is not installed in this repository",
+            remediation=(
+                "Install Spec Kit: `uvx --from specify-cli specify init --here` "
+                f"(supported range: {SUPPORTED_SPECKIT_RANGE})"
+            ),
+        )
+
+    compat = check_template_compatibility(cwd)
+    if compat.status == "unsupported":
+        return PrerequisiteCheck(
+            name="speckit_installed",
+            display_name="Spec Kit",
+            status=PreflightStatus.FAIL,
+            message=(
+                f"Spec Kit template version {compat.vendored_version} is unsupported "
+                f"(supported range: {compat.supported_range})"
+            ),
+            remediation=(
+                "Reinstall Spec Kit at a supported version: "
+                f"`uvx --from specify-cli specify init --here` "
+                f"(supported range: {compat.supported_range})"
+            ),
+        )
+
+    return PrerequisiteCheck(
+        name="speckit_installed",
+        display_name="Spec Kit",
+        status=PreflightStatus.PASS,
+        message=(
+            f"Spec Kit version {compat.vendored_version} installed"
+            if compat.status == "supported"
+            else "Spec Kit installed (template version unknown — proceeding structurally)"
+        ),
+    )
 
 
 # =============================================================================

--- a/src/maverick/library/actions/beads.py
+++ b/src/maverick/library/actions/beads.py
@@ -13,16 +13,22 @@ removed.
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from maverick.library.actions.types import (
     BeadCreationResult,
     DependencyWiringResult,
     MarkBeadCompleteResult,
+    RemediationBeadsResult,
     SelectNextBeadResult,
 )
 from maverick.logging import get_logger
+
+if TYPE_CHECKING:
+    from maverick.beads.client import BeadClient
+    from maverick.workflows.spec_chain.models import AnalyzeFinding
 
 logger = get_logger(__name__)
 
@@ -424,3 +430,168 @@ async def defer_bead(
     runner = CommandRunner(cwd=Path(cwd))
     await runner.run(["bd", "defer", bead_id])
     logger.info("bead_deferred", bead_id=bead_id, reason=reason)
+
+
+def _build_remediation_description(finding: AnalyzeFinding) -> str:
+    return (
+        f"## Finding\n\n{finding.title}\n\n"
+        f"## Category\n\n{finding.category}\n\n"
+        f"## Severity Hint\n\n{finding.severity_hint}\n\n"
+        f"## Location\n\n{finding.location}\n\n"
+        f"## Summary\n\n{finding.summary}\n"
+    )
+
+
+async def _existing_remediation_fingerprints(client: BeadClient) -> set[str]:
+    from maverick.workflows.spec_chain.constants import (
+        KEY_FINDING_FINGERPRINT,
+        SPEC_REMEDIATION_LABEL,
+    )
+
+    try:
+        candidates = await client.query("type=task")
+    except Exception as exc:  # noqa: BLE001 — best-effort idempotency probe
+        logger.warning("spec_remediation_fingerprint_query_failed", error=str(exc))
+        return set()
+
+    fingerprints: set[str] = set()
+    for candidate in candidates:
+        try:
+            details = await client.show(candidate.id)
+        except Exception as exc:  # noqa: BLE001 — one bad bead must not sink the scan
+            logger.debug(
+                "spec_remediation_fingerprint_show_failed", bead_id=candidate.id, error=str(exc)
+            )
+            continue
+        if SPEC_REMEDIATION_LABEL in (details.labels or []):
+            fingerprint = (details.state or {}).get(KEY_FINDING_FINGERPRINT)
+            if fingerprint:
+                fingerprints.add(fingerprint)
+    return fingerprints
+
+
+async def create_remediation_beads(
+    findings: Sequence[AnalyzeFinding],
+    *,
+    cwd: Path | str,
+) -> RemediationBeadsResult:
+    """Create one standalone ``spec-remediation`` bead per analyze finding (R6).
+
+    Beads are created unparented (the feature's epic doesn't exist until
+    ``refuel --speckit`` runs) and idempotent per
+    ``finding_fingerprint`` — re-running analyze never duplicates a bead
+    for the same finding. Best-effort per finding (Principle IV): one
+    finding's bd failure is logged and excluded from the result, never
+    raised, so it can't sink the others or the analyze step itself.
+
+    Args:
+        findings: Analyze findings to convert into remediation beads.
+        cwd: Workspace directory whose ``.beads/`` receives the writes.
+            Required — see module docstring.
+
+    Returns:
+        RemediationBeadsResult.
+    """
+    from maverick.beads.client import BeadClient
+    from maverick.beads.models import BeadCategory, BeadDefinition, BeadType
+    from maverick.workflows.spec_chain.constants import (
+        KEY_FINDING_FINGERPRINT,
+        KEY_REMEDIATION_SOURCE,
+        KEY_SPECKIT_FEATURE,
+        REMEDIATION_SOURCE_ANALYZE,
+        SPEC_REMEDIATION_LABEL,
+    )
+
+    if not findings:
+        return RemediationBeadsResult(
+            created_bead_ids=(), skipped_duplicate_fingerprints=(), errors=()
+        )
+
+    client = BeadClient(cwd=Path(cwd))
+    existing_fingerprints = await _existing_remediation_fingerprints(client)
+
+    created_ids: list[str] = []
+    skipped: list[str] = []
+    errors: list[str] = []
+
+    for finding in findings:
+        if finding.fingerprint in existing_fingerprints:
+            skipped.append(finding.fingerprint)
+            continue
+        try:
+            definition = BeadDefinition(
+                title=f"Spec remediation: {finding.title[:150]}",
+                bead_type=BeadType.TASK,
+                # Advisory by design — severity_hint lives in the
+                # description, not priority (FR-012: findings never block).
+                priority=2,
+                category=BeadCategory.CLEANUP,
+                description=_build_remediation_description(finding),
+                labels=[SPEC_REMEDIATION_LABEL],
+            )
+            created = await client.create_bead(definition, parent_id=None)
+            await client.set_state(
+                created.bd_id,
+                {
+                    KEY_SPECKIT_FEATURE: finding.feature_dir,
+                    KEY_REMEDIATION_SOURCE: REMEDIATION_SOURCE_ANALYZE,
+                    KEY_FINDING_FINGERPRINT: finding.fingerprint,
+                },
+                reason="spec-chain analyze finding",
+            )
+            created_ids.append(created.bd_id)
+            existing_fingerprints.add(finding.fingerprint)
+        except Exception as exc:  # noqa: BLE001 — one finding's failure must not sink the rest
+            logger.warning(
+                "spec_remediation_bead_creation_failed", title=finding.title, error=str(exc)
+            )
+            errors.append(f"{finding.title}: {exc}")
+
+    return RemediationBeadsResult(
+        created_bead_ids=tuple(created_ids),
+        skipped_duplicate_fingerprints=tuple(skipped),
+        errors=tuple(errors),
+    )
+
+
+async def adopt_remediation_bead(
+    client: BeadClient,
+    *,
+    bead_id: str,
+    epic_id: str,
+) -> None:
+    """Adopt a standalone ``spec-remediation`` bead under *epic_id* (R6).
+
+    Fallback primitive: no ``bd update --parent`` exists (verified
+    against T001's research — no live ``bd`` install to confirm a real
+    parent-reassignment command, and ``BeadClient`` exposes no such
+    method today). Wires a ``DISCOVERED_FROM`` dependency edge from the
+    epic (provenance/grouping only — does not affect readiness, unlike
+    ``BLOCKS``) plus the ``adopted_by_epic`` state stamp that callers use
+    for the idempotency check ("already adopted" — see
+    ``SpeckitRefuelWorkflow``'s post-ingest adoption step).
+
+    Args:
+        client: BeadClient bound to the user's checkout.
+        bead_id: The remediation bead to adopt.
+        epic_id: The epic to adopt it under.
+
+    Raises:
+        Exception: Any bd-layer failure — callers isolate per-bead
+            failures (Principle IV); this primitive itself does not.
+    """
+    from maverick.beads.models import BeadDependency, DependencyType
+    from maverick.workflows.spec_chain.constants import KEY_ADOPTED_BY_EPIC
+
+    await client.add_dependency(
+        BeadDependency(
+            blocker_id=epic_id,
+            blocked_id=bead_id,
+            dep_type=DependencyType.DISCOVERED_FROM,
+        )
+    )
+    await client.set_state(
+        bead_id,
+        {KEY_ADOPTED_BY_EPIC: epic_id},
+        reason=f"adopted under epic {epic_id}",
+    )

--- a/src/maverick/library/actions/types.py
+++ b/src/maverick/library/actions/types.py
@@ -814,3 +814,29 @@ class TechDebtIssueResult:
             "finding_id": self.finding_id,
             "error": self.error,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class RemediationBeadsResult:
+    """Result of creating standalone `spec-remediation` beads from
+    spec-chain analyze findings (R6).
+
+    Attributes:
+        created_bead_ids: IDs of beads newly created this call.
+        skipped_duplicate_fingerprints: Fingerprints that already had an
+            open remediation bead (idempotent re-run of analyze).
+        errors: Per-finding failure messages (best-effort — one finding's
+            failure never blocks the others).
+    """
+
+    created_bead_ids: tuple[str, ...]
+    skipped_duplicate_fingerprints: tuple[str, ...]
+    errors: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary representation."""
+        return {
+            "created_bead_ids": list(self.created_bead_ids),
+            "skipped_duplicate_fingerprints": list(self.skipped_duplicate_fingerprints),
+            "errors": list(self.errors),
+        }

--- a/src/maverick/main.py
+++ b/src/maverick/main.py
@@ -77,6 +77,10 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
         "maverick.cli.commands.runway:runway",
         "Manage the runway knowledge store.",
     ),
+    "spec": (
+        "maverick.cli.commands.spec:spec",
+        "Run the headless Spec Kit chain from a PRD.",
+    ),
     "uninstall": (
         "maverick.cli.commands.uninstall:uninstall",
         "Remove Maverick-installed skills and optionally the config file.",

--- a/src/maverick/squadron/spec_chain.py
+++ b/src/maverick/squadron/spec_chain.py
@@ -1,0 +1,53 @@
+"""``SpecChainSquadron`` — the single agent `maverick spec` needs.
+
+Binds to the existing ``"generate"`` role (R10) — the closest semantic
+match for long-form Spec Kit document synthesis. Constructed with the
+hidden workspace as ``cwd`` so its one :class:`SpecChainAgent` operates
+inside the isolated working copy, never the user's checkout.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from maverick.agents.base import Agent
+from maverick.agents.spec_chain import SpecChainAgent
+from maverick.runtime.agent_factory import runtime_for_agent
+from maverick.squadron.base import Squadron
+
+if TYPE_CHECKING:
+    from maverick.config import MaverickConfig
+    from maverick.runtime.registry import CostSink
+
+__all__ = ["SpecChainSquadron"]
+
+
+class SpecChainSquadron(Squadron):
+    """Squadron for the ``maverick spec`` headless chain workflow."""
+
+    chain_agent: SpecChainAgent
+
+    def __init__(
+        self,
+        *,
+        cwd: Path,
+        config: MaverickConfig,
+        cost_sink: CostSink | None = None,
+    ) -> None:
+        super().__init__(cwd=cwd, config=config, cost_sink=cost_sink)
+
+    async def _build_agents(self) -> None:
+        runtime, _ = runtime_for_agent("generate", agents_config=self._config.agents)
+        self.chain_agent = SpecChainAgent(
+            runtime=runtime,
+            cwd=str(self._cwd),
+            cost_sink=self._cost_sink,
+        )
+        await self.chain_agent.open()
+
+    def _all_agents(self) -> Iterable[Agent]:
+        agent = getattr(self, "chain_agent", None)
+        if agent is not None:
+            yield agent

--- a/src/maverick/workflows/refuel_speckit/constants.py
+++ b/src/maverick/workflows/refuel_speckit/constants.py
@@ -11,6 +11,7 @@ ENRICH = "enrich"
 CREATE_BEADS = "create_beads"
 WIRE_DEPS = "wire_deps"
 CHAIN_EPIC = "chain_epic"
+ADOPT_REMEDIATION = "adopt_remediation"
 RECORD_RUN = "record_run"
 COMMIT_OUTPUT = "commit_output"
 

--- a/src/maverick/workflows/refuel_speckit/models.py
+++ b/src/maverick/workflows/refuel_speckit/models.py
@@ -24,6 +24,9 @@ class SpeckitRefuelResult:
         dry_run: Whether this run performed zero writes.
         enriched: Whether ``--enrich`` succeeded for this run.
         warnings: Non-fatal warnings collected during the run.
+        adopted_remediation_bead_ids: Standalone `spec-remediation` beads
+            (from a prior `maverick spec` run) adopted under this epic
+            (R6 post-ingest adoption step).
     """
 
     feature_name: str
@@ -36,6 +39,7 @@ class SpeckitRefuelResult:
     dry_run: bool = False
     enriched: bool = False
     warnings: tuple[str, ...] = field(default=())
+    adopted_remediation_bead_ids: tuple[str, ...] = field(default=())
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to a plain dictionary for WorkflowResult.final_output."""
@@ -50,6 +54,7 @@ class SpeckitRefuelResult:
             "dry_run": self.dry_run,
             "enriched": self.enriched,
             "warnings": list(self.warnings),
+            "adopted_remediation_bead_ids": list(self.adopted_remediation_bead_ids),
         }
 
 

--- a/src/maverick/workflows/refuel_speckit/workflow.py
+++ b/src/maverick/workflows/refuel_speckit/workflow.py
@@ -23,6 +23,7 @@ from maverick.speckit.models import SpeckitFeature
 from maverick.speckit.parser import parse_spec_md, parse_tasks_md
 from maverick.workflows.base import PythonWorkflow
 from maverick.workflows.refuel_speckit.constants import (
+    ADOPT_REMEDIATION,
     CHAIN_EPIC,
     CHECK_TEMPLATE,
     COMMIT_OUTPUT,
@@ -210,6 +211,12 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
 
         # Delta no-op: nothing new to create, but not an error.
         if not plan.new_tasks:
+            adopted_ids: tuple[str, ...] = ()
+            if not dry_run and existing_epic_id:
+                adopted_ids = await self._adopt_remediation_beads(
+                    client, feature_name=feature_name, epic_id=existing_epic_id
+                )
+
             await self.emit_step_started(RECORD_RUN, display_label="Recording run")
             if not dry_run and existing_epic_id:
                 await self._record_run(cwd, feature_name, existing_epic_id, "refueled")
@@ -226,6 +233,7 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
                 delta_run=delta_run,
                 dry_run=dry_run,
                 warnings=tuple(warnings),
+                adopted_remediation_bead_ids=adopted_ids,
             )
             return result.to_dict()
 
@@ -359,6 +367,15 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
             await self.emit_step_completed(CHAIN_EPIC, output={"blocked_by": chained_behind})
 
         # ------------------------------------------------------------
+        # Step 9b: Adopt standalone remediation beads under this epic (R6)
+        # ------------------------------------------------------------
+        main_adopted_ids: tuple[str, ...] = ()
+        if not dry_run:
+            main_adopted_ids = await self._adopt_remediation_beads(
+                client, feature_name=feature_name, epic_id=epic_id
+            )
+
+        # ------------------------------------------------------------
         # Step 10: Record run metadata (skipped on dry-run)
         # ------------------------------------------------------------
         if not dry_run:
@@ -381,6 +398,7 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
             dry_run=dry_run,
             enriched=enriched,
             warnings=tuple(warnings),
+            adopted_remediation_bead_ids=main_adopted_ids,
         )
         return result.to_dict()
 
@@ -507,6 +525,74 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
                 )
 
         return tail_epic_id
+
+    async def _adopt_remediation_beads(
+        self,
+        client: Any,
+        *,
+        feature_name: str,
+        epic_id: str,
+    ) -> tuple[str, ...]:
+        """Adopt standalone ``spec-remediation`` beads for *feature_name*
+        under *epic_id* (R6 post-ingest adoption step).
+
+        Queries open task beads, keeps only those labeled
+        ``spec-remediation`` whose ``speckit_feature`` state matches
+        *feature_name* and that aren't already adopted (unparented, no
+        ``adopted_by_epic`` stamp), and adopts each one. Best-effort per
+        bead (Principle IV) — one failure never aborts ingestion.
+        """
+        from maverick.library.actions.beads import adopt_remediation_bead
+        from maverick.workflows.spec_chain.constants import (
+            KEY_ADOPTED_BY_EPIC,
+            KEY_SPECKIT_FEATURE,
+            SPEC_REMEDIATION_LABEL,
+        )
+
+        await self.emit_step_started(ADOPT_REMEDIATION, display_label="Adopting remediation beads")
+        try:
+            candidates = await client.query("type=task AND status=open")
+        except Exception as exc:
+            logger.warning("speckit_remediation_adoption_query_failed", error=str(exc))
+            await self.emit_step_completed(ADOPT_REMEDIATION, output={"adopted": 0})
+            return ()
+
+        adopted: list[str] = []
+        for candidate in candidates:
+            try:
+                details = await client.show(candidate.id)
+            except Exception as exc:
+                logger.debug(
+                    "speckit_remediation_adoption_show_failed",
+                    bead_id=candidate.id,
+                    error=str(exc),
+                )
+                continue
+            if SPEC_REMEDIATION_LABEL not in (details.labels or []):
+                continue
+            state = details.state or {}
+            if state.get(KEY_SPECKIT_FEATURE) != feature_name:
+                continue
+            if details.parent_id or state.get(KEY_ADOPTED_BY_EPIC):
+                continue  # already adopted — idempotent skip
+
+            try:
+                await adopt_remediation_bead(client, bead_id=candidate.id, epic_id=epic_id)
+                adopted.append(candidate.id)
+            except Exception as exc:  # noqa: BLE001 — one bead's failure must not sink ingestion
+                logger.warning(
+                    "speckit_remediation_adoption_failed",
+                    bead_id=candidate.id,
+                    error=str(exc),
+                )
+
+        if adopted:
+            await self.emit_output(
+                ADOPT_REMEDIATION,
+                f"Adopted {len(adopted)} remediation bead(s) under {epic_id}",
+            )
+        await self.emit_step_completed(ADOPT_REMEDIATION, output={"adopted": len(adopted)})
+        return tuple(adopted)
 
     async def _record_run(self, cwd: Path, feature_name: str, epic_id: str, status: str) -> None:
         from maverick.runway.run_metadata import RunMetadata, write_metadata

--- a/src/maverick/workflows/spec_chain/__init__.py
+++ b/src/maverick/workflows/spec_chain/__init__.py
@@ -1,0 +1,3 @@
+"""SpecChainWorkflow package — headless Spec Kit chain (`maverick spec`)."""
+
+from __future__ import annotations

--- a/src/maverick/workflows/spec_chain/clarify.py
+++ b/src/maverick/workflows/spec_chain/clarify.py
@@ -1,0 +1,160 @@
+"""Clarify answering-path policy (R2): interception vs. non-interactive upgrade.
+
+Both paths converge on :class:`ClarifyDecision` — filed as an
+assumption-ledger entry by the *workflow* (never the agent) after the
+clarify step completes (Guardrail X.3 / Principle II). See
+specs/050-headless-spec-chain/research.md R2.
+
+**Interception path**: activates when the runtime exposes a
+question-interception hook (:func:`supports_interception`). No current
+airframe adapter (0.9.0rc1) implements one — verified alongside the R1
+cwd-binding gate — so this path is a forward-looking seam: it activates
+automatically the moment an adapter adds the capability, with no further
+workflow change needed. :func:`decisions_from_interception` adopts the
+recommended option per question, or an informed default when none is
+given, and reports ``blocked=True`` only when a question has neither a
+recommended option nor any alternative to fall back on (no defensible
+default exists — FR-009's edge case).
+
+**Non-interactive path** (the one every provider takes today): the
+clarify step prompt invokes Spec Kit's own non-interactive convention,
+which records informed defaults as ``- Q: ... → A: ...`` bullets under
+spec.md's ``## Clarifications`` section (verified against this
+repository's own Spec Kit output — the more precise source than
+research.md's original "Assumptions section" framing).
+:func:`decisions_from_spec_md` parses that section back into
+:class:`ClarifyDecision` instances.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+from maverick.assumptions.models import Severity
+from maverick.workflows.spec_chain.models import ClarifyDecision
+
+__all__ = [
+    "ESCALATION_SIGNALS",
+    "assess_severity",
+    "decisions_from_interception",
+    "decisions_from_spec_md",
+    "supports_interception",
+]
+
+#: Category -> keyword signals that escalate a clarify question's severity
+#: to at least MEDIUM (R2, FR-007a). A question whose text matches any
+#: keyword in any category escalates; unmatched questions default to LOW.
+ESCALATION_SIGNALS: dict[str, tuple[str, ...]] = {
+    "scope": ("scope", "in-scope", "out of scope", "user role", "permission", "boundary"),
+    "security_privacy": (
+        "auth",
+        "credential",
+        "password",
+        "secret",
+        "pii",
+        "privacy",
+        "data protection",
+        "retention",
+    ),
+    "compliance": ("regulat", "legal", "compliance", "gdpr", "hipaa"),
+    "data_integrity": ("irreversible", "migration", "delet", "data loss"),
+}
+
+_CLARIFICATION_BULLET_RE = re.compile(r"^-\s+Q:\s*(.+?)\s*\u2192\s*A:\s*(.+)$")
+
+
+def assess_severity(question: str) -> tuple[Severity, bool]:
+    """Assess a clarify question's severity per :data:`ESCALATION_SIGNALS`.
+
+    Returns ``(severity, defaulted)`` — ``defaulted=True`` means no
+    signal matched and LOW was the harness default (FR-007a), not an
+    assessed MEDIUM.
+    """
+    lowered = question.casefold()
+    for keywords in ESCALATION_SIGNALS.values():
+        if any(keyword in lowered for keyword in keywords):
+            return Severity.MEDIUM, False
+    return Severity.LOW, True
+
+
+def supports_interception(runtime: object) -> bool:
+    """Capability probe: does *runtime* expose a question-interception hook?"""
+    return callable(getattr(runtime, "ask_question", None))
+
+
+def decisions_from_interception(
+    questions: Sequence[tuple[str, str | None, Sequence[str]]],
+) -> tuple[list[ClarifyDecision], bool]:
+    """Interception path: adopt the recommended option per question, or an
+    informed default (the first alternative) when none is given.
+
+    Args:
+        questions: ``(question, recommended_option, alternatives)``
+            triples already collected by the runtime's question callback.
+
+    Returns:
+        ``(decisions, blocked)`` — ``blocked`` is ``True`` iff at least
+        one question arrived with neither a recommended option nor any
+        alternative (no defensible default exists — FR-009). Questions
+        that block are excluded from *decisions*, not silently guessed
+        at; the caller halts the chain when ``blocked`` is ``True``.
+    """
+    decisions: list[ClarifyDecision] = []
+    blocked = False
+    for question, recommended, raw_alternatives in questions:
+        alternatives = tuple(raw_alternatives)
+        if recommended:
+            adopted = recommended
+            remaining = tuple(a for a in alternatives if a != recommended)
+        elif alternatives:
+            adopted = alternatives[0]
+            remaining = alternatives[1:]
+        else:
+            blocked = True
+            continue
+
+        severity, defaulted = assess_severity(question)
+        decisions.append(
+            ClarifyDecision(
+                question=question,
+                adopted_answer=adopted,
+                alternatives=remaining,
+                severity=severity,
+                severity_defaulted=defaulted,
+                path="interception",
+                ledger_bead_id=None,
+            )
+        )
+    return decisions, blocked
+
+
+def decisions_from_spec_md(spec_md_content: str) -> list[ClarifyDecision]:
+    """Non-interactive path: parse the clarify step's recorded defaults out
+    of an updated spec.md's ``## Clarifications`` section (Spec Kit's own
+    ``- Q: ... \u2192 A: ...`` convention) into :class:`ClarifyDecision`
+    instances.
+
+    Every parsed bullet becomes one decision — Spec Kit's own convention
+    only records a question once it has adopted an answer for it, so
+    there is no "no adopted answer" case to handle here.
+    """
+    decisions: list[ClarifyDecision] = []
+    for line in spec_md_content.splitlines():
+        m = _CLARIFICATION_BULLET_RE.match(line.strip())
+        if not m:
+            continue
+        question, answer = m.group(1).strip(), m.group(2).strip()
+        severity, defaulted = assess_severity(question)
+        decisions.append(
+            ClarifyDecision(
+                question=question,
+                adopted_answer=answer,
+                alternatives=(),
+                severity=severity,
+                severity_defaulted=defaulted,
+                path="non_interactive",
+                ledger_bead_id=None,
+            )
+        )
+    return decisions

--- a/src/maverick/workflows/spec_chain/constants.py
+++ b/src/maverick/workflows/spec_chain/constants.py
@@ -1,0 +1,86 @@
+"""Constants for the spec-chain workflow (`maverick spec`).
+
+Step ordering, bead/ledger labels and state keys, and timeouts shared
+across the ``spec_chain`` package. See specs/050-headless-spec-chain/
+data-model.md and contracts/ledger-and-beads.md for the authoritative
+contract.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = [
+    "CHAIN_STEP_ORDER",
+    "KEY_ADOPTED_BY_EPIC",
+    "KEY_FINDING_FINGERPRINT",
+    "KEY_REMEDIATION_SOURCE",
+    "KEY_SOURCE_REF",
+    "KEY_SPECKIT_FEATURE",
+    "REMEDIATION_SOURCE_ANALYZE",
+    "SOURCE_REF_CLARIFY",
+    "SPEC_REMEDIATION_LABEL",
+    "STEP_TIMEOUT_SECONDS",
+    "WORKSPACE_OP_TIMEOUT_SECONDS",
+    "ChainStep",
+]
+
+
+class ChainStep(StrEnum):
+    """Ordered spec-chain steps.
+
+    Order is the single source of truth for FR-002/FR-008 gating — see
+    :data:`CHAIN_STEP_ORDER`.
+    """
+
+    SPECIFY = "specify"
+    CLARIFY = "clarify"
+    PLAN = "plan"
+    TASKS = "tasks"
+    ANALYZE = "analyze"
+
+
+#: Strict execution order (FR-002). ``next_step()`` in ``models.py``
+#: derives the step to run next from this tuple.
+CHAIN_STEP_ORDER: tuple[ChainStep, ...] = (
+    ChainStep.SPECIFY,
+    ChainStep.CLARIFY,
+    ChainStep.PLAN,
+    ChainStep.TASKS,
+    ChainStep.ANALYZE,
+)
+
+#: Remediation bead label (analyze findings -> standalone beads, R6).
+SPEC_REMEDIATION_LABEL = "spec-remediation"
+
+#: ``remediation_source`` state-key value stamped on remediation beads.
+REMEDIATION_SOURCE_ANALYZE = "spec-chain:analyze"
+
+#: Remediation-bead state keys (contracts/ledger-and-beads.md).
+KEY_SPECKIT_FEATURE = "speckit_feature"
+KEY_REMEDIATION_SOURCE = "remediation_source"
+KEY_FINDING_FINGERPRINT = "finding_fingerprint"
+
+#: Adoption stamp (R6 fallback — no `bd update --parent` primitive exists;
+#: see research.md R6). Set alongside the DISCOVERED_FROM dependency edge
+#: when `refuel --speckit` adopts a standalone remediation bead under its
+#: epic; also the idempotency check for "already adopted".
+KEY_ADOPTED_BY_EPIC = "adopted_by_epic"
+
+#: Standalone ledger-entry state key (R5) — replaces ``source_bead`` when
+#: the chain files a clarify decision with no owning epic yet.
+KEY_SOURCE_REF = "source_ref"
+
+#: ``source_ref`` value stamped on clarify-derived ledger entries.
+SOURCE_REF_CLARIFY = "spec-chain:clarify"
+
+# ---------------------------------------------------------------------------
+# Timeouts
+# ---------------------------------------------------------------------------
+
+#: Per-step airframe ``execute()`` timeout — chain steps synthesize or
+#: parse full markdown artifacts and can run for several minutes.
+STEP_TIMEOUT_SECONDS: float = 1200.0
+
+#: Deterministic-op timeout — workspace create/forget, artifact landing.
+WORKSPACE_OP_TIMEOUT_SECONDS: float = 60.0

--- a/src/maverick/workflows/spec_chain/landing.py
+++ b/src/maverick/workflows/spec_chain/landing.py
@@ -1,0 +1,125 @@
+"""Per-step artifact landing: workspace -> user checkout, atomically.
+
+Only completed-step artifacts ever land (FR-016/FR-020). Landing is an
+atomic staged copy — write the full current feature-dir tree to a temp
+sibling, then rename it into place — so a crash mid-sync never leaves a
+half-written file in the user's ``specs/`` tree.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from maverick.logging import get_logger
+from maverick.workflows.spec_chain.constants import ChainStep
+
+__all__ = ["land_step_artifacts", "resolve_feature_dir", "verify_step_artifacts"]
+
+logger = get_logger(__name__)
+
+#: Artifact(s) each step is responsible for, verified to exist in the
+#: workspace's feature dir before the step counts as succeeded. Analyze is
+#: read-only (FR-011) — it produces no new required artifact.
+_STEP_ARTIFACTS: dict[ChainStep, tuple[str, ...]] = {
+    ChainStep.SPECIFY: ("spec.md",),
+    ChainStep.CLARIFY: ("spec.md",),
+    ChainStep.PLAN: ("plan.md",),
+    ChainStep.TASKS: ("tasks.md",),
+    ChainStep.ANALYZE: (),
+}
+
+
+def resolve_feature_dir(*, workspace: Path, checkout_specs_before: set[str]) -> str | None:
+    """Resolve the ``specs/NNN-<feature>`` directory the specify step
+    allocated (R8).
+
+    Diffs the workspace's ``specs/`` listing against the checkout's
+    pre-specify listing; cross-checks ``.specify/feature.json`` when the
+    diff is ambiguous (more than one new directory).
+
+    Args:
+        workspace: The hidden workspace, after the specify step ran.
+        checkout_specs_before: Directory names under the checkout's
+            ``specs/`` before the specify step started.
+
+    Returns:
+        The new feature directory's name (not a full path), or ``None``
+        when nothing new was found.
+    """
+    specs_dir = workspace / "specs"
+    if not specs_dir.is_dir():
+        return None
+    after = {p.name for p in specs_dir.iterdir() if p.is_dir()}
+    new_dirs = after - checkout_specs_before
+
+    if len(new_dirs) == 1:
+        return next(iter(new_dirs))
+
+    feature_json = workspace / ".specify" / "feature.json"
+    if feature_json.is_file():
+        try:
+            data = json.loads(feature_json.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            data = {}
+        feature_dir = data.get("feature_directory", "")
+        if feature_dir:
+            name = Path(feature_dir).name
+            if name in after:
+                return name
+
+    if len(new_dirs) > 1:
+        logger.warning("spec_chain_ambiguous_feature_dir", candidates=sorted(new_dirs))
+    return None
+
+
+def verify_step_artifacts(*, workspace: Path, feature_dir: str, step: ChainStep) -> list[str]:
+    """Return this step's feature-dir-relative artifact paths, verified to
+    exist on disk in the workspace.
+
+    The filesystem is ground truth (R9) — a well-formed agent report with
+    missing artifacts is still a step failure. An empty list for a
+    non-analyze step means the step failed to produce what it must.
+    """
+    feature_path = workspace / "specs" / feature_dir
+    return [name for name in _STEP_ARTIFACTS[step] if (feature_path / name).is_file()]
+
+
+def land_step_artifacts(*, workspace: Path, checkout: Path, feature_dir: str) -> None:
+    """Atomically sync ``specs/<feature_dir>/**`` from the workspace to the
+    user's checkout, and nothing else.
+
+    Always syncs the full current feature-dir tree (not just the latest
+    step's new file) so steps that touch earlier artifacts (e.g. clarify
+    rewriting ``spec.md``) land correctly too. Uses a staged
+    copy-then-rename so a crash mid-sync never leaves a half-written
+    directory in the checkout.
+
+    Raises:
+        OSError: The workspace feature dir is missing or the filesystem
+            operation fails.
+    """
+    src_dir = workspace / "specs" / feature_dir
+    if not src_dir.is_dir():
+        raise FileNotFoundError(f"workspace feature dir missing: {src_dir}")
+
+    dest_dir = checkout / "specs" / feature_dir
+    dest_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    staged = dest_dir.with_name(f"{dest_dir.name}.landing-tmp")
+    if staged.exists():
+        shutil.rmtree(staged)
+    shutil.copytree(src_dir, staged)
+
+    if dest_dir.exists():
+        backup = dest_dir.with_name(f"{dest_dir.name}.landing-prev")
+        if backup.exists():
+            shutil.rmtree(backup)
+        dest_dir.rename(backup)
+        staged.rename(dest_dir)
+        shutil.rmtree(backup)
+    else:
+        staged.rename(dest_dir)
+
+    logger.info("spec_chain_artifacts_landed", feature_dir=feature_dir, dest=str(dest_dir))

--- a/src/maverick/workflows/spec_chain/models.py
+++ b/src/maverick/workflows/spec_chain/models.py
@@ -35,6 +35,7 @@ __all__ = [
     "StepRecord",
     "StepReport",
     "StepStatus",
+    "is_valid_feature_slug",
     "next_step",
 ]
 
@@ -43,6 +44,19 @@ __all__ = [
 #: feature name can never traverse outside `specs/` or the hidden
 #: workspace root.
 _FEATURE_SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+
+
+def is_valid_feature_slug(feature: str) -> bool:
+    """Whether *feature* is a non-empty, filesystem-safe slug.
+
+    Rejects empty strings, path separators, and leading dots — the same
+    rule :class:`ChainState` enforces. Callers must apply this *before*
+    any path is built from ``feature`` (e.g. the hidden workspace dir),
+    since the model-level validator only fires once ``ChainState`` is
+    constructed, which is too late to stop a traversal.
+    """
+    return bool(feature) and _FEATURE_SLUG_RE.match(feature) is not None
+
 
 StepStatus = Literal["pending", "in_progress", "succeeded", "failed", "skipped"]
 ChainStatus = Literal["running", "halted", "completed", "failed"]

--- a/src/maverick/workflows/spec_chain/models.py
+++ b/src/maverick/workflows/spec_chain/models.py
@@ -1,0 +1,230 @@
+"""Typed models for the spec-chain workflow (`maverick spec`).
+
+Persisted state (``ChainState``, nested ``StepRecord``), the clarify
+answering-path convergence type (``ClarifyDecision``), the agent
+structured-output schema (``StepReport`` + ``ReportedQuestion`` /
+``ReportedFinding``), the analyze-finding-to-remediation-bead type
+(``AnalyzeFinding``), and the CLI-facing summary (``SpecChainReport``).
+
+See specs/050-headless-spec-chain/data-model.md for the authoritative
+contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from maverick.assumptions.models import Severity
+from maverick.workflows.spec_chain.constants import CHAIN_STEP_ORDER, ChainStep
+
+__all__ = [
+    "AnalyzeFinding",
+    "ChainState",
+    "ChainStatus",
+    "ClarifyDecision",
+    "ReportedFinding",
+    "ReportedQuestion",
+    "SpecChainReport",
+    "StepRecord",
+    "StepReport",
+    "StepStatus",
+    "next_step",
+]
+
+#: Feature name: non-empty, filesystem-safe slug (data-model.md
+#: "Validation rules"). Rejects path separators and leading dots so a
+#: feature name can never traverse outside `specs/` or the hidden
+#: workspace root.
+_FEATURE_SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+
+StepStatus = Literal["pending", "in_progress", "succeeded", "failed", "skipped"]
+ChainStatus = Literal["running", "halted", "completed", "failed"]
+
+
+class StepRecord(BaseModel):
+    """Outcome of one attempted chain step, nested in :class:`ChainState`."""
+
+    model_config = ConfigDict(frozen=True)
+
+    step: ChainStep = Field(description="Which chain step this record tracks")
+    status: StepStatus = Field(description="Current status of this step")
+    attempts: int = Field(default=0, description="Tenacity-visible attempt count")
+    artifacts: list[str] = Field(
+        default_factory=list,
+        description="Feature-dir-relative paths landed by this step",
+    )
+    landed: bool = Field(
+        default=False,
+        description="Whether artifacts were synced to the user checkout",
+    )
+    error: str | None = Field(default=None, description="Classified failure summary")
+    started_at: datetime | None = Field(default=None)
+    finished_at: datetime | None = Field(default=None)
+
+
+@dataclass(frozen=True, slots=True)
+class ClarifyDecision:
+    """One clarify question plus the answer adopted on the user's behalf.
+
+    The convergence type for both answering paths (R2): interception and
+    non-interactive-upgrade decisions both produce this shape before being
+    filed via ``record_standalone_assumption``.
+    """
+
+    question: str
+    adopted_answer: str
+    alternatives: tuple[str, ...]
+    severity: Severity
+    severity_defaulted: bool
+    path: Literal["interception", "non_interactive"]
+    ledger_bead_id: str | None = None
+
+
+class ChainState(BaseModel):
+    """Persisted spec-chain run state.
+
+    Written atomically to ``.maverick/runs/<run-id>/spec-chain.json`` after
+    every step transition (see contracts/chain-state.md).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    schema_version: int = Field(default=1, description="Guards future migrations")
+    run_id: str = Field(description="Matches the .maverick/runs/ directory name")
+    feature: str = Field(description="User-supplied feature name (resume key)")
+    feature_dir: str | None = Field(
+        default=None,
+        description="specs/NNN-<feature> allocated by specify; None until specify lands",
+    )
+    prd_path: str = Field(description="User-supplied PRD path (checkout-relative)")
+    prd_digest: str = Field(description="sha256 of PRD content at chain start")
+    workspace_path: str = Field(description="Hidden workspace root for this run")
+    status: ChainStatus = Field(description="Overall chain status")
+    steps: dict[ChainStep, StepRecord] = Field(
+        default_factory=dict, description="One record per attempted step"
+    )
+    clarify_decisions: list[ClarifyDecision] = Field(
+        default_factory=list, description="Filed clarify decisions (audit copy)"
+    )
+    remediation_bead_ids: list[str] = Field(
+        default_factory=list, description="Created remediation-finding bead ids"
+    )
+    started_at: datetime
+    updated_at: datetime
+
+    @model_validator(mode="after")
+    def _check_step_progression_invariant(self) -> ChainState:
+        """A step may be ``in_progress`` only if all prior steps succeeded."""
+        for step, record in self.steps.items():
+            if record.status != "in_progress":
+                continue
+            idx = CHAIN_STEP_ORDER.index(step)
+            for prior in CHAIN_STEP_ORDER[:idx]:
+                prior_record = self.steps.get(prior)
+                if prior_record is None or prior_record.status != "succeeded":
+                    raise ValueError(
+                        f"step {step!r} is in_progress but prior step {prior!r} has not succeeded"
+                    )
+        return self
+
+    @model_validator(mode="after")
+    def _check_feature_is_filesystem_safe_slug(self) -> ChainState:
+        if not self.feature or not _FEATURE_SLUG_RE.match(self.feature):
+            raise ValueError(
+                f"feature must be a non-empty, filesystem-safe slug: {self.feature!r}"
+            )
+        return self
+
+
+def next_step(steps: Mapping[ChainStep, StepRecord]) -> ChainStep | None:
+    """Derive the next step to run from :data:`CHAIN_STEP_ORDER`.
+
+    Returns the first step that is missing or not ``succeeded`` (a failed
+    step is retried, not skipped over). ``None`` when every step has
+    succeeded.
+    """
+    for step in CHAIN_STEP_ORDER:
+        record = steps.get(step)
+        if record is None or record.status != "succeeded":
+            return step
+    return None
+
+
+class ReportedQuestion(BaseModel):
+    """A clarify question and adopted answer as reported by the agent."""
+
+    question: str
+    adopted_answer: str
+    alternatives: list[str] = Field(default_factory=list)
+
+
+class ReportedFinding(BaseModel):
+    """An analyze finding as reported by the agent."""
+
+    title: str
+    category: str
+    severity_hint: str
+    location: str
+    summary: str
+
+
+class StepReport(BaseModel):
+    """Structured-output schema for :class:`SpecChainAgent` step reports.
+
+    The workflow treats the filesystem as ground truth for step success
+    (R9); this report is telemetry and a parse accelerator, not the
+    source of truth.
+    """
+
+    status: Literal["completed", "blocked", "failed"]
+    artifacts: list[str] = Field(default_factory=list)
+    questions: list[ReportedQuestion] = Field(default_factory=list)
+    findings: list[ReportedFinding] = Field(default_factory=list)
+    detail: str = Field(description="Free-text summary or failure reason")
+
+
+@dataclass(frozen=True, slots=True)
+class AnalyzeFinding:
+    """One analyze finding, ready to become a standalone remediation bead."""
+
+    title: str
+    category: str
+    severity_hint: str
+    location: str
+    summary: str
+    feature_dir: str
+
+    @property
+    def fingerprint(self) -> str:
+        """sha256 hex digest of normalized ``title + location`` (R6 idempotency)."""
+        normalized = f"{self.title.strip().casefold()}|{self.location.strip().casefold()}"
+        return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class SpecChainReport:
+    """Final chain-run summary returned to the CLI (FR-019)."""
+
+    feature_dir: str | None
+    status: ChainStatus
+    steps: tuple[StepRecord, ...] = field(default_factory=tuple)
+    ledger_entry_count: int = 0
+    remediation_bead_count: int = 0
+    resume_hint: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "feature_dir": self.feature_dir,
+            "status": self.status,
+            "steps": [step.model_dump(mode="json") for step in self.steps],
+            "ledger_entry_count": self.ledger_entry_count,
+            "remediation_bead_count": self.remediation_bead_count,
+            "resume_hint": self.resume_hint,
+        }

--- a/src/maverick/workflows/spec_chain/state.py
+++ b/src/maverick/workflows/spec_chain/state.py
@@ -1,0 +1,79 @@
+"""Chain-state persistence and resume discovery for the spec-chain workflow.
+
+Chain state is persisted to ``.maverick/runs/<run-id>/spec-chain.json``
+(schema_version 1) via atomic temp-file+rename writes after every step
+transition. See specs/050-headless-spec-chain/contracts/chain-state.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from maverick.logging import get_logger
+from maverick.utils.atomic import atomic_write_text
+from maverick.workflows.spec_chain.models import ChainState
+
+__all__ = ["discover_resumable", "load_chain_state", "save_chain_state"]
+
+logger = get_logger(__name__)
+
+_RUNS_SUBDIR = Path(".maverick") / "runs"
+_STATE_FILENAME = "spec-chain.json"
+
+#: Chain statuses discover_resumable treats as resumable. "running" covers
+#: crash/kill — staleness is assumed, not probed (single-user CLI).
+_RESUMABLE_STATUSES = frozenset({"halted", "running"})
+
+
+def _state_path(base: Path, run_id: str) -> Path:
+    return base / _RUNS_SUBDIR / run_id / _STATE_FILENAME
+
+
+async def save_chain_state(state: ChainState, base: Path) -> None:
+    """Atomically persist *state* to ``.maverick/runs/<run_id>/spec-chain.json``."""
+    path = _state_path(base, state.run_id)
+    content = json.dumps(state.model_dump(mode="json"), indent=2)
+    await asyncio.to_thread(atomic_write_text, path, content, mkdir=True)
+
+
+async def load_chain_state(run_id: str, base: Path) -> ChainState | None:
+    """Load a persisted chain state by run id. ``None`` if not found."""
+    path = _state_path(base, run_id)
+    if not await asyncio.to_thread(path.is_file):
+        return None
+    text = await asyncio.to_thread(path.read_text, encoding="utf-8")
+    return ChainState.model_validate(json.loads(text))
+
+
+async def discover_resumable(feature: str, base: Path) -> ChainState | None:
+    """Scan ``.maverick/runs/*/spec-chain.json`` for the newest resumable
+    state matching *feature* (contracts/chain-state.md "Resume resolution").
+
+    Returns the state with the newest ``updated_at`` among those with
+    ``feature == feature`` and ``status in {"halted", "running"}``.
+    Corrupt or unparseable sibling state files are skipped, not fatal.
+    """
+    runs_dir = base / _RUNS_SUBDIR
+    if not await asyncio.to_thread(runs_dir.is_dir):
+        return None
+
+    run_dirs = await asyncio.to_thread(lambda: list(runs_dir.iterdir()))
+    candidates: list[ChainState] = []
+    for run_dir in run_dirs:
+        state_path = run_dir / _STATE_FILENAME
+        if not await asyncio.to_thread(state_path.is_file):
+            continue
+        try:
+            text = await asyncio.to_thread(state_path.read_text, encoding="utf-8")
+            state = ChainState.model_validate(json.loads(text))
+        except Exception as exc:
+            logger.debug("spec_chain_state_unreadable", path=str(state_path), error=str(exc))
+            continue
+        if state.feature == feature and state.status in _RESUMABLE_STATUSES:
+            candidates.append(state)
+
+    if not candidates:
+        return None
+    return max(candidates, key=lambda s: s.updated_at)

--- a/src/maverick/workflows/spec_chain/steps.py
+++ b/src/maverick/workflows/spec_chain/steps.py
@@ -1,0 +1,99 @@
+"""Per-step prompt builders for the spec-chain workflow.
+
+Each chain step's prompt instructs the agent to run the target
+repository's own ``/speckit.*`` slash command (R1/FR-003). When the
+command's definition file is present in the workspace, its body is
+inlined too — a fallback for providers whose agent surface can't invoke
+slash commands natively, and a belt-and-suspenders reinforcement for
+providers that can. Either way the instructions still come from the
+target repository's own files, not from Maverick.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from maverick.workflows.spec_chain.constants import ChainStep
+
+__all__ = ["SLASH_COMMANDS", "build_step_prompt", "read_command_body"]
+
+#: Slash command name per chain step — the target repo's own `/speckit.*`
+#: surface.
+SLASH_COMMANDS: dict[ChainStep, str] = {
+    ChainStep.SPECIFY: "/speckit.specify",
+    ChainStep.CLARIFY: "/speckit.clarify",
+    ChainStep.PLAN: "/speckit.plan",
+    ChainStep.TASKS: "/speckit.tasks",
+    ChainStep.ANALYZE: "/speckit.analyze",
+}
+
+#: Command-definition file, relative to the workspace root, per step.
+_COMMAND_FILE: dict[ChainStep, str] = {
+    step: f".claude/commands/speckit.{step.value}.md" for step in ChainStep
+}
+
+_STRUCTURED_REPORT_INSTRUCTION = (
+    "When finished, report your outcome via the StructuredOutput tool per "
+    "the schema provided — status, artifact paths you wrote or updated, "
+    "any clarify questions and the answers you adopted, any analyze "
+    "findings, and a short detail summary."
+)
+
+
+def read_command_body(workspace: Path, step: ChainStep) -> str | None:
+    """Read *step*'s command-definition markdown from the workspace.
+
+    Returns ``None`` when no known command file exists there (the inline
+    fallback is simply omitted from the prompt in that case).
+    """
+    candidate = workspace / _COMMAND_FILE[step]
+    if not candidate.is_file():
+        return None
+    return candidate.read_text(encoding="utf-8")
+
+
+def build_step_prompt(
+    step: ChainStep,
+    *,
+    workspace: Path,
+    feature: str,
+    prd_content: str | None = None,
+) -> str:
+    """Build the prompt for one chain step.
+
+    Args:
+        step: The chain step to run.
+        workspace: The hidden workspace (cwd the agent operates in) — used
+            to look up the step's command-definition file for the inline
+            fallback.
+        feature: The feature name/slug this run is producing.
+        prd_content: The PRD body. Only consumed by the specify step
+            (R1) — ignored for every other step.
+
+    Returns:
+        The full prompt text for this step.
+    """
+    command = SLASH_COMMANDS[step]
+    parts: list[str] = []
+
+    if step is ChainStep.SPECIFY:
+        parts.append(
+            f'Run `{command}` for the feature "{feature}" using the '
+            "following product requirements document as input:\n\n"
+            f"---\n{prd_content or ''}\n---"
+        )
+    else:
+        parts.append(f'Run `{command}` for the current feature ("{feature}").')
+
+    body = read_command_body(workspace, step)
+    if body:
+        parts.append(
+            f"If your environment cannot invoke `{command}` as a slash "
+            "command directly, follow these instructions instead — they "
+            f"are `{command}`'s own definition from this repository:\n\n"
+            f"{body}"
+        )
+
+    parts.append(_STRUCTURED_REPORT_INSTRUCTION)
+
+    return "\n\n".join(parts)

--- a/src/maverick/workflows/spec_chain/workflow.py
+++ b/src/maverick/workflows/spec_chain/workflow.py
@@ -13,13 +13,20 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import shutil
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential
+from airframe.errors import RuntimeTransientError
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from maverick.assumptions.ledger import record_standalone_assumption
 from maverick.beads.client import BeadClient
@@ -49,6 +56,7 @@ from maverick.workflows.spec_chain.models import (
     StepRecord,
     StepReport,
     StepStatus,
+    is_valid_feature_slug,
 )
 from maverick.workflows.spec_chain.state import load_chain_state, save_chain_state
 from maverick.workflows.spec_chain.steps import build_step_prompt
@@ -64,6 +72,16 @@ WORKFLOW_NAME = "spec-chain"
 #: Step-run retry policy for transient runtime errors (constitution
 #: Principle IV: default 3 attempts, exponential backoff).
 _STEP_RETRY_ATTEMPTS = 3
+
+
+def _normalize_question(question: str) -> str:
+    """Casefold + collapse-whitespace normalization for dedup matching.
+
+    Mirrors ``maverick.assumptions.ledger._normalize_question`` so the
+    in-state clarify-decision dedup key aligns with the ledger's own
+    bead-dedup key — kept local to avoid importing a private helper.
+    """
+    return " ".join(question.split()).casefold()
 
 
 def _utcnow() -> datetime:
@@ -181,6 +199,17 @@ class SpecChainWorkflow(PythonWorkflow):
             :meth:`SpecChainReport.to_dict`.
         """
         feature: str = inputs["feature"]
+        # Validate the slug BEFORE any path is built from it: the hidden
+        # workspace dir is derived from `feature` (prepare_workspace) well
+        # before ChainState's model-level validator runs, so a value like
+        # "../../x" would otherwise traverse outside the workspace root and
+        # create a stray jj workspace before validation ever fires.
+        if not is_valid_feature_slug(feature):
+            raise WorkflowError(
+                f"invalid feature name {feature!r}: must be a non-empty, "
+                "filesystem-safe slug (letters, digits, hyphen, underscore; "
+                "no path separators or leading dots)"
+            )
         cwd = Path(inputs["cwd"])
         run_id_input: str | None = inputs.get("run_id") or None
         prd_path_str: str = inputs.get("prd_path", "")
@@ -350,6 +379,7 @@ class SpecChainWorkflow(PythonWorkflow):
             }
         )
         state = await self._verify_landed_or_reset(state, checkout=cwd)
+        self._reseed_workspace_from_checkout(state, workspace=workspace_path, checkout=cwd)
         await save_chain_state(state, cwd)
         return state, run_id, prd_content, workspace_path
 
@@ -384,6 +414,49 @@ class SpecChainWorkflow(PythonWorkflow):
             return state
         return state.model_copy(update={"steps": new_steps, "updated_at": _utcnow()})
 
+    def _reseed_workspace_from_checkout(
+        self, state: ChainState, *, workspace: Path, checkout: Path
+    ) -> None:
+        """Restore landed upstream artifacts into a freshly-recreated
+        workspace on resume.
+
+        Landed artifacts live only in the checkout's working copy (landing
+        copies workspace -> checkout after each step; nothing is committed
+        into the workspace). If the on-disk hidden workspace vanished
+        between runs (e.g. the user cleared ``~/.maverick/workspaces``),
+        ``prepare_workspace(reuse=True)`` rebuilds it from the *committed*
+        tree — which lacks those un-committed spec files — so the next step
+        would run against a workspace missing everything upstream. Copy the
+        checkout's landed feature dir back in to close that gap. Idempotent:
+        a no-op when the workspace already has all landed artifacts (the
+        normal reuse case).
+        """
+        if state.feature_dir is None:
+            return
+        feature_dir_name = Path(state.feature_dir).name
+        checkout_feature = checkout / "specs" / feature_dir_name
+        workspace_feature = workspace / "specs" / feature_dir_name
+        if not checkout_feature.is_dir():
+            return
+
+        landed_artifacts = {
+            artifact
+            for record in state.steps.values()
+            if record.status == "succeeded" and record.landed
+            for artifact in record.artifacts
+        }
+        if landed_artifacts and all(
+            (workspace_feature / artifact).is_file() for artifact in landed_artifacts
+        ):
+            return  # workspace already holds every landed artifact — reuse path.
+
+        shutil.copytree(checkout_feature, workspace_feature, dirs_exist_ok=True)
+        logger.info(
+            "spec_chain_workspace_reseeded_from_checkout",
+            feature_dir=feature_dir_name,
+            artifacts=sorted(landed_artifacts),
+        )
+
     async def _run_one_step(
         self,
         step: ChainStep,
@@ -413,6 +486,15 @@ class SpecChainWorkflow(PythonWorkflow):
             async for attempt in AsyncRetrying(
                 stop=stop_after_attempt(_STEP_RETRY_ATTEMPTS),
                 wait=wait_exponential(multiplier=1, min=2, max=20),
+                # Only transient runtime errors are worth retrying. Auth,
+                # model-not-found, context-overflow, budget-exceeded, etc.
+                # are deterministic — retrying just burns model calls and
+                # backoff before the same failure. Matches how the fly /
+                # refuel actions treat airframe errors (only
+                # RuntimeTransientError bumps a tier); everything else
+                # falls straight through to `_fail_step` below. CLAUDE.md:
+                # context-overflow is intentionally never retried.
+                retry=retry_if_exception_type(RuntimeTransientError),
                 reraise=True,
             ):
                 with attempt:
@@ -579,7 +661,19 @@ class SpecChainWorkflow(PythonWorkflow):
             count=len(filed),
             ledger_entries=sum(1 for d in filed if d.ledger_bead_id),
         )
-        return state.model_copy(update={"clarify_decisions": [*state.clarify_decisions, *filed]})
+        # Merge by normalized question rather than blindly appending: on a
+        # resume that re-runs clarify (e.g. it halted after filing but
+        # before the next step landed), `state.clarify_decisions` already
+        # holds the prior run's decisions and re-parsing spec.md yields the
+        # same questions. Blind append would double the list and inflate
+        # `ledger_entry_count` / the CLI's "Clarify questions answered"
+        # count, even though ledger dedup already prevented duplicate beads.
+        merged: dict[str, ClarifyDecision] = {
+            _normalize_question(d.question): d for d in state.clarify_decisions
+        }
+        for decision in filed:
+            merged[_normalize_question(decision.question)] = decision
+        return state.model_copy(update={"clarify_decisions": list(merged.values())})
 
     async def _create_remediation_beads(
         self,

--- a/src/maverick/workflows/spec_chain/workflow.py
+++ b/src/maverick/workflows/spec_chain/workflow.py
@@ -1,0 +1,664 @@
+"""``SpecChainWorkflow`` — headless Spec Kit chain orchestration (`maverick spec`).
+
+Async orchestration: hidden workspace -> sequential steps (specify ->
+clarify -> plan -> tasks -> analyze) with tenacity retries and explicit
+timeouts -> per-step landing -> checkpoint after every transition ->
+``SpecChainReport``. Step success is gated on verified filesystem
+artifacts, not agent claims (R9) — this workflow owns every deterministic
+effect (workspace lifecycle, ordering, checkpointing, landing);
+``SpecChainAgent`` provides judgment only (Guardrail X.3 / Principle II).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential
+
+from maverick.assumptions.ledger import record_standalone_assumption
+from maverick.beads.client import BeadClient
+from maverick.exceptions import WorkflowError
+from maverick.jj.client import JjClient
+from maverick.library.actions.beads import create_remediation_beads
+from maverick.logging import get_logger
+from maverick.payloads import AssumptionPayload
+from maverick.squadron.spec_chain import SpecChainSquadron
+from maverick.workflows.base import PythonWorkflow
+from maverick.workflows.spec_chain.clarify import decisions_from_spec_md
+from maverick.workflows.spec_chain.constants import (
+    CHAIN_STEP_ORDER,
+    SOURCE_REF_CLARIFY,
+    ChainStep,
+)
+from maverick.workflows.spec_chain.landing import (
+    land_step_artifacts,
+    resolve_feature_dir,
+    verify_step_artifacts,
+)
+from maverick.workflows.spec_chain.models import (
+    AnalyzeFinding,
+    ChainState,
+    ClarifyDecision,
+    SpecChainReport,
+    StepRecord,
+    StepReport,
+    StepStatus,
+)
+from maverick.workflows.spec_chain.state import load_chain_state, save_chain_state
+from maverick.workflows.spec_chain.steps import build_step_prompt
+from maverick.workspace.spec_chain import prepare_workspace
+
+__all__ = ["WORKFLOW_NAME", "SpecChainWorkflow"]
+
+logger = get_logger(__name__)
+
+#: Read by `execute_python_workflow` from this module's namespace.
+WORKFLOW_NAME = "spec-chain"
+
+#: Step-run retry policy for transient runtime errors (constitution
+#: Principle IV: default 3 attempts, exponential backoff).
+_STEP_RETRY_ATTEMPTS = 3
+
+
+def _utcnow() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+async def _read_text(path: Path) -> str:
+    return await asyncio.to_thread(path.read_text, encoding="utf-8")
+
+
+async def _list_dir_names(path: Path) -> set[str]:
+    def _list() -> set[str]:
+        if not path.is_dir():
+            return set()
+        return {p.name for p in path.iterdir() if p.is_dir()}
+
+    return await asyncio.to_thread(_list)
+
+
+def _set_step(
+    state: ChainState,
+    step: ChainStep,
+    *,
+    status: StepStatus,
+    artifacts: list[str] | None = None,
+    landed: bool | None = None,
+    error: str | None = None,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
+) -> ChainState:
+    """Return *state* with *step*'s record updated (functional — ``steps``
+    values are frozen models, so every transition builds a fresh record)."""
+    existing = state.steps.get(step)
+    attempts = existing.attempts if existing else 0
+    if status == "in_progress":
+        attempts += 1
+    record = StepRecord(
+        step=step,
+        status=status,
+        attempts=attempts,
+        artifacts=artifacts if artifacts is not None else (existing.artifacts if existing else []),
+        landed=landed if landed is not None else (existing.landed if existing else False),
+        error=error,
+        started_at=started_at
+        if started_at is not None
+        else (existing.started_at if existing else None),
+        finished_at=finished_at,
+    )
+    new_steps = dict(state.steps)
+    new_steps[step] = record
+    return state.model_copy(update={"steps": new_steps, "updated_at": _utcnow()})
+
+
+def _mark_downstream_skipped(state: ChainState, failed_step: ChainStep) -> ChainState:
+    """FR-010: every step after *failed_step* that never got a record is
+    marked ``skipped`` — so a halted chain's report names not just what
+    failed, but everything that consequently never ran.
+    """
+    idx = CHAIN_STEP_ORDER.index(failed_step)
+    new_steps = dict(state.steps)
+    for later in CHAIN_STEP_ORDER[idx + 1 :]:
+        if later not in new_steps:
+            new_steps[later] = StepRecord(
+                step=later,
+                status="skipped",
+                attempts=0,
+                artifacts=[],
+                landed=False,
+                error=None,
+                started_at=None,
+                finished_at=None,
+            )
+    return state.model_copy(update={"steps": new_steps})
+
+
+def _build_report(state: ChainState) -> SpecChainReport:
+    resume_hint = f"maverick spec {state.feature}" if state.status == "halted" else None
+    return SpecChainReport(
+        feature_dir=state.feature_dir,
+        status=state.status,
+        steps=tuple(state.steps[s] for s in CHAIN_STEP_ORDER if s in state.steps),
+        ledger_entry_count=len(state.clarify_decisions),
+        remediation_bead_count=len(state.remediation_bead_ids),
+        resume_hint=resume_hint,
+    )
+
+
+class SpecChainWorkflow(PythonWorkflow):
+    """Runs the headless Spec Kit chain for one feature."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        if "workflow_name" not in kwargs:
+            kwargs["workflow_name"] = WORKFLOW_NAME
+        super().__init__(**kwargs)
+
+    async def _run(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Execute the spec chain — fresh, or resumed from a halted/running
+        checkpoint (contracts/chain-state.md "Resume resolution").
+
+        Args:
+            inputs: Required: ``run_id`` (str — the CLI resolves this
+                *before* calling the workflow: either the run id of a
+                resumable chain discovered via
+                :func:`~maverick.workflows.spec_chain.state.discover_resumable`,
+                or a freshly generated one, so it can read the final
+                persisted state back afterward), ``feature`` (str), ``cwd``
+                (str, user checkout). ``prd_path`` (str) is required for a
+                fresh run, optional when resuming (the persisted state
+                already has the original PRD path/digest). Optional:
+                ``home`` (str) — override for ``~`` (tests only;
+                production never sets this, so ``prepare_workspace`` uses
+                the real home directory).
+
+        Returns:
+            :meth:`SpecChainReport.to_dict`.
+        """
+        feature: str = inputs["feature"]
+        cwd = Path(inputs["cwd"])
+        run_id_input: str | None = inputs.get("run_id") or None
+        prd_path_str: str = inputs.get("prd_path", "")
+        home_str: str | None = inputs.get("home")
+        home = Path(home_str) if home_str else None
+
+        await self.emit_step_started("prepare", display_label="Preparing")
+
+        existing_state = await load_chain_state(run_id_input, cwd) if run_id_input else None
+        resuming = existing_state is not None and existing_state.status in (
+            "running",
+            "halted",
+        )
+
+        if resuming:
+            assert existing_state is not None  # narrows for type checkers
+            state, run_id, prd_content, workspace_path = await self._resume(
+                existing_state, feature=feature, cwd=cwd, prd_path_str=prd_path_str, home=home
+            )
+        else:
+            if not prd_path_str:
+                raise WorkflowError("'prd_path' input is required for a fresh spec-chain run")
+            state, run_id, prd_content, workspace_path = await self._start_fresh(
+                run_id_input, feature=feature, cwd=cwd, prd_path_str=prd_path_str, home=home
+            )
+
+        async def _checkpoint_halted_on_cancel() -> None:
+            """Graceful-interrupt rollback (T032): flip status to `halted`
+            on the freshest on-disk checkpoint. Re-loads from disk rather
+            than an in-memory snapshot since `_run_one_step` checkpoints
+            *before* every cancellable await — the on-disk state is
+            always current up to the last safe boundary. A hard crash
+            (kill -9) never runs this and leaves `status="running"`,
+            which resume treats as stale-resumable (contracts/chain-state.md).
+            """
+            current = await load_chain_state(run_id, cwd)
+            if current is not None and current.status == "running":
+                halted = current.model_copy(update={"status": "halted", "updated_at": _utcnow()})
+                await save_chain_state(halted, cwd)
+                logger.info("spec_chain_checkpointed_halted_on_interrupt", run_id=run_id)
+
+        self.register_rollback("spec_chain_checkpoint_on_interrupt", _checkpoint_halted_on_cancel)
+
+        checkout_specs_before = await _list_dir_names(cwd / "specs")
+        await self.emit_step_completed("prepare", output={"workspace_path": str(workspace_path)})
+        logger.info(
+            "spec_chain_workspace_prepared",
+            run_id=run_id,
+            feature=feature,
+            workspace_path=str(workspace_path),
+            resumed=resuming,
+        )
+
+        async with SpecChainSquadron(cwd=workspace_path, config=self._config) as squadron:
+            for step in CHAIN_STEP_ORDER:
+                existing_record = state.steps.get(step)
+                if existing_record is not None and existing_record.status == "succeeded":
+                    continue  # resume: never regenerate a landed step (FR-020)
+                state = await self._run_one_step(
+                    step,
+                    state=state,
+                    squadron=squadron,
+                    workspace=workspace_path,
+                    checkout=cwd,
+                    checkout_specs_before=checkout_specs_before,
+                    prd_content=prd_content,
+                )
+                if state.status != "running":
+                    break
+
+        if state.status == "running":
+            state = state.model_copy(update={"status": "completed", "updated_at": _utcnow()})
+            await save_chain_state(state, cwd)
+
+        logger.info("spec_chain_finished", run_id=run_id, feature=feature, status=state.status)
+        return _build_report(state).to_dict()
+
+    async def _start_fresh(
+        self,
+        run_id_input: str | None,
+        *,
+        feature: str,
+        cwd: Path,
+        prd_path_str: str,
+        home: Path | None,
+    ) -> tuple[ChainState, str, str, Path]:
+        run_id = run_id_input or uuid4().hex[:8]
+        prd_path = Path(prd_path_str)
+        prd_content = await _read_text(prd_path)
+        prd_digest = hashlib.sha256(prd_content.encode("utf-8")).hexdigest()
+
+        jj_client = JjClient(cwd=cwd)
+        workspace_path = await prepare_workspace(
+            cwd=cwd,
+            feature=feature,
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=jj_client,
+            home=home,
+        )
+
+        now = _utcnow()
+        state = ChainState(
+            run_id=run_id,
+            feature=feature,
+            feature_dir=None,
+            prd_path=str(prd_path),
+            prd_digest=prd_digest,
+            workspace_path=str(workspace_path),
+            status="running",
+            steps={},
+            clarify_decisions=[],
+            remediation_bead_ids=[],
+            started_at=now,
+            updated_at=now,
+        )
+        await save_chain_state(state, cwd)
+        return state, run_id, prd_content, workspace_path
+
+    async def _resume(
+        self,
+        existing_state: ChainState,
+        *,
+        feature: str,
+        cwd: Path,
+        prd_path_str: str,
+        home: Path | None,
+    ) -> tuple[ChainState, str, str, Path]:
+        state = existing_state
+        run_id = state.run_id
+        prd_path = Path(state.prd_path)
+
+        if prd_path_str and Path(prd_path_str).resolve() != prd_path.resolve():
+            await self.emit_output(
+                "prepare",
+                f"Ignoring --from-prd on resume; continuing with the original PRD ({prd_path})",
+                level="warning",
+            )
+
+        prd_content = ""
+        if prd_path.is_file():
+            prd_content = await _read_text(prd_path)
+            current_digest = hashlib.sha256(prd_content.encode("utf-8")).hexdigest()
+            if current_digest != state.prd_digest:
+                await self.emit_output(
+                    "prepare",
+                    "PRD content has changed since this chain started — "
+                    "continuing without re-running specify (FR-020).",
+                    level="warning",
+                )
+
+        jj_client = JjClient(cwd=cwd)
+        workspace_path = await prepare_workspace(
+            cwd=cwd,
+            feature=feature,
+            prd_path=prd_path,
+            reuse=True,
+            jj_client=jj_client,
+            home=home,
+        )
+
+        state = state.model_copy(
+            update={
+                "status": "running",
+                "workspace_path": str(workspace_path),
+                "updated_at": _utcnow(),
+            }
+        )
+        state = await self._verify_landed_or_reset(state, checkout=cwd)
+        await save_chain_state(state, cwd)
+        return state, run_id, prd_content, workspace_path
+
+    async def _verify_landed_or_reset(self, state: ChainState, *, checkout: Path) -> ChainState:
+        """Resume guarantee (contracts/chain-state.md): verify each
+        `landed` step's artifacts still exist in the checkout; a step
+        whose artifacts vanished (e.g. the user deleted the spec dir) is
+        reset to `pending` so it re-runs instead of being trusted blindly.
+        """
+        if state.feature_dir is None:
+            return state
+        feature_dir_name = Path(state.feature_dir).name
+        feature_path = checkout / "specs" / feature_dir_name
+
+        new_steps = dict(state.steps)
+        changed = False
+        for step, record in state.steps.items():
+            if record.status != "succeeded" or not record.landed:
+                continue
+            missing = [a for a in record.artifacts if not (feature_path / a).is_file()]
+            if missing:
+                new_steps[step] = record.model_copy(
+                    update={"status": "pending", "landed": False, "artifacts": []}
+                )
+                changed = True
+                logger.warning(
+                    "spec_chain_landed_artifacts_missing_resetting_step",
+                    step=step.value,
+                    missing=missing,
+                )
+        if not changed:
+            return state
+        return state.model_copy(update={"steps": new_steps, "updated_at": _utcnow()})
+
+    async def _run_one_step(
+        self,
+        step: ChainStep,
+        *,
+        state: ChainState,
+        squadron: SpecChainSquadron,
+        workspace: Path,
+        checkout: Path,
+        checkout_specs_before: set[str],
+        prd_content: str,
+    ) -> ChainState:
+        display = step.value.title()
+        await self.emit_step_started(step.value, display_label=display)
+        started_at = _utcnow()
+        state = _set_step(state, step, status="in_progress", started_at=started_at)
+        await save_chain_state(state, checkout)
+        logger.info("spec_chain_step_started", step=step.value, run_id=state.run_id)
+
+        prompt = build_step_prompt(
+            step,
+            workspace=workspace,
+            feature=state.feature,
+            prd_content=prd_content if step is ChainStep.SPECIFY else None,
+        )
+
+        try:
+            async for attempt in AsyncRetrying(
+                stop=stop_after_attempt(_STEP_RETRY_ATTEMPTS),
+                wait=wait_exponential(multiplier=1, min=2, max=20),
+                reraise=True,
+            ):
+                with attempt:
+                    report = await squadron.chain_agent.run_step(prompt)
+        except Exception as exc:  # noqa: BLE001 - any runtime failure halts this step
+            logger.warning("spec_chain_step_run_failed", step=step.value, error=str(exc))
+            return await self._fail_step(state, step, checkout, started_at, str(exc), display)
+
+        # The filesystem is ground truth for *success* (R9) — a
+        # well-formed "completed" report with no artifacts is still a
+        # failure, checked below. But an honest agent self-report of
+        # "blocked" or "failed" (FR-009's clarify-can't-form-a-defensible-
+        # default edge case) must not be silently overridden just because
+        # some file happens to already exist from an earlier step.
+        if report.status in ("blocked", "failed"):
+            return await self._fail_step(
+                state,
+                step,
+                checkout,
+                started_at,
+                report.detail or f"agent reported {report.status}",
+                display,
+            )
+
+        if step is ChainStep.SPECIFY and state.feature_dir is None:
+            feature_dir_name = resolve_feature_dir(
+                workspace=workspace, checkout_specs_before=checkout_specs_before
+            )
+            if feature_dir_name is None:
+                return await self._fail_step(
+                    state,
+                    step,
+                    checkout,
+                    started_at,
+                    "specify did not allocate a resolvable specs/NNN-<feature> directory",
+                    display,
+                )
+            state = state.model_copy(update={"feature_dir": f"specs/{feature_dir_name}"})
+
+        if state.feature_dir is None:
+            return await self._fail_step(
+                state, step, checkout, started_at, "no feature directory known yet", display
+            )
+        feature_dir_name = Path(state.feature_dir).name
+
+        artifacts = verify_step_artifacts(
+            workspace=workspace, feature_dir=feature_dir_name, step=step
+        )
+        if step is not ChainStep.ANALYZE and not artifacts:
+            return await self._fail_step(
+                state,
+                step,
+                checkout,
+                started_at,
+                f"{step.value} produced no verifiable artifacts",
+                display,
+            )
+
+        if step is ChainStep.CLARIFY:
+            state = await self._file_clarify_decisions(
+                state,
+                workspace=workspace,
+                checkout=checkout,
+                feature_dir_name=feature_dir_name,
+            )
+
+        if step is ChainStep.ANALYZE:
+            state = await self._create_remediation_beads(
+                state, checkout=checkout, feature_dir_name=feature_dir_name, report=report
+            )
+
+        try:
+            land_step_artifacts(
+                workspace=workspace, checkout=checkout, feature_dir=feature_dir_name
+            )
+        except OSError as exc:
+            return await self._fail_step(
+                state, step, checkout, started_at, f"landing failed: {exc}", display
+            )
+        logger.info(
+            "spec_chain_step_landed",
+            step=step.value,
+            feature_dir=state.feature_dir,
+            artifacts=artifacts,
+        )
+
+        finished_at = _utcnow()
+        state = _set_step(
+            state,
+            step,
+            status="succeeded",
+            artifacts=artifacts,
+            landed=True,
+            finished_at=finished_at,
+        )
+        await save_chain_state(state, checkout)
+        logger.info(
+            "spec_chain_step_checkpointed",
+            step=step.value,
+            status="succeeded",
+            run_id=state.run_id,
+        )
+        await self.emit_step_completed(
+            step.value, output={"artifacts": artifacts}, display_label=display
+        )
+        return state
+
+    async def _file_clarify_decisions(
+        self,
+        state: ChainState,
+        *,
+        workspace: Path,
+        checkout: Path,
+        feature_dir_name: str,
+    ) -> ChainState:
+        """File every clarify decision recorded in spec.md as a standalone
+        assumption-ledger entry (R2/R5) — in the user's checkout, never the
+        workspace (Guardrail X.3: the workflow owns deterministic side
+        effects, the agent never writes beads).
+
+        Best-effort per decision: a single bd failure is logged and the
+        decision is still recorded on ``ChainState`` (without a
+        ``ledger_bead_id``) rather than sinking clarify's success — the
+        audit trail is advisory, not load-bearing for chain progress.
+        """
+        spec_md_path = workspace / "specs" / feature_dir_name / "spec.md"
+        if not spec_md_path.is_file():
+            return state
+        spec_content = await _read_text(spec_md_path)
+        parsed_decisions = decisions_from_spec_md(spec_content)
+        if not parsed_decisions:
+            return state
+
+        bead_client = BeadClient(cwd=checkout)
+        filed: list[ClarifyDecision] = []
+        for decision in parsed_decisions:
+            payload = AssumptionPayload(
+                question=decision.question,
+                adopted_answer=decision.adopted_answer,
+                alternatives=decision.alternatives,
+                severity=decision.severity.value,
+                severity_defaulted=decision.severity_defaulted,
+            )
+            try:
+                record = await record_standalone_assumption(
+                    bead_client,
+                    payload=payload,
+                    owner_spec=feature_dir_name,
+                    source_ref=SOURCE_REF_CLARIFY,
+                )
+            except Exception as exc:  # noqa: BLE001 — one bad entry must not sink clarify
+                logger.warning(
+                    "spec_chain_clarify_ledger_filing_failed",
+                    question=decision.question,
+                    error=str(exc),
+                )
+                filed.append(decision)
+                continue
+            bead_id = record.bead_id if record is not None else None
+            filed.append(replace(decision, ledger_bead_id=bead_id))
+
+        logger.info(
+            "spec_chain_clarify_decisions_filed",
+            count=len(filed),
+            ledger_entries=sum(1 for d in filed if d.ledger_bead_id),
+        )
+        return state.model_copy(update={"clarify_decisions": [*state.clarify_decisions, *filed]})
+
+    async def _create_remediation_beads(
+        self,
+        state: ChainState,
+        *,
+        checkout: Path,
+        feature_dir_name: str,
+        report: StepReport,
+    ) -> ChainState:
+        """After a successful analyze step, convert each reported finding
+        into a standalone remediation bead (R6) — in the user's checkout,
+        never the workspace. Best-effort: bd failures are logged, never
+        raised — analyze findings must never block an otherwise-successful
+        run (FR-012).
+        """
+        if not report.findings:
+            return state
+
+        findings = [
+            AnalyzeFinding(
+                title=f.title,
+                category=f.category,
+                severity_hint=f.severity_hint,
+                location=f.location,
+                summary=f.summary,
+                feature_dir=feature_dir_name,
+            )
+            for f in report.findings
+        ]
+
+        try:
+            result = await create_remediation_beads(findings, cwd=checkout)
+        except Exception as exc:  # noqa: BLE001 — analyze findings must never block the chain
+            logger.warning("spec_chain_remediation_bead_creation_failed", error=str(exc))
+            return state
+
+        if result.errors:
+            logger.warning("spec_chain_remediation_bead_partial_failure", errors=result.errors)
+        logger.info(
+            "spec_chain_remediation_beads_created",
+            count=len(result.created_bead_ids),
+            skipped=len(result.skipped_duplicate_fingerprints),
+        )
+        return state.model_copy(
+            update={
+                "remediation_bead_ids": [
+                    *state.remediation_bead_ids,
+                    *result.created_bead_ids,
+                ]
+            }
+        )
+
+    async def _fail_step(
+        self,
+        state: ChainState,
+        step: ChainStep,
+        checkout: Path,
+        started_at: datetime,
+        error: str,
+        display: str,
+    ) -> ChainState:
+        """Record *step* as failed and halt the chain — unless *step* is
+        ``analyze``, whose failures degrade to a warning (FR-012) and never
+        block an otherwise-successful run.
+        """
+        finished_at = _utcnow()
+        state = _set_step(state, step, status="failed", error=error, finished_at=finished_at)
+        new_status = "completed" if step is ChainStep.ANALYZE else "halted"
+        if new_status == "halted":
+            state = _mark_downstream_skipped(state, step)
+        state = state.model_copy(update={"status": new_status, "updated_at": finished_at})
+        await save_chain_state(state, checkout)
+        if step is ChainStep.ANALYZE:
+            await self.emit_output(
+                step.value, f"analyze failed (non-fatal): {error}", level="warning"
+            )
+            await self.emit_step_completed(
+                step.value, output={"error": error}, display_label=display
+            )
+        else:
+            await self.emit_step_failed(step.value, error, display_label=display)
+        return state

--- a/src/maverick/workspace/__init__.py
+++ b/src/maverick/workspace/__init__.py
@@ -1,0 +1,3 @@
+"""Hidden-workspace helpers for workflows that require execution isolation."""
+
+from __future__ import annotations

--- a/src/maverick/workspace/spec_chain.py
+++ b/src/maverick/workspace/spec_chain.py
@@ -63,13 +63,23 @@ async def prepare_workspace(
     workspace_dir = _workspace_dir(home=home, cwd=cwd, feature=feature)
 
     if not (reuse and workspace_dir.exists()):
+        # Forget any jj-registered workspace of this name BEFORE recreating.
+        # Do this even when the on-disk dir is gone: the user may have
+        # cleared ``~/.maverick/workspaces`` while jj still tracks the
+        # workspace, and ``jj workspace add`` fails on that lingering
+        # name collision. Best-effort — a name that was never registered
+        # (a genuinely fresh feature) makes ``forget`` error, which is not
+        # a problem; a real collision instead surfaces on ``workspace_add``
+        # below.
+        try:
+            await jj_client.workspace_forget(workspace_dir.name)
+        except JjError as exc:
+            logger.debug(
+                "spec_chain_workspace_forget_skipped",
+                workspace=str(workspace_dir),
+                error=str(exc),
+            )
         if workspace_dir.exists():
-            try:
-                await jj_client.workspace_forget(workspace_dir.name)
-            except JjError as exc:
-                raise SpecChainWorkspaceError(
-                    f"failed to forget stale workspace {workspace_dir}: {exc}"
-                ) from exc
             shutil.rmtree(workspace_dir)
 
         try:

--- a/src/maverick/workspace/spec_chain.py
+++ b/src/maverick/workspace/spec_chain.py
@@ -1,0 +1,92 @@
+"""Hidden jj-workspace lifecycle for the spec-chain workflow (R3).
+
+Per-feature isolated workspace under
+``~/.maverick/workspaces/<project-slug>/spec-chain/<feature>/``, built on
+the canonical :class:`~maverick.jj.client.JjClient`. bd never runs inside
+this workspace — all bead/ledger writes happen in the user's checkout via
+the workflow, which is why the historic bd/workspace impedance mismatch
+that retired the general-purpose ``WorkspaceManager`` does not apply here.
+See specs/050-headless-spec-chain/research.md R3.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from maverick.exceptions import JjError, SpecChainWorkspaceError
+from maverick.logging import get_logger
+
+if TYPE_CHECKING:
+    from maverick.jj.client import JjClient
+
+__all__ = ["prepare_workspace"]
+
+logger = get_logger(__name__)
+
+
+def _workspace_dir(*, home: Path, cwd: Path, feature: str) -> Path:
+    return home / ".maverick" / "workspaces" / cwd.name / "spec-chain" / feature
+
+
+async def prepare_workspace(
+    *,
+    cwd: Path,
+    feature: str,
+    prd_path: Path,
+    reuse: bool,
+    jj_client: JjClient,
+    home: Path | None = None,
+) -> Path:
+    """Create, reuse, or recreate the hidden workspace for *feature*.
+
+    Args:
+        cwd: The user's colocated checkout (source repo for ``workspace_add``).
+        feature: Feature slug — the workspace path is per-feature, so two
+            features never share a directory.
+        prd_path: PRD file to copy into the workspace (it may be untracked
+            in the user's checkout).
+        reuse: ``True`` for an active, resumable chain — reuse the on-disk
+            workspace as-is. ``False`` for a completed or fresh chain —
+            forget+wipe any stale workspace, then create clean.
+        jj_client: Injected :class:`JjClient` bound to *cwd*.
+        home: Override for ``~`` (tests only). Defaults to :meth:`Path.home`.
+
+    Returns:
+        The resolved workspace directory path.
+
+    Raises:
+        SpecChainWorkspaceError: The underlying jj workspace operation failed.
+    """
+    home = home or Path.home()
+    workspace_dir = _workspace_dir(home=home, cwd=cwd, feature=feature)
+
+    if not (reuse and workspace_dir.exists()):
+        if workspace_dir.exists():
+            try:
+                await jj_client.workspace_forget(workspace_dir.name)
+            except JjError as exc:
+                raise SpecChainWorkspaceError(
+                    f"failed to forget stale workspace {workspace_dir}: {exc}"
+                ) from exc
+            shutil.rmtree(workspace_dir)
+
+        try:
+            await jj_client.workspace_add(workspace_dir)
+        except JjError as exc:
+            raise SpecChainWorkspaceError(
+                f"failed to create workspace {workspace_dir}: {exc}"
+            ) from exc
+
+    inputs_dir = workspace_dir / "inputs"
+    inputs_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(prd_path, inputs_dir / prd_path.name)
+
+    logger.info(
+        "spec_chain_workspace_ready",
+        feature=feature,
+        workspace_path=str(workspace_dir),
+        reused=reuse and workspace_dir.exists(),
+    )
+    return workspace_dir

--- a/tests/integration/spec_chain/__init__.py
+++ b/tests/integration/spec_chain/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for the spec-chain workflow."""

--- a/tests/integration/spec_chain/conftest.py
+++ b/tests/integration/spec_chain/conftest.py
@@ -1,0 +1,253 @@
+"""Shared fixtures/helpers for spec-chain integration tests.
+
+Builds a real tmp jj+git colocated repo with the Spec Kit command/marker
+surface `SpecChainWorkflow` expects, plus a configurable stubbed airframe
+runtime — no live model calls, no real `bd` install required.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from airframe.cost import CostRecord
+from airframe.protocol import RuntimeResult
+
+from maverick.beads.client import BeadClient
+from maverick.beads.models import BeadSummary
+from maverick.config import AgentBindingConfig, AgentsConfig, MaverickConfig
+from maverick.workflows.spec_chain.constants import ChainStep
+
+pytestmark = pytest.mark.integration
+
+FEATURE = "widget-export"
+FEATURE_DIR = f"001-{FEATURE}"
+
+COMMAND_STEPS = (
+    ChainStep.SPECIFY,
+    ChainStep.CLARIFY,
+    ChainStep.PLAN,
+    ChainStep.TASKS,
+    ChainStep.ANALYZE,
+)
+
+#: Artifact each step writes by default (mirrors landing.py's expected set).
+_DEFAULT_ARTIFACT = {
+    ChainStep.SPECIFY: "spec.md",
+    ChainStep.PLAN: "plan.md",
+    ChainStep.TASKS: "tasks.md",
+}
+
+
+def _run(cmd: list[str], *, cwd: Path) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def build_speckit_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init", "-q"], cwd=repo)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=repo)
+    _run(["git", "config", "user.name", "Test"], cwd=repo)
+    _run(["jj", "git", "init", "--colocate"], cwd=repo)
+
+    commands_dir = repo / ".claude" / "commands"
+    commands_dir.mkdir(parents=True)
+    for step in COMMAND_STEPS:
+        (commands_dir / f"speckit.{step.value}.md").write_text(
+            f"Instructions for /speckit.{step.value}.\n", encoding="utf-8"
+        )
+
+    specify_dir = repo / ".specify"
+    specify_dir.mkdir()
+    (specify_dir / "init-options.json").write_text(
+        '{"speckit_version": "0.14.0"}', encoding="utf-8"
+    )
+
+    docs_dir = repo / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "prd.md").write_text(
+        "# Widget Export PRD\n\nExport widgets to CSV.\n", encoding="utf-8"
+    )
+
+    _run(["jj", "commit", "-m", "initial speckit repo"], cwd=repo)
+    return repo
+
+
+def make_cost() -> CostRecord:
+    return CostRecord(
+        provider_id="anthropic",
+        model_id="claude-haiku-4-5",
+        cost_usd=0.01,
+        input_tokens=10,
+        output_tokens=20,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        finish="end_turn",
+    )
+
+
+#: A step handler receives (feature_path, runtime) and returns the
+#: structured StepReport-shaped payload. Override via `step_handlers` to
+#: simulate a failure/blocked step for halt/resume tests.
+StepHandler = Callable[[Path, "ConfigurableSpeckitRuntime"], dict[str, Any]]
+
+
+class ConfigurableSpeckitRuntime:
+    """Stand-in airframe runtime with per-step overridable behavior."""
+
+    label = "stub"
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        step_handlers: dict[ChainStep, StepHandler] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.model = model
+        self.execute_calls: list[dict[str, Any]] = []
+        self.written_content: dict[str, str] = {}
+        self._step_handlers = step_handlers or {}
+
+    async def execute(self, prompt: str, **kwargs: Any) -> RuntimeResult:
+        self.execute_calls.append({"prompt": prompt, **kwargs})
+        step = self._infer_step(prompt)
+        feature_path = Path.cwd() / "specs" / FEATURE_DIR
+        feature_path.mkdir(parents=True, exist_ok=True)
+
+        handler = self._step_handlers.get(step)
+        structured = handler(feature_path, self) if handler else self._default(step, feature_path)
+        return RuntimeResult(text="", structured=structured, cost=make_cost(), finish="end_turn")
+
+    def _default(self, step: ChainStep, feature_path: Path) -> dict[str, Any]:
+        if step is ChainStep.CLARIFY:
+            spec_path = feature_path / "spec.md"
+            existing = spec_path.read_text(encoding="utf-8") if spec_path.is_file() else ""
+            updated = existing + (
+                "\n## Clarifications\n\n### Session 2026-07-24\n\n"
+                "- Q: Should exports include archived widgets? "
+                "→ A: No, exclude archived widgets.\n"
+            )
+            spec_path.write_text(updated, encoding="utf-8")
+            self.written_content["spec.md"] = updated
+            return {
+                "status": "completed",
+                "artifacts": ["spec.md"],
+                "questions": [
+                    {
+                        "question": "Should exports include archived widgets?",
+                        "adopted_answer": "No, exclude archived widgets.",
+                        "alternatives": ["Include all widgets"],
+                    }
+                ],
+                "findings": [],
+                "detail": "Clarify complete.",
+            }
+        if step is ChainStep.ANALYZE:
+            return {
+                "status": "completed",
+                "artifacts": [],
+                "questions": [],
+                "findings": [],
+                "detail": "Analyze complete.",
+            }
+        name = _DEFAULT_ARTIFACT[step]
+        content = f"# {step.value.title()}\n\nContent for {step.value}.\n"
+        (feature_path / name).write_text(content, encoding="utf-8")
+        self.written_content[name] = content
+        return {
+            "status": "completed",
+            "artifacts": [name],
+            "questions": [],
+            "findings": [],
+            "detail": f"{step.value} written.",
+        }
+
+    @staticmethod
+    def _infer_step(prompt: str) -> ChainStep:
+        for step in COMMAND_STEPS:
+            if f"/speckit.{step.value}" in prompt:
+                return step
+        raise AssertionError(f"could not infer step from prompt: {prompt!r}")
+
+    async def reset(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    def validate_binding(self, _binding: Any) -> bool:
+        return True
+
+
+def stub_runtime_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    step_handlers: dict[ChainStep, StepHandler] | None = None,
+) -> list[ConfigurableSpeckitRuntime]:
+    """Patch `airframe.runtime_for`; returns the constructed-instances list."""
+    constructed: list[ConfigurableSpeckitRuntime] = []
+
+    def _factory(provider_id: str) -> type[ConfigurableSpeckitRuntime]:
+        class _Bound(ConfigurableSpeckitRuntime):
+            def __init__(self, *, model: str | None = None, **kwargs: Any) -> None:
+                super().__init__(model=model, step_handlers=step_handlers, **kwargs)
+                constructed.append(self)
+
+        return _Bound
+
+    monkeypatch.setattr("airframe.runtime_for", _factory)
+    return constructed
+
+
+def make_config() -> MaverickConfig:
+    return MaverickConfig(
+        agents=AgentsConfig(generate=AgentBindingConfig(provider="claude", model_id="stub-model"))
+    )
+
+
+@pytest.fixture
+def speckit_repo(tmp_path: Path) -> Path:
+    return build_speckit_repo(tmp_path)
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path) -> Path:
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    return home
+
+
+@pytest.fixture
+def bd_stubs() -> Any:
+    """Patch bd calls so `record_standalone_assumption` needs no real
+    `bd` install. Yields the list of created bead ids."""
+    created: list[str] = []
+
+    async def fake_query(self: BeadClient, expr: str) -> list[BeadSummary]:
+        return []
+
+    async def fake_create_bead(
+        self: BeadClient, definition: object, parent_id: str | None = None
+    ) -> object:
+        bd_id = f"dea-{len(created) + 1}"
+        created.append(bd_id)
+        return type("CreatedBead", (), {"bd_id": bd_id})()
+
+    async def fake_set_state(
+        self: BeadClient, bead_id: str, state: dict[str, str], reason: str = ""
+    ) -> None:
+        return None
+
+    with (
+        patch.object(BeadClient, "query", new=fake_query),
+        patch.object(BeadClient, "create_bead", new=fake_create_bead),
+        patch.object(BeadClient, "set_state", new=fake_set_state),
+        patch("maverick.library.actions.beads.defer_bead", new=AsyncMock()),
+    ):
+        yield created

--- a/tests/integration/spec_chain/test_full_chain.py
+++ b/tests/integration/spec_chain/test_full_chain.py
@@ -1,0 +1,364 @@
+"""Full five-step happy-path integration test for `SpecChainWorkflow`.
+
+Runs against a real tmp jj+git colocated repo fixture (with
+`.claude/commands/speckit.*.md` and `.specify/` markers) and a stubbed
+airframe runtime that writes canned artifacts — no live model calls.
+Asserts strict ordering, artifact landing, final report counts, that no
+interactive input is ever requested (FR-004), and that spec/plan/tasks
+artifact content is byte-identical before and after the analyze step
+(FR-011).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from airframe.cost import CostRecord
+from airframe.protocol import RuntimeResult
+
+from maverick.beads.client import BeadClient
+from maverick.beads.models import BeadSummary
+from maverick.config import AgentBindingConfig, AgentsConfig, MaverickConfig
+from maverick.workflows.spec_chain.constants import ChainStep
+from maverick.workflows.spec_chain.state import load_chain_state
+from maverick.workflows.spec_chain.workflow import SpecChainWorkflow
+
+FEATURE = "widget-export"
+FEATURE_DIR = f"001-{FEATURE}"
+
+_COMMAND_STEPS = (
+    ChainStep.SPECIFY,
+    ChainStep.CLARIFY,
+    ChainStep.PLAN,
+    ChainStep.TASKS,
+    ChainStep.ANALYZE,
+)
+
+
+def _run(cmd: list[str], *, cwd: Path) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _build_speckit_repo(tmp_path: Path) -> Path:
+    """A real, colocated jj+git repo with the Spec Kit command/marker
+    surface `SpecChainWorkflow` expects, plus a sample PRD."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init", "-q"], cwd=repo)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=repo)
+    _run(["git", "config", "user.name", "Test"], cwd=repo)
+    _run(["jj", "git", "init", "--colocate"], cwd=repo)
+
+    commands_dir = repo / ".claude" / "commands"
+    commands_dir.mkdir(parents=True)
+    for step in _COMMAND_STEPS:
+        (commands_dir / f"speckit.{step.value}.md").write_text(
+            f"Instructions for /speckit.{step.value}.\n", encoding="utf-8"
+        )
+
+    specify_dir = repo / ".specify"
+    specify_dir.mkdir()
+    (specify_dir / "init-options.json").write_text(
+        '{"speckit_version": "0.14.0"}', encoding="utf-8"
+    )
+
+    docs_dir = repo / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "prd.md").write_text(
+        "# Widget Export PRD\n\nExport widgets to CSV.\n", encoding="utf-8"
+    )
+
+    _run(["jj", "commit", "-m", "initial speckit repo"], cwd=repo)
+    return repo
+
+
+def _cost() -> CostRecord:
+    return CostRecord(
+        provider_id="anthropic",
+        model_id="claude-haiku-4-5",
+        cost_usd=0.01,
+        input_tokens=10,
+        output_tokens=20,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        finish="end_turn",
+    )
+
+
+class _CannedSpeckitRuntime:
+    """Stand-in for the airframe runtime — writes canned artifacts to the
+    current working directory (the SpecChainAgent has already `os.chdir`ed
+    into the hidden workspace by the time `execute()` runs) instead of
+    calling a real model."""
+
+    label = "stub"
+
+    def __init__(self, *, model: str | None = None, **kwargs: Any) -> None:
+        self.model = model
+        self.execute_calls: list[dict[str, Any]] = []
+        #: Content written for spec.md/plan.md/tasks.md, keyed by
+        #: feature-dir-relative filename — used to prove analyze never
+        #: touches them (FR-011).
+        self.written_content: dict[str, str] = {}
+
+    async def execute(self, prompt: str, **kwargs: Any) -> RuntimeResult:
+        self.execute_calls.append({"prompt": prompt, **kwargs})
+        step = self._infer_step(prompt)
+        feature_path = Path.cwd() / "specs" / FEATURE_DIR
+        feature_path.mkdir(parents=True, exist_ok=True)
+
+        structured: dict[str, Any]
+        if step is ChainStep.SPECIFY:
+            content = "# Widget Export Spec\n\nSpecified from PRD.\n"
+            (feature_path / "spec.md").write_text(content, encoding="utf-8")
+            self.written_content["spec.md"] = content
+            structured = {
+                "status": "completed",
+                "artifacts": ["spec.md"],
+                "questions": [],
+                "findings": [],
+                "detail": "Spec written from PRD.",
+            }
+        elif step is ChainStep.CLARIFY:
+            # Simulates Spec Kit's own non-interactive convention: clarify
+            # rewrites spec.md, appending a "## Clarifications" section
+            # with the adopted defaults (R2).
+            spec_path = feature_path / "spec.md"
+            existing = spec_path.read_text(encoding="utf-8") if spec_path.is_file() else ""
+            updated = existing + (
+                "\n## Clarifications\n\n### Session 2026-07-24\n\n"
+                "- Q: Should exports include archived widgets? "
+                "→ A: No, exclude archived widgets.\n"
+            )
+            spec_path.write_text(updated, encoding="utf-8")
+            self.written_content["spec.md"] = updated
+            structured = {
+                "status": "completed",
+                "artifacts": ["spec.md"],
+                "questions": [
+                    {
+                        "question": "Should exports include archived widgets?",
+                        "adopted_answer": "No, exclude archived widgets.",
+                        "alternatives": ["Include all widgets"],
+                    }
+                ],
+                "findings": [],
+                "detail": "Clarify complete, no ambiguity remained unresolved.",
+            }
+        elif step is ChainStep.PLAN:
+            content = "# Plan\n\nImplementation plan for widget export.\n"
+            (feature_path / "plan.md").write_text(content, encoding="utf-8")
+            self.written_content["plan.md"] = content
+            structured = {
+                "status": "completed",
+                "artifacts": ["plan.md"],
+                "questions": [],
+                "findings": [],
+                "detail": "Plan written.",
+            }
+        elif step is ChainStep.TASKS:
+            content = "# Tasks\n\n- [ ] T001 Implement export\n"
+            (feature_path / "tasks.md").write_text(content, encoding="utf-8")
+            self.written_content["tasks.md"] = content
+            structured = {
+                "status": "completed",
+                "artifacts": ["tasks.md"],
+                "questions": [],
+                "findings": [],
+                "detail": "Tasks written.",
+            }
+        else:
+            structured = {
+                "status": "completed",
+                "artifacts": [],
+                "questions": [],
+                "findings": [
+                    {
+                        "title": "Ambiguous export format",
+                        "category": "ambiguity",
+                        "severity_hint": "low",
+                        "location": "spec.md",
+                        "summary": "CSV column order unspecified.",
+                    }
+                ],
+                "detail": "Analyze complete.",
+            }
+
+        return RuntimeResult(text="", structured=structured, cost=_cost(), finish="end_turn")
+
+    @staticmethod
+    def _infer_step(prompt: str) -> ChainStep:
+        for step in _COMMAND_STEPS:
+            if f"/speckit.{step.value}" in prompt:
+                return step
+        raise AssertionError(f"could not infer step from prompt: {prompt!r}")
+
+    async def reset(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    def validate_binding(self, _binding: Any) -> bool:
+        return True
+
+
+@pytest.fixture
+def speckit_repo(tmp_path: Path) -> Path:
+    return _build_speckit_repo(tmp_path)
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path) -> Path:
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    return home
+
+
+async def test_full_chain_happy_path(
+    speckit_repo: Path,
+    fake_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructed: list[_CannedSpeckitRuntime] = []
+
+    def _factory(provider_id: str) -> type[_CannedSpeckitRuntime]:
+        class _Bound(_CannedSpeckitRuntime):
+            def __init__(self, *, model: str | None = None, **kwargs: Any) -> None:
+                super().__init__(model=model, **kwargs)
+                constructed.append(self)
+
+        return _Bound
+
+    monkeypatch.setattr("airframe.runtime_for", _factory)
+
+    config = MaverickConfig(
+        agents=AgentsConfig(generate=AgentBindingConfig(provider="claude", model_id="stub-model"))
+    )
+    workflow = SpecChainWorkflow(config=config)
+
+    run_id = "test-run-1"
+    inputs = {
+        "run_id": run_id,
+        "feature": FEATURE,
+        "cwd": str(speckit_repo),
+        "prd_path": str(speckit_repo / "docs" / "prd.md"),
+        "home": str(fake_home),
+    }
+
+    # Clarify decisions are filed as standalone assumption-ledger entries
+    # in the user's checkout (never the workspace) — stub the bd calls
+    # `record_standalone_assumption` makes so this test never needs a
+    # real `bd` install (T026).
+    created_beads: list[str] = []
+
+    async def fake_query(self: BeadClient, expr: str) -> list[BeadSummary]:
+        return []  # no existing epics/entries to dedup against
+
+    async def fake_create_bead(
+        self: BeadClient, definition: object, parent_id: str | None = None
+    ) -> object:
+        bd_id = f"dea-{len(created_beads) + 1}"
+        created_beads.append(bd_id)
+        return type("CreatedBead", (), {"bd_id": bd_id})()
+
+    async def fake_set_state(
+        self: BeadClient, bead_id: str, state: dict[str, str], reason: str = ""
+    ) -> None:
+        return None
+
+    with (
+        patch.object(BeadClient, "query", new=fake_query),
+        patch.object(BeadClient, "create_bead", new=fake_create_bead),
+        patch.object(BeadClient, "set_state", new=fake_set_state),
+        patch("maverick.library.actions.beads.defer_bead", new=AsyncMock()),
+    ):
+        events = [event async for event in workflow.execute(inputs)]
+
+    assert workflow.result is not None
+    assert workflow.result.success is True, [e for e in events if hasattr(e, "error")]
+
+    # Exactly one runtime constructed (one squadron, one chain agent).
+    assert len(constructed) == 1
+    runtime = constructed[0]
+
+    # Strict ordering: five step-completed events for the chain steps
+    # (plus "prepare"), all successful, in the exact chain order.
+    step_completed_names = [
+        e.step_name
+        for e in events
+        if type(e).__name__ == "StepCompleted" and e.success and e.step_name != "prepare"
+    ]
+    assert step_completed_names == [s.value for s in ChainStep]
+
+    step_failed_names = [
+        e.step_name for e in events if type(e).__name__ == "StepCompleted" and not e.success
+    ]
+    assert step_failed_names == []
+
+    # No interactive input was ever requested — the runtime stub has no
+    # input-request surface at all; every call is a plain execute().
+    assert len(runtime.execute_calls) == 5
+    for call in runtime.execute_calls:
+        assert call["schema"] is not None  # structured-output path only
+
+    # Final chain state: completed, feature_dir resolved, every step
+    # succeeded and landed.
+    final_state = await load_chain_state(run_id, speckit_repo)
+    assert final_state is not None
+    assert final_state.status == "completed"
+    assert final_state.feature_dir == f"specs/{FEATURE_DIR}"
+    for step in ChainStep:
+        record = final_state.steps[step]
+        assert record.status == "succeeded", f"{step} did not succeed: {record.error}"
+        assert record.landed is True
+
+    # Artifacts landed in the checkout as ordinary markdown.
+    feature_path = speckit_repo / "specs" / FEATURE_DIR
+    assert (feature_path / "spec.md").is_file()
+    assert (feature_path / "plan.md").is_file()
+    assert (feature_path / "tasks.md").is_file()
+
+    # FR-011: spec/plan/tasks content is byte-identical before and after
+    # analyze — the stub never writes to those files during the analyze
+    # step, so the landed content must match exactly what specify/plan/
+    # tasks wrote.
+    for name, content in runtime.written_content.items():
+        assert (feature_path / name).read_text(encoding="utf-8") == content
+
+    report = workflow.result.final_output
+    assert report["status"] == "completed"
+    assert report["feature_dir"] == f"specs/{FEATURE_DIR}"
+    assert report["resume_hint"] is None
+
+    # T026: the clarify decision recorded in spec.md's "## Clarifications"
+    # section was filed as a standalone ledger entry — one bd created, and
+    # the chain state + report both reflect it.
+    assert len(final_state.clarify_decisions) == 1
+    decision = final_state.clarify_decisions[0]
+    assert decision.question == "Should exports include archived widgets?"
+    assert decision.adopted_answer == "No, exclude archived widgets."
+    assert decision.path == "non_interactive"
+    assert decision.ledger_bead_id is not None
+    assert report["ledger_entry_count"] == 1
+
+    # T035: the analyze finding became a standalone remediation bead.
+    assert report["remediation_bead_count"] == 1
+    assert len(final_state.remediation_bead_ids) == 1
+
+    # Two beads total were created: the clarify ledger entry + the
+    # remediation bead.
+    assert len(created_beads) == 2
+    assert decision.ledger_bead_id in created_beads
+    assert final_state.remediation_bead_ids[0] in created_beads
+
+
+def test_prd_digest_is_sha256_of_content(speckit_repo: Path) -> None:
+    prd_path = speckit_repo / "docs" / "prd.md"
+    content = prd_path.read_text(encoding="utf-8")
+    assert hashlib.sha256(content.encode("utf-8")).hexdigest()

--- a/tests/integration/spec_chain/test_halt.py
+++ b/tests/integration/spec_chain/test_halt.py
@@ -1,0 +1,233 @@
+"""Integration tests for halt semantics (US3, T027).
+
+A failed clarify halts the chain before plan/tasks/analyze ever run
+(FR-008/FR-009); a mid-chain plan failure halts the same way; an analyze
+failure degrades to a warning and the chain still completes (FR-012).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from maverick.workflows.spec_chain.constants import ChainStep
+from maverick.workflows.spec_chain.state import load_chain_state
+from maverick.workflows.spec_chain.workflow import SpecChainWorkflow
+from tests.integration.spec_chain.conftest import (
+    FEATURE,
+    FEATURE_DIR,
+    make_config,
+    stub_runtime_factory,
+)
+
+
+def _blocked_handler(feature_path: Path, runtime: Any) -> dict[str, Any]:
+    return {
+        "status": "blocked",
+        "artifacts": [],
+        "questions": [],
+        "findings": [],
+        "detail": "Cannot form a defensible default for a critical question.",
+    }
+
+
+def _failing_no_artifacts_handler(feature_path: Path, runtime: Any) -> dict[str, Any]:
+    """Reports success but writes nothing — filesystem is ground truth (R9),
+    so this must still be treated as a failure."""
+    return {
+        "status": "completed",
+        "artifacts": [],
+        "questions": [],
+        "findings": [],
+        "detail": "Claims success but wrote nothing.",
+    }
+
+
+async def _run_workflow(
+    speckit_repo: Path, fake_home: Path, *, run_id: str = "test-halt"
+) -> tuple[Any, list]:
+    workflow = SpecChainWorkflow(config=make_config())
+    inputs = {
+        "run_id": run_id,
+        "feature": FEATURE,
+        "cwd": str(speckit_repo),
+        "prd_path": str(speckit_repo / "docs" / "prd.md"),
+        "home": str(fake_home),
+    }
+    events = [event async for event in workflow.execute(inputs)]
+    return workflow, events
+
+
+class TestClarifyFailureHalts:
+    async def test_clarify_blocked_halts_before_plan(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        stub_runtime_factory(monkeypatch, step_handlers={ChainStep.CLARIFY: _blocked_handler})
+        workflow, events = await _run_workflow(speckit_repo, fake_home, run_id="test-clarify-halt")
+
+        assert workflow.result is not None
+        # _run() doesn't raise on a domain halt — it's a reported failure,
+        # not a crash (base.py distinguishes the two).
+        assert workflow.result.success is True
+
+        state = await load_chain_state("test-clarify-halt", speckit_repo)
+        assert state is not None
+        assert state.status == "halted"
+        assert state.steps[ChainStep.SPECIFY].status == "succeeded"
+        assert state.steps[ChainStep.CLARIFY].status == "failed"
+        assert state.steps[ChainStep.PLAN].status == "skipped"
+        assert state.steps[ChainStep.TASKS].status == "skipped"
+        assert state.steps[ChainStep.ANALYZE].status == "skipped"
+
+        # plan.md/tasks.md never landed in the checkout.
+        feature_path = speckit_repo / "specs" / FEATURE_DIR
+        assert (feature_path / "spec.md").is_file()
+        assert not (feature_path / "plan.md").exists()
+        assert not (feature_path / "tasks.md").exists()
+
+        report = workflow.result.final_output
+        assert report["status"] == "halted"
+        assert report["resume_hint"] == f"maverick spec {FEATURE}"
+
+    async def test_clarify_no_artifacts_halts(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        """Clarify claims success but the filesystem shows no spec.md
+        left behind — R9: filesystem wins over the agent's claim."""
+
+        def _clarify_deletes_spec(feature_path: Path, runtime: Any) -> dict[str, Any]:
+            spec_path = feature_path / "spec.md"
+            if spec_path.is_file():
+                spec_path.unlink()
+            return {
+                "status": "completed",
+                "artifacts": [],
+                "questions": [],
+                "findings": [],
+                "detail": "oops",
+            }
+
+        stub_runtime_factory(monkeypatch, step_handlers={ChainStep.CLARIFY: _clarify_deletes_spec})
+        workflow, _ = await _run_workflow(speckit_repo, fake_home, run_id="test-clarify-no-art")
+
+        state = await load_chain_state("test-clarify-no-art", speckit_repo)
+        assert state is not None
+        assert state.status == "halted"
+        assert state.steps[ChainStep.CLARIFY].status == "failed"
+
+
+class TestMidChainStepFailureHalts:
+    async def test_plan_failure_halts_before_tasks_and_analyze(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        stub_runtime_factory(
+            monkeypatch, step_handlers={ChainStep.PLAN: _failing_no_artifacts_handler}
+        )
+        workflow, _ = await _run_workflow(speckit_repo, fake_home, run_id="test-plan-halt")
+
+        state = await load_chain_state("test-plan-halt", speckit_repo)
+        assert state is not None
+        assert state.status == "halted"
+        assert state.steps[ChainStep.SPECIFY].status == "succeeded"
+        assert state.steps[ChainStep.CLARIFY].status == "succeeded"
+        assert state.steps[ChainStep.PLAN].status == "failed"
+        assert state.steps[ChainStep.TASKS].status == "skipped"
+        assert state.steps[ChainStep.ANALYZE].status == "skipped"
+
+        feature_path = speckit_repo / "specs" / FEATURE_DIR
+        assert (feature_path / "spec.md").is_file()
+        assert not (feature_path / "tasks.md").exists()
+
+        report = workflow.result.final_output
+        assert report["status"] == "halted"
+
+
+class TestAnalyzeFailureIsAWarningNotAHalt:
+    async def test_analyze_failure_degrades_to_warning_chain_still_completes(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        stub_runtime_factory(
+            monkeypatch, step_handlers={ChainStep.ANALYZE: _failing_no_artifacts_handler}
+        )
+        # (analyze's handler "failing" here just needs status != completed
+        # with no verifiable artifacts to trigger `_fail_step`; since
+        # analyze requires zero artifacts, force a genuine failure via a
+        # status="failed" report instead.)
+
+        def _analyze_fails(feature_path: Path, runtime: Any) -> dict[str, Any]:
+            return {
+                "status": "failed",
+                "artifacts": [],
+                "questions": [],
+                "findings": [],
+                "detail": "analyze crashed",
+            }
+
+        stub_runtime_factory(monkeypatch, step_handlers={ChainStep.ANALYZE: _analyze_fails})
+        workflow, events = await _run_workflow(speckit_repo, fake_home, run_id="test-analyze-warn")
+
+        # The step record itself does show "failed" (it genuinely failed —
+        # the agent self-reported it and the workflow trusts that per
+        # FR-009's honest-blocked/failed-report handling); FR-012 is about
+        # the *chain*, not the step record: the chain still completes
+        # (status="completed") rather than halting.
+        state = await load_chain_state("test-analyze-warn", speckit_repo)
+        assert state is not None
+        assert state.status == "completed"
+        assert state.steps[ChainStep.ANALYZE].status == "failed"
+
+        report = workflow.result.final_output
+        assert report["status"] == "completed"
+
+    async def test_analyze_runtime_exception_is_warning_not_halt(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        """A genuine analyze-step runtime failure (e.g. every retry attempt
+        raises) still degrades to a warning — FR-012 — rather than halting
+        the otherwise-successful chain."""
+
+        def _analyze_raises(feature_path: Path, runtime: Any) -> dict[str, Any]:
+            raise RuntimeError("analyze runtime crashed")
+
+        stub_runtime_factory(monkeypatch, step_handlers={ChainStep.ANALYZE: _analyze_raises})
+        workflow, events = await _run_workflow(
+            speckit_repo, fake_home, run_id="test-analyze-crash"
+        )
+
+        state = await load_chain_state("test-analyze-crash", speckit_repo)
+        assert state is not None
+        assert state.status == "completed"
+        assert state.steps[ChainStep.ANALYZE].status == "failed"
+
+        warning_events = [
+            e
+            for e in events
+            if type(e).__name__ == "StepOutput" and getattr(e, "level", None) == "warning"
+        ]
+        assert any("analyze failed" in e.message for e in warning_events)
+
+        report = workflow.result.final_output
+        assert report["status"] == "completed"
+        assert report["resume_hint"] is None

--- a/tests/integration/spec_chain/test_resume.py
+++ b/tests/integration/spec_chain/test_resume.py
@@ -1,0 +1,239 @@
+"""Integration tests for resume (US3, T028).
+
+A halted chain re-run continues from the failed step without
+regenerating landed artifacts; a landed step whose artifacts vanished
+from the checkout gets re-run; a PRD digest mismatch on resume warns
+without re-running specify; a completed chain blocks a fresh run for the
+same feature as a collision.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from maverick.cli.context import ExitCode
+from maverick.main import cli
+from maverick.workflows.spec_chain.constants import ChainStep
+from maverick.workflows.spec_chain.state import load_chain_state
+from maverick.workflows.spec_chain.workflow import SpecChainWorkflow
+from tests.integration.spec_chain.conftest import (
+    FEATURE,
+    FEATURE_DIR,
+    make_config,
+    stub_runtime_factory,
+)
+
+
+def _failing_handler(feature_path: Path, runtime: Any) -> dict[str, Any]:
+    return {
+        "status": "failed",
+        "artifacts": [],
+        "questions": [],
+        "findings": [],
+        "detail": "induced failure",
+    }
+
+
+async def _run_once(
+    speckit_repo: Path, fake_home: Path, *, run_id: str, prd_path: Path | None = None
+) -> tuple[Any, list]:
+    workflow = SpecChainWorkflow(config=make_config())
+    inputs = {
+        "run_id": run_id,
+        "feature": FEATURE,
+        "cwd": str(speckit_repo),
+        "prd_path": str(prd_path or (speckit_repo / "docs" / "prd.md")),
+        "home": str(fake_home),
+    }
+    events = [event async for event in workflow.execute(inputs)]
+    return workflow, events
+
+
+class TestHaltedChainResumesFromFailedStep:
+    async def test_resume_continues_without_rerunning_specify(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        run_id = "resume-continues"
+
+        # Run 1: clarify fails, chain halts.
+        stub_runtime_factory(monkeypatch, step_handlers={ChainStep.CLARIFY: _failing_handler})
+        await _run_once(speckit_repo, fake_home, run_id=run_id)
+
+        state_after_halt = await load_chain_state(run_id, speckit_repo)
+        assert state_after_halt is not None
+        assert state_after_halt.status == "halted"
+        assert state_after_halt.steps[ChainStep.SPECIFY].status == "succeeded"
+        assert state_after_halt.steps[ChainStep.CLARIFY].status == "failed"
+
+        # Run 2 (resume): clarify now succeeds, chain completes.
+        second_runtimes = stub_runtime_factory(monkeypatch)
+        workflow2, _ = await _run_once(speckit_repo, fake_home, run_id=run_id)
+
+        # specify was never re-invoked in the resumed run.
+        assert len(second_runtimes) == 1
+        prompts = [c["prompt"] for c in second_runtimes[0].execute_calls]
+        assert not any("/speckit.specify" in p for p in prompts)
+        assert any("/speckit.clarify" in p for p in prompts)
+
+        final_state = await load_chain_state(run_id, speckit_repo)
+        assert final_state is not None
+        assert final_state.status == "completed"
+        for step in ChainStep:
+            assert final_state.steps[step].status == "succeeded"
+
+        report = workflow2.result.final_output
+        assert report["status"] == "completed"
+
+
+class TestLandedArtifactVerification:
+    async def test_missing_landed_artifact_reruns_its_step(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        run_id = "resume-missing-artifact"
+
+        # Run 1: halt at tasks, so specify/clarify/plan are succeeded+landed.
+        stub_runtime_factory(monkeypatch, step_handlers={ChainStep.TASKS: _failing_handler})
+        await _run_once(speckit_repo, fake_home, run_id=run_id)
+
+        state = await load_chain_state(run_id, speckit_repo)
+        assert state is not None
+        assert state.status == "halted"
+        assert state.steps[ChainStep.PLAN].status == "succeeded"
+        assert state.steps[ChainStep.PLAN].landed is True
+
+        # The user (or something) deletes the landed plan.md.
+        plan_path = speckit_repo / "specs" / FEATURE_DIR / "plan.md"
+        assert plan_path.is_file()
+        plan_path.unlink()
+
+        # Run 2 (resume): plan.md is missing, so plan must re-run even
+        # though it was previously "succeeded" — specify/clarify are
+        # untouched and must NOT re-run.
+        second_runtimes = stub_runtime_factory(monkeypatch)
+        await _run_once(speckit_repo, fake_home, run_id=run_id)
+
+        prompts = [c["prompt"] for c in second_runtimes[0].execute_calls]
+        assert not any("/speckit.specify" in p for p in prompts)
+        assert not any("/speckit.clarify" in p for p in prompts)
+        assert any("/speckit.plan" in p for p in prompts)
+
+        final_state = await load_chain_state(run_id, speckit_repo)
+        assert final_state is not None
+        assert final_state.status == "completed"
+        assert final_state.steps[ChainStep.PLAN].status == "succeeded"
+        assert plan_path.is_file()
+
+
+class TestPrdDigestMismatchWarns:
+    async def test_changed_prd_warns_without_rerunning_specify(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        run_id = "resume-prd-changed"
+
+        stub_runtime_factory(monkeypatch, step_handlers={ChainStep.PLAN: _failing_handler})
+        await _run_once(speckit_repo, fake_home, run_id=run_id)
+
+        state = await load_chain_state(run_id, speckit_repo)
+        assert state is not None
+        assert state.status == "halted"
+
+        # PRD content changes between halt and resume.
+        prd_path = speckit_repo / "docs" / "prd.md"
+        prd_path.write_text(
+            "# Widget Export PRD (v2)\n\nDifferent content now.\n", encoding="utf-8"
+        )
+
+        second_runtimes = stub_runtime_factory(monkeypatch)
+        _workflow, events = await _run_once(speckit_repo, fake_home, run_id=run_id)
+
+        prompts = [c["prompt"] for c in second_runtimes[0].execute_calls]
+        assert not any("/speckit.specify" in p for p in prompts)
+
+        warning_events = [
+            e
+            for e in events
+            if type(e).__name__ == "StepOutput" and getattr(e, "level", None) == "warning"
+        ]
+        assert any("PRD content has changed" in e.message for e in warning_events)
+
+        final_state = await load_chain_state(run_id, speckit_repo)
+        assert final_state is not None
+        assert final_state.status == "completed"
+
+
+class TestCompletedChainCollision:
+    def test_completed_chain_same_feature_exits_partial(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A *completed* chain is not auto-resumable — re-running for the
+        same feature without deleting the spec dir is a collision
+        (FR-015), not a resume."""
+        from maverick.workflows.spec_chain.models import ChainState, StepRecord
+        from maverick.workflows.spec_chain.state import save_chain_state
+
+        now = datetime.now(tz=UTC)
+        completed_state = ChainState(
+            run_id="already-done",
+            feature=FEATURE,
+            feature_dir=f"specs/{FEATURE_DIR}",
+            prd_path=str(speckit_repo / "docs" / "prd.md"),
+            prd_digest="0" * 64,
+            workspace_path=str(
+                fake_home / ".maverick" / "workspaces" / "repo" / "spec-chain" / FEATURE
+            ),
+            status="completed",
+            steps={
+                step: StepRecord(
+                    step=step,
+                    status="succeeded",
+                    attempts=1,
+                    artifacts=[],
+                    landed=True,
+                )
+                for step in ChainStep
+            },
+            clarify_decisions=[],
+            remediation_bead_ids=[],
+            started_at=now,
+            updated_at=now,
+        )
+
+        import asyncio
+
+        asyncio.run(save_chain_state(completed_state, speckit_repo))
+        (speckit_repo / "specs" / FEATURE_DIR).mkdir(parents=True)
+
+        import os
+
+        os.chdir(speckit_repo)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.setattr("maverick.cli.commands.spec.verify_bd_ready", lambda cwd=None: None)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["spec", FEATURE, "--from-prd", str(speckit_repo / "docs" / "prd.md")],
+        )
+
+        assert result.exit_code == ExitCode.PARTIAL
+        assert "already exists" in result.output

--- a/tests/integration/spec_chain/test_resume.py
+++ b/tests/integration/spec_chain/test_resume.py
@@ -137,6 +137,52 @@ class TestLandedArtifactVerification:
         assert plan_path.is_file()
 
 
+class TestWorkspaceReseedOnResume:
+    async def test_deleted_workspace_is_reseeded_from_checkout(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        """If the hidden workspace vanishes between runs (user cleared
+        ~/.maverick/workspaces), resume recreates it from the *committed*
+        tree — which lacks the un-committed landed spec files. The reseed
+        restores those landed upstream artifacts so the next step doesn't
+        run against an empty workspace."""
+        import shutil
+
+        run_id = "resume-workspace-deleted"
+
+        # Run 1: halt at tasks, so specify/clarify/plan are succeeded+landed.
+        stub_runtime_factory(monkeypatch, step_handlers={ChainStep.TASKS: _failing_handler})
+        await _run_once(speckit_repo, fake_home, run_id=run_id)
+
+        state = await load_chain_state(run_id, speckit_repo)
+        assert state is not None
+        assert state.status == "halted"
+        assert state.steps[ChainStep.PLAN].landed is True
+
+        # The entire hidden workspace is wiped between runs.
+        workspace_root = fake_home / ".maverick" / "workspaces" / "repo" / "spec-chain" / FEATURE
+        assert workspace_root.exists()
+        shutil.rmtree(workspace_root)
+
+        # Run 2 (resume): workspace is recreated fresh, then reseeded with
+        # the landed upstream artifacts before tasks re-runs.
+        stub_runtime_factory(monkeypatch)
+        await _run_once(speckit_repo, fake_home, run_id=run_id)
+
+        # The reseed restored upstream artifacts into the fresh workspace.
+        ws_feature = workspace_root / "specs" / FEATURE_DIR
+        assert (ws_feature / "spec.md").is_file()
+        assert (ws_feature / "plan.md").is_file()
+
+        final_state = await load_chain_state(run_id, speckit_repo)
+        assert final_state is not None
+        assert final_state.status == "completed"
+
+
 class TestPrdDigestMismatchWarns:
     async def test_changed_prd_warns_without_rerunning_specify(
         self,

--- a/tests/integration/spec_chain/test_retry.py
+++ b/tests/integration/spec_chain/test_retry.py
@@ -1,0 +1,93 @@
+"""Integration tests for the per-step retry predicate.
+
+The step-run retry loop only retries airframe ``RuntimeTransientError``.
+Deterministic failures (auth, model-not-found, context-overflow, budget)
+must fail fast — retrying just burns model calls and backoff before the
+same failure halts the step. Observed via the stub runtime's
+``execute_calls`` count: a transient error is attempted the full
+``_STEP_RETRY_ATTEMPTS`` times; a non-transient error is attempted once.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from airframe.errors import RuntimeModelNotFoundError, RuntimeTransientError
+
+from maverick.workflows.spec_chain.constants import ChainStep
+from maverick.workflows.spec_chain.state import load_chain_state
+from maverick.workflows.spec_chain.workflow import (
+    _STEP_RETRY_ATTEMPTS,
+    SpecChainWorkflow,
+)
+from tests.integration.spec_chain.conftest import (
+    FEATURE,
+    make_config,
+    stub_runtime_factory,
+)
+
+
+async def _run_once(speckit_repo: Path, fake_home: Path, *, run_id: str) -> None:
+    workflow = SpecChainWorkflow(config=make_config())
+    inputs = {
+        "run_id": run_id,
+        "feature": FEATURE,
+        "cwd": str(speckit_repo),
+        "prd_path": str(speckit_repo / "docs" / "prd.md"),
+        "home": str(fake_home),
+    }
+    async for _ in workflow.execute(inputs):
+        pass
+
+
+def _raise_transient(_feature_path: Path, _runtime: Any) -> dict[str, Any]:
+    raise RuntimeTransientError("temporary blip")
+
+
+def _raise_model_not_found(_feature_path: Path, _runtime: Any) -> dict[str, Any]:
+    raise RuntimeModelNotFoundError("no such model")
+
+
+class TestRetryPredicate:
+    async def test_transient_error_is_retried_full_attempts(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        runtimes = stub_runtime_factory(
+            monkeypatch, step_handlers={ChainStep.SPECIFY: _raise_transient}
+        )
+        await _run_once(speckit_repo, fake_home, run_id="retry-transient")
+
+        # specify raised a transient error on every attempt -> retried the
+        # full budget before halting.
+        assert len(runtimes[0].execute_calls) == _STEP_RETRY_ATTEMPTS
+
+        state = await load_chain_state("retry-transient", speckit_repo)
+        assert state is not None
+        assert state.status == "halted"
+        assert state.steps[ChainStep.SPECIFY].status == "failed"
+
+    async def test_non_transient_error_fails_fast(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        runtimes = stub_runtime_factory(
+            monkeypatch, step_handlers={ChainStep.SPECIFY: _raise_model_not_found}
+        )
+        await _run_once(speckit_repo, fake_home, run_id="retry-model-not-found")
+
+        # A deterministic model-not-found error is not retried at all.
+        assert len(runtimes[0].execute_calls) == 1
+
+        state = await load_chain_state("retry-model-not-found", speckit_repo)
+        assert state is not None
+        assert state.status == "halted"
+        assert state.steps[ChainStep.SPECIFY].status == "failed"

--- a/tests/unit/agents/test_system_prompts.py
+++ b/tests/unit/agents/test_system_prompts.py
@@ -3,7 +3,7 @@
 Two surfaces are covered:
 
 1. ``load_persona_system_prompt`` — file lookup, missing-file fallback,
-   the 18 expected personas are all loadable.
+   the 19 expected personas are all loadable.
 2. :meth:`Agent._execute_via_runtime` forwards the loaded prompt as
    ``system=`` on every adapter call.
 """
@@ -45,8 +45,8 @@ def test_load_returns_body_for_known_persona() -> None:
     assert "knowledge consolidator" in prompt
 
 
-def test_available_personas_lists_all_eighteen() -> None:
-    """The 18 personas we shipped under runtime/opencode/profile/agents/."""
+def test_available_personas_lists_all_nineteen() -> None:
+    """The 19 personas we shipped under runtime/opencode/profile/agents/."""
     expected = {
         "maverick.codebase-analyst",
         "maverick.completeness-reviewer",
@@ -64,6 +64,7 @@ def test_available_personas_lists_all_eighteen() -> None:
         "maverick.recon",
         "maverick.runway-seed",
         "maverick.scopist",
+        "maverick.spec-chain",
         "maverick.structuralist",
         "maverick.validation-fixer",
     }

--- a/tests/unit/assumptions/test_standalone_compat.py
+++ b/tests/unit/assumptions/test_standalone_compat.py
@@ -1,0 +1,183 @@
+"""Regression test: standalone (unparented, `source_ref`-keyed) ledger
+entries flow through the existing spec-049 readers unchanged.
+
+Pins the compatibility invariant from
+specs/050-headless-spec-chain/contracts/ledger-and-beads.md: `maverick
+brief` (`per_spec_counts`), `maverick review` (label lookup), and the
+land gate (`open_blocking_entries`) key on labels + state keys only, not
+the parent edge — so standalone entries participate in all three exactly
+like parented ones.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from click.testing import CliRunner
+
+from maverick.assumptions.ledger import open_blocking_entries
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    ASSUMPTION_REVIEW_LABEL,
+    KEY_OWNER_SPEC,
+    KEY_SEVERITY,
+    KEY_SOURCE_REF,
+    KEY_STATUS,
+    NEEDS_HUMAN_REVIEW_LABEL,
+    STATUS_OPEN,
+    Severity,
+)
+from maverick.assumptions.report import per_spec_counts
+from maverick.beads.client import BeadClient
+from maverick.beads.models import BeadDetails, BeadSummary
+from maverick.cli.commands.review import review
+
+_STANDALONE_DESCRIPTION = (
+    "## Question\n\nShould exports include archived widgets?\n\n"
+    "## Adopted Answer\n\nNo, exclude archived widgets by default.\n\n"
+    "## Alternatives Considered\n\n- Include all widgets\n\n"
+    "## Context\n\nSource bead: spec-chain:clarify — spec-chain:clarify\n"
+)
+
+
+def _standalone_entry(**state: str) -> BeadDetails:
+    return BeadDetails(
+        id="dea-standalone",
+        title="Assumption: Should exports include archived widgets?",
+        description=_STANDALONE_DESCRIPTION,
+        bead_type="task",
+        status="open",
+        parent_id=None,
+        labels=[ASSUMPTION_LABEL, ASSUMPTION_REVIEW_LABEL, NEEDS_HUMAN_REVIEW_LABEL],
+        state=state,
+    )
+
+
+class TestPerSpecCountsUnaffectedByMissingParent:
+    async def test_standalone_entry_is_counted_under_its_owner_spec(self) -> None:
+        client = BeadClient(cwd=Path("/tmp/repo"))
+        entry = _standalone_entry(
+            **{
+                KEY_SEVERITY: "medium",
+                KEY_STATUS: STATUS_OPEN,
+                KEY_OWNER_SPEC: "050-headless-spec-chain",
+                KEY_SOURCE_REF: "spec-chain:clarify",
+            }
+        )
+
+        async def fake_query(self: BeadClient, expr: str) -> list[BeadSummary]:
+            if "epic" in expr:
+                return []  # no epic exists yet for this spec
+            return [
+                BeadSummary(
+                    id="dea-standalone", title=entry.title, status="open", bead_type="task"
+                )
+            ]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return entry
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            counts = await per_spec_counts(client)
+
+        by_spec = {row.owner_spec: row for row in counts}
+        assert "050-headless-spec-chain" in by_spec
+        assert by_spec["050-headless-spec-chain"].open[Severity.MEDIUM] == 1
+
+
+class TestOpenBlockingEntriesUnaffectedByMissingParent:
+    async def test_standalone_medium_entry_blocks(self) -> None:
+        client = BeadClient(cwd=Path("/tmp/repo"))
+        entry = _standalone_entry(
+            **{
+                KEY_SEVERITY: "medium",
+                KEY_STATUS: STATUS_OPEN,
+                KEY_OWNER_SPEC: "050-headless-spec-chain",
+                KEY_SOURCE_REF: "spec-chain:clarify",
+            }
+        )
+
+        async def fake_query(self: BeadClient, expr: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(
+                    id="dea-standalone", title=entry.title, status="open", bead_type="task"
+                )
+            ]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return entry
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            blocking = await open_blocking_entries(client)
+
+        assert len(blocking) == 1
+        assert blocking[0].bead_id == "dea-standalone"
+        assert blocking[0].owner_spec == "050-headless-spec-chain"
+
+    async def test_standalone_low_entry_does_not_block(self) -> None:
+        client = BeadClient(cwd=Path("/tmp/repo"))
+        entry = _standalone_entry(
+            **{
+                KEY_SEVERITY: "low",
+                KEY_STATUS: STATUS_OPEN,
+                KEY_OWNER_SPEC: "050-headless-spec-chain",
+                KEY_SOURCE_REF: "spec-chain:clarify",
+            }
+        )
+
+        async def fake_query(self: BeadClient, expr: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(
+                    id="dea-standalone", title=entry.title, status="open", bead_type="task"
+                )
+            ]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return entry
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            blocking = await open_blocking_entries(client)
+
+        assert blocking == ()
+
+
+class TestReviewLabelLookupUnaffectedByMissingParent:
+    def test_answer_flow_works_on_standalone_entry(self) -> None:
+        runner = CliRunner()
+        entry = _standalone_entry(
+            **{
+                KEY_SEVERITY: "medium",
+                KEY_STATUS: STATUS_OPEN,
+                KEY_OWNER_SPEC: "050-headless-spec-chain",
+                KEY_SOURCE_REF: "spec-chain:clarify",
+            }
+        )
+
+        with (
+            patch(
+                "maverick.beads.client.BeadClient.verify_available",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "maverick.beads.client.BeadClient.show",
+                new=AsyncMock(return_value=entry),
+            ),
+            patch("maverick.assumptions.ledger.answer", new=AsyncMock()) as mock_answer,
+        ):
+            result = runner.invoke(
+                review, ["dea-standalone", "--answer", "No, exclude archived widgets."]
+            )
+
+        assert result.exit_code == 0
+        mock_answer.assert_awaited_once()
+        assert "answered and closed" in result.output

--- a/tests/unit/assumptions/test_standalone_ledger.py
+++ b/tests/unit/assumptions/test_standalone_ledger.py
@@ -1,0 +1,309 @@
+"""Tests for maverick.assumptions.ledger.record_standalone_assumption (R5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from maverick.assumptions.errors import AssumptionLedgerError
+from maverick.assumptions.ledger import record_standalone_assumption
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    KEY_OWNER_SPEC,
+    KEY_SEVERITY,
+    KEY_SEVERITY_DEFAULTED,
+    KEY_SOURCE_REF,
+    KEY_STATUS,
+    STATUS_OPEN,
+    Severity,
+)
+from maverick.beads.client import BeadClient
+from maverick.beads.models import BeadDetails, BeadSummary
+from maverick.payloads import AssumptionPayload
+
+
+def _client() -> BeadClient:
+    return BeadClient(cwd=Path("/tmp/repo"))
+
+
+class TestBeadShape:
+    @pytest.mark.asyncio
+    async def test_created_unparented_with_source_ref_state_key(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(
+            question="Should exports include archived widgets?",
+            adopted_answer="No, exclude archived widgets.",
+            severity="high",
+        )
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+        create_bead_mock = AsyncMock(return_value=created)
+
+        with (
+            patch.object(BeadClient, "query", new=AsyncMock(return_value=[])),
+            patch.object(BeadClient, "create_bead", new=create_bead_mock),
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+        ):
+            record = await record_standalone_assumption(
+                client,
+                payload=payload,
+                owner_spec="050-headless-spec-chain",
+                source_ref="spec-chain:clarify",
+            )
+
+        assert record is not None
+        assert record.bead_id == "dea-1"
+        definition = create_bead_mock.await_args.args[0]
+        parent_id = create_bead_mock.await_args.kwargs.get("parent_id")
+        assert parent_id is None
+        assert ASSUMPTION_LABEL in definition.labels
+        assert "assumption-review" in definition.labels
+        assert "needs-human-review" in definition.labels
+        assert definition.assignee == "human"
+
+        state_dict = mock_set_state.await_args.args[1]
+        assert state_dict[KEY_SEVERITY] == Severity.HIGH.value
+        assert state_dict[KEY_STATUS] == STATUS_OPEN
+        assert state_dict[KEY_OWNER_SPEC] == "050-headless-spec-chain"
+        assert state_dict[KEY_SOURCE_REF] == "spec-chain:clarify"
+        assert "source_bead" not in state_dict
+
+    @pytest.mark.asyncio
+    async def test_severity_defaulted_flag_persisted(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="bogus")
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        with (
+            patch.object(BeadClient, "query", new=AsyncMock(return_value=[])),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+        ):
+            record = await record_standalone_assumption(
+                client,
+                payload=payload,
+                owner_spec="050-headless-spec-chain",
+                source_ref="spec-chain:clarify",
+            )
+
+        assert record is not None
+        assert record.severity_defaulted is True
+        state_dict = mock_set_state.await_args.args[1]
+        assert state_dict[KEY_SEVERITY_DEFAULTED] == "true"
+
+    @pytest.mark.asyncio
+    async def test_low_severity_is_deferred(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.", severity="low")
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        with (
+            patch.object(BeadClient, "query", new=AsyncMock(return_value=[])),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch("maverick.library.actions.beads.defer_bead", new=AsyncMock()) as mock_defer,
+        ):
+            await record_standalone_assumption(
+                client,
+                payload=payload,
+                owner_spec="050-headless-spec-chain",
+                source_ref="spec-chain:clarify",
+            )
+
+        mock_defer.assert_awaited_once()
+        assert mock_defer.await_args.args[0] == "dea-1"
+
+
+class TestDedup:
+    @pytest.mark.asyncio
+    async def test_existing_open_entry_same_owner_spec_and_question_merges(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(
+            question="  Should exports include archived widgets?  ",
+            adopted_answer="No.",
+            severity="low",
+        )
+
+        existing_entry = BeadDetails(
+            id="dea-existing",
+            title="Assumption: Should exports include archived widgets?",
+            description=(
+                "## Question\n\nShould exports include archived widgets?\n\n"
+                "## Adopted Answer\n\nNo.\n\n"
+                "## Alternatives Considered\n\n(none)\n\n"
+                "## Context\n\nSource bead: spec-chain:clarify — spec-chain:clarify\n"
+            ),
+            bead_type="task",
+            status="open",
+            labels=[ASSUMPTION_LABEL, "assumption-review", "needs-human-review"],
+            state={
+                KEY_SEVERITY: "medium",
+                KEY_STATUS: STATUS_OPEN,
+                KEY_OWNER_SPEC: "050-headless-spec-chain",
+                KEY_SOURCE_REF: "spec-chain:clarify",
+            },
+        )
+
+        async def fake_query(self: BeadClient, expr: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(
+                    id="dea-existing",
+                    title=existing_entry.title,
+                    status="open",
+                    bead_type="task",
+                )
+            ]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return existing_entry
+
+        create_bead_mock = AsyncMock()
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "create_bead", new=create_bead_mock),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+        ):
+            record = await record_standalone_assumption(
+                client,
+                payload=payload,
+                owner_spec="050-headless-spec-chain",
+                source_ref="spec-chain:clarify",
+            )
+
+        create_bead_mock.assert_not_awaited()
+        assert record is not None
+        assert record.bead_id == "dea-existing"
+
+    @pytest.mark.asyncio
+    async def test_different_owner_spec_does_not_dedup(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Same question?", adopted_answer="A.")
+
+        other_spec_entry = BeadDetails(
+            id="dea-other",
+            title="Assumption: Same question?",
+            description=(
+                "## Question\n\nSame question?\n\n"
+                "## Adopted Answer\n\nOther answer.\n\n"
+                "## Alternatives Considered\n\n(none)\n\n"
+                "## Context\n\nSource bead: x — x\n"
+            ),
+            bead_type="task",
+            status="open",
+            labels=[ASSUMPTION_LABEL],
+            state={
+                KEY_SEVERITY: "low",
+                KEY_STATUS: STATUS_OPEN,
+                KEY_OWNER_SPEC: "051-other-feature",
+            },
+        )
+
+        async def fake_query(self: BeadClient, expr: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(
+                    id="dea-other", title=other_spec_entry.title, status="open", bead_type="task"
+                )
+            ]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return other_spec_entry
+
+        created = type("CreatedBead", (), {"bd_id": "dea-new"})()
+        create_bead_mock = AsyncMock(return_value=created)
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "create_bead", new=create_bead_mock),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+        ):
+            record = await record_standalone_assumption(
+                client,
+                payload=payload,
+                owner_spec="050-headless-spec-chain",
+                source_ref="spec-chain:clarify",
+            )
+
+        create_bead_mock.assert_awaited_once()
+        assert record is not None
+        assert record.bead_id == "dea-new"
+
+    @pytest.mark.asyncio
+    async def test_severity_escalation_on_merge(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(
+            question="Should exports include archived widgets?",
+            adopted_answer="No.",
+            severity="high",
+        )
+
+        existing_entry = BeadDetails(
+            id="dea-existing",
+            title="Assumption: Should exports include archived widgets?",
+            description=(
+                "## Question\n\nShould exports include archived widgets?\n\n"
+                "## Adopted Answer\n\nNo.\n\n"
+                "## Alternatives Considered\n\n(none)\n\n"
+                "## Context\n\nSource bead: x — x\n"
+            ),
+            bead_type="task",
+            status="open",
+            labels=[ASSUMPTION_LABEL],
+            state={
+                KEY_SEVERITY: "low",
+                KEY_STATUS: STATUS_OPEN,
+                KEY_OWNER_SPEC: "050-headless-spec-chain",
+            },
+        )
+
+        async def fake_query(self: BeadClient, expr: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(
+                    id="dea-existing", title=existing_entry.title, status="open", bead_type="task"
+                )
+            ]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return existing_entry
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "create_bead", new=AsyncMock()),
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+        ):
+            record = await record_standalone_assumption(
+                client,
+                payload=payload,
+                owner_spec="050-headless-spec-chain",
+                source_ref="spec-chain:clarify",
+            )
+
+        assert record is not None
+        assert record.severity is Severity.HIGH
+        state_dict = mock_set_state.await_args.args[1]
+        assert state_dict[KEY_SEVERITY] == Severity.HIGH.value
+
+
+class TestErrors:
+    @pytest.mark.asyncio
+    async def test_bd_failure_raises_assumption_ledger_error(self) -> None:
+        client = _client()
+        payload = AssumptionPayload(question="Q?", adopted_answer="A.")
+
+        from maverick.exceptions.beads import BeadQueryError
+
+        async def failing_query(self: BeadClient, expr: str) -> list:
+            raise BeadQueryError("boom")
+
+        with patch.object(BeadClient, "query", new=failing_query):
+            with pytest.raises(AssumptionLedgerError):
+                await record_standalone_assumption(
+                    client,
+                    payload=payload,
+                    owner_spec="050-headless-spec-chain",
+                    source_ref="spec-chain:clarify",
+                )

--- a/tests/unit/beads/test_update_parent.py
+++ b/tests/unit/beads/test_update_parent.py
@@ -1,0 +1,67 @@
+"""Tests for `maverick.library.actions.beads.adopt_remediation_bead` (R6
+adoption primitive fallback — no `bd update --parent` exists)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from maverick.beads.client import BeadClient
+from maverick.beads.models import DependencyType
+from maverick.library.actions.beads import adopt_remediation_bead
+from maverick.workflows.spec_chain.constants import KEY_ADOPTED_BY_EPIC
+
+
+def _client() -> BeadClient:
+    return BeadClient(cwd=Path("/tmp/repo"))
+
+
+class TestAdoptRemediationBead:
+    @pytest.mark.asyncio
+    async def test_wires_discovered_from_edge_epic_to_bead(self) -> None:
+        client = _client()
+        with (
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()) as mock_add_dep,
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+        ):
+            await adopt_remediation_bead(client, bead_id="dea-1", epic_id="epic-1")
+
+        dep = mock_add_dep.await_args.args[0]
+        assert dep.blocker_id == "epic-1"
+        assert dep.blocked_id == "dea-1"
+        assert dep.dep_type == DependencyType.DISCOVERED_FROM
+
+    @pytest.mark.asyncio
+    async def test_stamps_adopted_by_epic_state(self) -> None:
+        client = _client()
+        with (
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()),
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+        ):
+            await adopt_remediation_bead(client, bead_id="dea-1", epic_id="epic-1")
+
+        bead_id_arg = mock_set_state.await_args.args[0]
+        state_dict = mock_set_state.await_args.args[1]
+        assert bead_id_arg == "dea-1"
+        assert state_dict[KEY_ADOPTED_BY_EPIC] == "epic-1"
+
+    @pytest.mark.asyncio
+    async def test_dependency_failure_propagates(self) -> None:
+        client = _client()
+        with patch.object(
+            BeadClient, "add_dependency", new=AsyncMock(side_effect=RuntimeError("boom"))
+        ):
+            with pytest.raises(RuntimeError):
+                await adopt_remediation_bead(client, bead_id="dea-1", epic_id="epic-1")
+
+    @pytest.mark.asyncio
+    async def test_set_state_failure_propagates(self) -> None:
+        client = _client()
+        with (
+            patch.object(BeadClient, "add_dependency", new=AsyncMock()),
+            patch.object(BeadClient, "set_state", new=AsyncMock(side_effect=RuntimeError("boom"))),
+        ):
+            with pytest.raises(RuntimeError):
+                await adopt_remediation_bead(client, bead_id="dea-1", epic_id="epic-1")

--- a/tests/unit/cli/test_spec_command.py
+++ b/tests/unit/cli/test_spec_command.py
@@ -1,0 +1,198 @@
+"""CLI contract tests for ``maverick spec`` (argument/option parsing,
+preflight failures) per specs/050-headless-spec-chain/contracts/cli-spec.md.
+
+Full happy-path chain execution is covered at the workflow level by
+tests/integration/spec_chain/test_full_chain.py — these tests only
+exercise the CLI's own argument parsing and preflight gate, without ever
+constructing an airframe runtime.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from maverick.cli.context import ExitCode
+from maverick.main import cli
+
+
+class TestSpecRegistered:
+    def test_spec_in_cli_help(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(cli, ["--help"])
+        assert "spec" in result.output
+
+    def test_spec_help_shows_from_prd(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(cli, ["spec", "--help"])
+        assert result.exit_code == 0
+        assert "--from-prd" in result.output
+
+
+class TestArgumentParsing:
+    def test_missing_feature_argument_is_usage_error(
+        self, cli_runner: CliRunner, temp_dir: Path
+    ) -> None:
+        result = cli_runner.invoke(cli, ["spec", "--from-prd", str(temp_dir / "prd.md")])
+        assert result.exit_code == ExitCode.PARTIAL
+
+    def test_missing_from_prd_option_is_usage_error(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--from-prd is optional at the Click level (resume doesn't need
+        it) but still required when starting a fresh chain — enforced in
+        the command body, once past preflight and resume discovery."""
+        import os
+
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        (temp_dir / ".specify").mkdir()
+        (temp_dir / ".specify" / "init-options.json").write_text(
+            '{"speckit_version": "0.14.0"}', encoding="utf-8"
+        )
+        monkeypatch.setattr("maverick.cli.commands.spec.verify_bd_ready", lambda cwd=None: None)
+
+        result = cli_runner.invoke(cli, ["spec", "my-feature"])
+        assert result.exit_code == ExitCode.PARTIAL
+
+    def test_nonexistent_prd_file_is_usage_error(
+        self, cli_runner: CliRunner, temp_dir: Path
+    ) -> None:
+        result = cli_runner.invoke(
+            cli, ["spec", "my-feature", "--from-prd", str(temp_dir / "does-not-exist.md")]
+        )
+        assert result.exit_code == ExitCode.PARTIAL
+
+
+class TestPreflight:
+    """Preflight checks run before any workspace is created (FR-001/FR-018)."""
+
+    def test_missing_bd_exits_nonzero_before_workspace_creation(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        prd = temp_dir / "prd.md"
+        prd.write_text("# PRD\n\nSome content.\n", encoding="utf-8")
+
+        with patch("shutil.which", return_value=None):
+            result = cli_runner.invoke(cli, ["spec", "my-feature", "--from-prd", str(prd)])
+
+        assert result.exit_code != ExitCode.SUCCESS
+        assert not (temp_dir / ".maverick" / "runs").exists()
+
+    def test_missing_speckit_exits_partial_with_guidance(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        prd = temp_dir / "prd.md"
+        prd.write_text("# PRD\n\nSome content.\n", encoding="utf-8")
+        # No .specify/ directory anywhere under temp_dir.
+
+        monkeypatch.setattr("maverick.cli.commands.spec.verify_bd_ready", lambda cwd=None: None)
+
+        result = cli_runner.invoke(cli, ["spec", "my-feature", "--from-prd", str(prd)])
+
+        assert result.exit_code == ExitCode.PARTIAL
+        assert not (temp_dir / ".maverick" / "runs").exists()
+
+    def test_empty_prd_exits_partial(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        (temp_dir / ".specify").mkdir()
+        (temp_dir / ".specify" / "init-options.json").write_text(
+            '{"speckit_version": "0.14.0"}', encoding="utf-8"
+        )
+        prd = temp_dir / "prd.md"
+        prd.write_text("", encoding="utf-8")
+
+        monkeypatch.setattr("maverick.cli.commands.spec.verify_bd_ready", lambda cwd=None: None)
+
+        result = cli_runner.invoke(cli, ["spec", "my-feature", "--from-prd", str(prd)])
+
+        assert result.exit_code == ExitCode.PARTIAL
+
+    def test_existing_spec_dir_for_feature_is_a_collision(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        (temp_dir / ".specify").mkdir()
+        (temp_dir / ".specify" / "init-options.json").write_text(
+            '{"speckit_version": "0.14.0"}', encoding="utf-8"
+        )
+        (temp_dir / "specs" / "001-my-feature").mkdir(parents=True)
+        prd = temp_dir / "prd.md"
+        prd.write_text("# PRD\n\ncontent\n", encoding="utf-8")
+
+        monkeypatch.setattr("maverick.cli.commands.spec.verify_bd_ready", lambda cwd=None: None)
+
+        result = cli_runner.invoke(cli, ["spec", "my-feature", "--from-prd", str(prd)])
+
+        assert result.exit_code == ExitCode.PARTIAL
+
+    def test_all_preflight_checks_pass_reaches_workflow_dispatch(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Once preflight passes, the command proceeds to dispatch the
+        workflow (verified by patching execute_python_workflow itself, so
+        this test never touches jj/airframe)."""
+        os.chdir(temp_dir)
+        monkeypatch.setattr(Path, "home", lambda: temp_dir)
+        (temp_dir / ".specify").mkdir()
+        (temp_dir / ".specify" / "init-options.json").write_text(
+            '{"speckit_version": "0.14.0"}', encoding="utf-8"
+        )
+        prd = temp_dir / "prd.md"
+        prd.write_text("# PRD\n\ncontent\n", encoding="utf-8")
+
+        monkeypatch.setattr("maverick.cli.commands.spec.verify_bd_ready", lambda cwd=None: None)
+
+        called: dict[str, object] = {}
+
+        async def _fake_execute(ctx: object, run_config: object) -> None:
+            called["run_config"] = run_config
+
+        async def _fake_load_chain_state(run_id: str, base: Path) -> None:
+            called["run_id"] = run_id
+            return None
+
+        monkeypatch.setattr(
+            "maverick.cli.workflow_executor.execute_python_workflow", _fake_execute
+        )
+        monkeypatch.setattr(
+            "maverick.workflows.spec_chain.state.load_chain_state", _fake_load_chain_state
+        )
+
+        cli_runner.invoke(cli, ["spec", "my-feature", "--from-prd", str(prd)])
+
+        assert "run_config" in called

--- a/tests/unit/init/test_speckit_offer.py
+++ b/tests/unit/init/test_speckit_offer.py
@@ -1,0 +1,134 @@
+"""Unit tests for the `maverick init` Spec Kit install-offer flow (R7/US5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from maverick.init import _maybe_offer_speckit_install, install_speckit
+
+
+class TestAlreadyInstalled:
+    async def test_compatible_speckit_present_is_silent_no_offer(self, tmp_path: Path) -> None:
+        specify_dir = tmp_path / ".specify"
+        specify_dir.mkdir()
+        (specify_dir / "init-options.json").write_text(
+            '{"speckit_version": "0.14.0"}', encoding="utf-8"
+        )
+
+        with patch("click.confirm") as mock_confirm:
+            result = await _maybe_offer_speckit_install(tmp_path, verbose=False)
+
+        assert result is None
+        mock_confirm.assert_not_called()
+
+
+class TestInteractiveAccept:
+    async def test_accept_invokes_installer_via_command_runner(self, tmp_path: Path) -> None:
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("click.confirm", return_value=True),
+            patch(
+                "maverick.init.install_speckit", new=AsyncMock(return_value=True)
+            ) as mock_install,
+        ):
+            mock_stdin.isatty.return_value = True
+            result = await _maybe_offer_speckit_install(tmp_path, verbose=False)
+
+        assert result is True
+        mock_install.assert_awaited_once_with(tmp_path)
+
+    async def test_install_speckit_runs_pinned_uvx_command(self, tmp_path: Path) -> None:
+        from maverick.runners.command import CommandRunner
+        from maverick.runners.models import CommandResult
+
+        async def fake_run(self: CommandRunner, cmd: list[str], **kwargs: object) -> CommandResult:
+            fake_run.captured = cmd  # type: ignore[attr-defined]
+            return CommandResult(returncode=0, stdout="", stderr="", duration_ms=10)
+
+        with patch.object(CommandRunner, "run", new=fake_run):
+            result = await install_speckit(tmp_path)
+
+        assert result is True
+        cmd = fake_run.captured  # type: ignore[attr-defined]
+        assert cmd[0] == "uvx"
+        assert "--from" in cmd
+        assert any(arg.startswith("specify-cli==") for arg in cmd)
+        assert cmd[-2:] == ["init", "--here"]
+
+    async def test_install_failure_returns_false(self, tmp_path: Path) -> None:
+        from maverick.runners.command import CommandRunner
+        from maverick.runners.models import CommandResult
+
+        async def fake_run(self: CommandRunner, cmd: list[str], **kwargs: object) -> CommandResult:
+            return CommandResult(returncode=1, stdout="", stderr="boom", duration_ms=10)
+
+        with patch.object(CommandRunner, "run", new=fake_run):
+            result = await install_speckit(tmp_path)
+
+        assert result is False
+
+
+class TestInteractiveDecline:
+    async def test_decline_returns_none_and_does_not_install(self, tmp_path: Path) -> None:
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("click.confirm", return_value=False),
+            patch("maverick.init.install_speckit", new=AsyncMock()) as mock_install,
+        ):
+            mock_stdin.isatty.return_value = True
+            result = await _maybe_offer_speckit_install(tmp_path, verbose=False)
+
+        assert result is None
+        mock_install.assert_not_called()
+
+
+class TestNonInteractive:
+    async def test_non_tty_skips_offer_entirely(self, tmp_path: Path) -> None:
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("click.confirm") as mock_confirm,
+            patch("maverick.init.install_speckit", new=AsyncMock()) as mock_install,
+        ):
+            mock_stdin.isatty.return_value = False
+            result = await _maybe_offer_speckit_install(tmp_path, verbose=False)
+
+        assert result is None
+        mock_confirm.assert_not_called()
+        mock_install.assert_not_called()
+
+
+class TestIdempotentReinit:
+    async def test_unsupported_version_still_offers_on_reinit(self, tmp_path: Path) -> None:
+        """Present-but-incompatible version is not silently accepted —
+        re-init still surfaces the offer (or notice) rather than treating
+        "something is there" as good enough."""
+        specify_dir = tmp_path / ".specify"
+        specify_dir.mkdir()
+        (specify_dir / "init-options.json").write_text(
+            '{"speckit_version": "0.9.0"}', encoding="utf-8"
+        )
+
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("click.confirm") as mock_confirm,
+        ):
+            mock_stdin.isatty.return_value = False
+            result = await _maybe_offer_speckit_install(tmp_path, verbose=False)
+
+        assert result is None
+        mock_confirm.assert_not_called()  # non-interactive: notice only, no prompt
+
+    async def test_compatible_reinit_never_calls_confirm(self, tmp_path: Path) -> None:
+        specify_dir = tmp_path / ".specify"
+        specify_dir.mkdir()
+        (specify_dir / "init-options.json").write_text(
+            '{"speckit_version": "0.14.0"}', encoding="utf-8"
+        )
+
+        with patch("sys.stdin") as mock_stdin, patch("click.confirm") as mock_confirm:
+            mock_stdin.isatty.return_value = True
+            result = await _maybe_offer_speckit_install(tmp_path, verbose=True)
+
+        assert result is None
+        mock_confirm.assert_not_called()

--- a/tests/unit/init/test_speckit_prereq.py
+++ b/tests/unit/init/test_speckit_prereq.py
@@ -1,0 +1,65 @@
+"""Unit tests for `maverick.init.prereqs.check_speckit_installed` (R7, US5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from maverick.init.models import PreflightStatus
+from maverick.init.prereqs import check_speckit_installed
+
+
+class TestCheckSpeckitInstalled:
+    def test_missing_specify_dir_fails(self, tmp_path: Path) -> None:
+        result = check_speckit_installed(tmp_path)
+        assert result.status == PreflightStatus.FAIL
+        assert result.name == "speckit_installed"
+        assert result.remediation is not None
+        assert "specify init" in result.remediation
+
+    def test_specify_dir_present_no_init_options_json_passes_as_unknown_version(
+        self, tmp_path: Path
+    ) -> None:
+        """`.specify/` present but no version metadata — treated as
+        "installed, proceed structurally" (matches refuel's tolerance for
+        "unknown" template versions), not a hard failure."""
+        (tmp_path / ".specify").mkdir()
+        result = check_speckit_installed(tmp_path)
+        assert result.status == PreflightStatus.PASS
+
+    def test_supported_version_passes(self, tmp_path: Path) -> None:
+        specify_dir = tmp_path / ".specify"
+        specify_dir.mkdir()
+        (specify_dir / "init-options.json").write_text(
+            '{"speckit_version": "0.14.0"}', encoding="utf-8"
+        )
+        result = check_speckit_installed(tmp_path)
+        assert result.status == PreflightStatus.PASS
+        assert "0.14.0" in result.message
+
+    def test_unsupported_version_fails(self, tmp_path: Path) -> None:
+        specify_dir = tmp_path / ".specify"
+        specify_dir.mkdir()
+        (specify_dir / "init-options.json").write_text(
+            '{"speckit_version": "0.9.0"}', encoding="utf-8"
+        )
+        result = check_speckit_installed(tmp_path)
+        assert result.status == PreflightStatus.FAIL
+        assert "0.9.0" in result.message
+        assert result.remediation is not None
+
+    def test_unparseable_init_options_json_treated_as_unknown_version(
+        self, tmp_path: Path
+    ) -> None:
+        specify_dir = tmp_path / ".specify"
+        specify_dir.mkdir()
+        (specify_dir / "init-options.json").write_text("not valid json{{{", encoding="utf-8")
+        result = check_speckit_installed(tmp_path)
+        assert result.status == PreflightStatus.PASS
+
+    def test_never_raises_only_returns_prerequisite_check(self, tmp_path: Path) -> None:
+        """Advisory contract: this check must never hard-fail (raise) —
+        callers (init's offer flow, `maverick spec`'s own preflight) rely
+        on inspecting the returned PrerequisiteCheck, not exception
+        handling."""
+        result = check_speckit_installed(tmp_path / "does" / "not" / "exist")
+        assert result.status == PreflightStatus.FAIL

--- a/tests/unit/squadron/test_spec_chain_squadron.py
+++ b/tests/unit/squadron/test_spec_chain_squadron.py
@@ -1,0 +1,30 @@
+"""Tests for :class:`maverick.squadron.spec_chain.SpecChainSquadron`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from maverick.config import MaverickConfig
+from maverick.squadron.spec_chain import SpecChainSquadron
+
+
+async def test_spec_chain_squadron_builds_chain_agent(
+    stub_airframe_runtime: dict[str, Any],
+    config_with_agents: MaverickConfig,
+    tmp_path: Path,
+) -> None:
+    async with SpecChainSquadron(cwd=tmp_path, config=config_with_agents) as squadron:
+        assert squadron.chain_agent is not None
+    # Exactly one runtime built (the chain agent, bound to the "generate" role).
+    assert len(stub_airframe_runtime["constructed"]) == 1
+
+
+async def test_spec_chain_squadron_close_closes_chain_agent_runtime(
+    stub_airframe_runtime: dict[str, Any],
+    config_with_agents: MaverickConfig,
+    tmp_path: Path,
+) -> None:
+    async with SpecChainSquadron(cwd=tmp_path, config=config_with_agents) as squadron:
+        runtime = squadron.chain_agent._runtime
+    assert runtime.close_calls == 1

--- a/tests/unit/workflows/refuel_speckit/conftest.py
+++ b/tests/unit/workflows/refuel_speckit/conftest.py
@@ -39,12 +39,17 @@ def make_mock_bead_client(
     epic_details_by_id: dict[str, BeadDetails] | None = None,
     children_by_epic: dict[str, list[BeadSummary]] | None = None,
     create_bead_side_effect: Any = None,
+    remediation_candidates: list[BeadSummary] | None = None,
 ) -> MagicMock:
     """Build a MagicMock standing in for ``BeadClient``.
 
     All async methods used by SpeckitRefuelWorkflow are stubbed:
     ``create_bead``, ``add_dependency``, ``set_state``, ``query``,
-    ``show``, ``children``.
+    ``show``, ``children``. ``query`` branches on the filter expression:
+    a ``type=epic...`` query returns *existing_epics*; a
+    ``type=task...`` query (the post-ingest remediation-bead adoption
+    scan) returns *remediation_candidates* (defaults to none, so existing
+    callers that don't pass it see no adoption candidates, unchanged).
     """
     client = MagicMock()
     epic_details_by_id = dict(epic_details_by_id or {})
@@ -58,7 +63,13 @@ def make_mock_bead_client(
     client.create_bead = AsyncMock(side_effect=create_bead_side_effect or _default_create_bead)
     client.add_dependency = AsyncMock(return_value=None)
     client.set_state = AsyncMock(return_value=None)
-    client.query = AsyncMock(return_value=existing_epics or [])
+
+    async def _query(expr: str) -> list[BeadSummary]:
+        if "task" in expr:
+            return remediation_candidates or []
+        return existing_epics or []
+
+    client.query = AsyncMock(side_effect=_query)
 
     async def _show(bead_id: str) -> BeadDetails:
         if bead_id in epic_details_by_id:

--- a/tests/unit/workflows/refuel_speckit/test_adoption.py
+++ b/tests/unit/workflows/refuel_speckit/test_adoption.py
@@ -1,0 +1,229 @@
+"""Tests for SpeckitRefuelWorkflow's post-ingest remediation-bead adoption
+step (US4, T037/contracts/ledger-and-beads.md "Adoption")."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from maverick.beads.models import BeadDetails, BeadSummary
+from maverick.workflows.refuel_speckit.workflow import SpeckitRefuelWorkflow
+from maverick.workflows.spec_chain.constants import (
+    KEY_ADOPTED_BY_EPIC,
+    KEY_SPECKIT_FEATURE,
+    SPEC_REMEDIATION_LABEL,
+)
+from tests.unit.workflows.refuel_speckit.conftest import make_mock_bead_client
+from tests.unit.workflows.refuel_speckit.test_workflow import make_feature_dir, make_inputs
+
+_PATCH_CLIENT = "maverick.beads.client.BeadClient"
+
+
+def _remediation_bead(
+    bead_id: str, *, feature: str, parent_id: str | None = None, adopted_by: str | None = None
+) -> BeadDetails:
+    state = {KEY_SPECKIT_FEATURE: feature}
+    if adopted_by:
+        state[KEY_ADOPTED_BY_EPIC] = adopted_by
+    return BeadDetails(
+        id=bead_id,
+        title=f"Spec remediation: finding for {feature}",
+        bead_type="task",
+        status="open",
+        parent_id=parent_id,
+        labels=[SPEC_REMEDIATION_LABEL],
+        state=state,
+    )
+
+
+class TestAdoptionOnFreshRun:
+    @pytest.mark.asyncio
+    async def test_unparented_matching_bead_is_adopted_under_new_epic(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path, name="048-workflow-sample")
+        remediation = _remediation_bead("dea-rem-1", feature="048-workflow-sample")
+        mock_client = make_mock_bead_client(
+            remediation_candidates=[
+                BeadSummary(
+                    id="dea-rem-1", title=remediation.title, status="open", bead_type="task"
+                )
+            ],
+        )
+        mock_client.show.side_effect = lambda bead_id: (
+            remediation if bead_id == "dea-rem-1" else _raise_lookup(bead_id)
+        )
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            from tests.unit.workflows.refuel_speckit.conftest import collect_events
+
+            _events, result = await collect_events(workflow, make_inputs(feature_dir, tmp_path))
+
+        assert result is not None
+        assert result.success
+        output = result.final_output
+        assert output["adopted_remediation_bead_ids"] == ["dea-rem-1"]
+
+        # Adopted via add_dependency (DISCOVERED_FROM epic->bead) + state stamp.
+        adopt_dep_calls = [
+            c
+            for c in mock_client.add_dependency.call_args_list
+            if c.args[0].blocked_id == "dea-rem-1"
+        ]
+        assert len(adopt_dep_calls) == 1
+        assert adopt_dep_calls[0].args[0].blocker_id == output["epic_id"]
+
+        adopt_state_calls = [
+            c for c in mock_client.set_state.call_args_list if c.args[0] == "dea-rem-1"
+        ]
+        assert len(adopt_state_calls) == 1
+        assert adopt_state_calls[0].args[1][KEY_ADOPTED_BY_EPIC] == output["epic_id"]
+
+
+class TestAdoptionIdempotency:
+    @pytest.mark.asyncio
+    async def test_already_parented_bead_is_skipped(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path, name="048-workflow-sample")
+        already_parented = _remediation_bead(
+            "dea-rem-2", feature="048-workflow-sample", parent_id="epic-existing"
+        )
+        mock_client = make_mock_bead_client(
+            remediation_candidates=[
+                BeadSummary(
+                    id="dea-rem-2",
+                    title=already_parented.title,
+                    status="open",
+                    bead_type="task",
+                )
+            ],
+        )
+        mock_client.show.side_effect = lambda bead_id: (
+            already_parented if bead_id == "dea-rem-2" else _raise_lookup(bead_id)
+        )
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            from tests.unit.workflows.refuel_speckit.conftest import collect_events
+
+            _events, result = await collect_events(workflow, make_inputs(feature_dir, tmp_path))
+
+        assert result is not None
+        output = result.final_output
+        assert output["adopted_remediation_bead_ids"] == []
+        adopt_dep_calls = [
+            c
+            for c in mock_client.add_dependency.call_args_list
+            if c.args[0].blocked_id == "dea-rem-2"
+        ]
+        assert adopt_dep_calls == []
+
+    @pytest.mark.asyncio
+    async def test_already_stamped_bead_is_skipped(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path, name="048-workflow-sample")
+        already_stamped = _remediation_bead(
+            "dea-rem-3", feature="048-workflow-sample", adopted_by="epic-prior"
+        )
+        mock_client = make_mock_bead_client(
+            remediation_candidates=[
+                BeadSummary(
+                    id="dea-rem-3", title=already_stamped.title, status="open", bead_type="task"
+                )
+            ],
+        )
+        mock_client.show.side_effect = lambda bead_id: (
+            already_stamped if bead_id == "dea-rem-3" else _raise_lookup(bead_id)
+        )
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            from tests.unit.workflows.refuel_speckit.conftest import collect_events
+
+            _events, result = await collect_events(workflow, make_inputs(feature_dir, tmp_path))
+
+        assert result is not None
+        output = result.final_output
+        assert output["adopted_remediation_bead_ids"] == []
+
+    @pytest.mark.asyncio
+    async def test_non_matching_feature_is_ignored(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path, name="048-workflow-sample")
+        other_feature = _remediation_bead("dea-rem-4", feature="099-unrelated-feature")
+        mock_client = make_mock_bead_client(
+            remediation_candidates=[
+                BeadSummary(
+                    id="dea-rem-4", title=other_feature.title, status="open", bead_type="task"
+                )
+            ],
+        )
+        mock_client.show.side_effect = lambda bead_id: (
+            other_feature if bead_id == "dea-rem-4" else _raise_lookup(bead_id)
+        )
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            from tests.unit.workflows.refuel_speckit.conftest import collect_events
+
+            _events, result = await collect_events(workflow, make_inputs(feature_dir, tmp_path))
+
+        assert result is not None
+        output = result.final_output
+        assert output["adopted_remediation_bead_ids"] == []
+
+
+class TestAdoptionBestEffort:
+    @pytest.mark.asyncio
+    async def test_one_bead_adoption_failure_does_not_abort_ingestion(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        feature_dir = make_feature_dir(tmp_path, name="048-workflow-sample")
+        failing = _remediation_bead("dea-rem-fail", feature="048-workflow-sample")
+        ok = _remediation_bead("dea-rem-ok", feature="048-workflow-sample")
+
+        mock_client = make_mock_bead_client(
+            remediation_candidates=[
+                BeadSummary(
+                    id="dea-rem-fail", title=failing.title, status="open", bead_type="task"
+                ),
+                BeadSummary(id="dea-rem-ok", title=ok.title, status="open", bead_type="task"),
+            ],
+        )
+
+        def _show(bead_id: str) -> BeadDetails:
+            if bead_id == "dea-rem-fail":
+                return failing
+            if bead_id == "dea-rem-ok":
+                return ok
+            _raise_lookup(bead_id)
+            raise AssertionError("unreachable")
+
+        mock_client.show.side_effect = _show
+
+        async def _flaky_add_dependency(dep: object) -> None:
+            if getattr(dep, "blocked_id", None) == "dea-rem-fail":
+                raise RuntimeError("bd add-dep failed")
+
+        mock_client.add_dependency.side_effect = _flaky_add_dependency
+
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            from tests.unit.workflows.refuel_speckit.conftest import collect_events
+
+            _events, result = await collect_events(workflow, make_inputs(feature_dir, tmp_path))
+
+        assert result is not None
+        assert result.success
+        output = result.final_output
+        assert output["adopted_remediation_bead_ids"] == ["dea-rem-ok"]
+
+
+def _raise_lookup(bead_id: str) -> BeadDetails:
+    raise LookupError(bead_id)

--- a/tests/unit/workflows/spec_chain/__init__.py
+++ b/tests/unit/workflows/spec_chain/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the spec-chain workflow package."""

--- a/tests/unit/workflows/spec_chain/test_agent.py
+++ b/tests/unit/workflows/spec_chain/test_agent.py
@@ -1,0 +1,125 @@
+"""Tests for :class:`maverick.agents.spec_chain.SpecChainAgent`.
+
+Uses a fake airframe runtime (same pattern as
+``tests/unit/agents/test_generator_agent.py``) — no real adapter SDK is
+touched.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from airframe.cost import CostRecord
+from airframe.protocol import RuntimeResult
+
+from maverick.agents.spec_chain import SpecChainAgent
+from maverick.workflows.spec_chain.models import StepReport
+
+
+def _report_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "status": "completed",
+        "artifacts": ["specs/001-foo/spec.md"],
+        "questions": [],
+        "findings": [],
+        "detail": "Spec written from PRD.",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _cost() -> CostRecord:
+    return CostRecord(
+        provider_id="anthropic",
+        model_id="claude-haiku-4-5",
+        cost_usd=0.01,
+        input_tokens=10,
+        output_tokens=20,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        finish="end_turn",
+    )
+
+
+def _make_runtime(
+    structured: dict[str, Any],
+    *,
+    on_execute: Callable[[], None] | None = None,
+) -> Any:
+    runtime = MagicMock()
+    runtime.label = "stub"
+
+    async def _execute(prompt: str, **kwargs: Any) -> RuntimeResult:
+        if on_execute is not None:
+            on_execute()
+        return RuntimeResult(text="", structured=structured, cost=_cost(), finish="end_turn")
+
+    runtime.execute = AsyncMock(side_effect=_execute)
+    runtime.reset = AsyncMock()
+    runtime.close = AsyncMock()
+    return runtime
+
+
+async def test_run_step_returns_step_report(tmp_path: Path) -> None:
+    runtime = _make_runtime(_report_payload())
+    agent = SpecChainAgent(runtime=runtime, cwd=str(tmp_path))
+    async with agent:
+        report = await agent.run_step("/speckit.specify do the thing")
+    assert isinstance(report, StepReport)
+    assert report.status == "completed"
+    assert report.artifacts == ["specs/001-foo/spec.md"]
+
+
+async def test_run_step_uses_spec_chain_persona_and_schema(tmp_path: Path) -> None:
+    runtime = _make_runtime(_report_payload())
+    agent = SpecChainAgent(runtime=runtime, cwd=str(tmp_path))
+    async with agent:
+        await agent.run_step("prompt")
+    call = runtime.execute.await_args
+    assert call.kwargs["persona"] == "maverick.spec-chain"
+    assert call.kwargs["schema"] is StepReport
+
+
+async def test_run_step_binds_cwd_to_workspace_during_execute(tmp_path: Path) -> None:
+    original_cwd = os.getcwd()
+    observed: list[str] = []
+
+    def _capture() -> None:
+        observed.append(os.path.realpath(os.getcwd()))
+
+    runtime = _make_runtime(_report_payload(), on_execute=_capture)
+    agent = SpecChainAgent(runtime=runtime, cwd=str(tmp_path))
+    async with agent:
+        await agent.run_step("prompt")
+
+    assert observed == [os.path.realpath(str(tmp_path))]
+    assert os.getcwd() == original_cwd
+
+
+async def test_run_step_restores_cwd_even_on_failure(tmp_path: Path) -> None:
+    original_cwd = os.getcwd()
+    runtime = MagicMock()
+    runtime.label = "stub"
+    runtime.execute = AsyncMock(side_effect=RuntimeError("boom"))
+    runtime.reset = AsyncMock()
+    runtime.close = AsyncMock()
+
+    agent = SpecChainAgent(runtime=runtime, cwd=str(tmp_path))
+    async with agent:
+        with pytest.raises(RuntimeError):
+            await agent.run_step("prompt")
+
+    assert os.getcwd() == original_cwd
+
+
+async def test_close_routes_to_runtime(tmp_path: Path) -> None:
+    runtime = _make_runtime(_report_payload())
+    agent = SpecChainAgent(runtime=runtime, cwd=str(tmp_path))
+    async with agent:
+        pass
+    runtime.close.assert_awaited_once()

--- a/tests/unit/workflows/spec_chain/test_clarify.py
+++ b/tests/unit/workflows/spec_chain/test_clarify.py
@@ -1,0 +1,188 @@
+"""Tests for the clarify answering-path policy seam
+(`maverick.workflows.spec_chain.clarify`) — R2."""
+
+from __future__ import annotations
+
+from maverick.assumptions.models import Severity
+from maverick.workflows.spec_chain.clarify import (
+    assess_severity,
+    decisions_from_interception,
+    decisions_from_spec_md,
+    supports_interception,
+)
+
+
+class TestSupportsInterception:
+    def test_runtime_without_ask_question_does_not_support(self) -> None:
+        class _PlainRuntime:
+            pass
+
+        assert supports_interception(_PlainRuntime()) is False
+
+    def test_runtime_with_non_callable_ask_question_does_not_support(self) -> None:
+        class _FakeRuntime:
+            ask_question = "not-a-method"
+
+        assert supports_interception(_FakeRuntime()) is False
+
+    def test_runtime_with_ask_question_method_supports(self) -> None:
+        class _InterceptingRuntime:
+            async def ask_question(
+                self, question: str, *, recommended: str | None, alternatives: list[str]
+            ) -> str:
+                return recommended or ""
+
+        assert supports_interception(_InterceptingRuntime()) is True
+
+
+class TestAssessSeverity:
+    def test_unmatched_question_defaults_low(self) -> None:
+        severity, defaulted = assess_severity("Should the button be blue or green?")
+        assert severity is Severity.LOW
+        assert defaulted is True
+
+    def test_scope_keyword_escalates_medium(self) -> None:
+        severity, defaulted = assess_severity("What is out of scope for this feature?")
+        assert severity is Severity.MEDIUM
+        assert defaulted is False
+
+    def test_security_keyword_escalates_medium(self) -> None:
+        severity, defaulted = assess_severity("How should we store the user's credential?")
+        assert severity is Severity.MEDIUM
+        assert defaulted is False
+
+    def test_compliance_keyword_escalates_medium(self) -> None:
+        severity, defaulted = assess_severity("Does this need GDPR compliance review?")
+        assert severity is Severity.MEDIUM
+        assert defaulted is False
+
+    def test_data_integrity_keyword_escalates_medium(self) -> None:
+        severity, defaulted = assess_severity("Is this migration irreversible?")
+        assert severity is Severity.MEDIUM
+        assert defaulted is False
+
+    def test_case_insensitive_matching(self) -> None:
+        severity, _ = assess_severity("What PERMISSION level is required?")
+        assert severity is Severity.MEDIUM
+
+
+class TestDecisionsFromInterception:
+    def test_adopts_recommended_option(self) -> None:
+        decisions, blocked = decisions_from_interception([("Should X?", "Yes", ["No", "Maybe"])])
+        assert blocked is False
+        assert len(decisions) == 1
+        decision = decisions[0]
+        assert decision.question == "Should X?"
+        assert decision.adopted_answer == "Yes"
+        assert decision.alternatives == ("No", "Maybe")
+        assert decision.path == "interception"
+        assert decision.ledger_bead_id is None
+
+    def test_no_recommended_option_falls_back_to_first_alternative(self) -> None:
+        decisions, blocked = decisions_from_interception(
+            [("Should X?", None, ["Option A", "Option B"])]
+        )
+        assert blocked is False
+        assert len(decisions) == 1
+        assert decisions[0].adopted_answer == "Option A"
+        assert decisions[0].alternatives == ("Option B",)
+
+    def test_no_recommended_option_and_no_alternatives_blocks(self) -> None:
+        decisions, blocked = decisions_from_interception([("Should X?", None, [])])
+        assert blocked is True
+        assert decisions == []
+
+    def test_never_silently_skips_a_question_without_blocking(self) -> None:
+        """Every question either produces a decision or trips `blocked` —
+        never both absent (edge case: never silently skip)."""
+        decisions, blocked = decisions_from_interception(
+            [
+                ("Q1 with recommendation", "A1", []),
+                ("Q2 with no recommendation but alternatives", None, ["Alt"]),
+                ("Q3 fully unresolvable", None, []),
+            ]
+        )
+        assert blocked is True
+        # Q1 and Q2 still produced decisions even though Q3 blocked.
+        assert {d.question for d in decisions} == {
+            "Q1 with recommendation",
+            "Q2 with no recommendation but alternatives",
+        }
+
+    def test_severity_assessed_per_question(self) -> None:
+        decisions, _ = decisions_from_interception([("What is in scope here?", "Everything", [])])
+        assert decisions[0].severity is Severity.MEDIUM
+        assert decisions[0].severity_defaulted is False
+
+    def test_multiple_questions_preserve_order(self) -> None:
+        decisions, _ = decisions_from_interception(
+            [
+                ("Q1?", "A1", []),
+                ("Q2?", "A2", []),
+                ("Q3?", "A3", []),
+            ]
+        )
+        assert [d.question for d in decisions] == ["Q1?", "Q2?", "Q3?"]
+
+
+class TestDecisionsFromSpecMd:
+    def test_parses_single_clarification_bullet(self) -> None:
+        content = (
+            "## Clarifications\n\n"
+            "### Session 2026-07-24\n\n"
+            "- Q: Where should the chain execute? → A: Hidden workspace.\n"
+        )
+        decisions = decisions_from_spec_md(content)
+        assert len(decisions) == 1
+        assert decisions[0].question == "Where should the chain execute?"
+        assert decisions[0].adopted_answer == "Hidden workspace."
+        assert decisions[0].alternatives == ()
+        assert decisions[0].path == "non_interactive"
+
+    def test_parses_multiple_bullets_across_sessions(self) -> None:
+        content = (
+            "## Clarifications\n\n"
+            "### Session 2026-07-24\n\n"
+            "- Q: Q1? → A: A1.\n"
+            "- Q: Q2? → A: A2.\n\n"
+            "### Session 2026-07-25\n\n"
+            "- Q: Q3? → A: A3.\n"
+        )
+        decisions = decisions_from_spec_md(content)
+        assert [d.question for d in decisions] == ["Q1?", "Q2?", "Q3?"]
+        assert [d.adopted_answer for d in decisions] == ["A1.", "A2.", "A3."]
+
+    def test_no_clarifications_section_yields_no_decisions(self) -> None:
+        content = "# Feature Specification: Foo\n\nNo clarifications here.\n"
+        assert decisions_from_spec_md(content) == []
+
+    def test_ignores_non_bullet_lines_in_clarifications_section(self) -> None:
+        content = (
+            "## Clarifications\n\n"
+            "### Session 2026-07-24\n\n"
+            "Some prose that is not a Q/A bullet.\n"
+            "- Q: Real question? → A: Real answer.\n"
+        )
+        decisions = decisions_from_spec_md(content)
+        assert len(decisions) == 1
+        assert decisions[0].question == "Real question?"
+
+    def test_severity_escalation_applies_to_parsed_questions(self) -> None:
+        content = (
+            "## Clarifications\n\n"
+            "### Session 2026-07-24\n\n"
+            "- Q: What data retention policy applies? → A: 30 days.\n"
+        )
+        decisions = decisions_from_spec_md(content)
+        assert decisions[0].severity is Severity.MEDIUM
+        assert decisions[0].severity_defaulted is False
+
+    def test_unmatched_question_defaults_to_low_severity(self) -> None:
+        content = (
+            "## Clarifications\n\n"
+            "### Session 2026-07-24\n\n"
+            "- Q: What color should the button be? → A: Blue.\n"
+        )
+        decisions = decisions_from_spec_md(content)
+        assert decisions[0].severity is Severity.LOW
+        assert decisions[0].severity_defaulted is True

--- a/tests/unit/workflows/spec_chain/test_interrupt.py
+++ b/tests/unit/workflows/spec_chain/test_interrupt.py
@@ -1,0 +1,219 @@
+"""Unit tests for graceful-interrupt handling (US3, T029).
+
+A graceful SIGINT during a step cancels `SpecChainWorkflow._run()`;
+`PythonWorkflow._run_with_cleanup`'s CancelledError handling runs the
+workflow's registered rollbacks, which flip the freshest on-disk
+checkpoint's status to ``halted`` (never re-deriving from a possibly
+stale in-memory snapshot). A hard crash never reaches that rollback and
+leaves ``status="running"`` — which `discover_resumable` still treats as
+stale-resumable (contracts/chain-state.md).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from maverick.config import AgentBindingConfig, AgentsConfig, MaverickConfig
+from maverick.workflows.spec_chain.constants import ChainStep
+from maverick.workflows.spec_chain.state import discover_resumable, load_chain_state
+from maverick.workflows.spec_chain.workflow import SpecChainWorkflow
+from tests.integration.spec_chain.conftest import FEATURE, build_speckit_repo
+
+
+class _HangingRuntime:
+    """Never returns from `execute()` until cancelled — lets the test
+    control exactly when mid-step cancellation happens."""
+
+    label = "stub"
+
+    def __init__(self, *, model: str | None = None, **kwargs: Any) -> None:
+        self.model = model
+        self.entered = asyncio.Event()
+
+    async def execute(self, prompt: str, **kwargs: Any) -> Any:
+        self.entered.set()
+        await asyncio.sleep(999)
+
+    async def reset(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    def validate_binding(self, _binding: Any) -> bool:
+        return True
+
+
+def _make_config() -> MaverickConfig:
+    return MaverickConfig(
+        agents=AgentsConfig(generate=AgentBindingConfig(provider="claude", model_id="stub-model"))
+    )
+
+
+async def _drive_and_cancel_mid_step(
+    speckit_repo: Path, fake_home: Path, monkeypatch: pytest.MonkeyPatch, run_id: str
+) -> tuple[SpecChainWorkflow, str]:
+    """Start the chain, wait for the first step to actually enter its
+    (hanging) runtime call, then cancel — mirroring how a graceful SIGINT
+    cancels the workflow's own background task in production
+    (`PythonWorkflow._run_with_cleanup`)."""
+    constructed: list[_HangingRuntime] = []
+
+    def _factory(provider_id: str) -> type[_HangingRuntime]:
+        class _Bound(_HangingRuntime):
+            def __init__(self, *, model: str | None = None, **kwargs: Any) -> None:
+                super().__init__(model=model, **kwargs)
+                constructed.append(self)
+
+        return _Bound
+
+    monkeypatch.setattr("airframe.runtime_for", _factory)
+
+    workflow = SpecChainWorkflow(config=_make_config())
+    inputs = {
+        "run_id": run_id,
+        "feature": FEATURE,
+        "cwd": str(speckit_repo),
+        "prd_path": str(speckit_repo / "docs" / "prd.md"),
+        "home": str(fake_home),
+    }
+
+    # Mirror PythonWorkflow.execute()'s own setup so this test has direct
+    # access to the background task PythonWorkflow._run_with_cleanup runs
+    # as `run_task` internally — the same object graceful shutdown cancels.
+    workflow._event_queue = asyncio.Queue()
+    workflow._step_results = []
+    workflow._step_start_times = {}
+    workflow._current_step = None
+    workflow._rollback_stack = []
+    workflow.result = None
+
+    run_task = asyncio.create_task(workflow._run_with_cleanup(inputs))
+
+    # Wait until the hanging runtime is actually inside execute() — i.e.
+    # we're mid-step, not still in workspace prep.
+    for _ in range(200):
+        if constructed and constructed[0].entered.is_set():
+            break
+        await asyncio.sleep(0.01)
+    else:
+        raise AssertionError("runtime never entered execute() — test setup broken")
+
+    run_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+    return workflow, run_id
+
+
+class TestGracefulInterruptCheckspointsHalted:
+    async def test_status_flipped_to_halted_on_cancel(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        speckit_repo = build_speckit_repo(tmp_path)
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+
+        _workflow, run_id = await _drive_and_cancel_mid_step(
+            speckit_repo, fake_home, monkeypatch, "interrupt-halted"
+        )
+
+        state = await load_chain_state(run_id, speckit_repo)
+        assert state is not None
+        assert state.status == "halted"
+
+    async def test_specify_step_left_in_progress_not_falsely_succeeded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        speckit_repo = build_speckit_repo(tmp_path)
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+
+        _workflow, run_id = await _drive_and_cancel_mid_step(
+            speckit_repo, fake_home, monkeypatch, "interrupt-in-progress"
+        )
+
+        state = await load_chain_state(run_id, speckit_repo)
+        assert state is not None
+        assert state.steps[ChainStep.SPECIFY].status == "in_progress"
+
+    async def test_workspace_preserved_for_resume(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        speckit_repo = build_speckit_repo(tmp_path)
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+
+        _workflow, run_id = await _drive_and_cancel_mid_step(
+            speckit_repo, fake_home, monkeypatch, "interrupt-workspace"
+        )
+
+        state = await load_chain_state(run_id, speckit_repo)
+        assert state is not None
+        assert Path(state.workspace_path).is_dir()
+
+    async def test_halted_state_is_discoverable_as_resumable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        speckit_repo = build_speckit_repo(tmp_path)
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+
+        await _drive_and_cancel_mid_step(
+            speckit_repo, fake_home, monkeypatch, "interrupt-resumable"
+        )
+
+        resumable = await discover_resumable(FEATURE, speckit_repo)
+        assert resumable is not None
+        assert resumable.run_id == "interrupt-resumable"
+        assert resumable.status == "halted"
+
+
+class TestHardCrashLeavesRunningStatus:
+    async def test_state_saved_before_cancellation_hook_runs_still_shows_running(
+        self, tmp_path: Path
+    ) -> None:
+        """A hard crash (kill -9, power loss) never gets a chance to run
+        any rollback — simulated here by checkpointing "in_progress" the
+        same way `_run_one_step` does, then asserting on that raw
+        checkpoint without ever invoking the cancellation/rollback path.
+        `discover_resumable` still treats `status="running"` as
+        stale-resumable (contracts/chain-state.md), which the resume
+        integration tests already verify end-to-end."""
+        from datetime import UTC, datetime
+
+        from maverick.workflows.spec_chain.models import ChainState, StepRecord
+        from maverick.workflows.spec_chain.state import save_chain_state
+
+        now = datetime.now(tz=UTC)
+        state = ChainState(
+            run_id="hard-crash",
+            feature=FEATURE,
+            feature_dir=None,
+            prd_path="docs/prd.md",
+            prd_digest="0" * 64,
+            workspace_path=str(tmp_path / "workspace"),
+            status="running",
+            steps={
+                ChainStep.SPECIFY: StepRecord(
+                    step=ChainStep.SPECIFY, status="in_progress", started_at=now
+                )
+            },
+            clarify_decisions=[],
+            remediation_bead_ids=[],
+            started_at=now,
+            updated_at=now,
+        )
+        await save_chain_state(state, tmp_path)
+
+        loaded = await load_chain_state("hard-crash", tmp_path)
+        assert loaded is not None
+        assert loaded.status == "running"
+
+        resumable = await discover_resumable(FEATURE, tmp_path)
+        assert resumable is not None
+        assert resumable.status == "running"

--- a/tests/unit/workflows/spec_chain/test_landing.py
+++ b/tests/unit/workflows/spec_chain/test_landing.py
@@ -1,0 +1,186 @@
+"""Tests for atomic per-step artifact landing
+(`maverick.workflows.spec_chain.landing`)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from maverick.workflows.spec_chain.constants import ChainStep
+from maverick.workflows.spec_chain.landing import (
+    land_step_artifacts,
+    resolve_feature_dir,
+    verify_step_artifacts,
+)
+
+
+def _make_workspace_feature(tmp_path: Path, feature_dir: str, **files: str) -> Path:
+    workspace = tmp_path / "workspace"
+    feature_path = workspace / "specs" / feature_dir
+    feature_path.mkdir(parents=True)
+    for name, content in files.items():
+        (feature_path / name).write_text(content, encoding="utf-8")
+    return workspace
+
+
+class TestResolveFeatureDir:
+    def test_single_new_dir_is_resolved(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        (workspace / "specs" / "001-existing").mkdir(parents=True)
+        (workspace / "specs" / "002-new-feature").mkdir(parents=True)
+
+        result = resolve_feature_dir(workspace=workspace, checkout_specs_before={"001-existing"})
+        assert result == "002-new-feature"
+
+    def test_no_specs_dir_returns_none(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        assert resolve_feature_dir(workspace=workspace, checkout_specs_before=set()) is None
+
+    def test_no_new_dirs_returns_none(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        (workspace / "specs" / "001-existing").mkdir(parents=True)
+        result = resolve_feature_dir(workspace=workspace, checkout_specs_before={"001-existing"})
+        assert result is None
+
+    def test_ambiguous_diff_falls_back_to_feature_json(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        (workspace / "specs" / "002-candidate-a").mkdir(parents=True)
+        (workspace / "specs" / "003-candidate-b").mkdir(parents=True)
+        specify_dir = workspace / ".specify"
+        specify_dir.mkdir(parents=True)
+        (specify_dir / "feature.json").write_text(
+            '{"feature_directory": "specs/003-candidate-b"}', encoding="utf-8"
+        )
+
+        result = resolve_feature_dir(workspace=workspace, checkout_specs_before=set())
+        assert result == "003-candidate-b"
+
+    def test_ambiguous_diff_with_no_feature_json_returns_none(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        (workspace / "specs" / "002-candidate-a").mkdir(parents=True)
+        (workspace / "specs" / "003-candidate-b").mkdir(parents=True)
+
+        result = resolve_feature_dir(workspace=workspace, checkout_specs_before=set())
+        assert result is None
+
+    def test_malformed_feature_json_does_not_raise(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        (workspace / "specs" / "002-candidate-a").mkdir(parents=True)
+        (workspace / "specs" / "003-candidate-b").mkdir(parents=True)
+        specify_dir = workspace / ".specify"
+        specify_dir.mkdir(parents=True)
+        (specify_dir / "feature.json").write_text("not valid json{{{", encoding="utf-8")
+
+        result = resolve_feature_dir(workspace=workspace, checkout_specs_before=set())
+        assert result is None
+
+
+class TestVerifyStepArtifacts:
+    def test_specify_verified_when_spec_md_exists(self, tmp_path: Path) -> None:
+        workspace = _make_workspace_feature(tmp_path, "001-foo", **{"spec.md": "content"})
+        result = verify_step_artifacts(
+            workspace=workspace, feature_dir="001-foo", step=ChainStep.SPECIFY
+        )
+        assert result == ["spec.md"]
+
+    def test_specify_fails_verification_when_spec_md_missing(self, tmp_path: Path) -> None:
+        workspace = _make_workspace_feature(tmp_path, "001-foo")
+        result = verify_step_artifacts(
+            workspace=workspace, feature_dir="001-foo", step=ChainStep.SPECIFY
+        )
+        assert result == []
+
+    def test_plan_requires_plan_md(self, tmp_path: Path) -> None:
+        workspace = _make_workspace_feature(
+            tmp_path, "001-foo", **{"spec.md": "x", "plan.md": "y"}
+        )
+        result = verify_step_artifacts(
+            workspace=workspace, feature_dir="001-foo", step=ChainStep.PLAN
+        )
+        assert result == ["plan.md"]
+
+    def test_tasks_requires_tasks_md(self, tmp_path: Path) -> None:
+        workspace = _make_workspace_feature(tmp_path, "001-foo", **{"tasks.md": "z"})
+        result = verify_step_artifacts(
+            workspace=workspace, feature_dir="001-foo", step=ChainStep.TASKS
+        )
+        assert result == ["tasks.md"]
+
+    def test_analyze_requires_no_new_artifact(self, tmp_path: Path) -> None:
+        workspace = _make_workspace_feature(tmp_path, "001-foo")
+        result = verify_step_artifacts(
+            workspace=workspace, feature_dir="001-foo", step=ChainStep.ANALYZE
+        )
+        assert result == []
+
+    def test_missing_feature_dir_entirely_returns_empty(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        result = verify_step_artifacts(
+            workspace=workspace, feature_dir="001-foo", step=ChainStep.SPECIFY
+        )
+        assert result == []
+
+
+class TestLandStepArtifacts:
+    def test_lands_full_feature_dir_into_checkout(self, tmp_path: Path) -> None:
+        workspace = _make_workspace_feature(tmp_path, "001-foo", **{"spec.md": "spec content"})
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+
+        land_step_artifacts(workspace=workspace, checkout=checkout, feature_dir="001-foo")
+
+        landed = checkout / "specs" / "001-foo" / "spec.md"
+        assert landed.is_file()
+        assert landed.read_text(encoding="utf-8") == "spec content"
+
+    def test_second_landing_overwrites_with_current_content(self, tmp_path: Path) -> None:
+        workspace = _make_workspace_feature(
+            tmp_path, "001-foo", **{"spec.md": "v1", "plan.md": "v1 plan"}
+        )
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        land_step_artifacts(workspace=workspace, checkout=checkout, feature_dir="001-foo")
+
+        # A later step adds tasks.md and updates plan.md in the workspace.
+        (workspace / "specs" / "001-foo" / "plan.md").write_text("v2 plan", encoding="utf-8")
+        (workspace / "specs" / "001-foo" / "tasks.md").write_text("v1 tasks", encoding="utf-8")
+
+        land_step_artifacts(workspace=workspace, checkout=checkout, feature_dir="001-foo")
+
+        feature_path = checkout / "specs" / "001-foo"
+        assert (feature_path / "spec.md").read_text(encoding="utf-8") == "v1"
+        assert (feature_path / "plan.md").read_text(encoding="utf-8") == "v2 plan"
+        assert (feature_path / "tasks.md").read_text(encoding="utf-8") == "v1 tasks"
+
+    def test_no_leftover_staging_directories(self, tmp_path: Path) -> None:
+        workspace = _make_workspace_feature(tmp_path, "001-foo", **{"spec.md": "x"})
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+
+        land_step_artifacts(workspace=workspace, checkout=checkout, feature_dir="001-foo")
+
+        specs_dir = checkout / "specs"
+        entries = {p.name for p in specs_dir.iterdir()}
+        assert entries == {"001-foo"}
+
+    def test_missing_workspace_feature_dir_raises(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+
+        with pytest.raises(FileNotFoundError):
+            land_step_artifacts(workspace=workspace, checkout=checkout, feature_dir="001-foo")
+
+    def test_creates_specs_parent_dir_if_absent(self, tmp_path: Path) -> None:
+        workspace = _make_workspace_feature(tmp_path, "001-foo", **{"spec.md": "x"})
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        assert not (checkout / "specs").exists()
+
+        land_step_artifacts(workspace=workspace, checkout=checkout, feature_dir="001-foo")
+
+        assert (checkout / "specs" / "001-foo" / "spec.md").is_file()

--- a/tests/unit/workflows/spec_chain/test_models.py
+++ b/tests/unit/workflows/spec_chain/test_models.py
@@ -1,0 +1,927 @@
+"""Tests for maverick.workflows.spec_chain constants and models.
+
+T004: ChainStep ordering, ChainState/StepRecord/ClarifyDecision/StepReport/
+AnalyzeFinding validation, and the "in_progress only after all prior steps
+succeeded" state-transition invariant — per
+specs/050-headless-spec-chain/data-model.md.
+
+Written before implementation (TDD, Constitution Principle V):
+``src/maverick/workflows/spec_chain/constants.py`` and
+``.../models.py`` are still placeholder stubs, so every test in this
+module MUST fail (ImportError / AttributeError) until T007 (constants.py)
+and T008 (models.py) land.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from maverick.workflows.spec_chain.models import ChainState, StepRecord
+
+
+# ===========================================================================
+# Shared fixtures / builders
+# ===========================================================================
+
+
+def _now() -> datetime:
+    return datetime(2026, 7, 24, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_step_record(step: Any, status: str = "pending", **overrides: Any) -> StepRecord:
+    """Build a valid StepRecord for *step* with sensible fresh defaults."""
+    from maverick.workflows.spec_chain.models import StepRecord
+
+    defaults: dict[str, Any] = {
+        "step": step,
+        "status": status,
+        "attempts": 0,
+        "artifacts": [],
+        "landed": False,
+        "error": None,
+        "started_at": None,
+        "finished_at": None,
+    }
+    defaults.update(overrides)
+    return StepRecord(**defaults)
+
+
+def _make_chain_state(**overrides: Any) -> ChainState:
+    """Build a valid ChainState from sample data."""
+    from maverick.workflows.spec_chain.models import ChainState
+
+    defaults: dict[str, Any] = {
+        "run_id": "run-20260724-120000",
+        "feature": "headless-spec-chain",
+        "feature_dir": None,
+        "prd_path": "docs/prd.md",
+        "prd_digest": hashlib.sha256(b"prd content").hexdigest(),
+        "workspace_path": ("/home/user/.maverick/workspaces/proj/spec-chain/headless-spec-chain/"),
+        "status": "running",
+        "steps": {},
+        "clarify_decisions": [],
+        "remediation_bead_ids": [],
+        "started_at": _now(),
+        "updated_at": _now(),
+    }
+    defaults.update(overrides)
+    return ChainState(**defaults)
+
+
+# ===========================================================================
+# ChainStep (enum) — constants.py
+# ===========================================================================
+
+
+class TestChainStepOrder:
+    """ChainStep enum ordering: SPECIFY -> CLARIFY -> PLAN -> TASKS -> ANALYZE.
+
+    "The order is the single source of truth for FR-002/FR-008 gating."
+    """
+
+    def test_members_exist(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        assert {member.name for member in ChainStep} == {
+            "SPECIFY",
+            "CLARIFY",
+            "PLAN",
+            "TASKS",
+            "ANALYZE",
+        }
+
+    def test_string_values(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        assert ChainStep.SPECIFY == "specify"
+        assert ChainStep.CLARIFY == "clarify"
+        assert ChainStep.PLAN == "plan"
+        assert ChainStep.TASKS == "tasks"
+        assert ChainStep.ANALYZE == "analyze"
+
+    def test_chain_step_order_sequence(self) -> None:
+        from maverick.workflows.spec_chain.constants import CHAIN_STEP_ORDER, ChainStep
+
+        assert CHAIN_STEP_ORDER == (
+            ChainStep.SPECIFY,
+            ChainStep.CLARIFY,
+            ChainStep.PLAN,
+            ChainStep.TASKS,
+            ChainStep.ANALYZE,
+        )
+
+    def test_order_is_single_source_of_truth(self) -> None:
+        from maverick.workflows.spec_chain.constants import CHAIN_STEP_ORDER, ChainStep
+
+        assert len(CHAIN_STEP_ORDER) == len(list(ChainStep))
+        assert set(CHAIN_STEP_ORDER) == set(ChainStep)
+        assert len(set(CHAIN_STEP_ORDER)) == len(CHAIN_STEP_ORDER)  # no duplicates
+
+
+class TestNextStep:
+    """``next_step(...)`` derives the next step to run from CHAIN_STEP_ORDER
+    (data-model.md: "next_step(state) derives from it"; contracts/chain-state.md:
+    "continue from the first step whose status is not succeeded")."""
+
+    def test_empty_steps_returns_first_step(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+        from maverick.workflows.spec_chain.models import next_step
+
+        assert next_step({}) == ChainStep.SPECIFY
+
+    def test_returns_first_non_succeeded_step(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+        from maverick.workflows.spec_chain.models import next_step
+
+        steps = {ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="succeeded")}
+        assert next_step(steps) == ChainStep.CLARIFY
+
+    def test_skips_over_multiple_succeeded_steps(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+        from maverick.workflows.spec_chain.models import next_step
+
+        steps = {
+            ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="succeeded"),
+            ChainStep.CLARIFY: _make_step_record(ChainStep.CLARIFY, status="succeeded"),
+            ChainStep.PLAN: _make_step_record(ChainStep.PLAN, status="succeeded"),
+        }
+        assert next_step(steps) == ChainStep.TASKS
+
+    def test_failed_step_is_the_next_step_to_retry(self) -> None:
+        """A failed step is retried on resume, not skipped over."""
+        from maverick.workflows.spec_chain.constants import ChainStep
+        from maverick.workflows.spec_chain.models import next_step
+
+        steps = {
+            ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="succeeded"),
+            ChainStep.CLARIFY: _make_step_record(ChainStep.CLARIFY, status="failed"),
+        }
+        assert next_step(steps) == ChainStep.CLARIFY
+
+    def test_all_succeeded_returns_none(self) -> None:
+        from maverick.workflows.spec_chain.constants import CHAIN_STEP_ORDER
+        from maverick.workflows.spec_chain.models import next_step
+
+        steps = {s: _make_step_record(s, status="succeeded") for s in CHAIN_STEP_ORDER}
+        assert next_step(steps) is None
+
+    def test_works_from_a_chain_state_steps_mapping(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+        from maverick.workflows.spec_chain.models import next_step
+
+        state = _make_chain_state(
+            steps={ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="succeeded")}
+        )
+        assert next_step(state.steps) == ChainStep.CLARIFY
+
+
+# ===========================================================================
+# StepRecord — nested in ChainState
+# ===========================================================================
+
+
+class TestStepRecord:
+    def test_minimal_construction_defaults(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+        from maverick.workflows.spec_chain.models import StepRecord
+
+        record = StepRecord(step=ChainStep.SPECIFY, status="pending")
+        assert record.step == ChainStep.SPECIFY
+        assert record.status == "pending"
+        assert record.attempts == 0
+        assert list(record.artifacts) == []
+        assert record.landed is False
+        assert record.error is None
+        assert record.started_at is None
+        assert record.finished_at is None
+
+    def test_all_fields_construction(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+        from maverick.workflows.spec_chain.models import StepRecord
+
+        started = _now()
+        record = StepRecord(
+            step=ChainStep.PLAN,
+            status="succeeded",
+            attempts=2,
+            artifacts=["specs/001-foo/plan.md"],
+            landed=True,
+            error=None,
+            started_at=started,
+            finished_at=started,
+        )
+        assert record.attempts == 2
+        assert record.artifacts == ["specs/001-foo/plan.md"]
+        assert record.landed is True
+        assert record.started_at == started
+
+    def test_artifacts_is_list(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        record = _make_step_record(ChainStep.SPECIFY, artifacts=["a.md", "b.md"])
+        assert isinstance(record.artifacts, list)
+
+    @pytest.mark.parametrize(
+        "status", ["pending", "in_progress", "succeeded", "failed", "skipped"]
+    )
+    def test_valid_status_values(self, status: str) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+        from maverick.workflows.spec_chain.models import StepRecord
+
+        record = StepRecord(step=ChainStep.SPECIFY, status=status)
+        assert record.status == status
+
+    def test_invalid_status_raises(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+        from maverick.workflows.spec_chain.models import StepRecord
+
+        with pytest.raises(ValidationError):
+            StepRecord(step=ChainStep.SPECIFY, status="not-a-real-status")
+
+    def test_error_field_carries_failure_summary(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        record = _make_step_record(ChainStep.CLARIFY, status="failed", error="model timeout")
+        assert record.error == "model timeout"
+
+    def test_started_and_finished_at_accept_datetimes(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+        from maverick.workflows.spec_chain.models import StepRecord
+
+        started = _now()
+        record = StepRecord(step=ChainStep.SPECIFY, status="in_progress", started_at=started)
+        assert record.started_at == started
+        assert record.finished_at is None
+
+    def test_invalid_step_raises(self) -> None:
+        from maverick.workflows.spec_chain.models import StepRecord
+
+        with pytest.raises(ValidationError):
+            StepRecord(step="not-a-chain-step", status="pending")  # type: ignore[arg-type]
+
+
+# ===========================================================================
+# ChainState — schema_version, required fields, defaults
+# ===========================================================================
+
+
+class TestChainStateFields:
+    def test_construction_all_fields(self) -> None:
+        from maverick.workflows.spec_chain.models import ChainState
+
+        state = _make_chain_state()
+        assert isinstance(state, ChainState)
+
+    def test_required_fields_accessible(self) -> None:
+        state = _make_chain_state()
+        assert state.run_id == "run-20260724-120000"
+        assert state.feature == "headless-spec-chain"
+        assert state.status == "running"
+        assert state.prd_path == "docs/prd.md"
+
+    def test_schema_version_defaults_to_1(self) -> None:
+        state = _make_chain_state()
+        assert state.schema_version == 1
+
+    def test_schema_version_explicit(self) -> None:
+        state = _make_chain_state(schema_version=1)
+        assert state.schema_version == 1
+
+    def test_feature_dir_defaults_to_none(self) -> None:
+        """feature_dir is None until specify lands."""
+        state = _make_chain_state()
+        assert state.feature_dir is None
+
+    def test_feature_dir_set_after_specify(self) -> None:
+        state = _make_chain_state(feature_dir="specs/051-headless-spec-chain")
+        assert state.feature_dir == "specs/051-headless-spec-chain"
+
+    def test_clarify_decisions_defaults_to_empty_list(self) -> None:
+        state = _make_chain_state()
+        assert list(state.clarify_decisions) == []
+
+    def test_remediation_bead_ids_defaults_to_empty_list(self) -> None:
+        state = _make_chain_state()
+        assert list(state.remediation_bead_ids) == []
+
+    def test_remediation_bead_ids_is_list_of_str(self) -> None:
+        state = _make_chain_state(remediation_bead_ids=["bd-1", "bd-2"])
+        assert state.remediation_bead_ids == ["bd-1", "bd-2"]
+
+    @pytest.mark.parametrize("status", ["running", "halted", "completed", "failed"])
+    def test_valid_status_values(self, status: str) -> None:
+        state = _make_chain_state(status=status)
+        assert state.status == status
+
+    def test_invalid_status_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_chain_state(status="not-a-status")
+
+    def test_missing_required_field_raises(self) -> None:
+        from maverick.workflows.spec_chain.models import ChainState
+
+        with pytest.raises(ValidationError):
+            ChainState(  # type: ignore[call-arg]
+                feature="headless-spec-chain",
+                prd_path="docs/prd.md",
+                prd_digest=hashlib.sha256(b"x").hexdigest(),
+                workspace_path="/tmp/ws",
+                status="running",
+                steps={},
+                clarify_decisions=[],
+                remediation_bead_ids=[],
+                started_at=_now(),
+                updated_at=_now(),
+            )  # run_id omitted
+
+    def test_steps_dict_keyed_by_chain_step(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        state = _make_chain_state(
+            steps={ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="succeeded")}
+        )
+        assert ChainStep.SPECIFY in state.steps
+        assert state.steps[ChainStep.SPECIFY].status == "succeeded"
+
+    def test_json_round_trip_preserves_steps(self) -> None:
+        """Persisted to .maverick/runs/<run-id>/spec-chain.json as JSON;
+        dict[ChainStep, StepRecord] keys must serialise to plain strings
+        and round-trip through model_validate."""
+        from maverick.workflows.spec_chain.constants import ChainStep
+        from maverick.workflows.spec_chain.models import ChainState
+
+        state = _make_chain_state(
+            steps={ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="succeeded")}
+        )
+        dumped = state.model_dump(mode="json")
+        assert set(dumped["steps"].keys()) == {"specify"}
+        assert dumped["steps"]["specify"]["status"] == "succeeded"
+
+        restored = ChainState.model_validate(dumped)
+        assert restored.steps[ChainStep.SPECIFY].status == "succeeded"
+        assert restored == state
+
+
+# ===========================================================================
+# ChainState — Validation rules: feature name, non-empty, filesystem-safe slug
+# ===========================================================================
+
+
+class TestChainStateFeatureValidation:
+    """Validation rules: "Feature name: non-empty, filesystem-safe slug."""
+
+    def test_empty_feature_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_chain_state(feature="")
+
+    def test_feature_with_parent_dir_traversal_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_chain_state(feature="../escape")
+
+    def test_feature_with_slash_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_chain_state(feature="foo/bar")
+
+    def test_valid_kebab_slug_accepted(self) -> None:
+        state = _make_chain_state(feature="headless-spec-chain")
+        assert state.feature == "headless-spec-chain"
+
+
+# ===========================================================================
+# ChainState — state-transition invariant: in_progress only after all
+# prior steps have succeeded.
+# ===========================================================================
+
+
+class TestChainStateStepInvariant:
+    """ "Invariant: a step may be in_progress only if all steps ordered
+    before it are succeeded." (data-model.md "State transitions")."""
+
+    def test_fresh_state_with_no_steps_is_valid(self) -> None:
+        state = _make_chain_state(steps={})
+        assert state.steps == {}
+
+    def test_first_step_in_progress_is_valid(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        state = _make_chain_state(
+            steps={ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="in_progress")}
+        )
+        assert state.steps[ChainStep.SPECIFY].status == "in_progress"
+
+    def test_ascending_progress_is_valid(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        state = _make_chain_state(
+            steps={
+                ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="succeeded"),
+                ChainStep.CLARIFY: _make_step_record(ChainStep.CLARIFY, status="succeeded"),
+                ChainStep.PLAN: _make_step_record(ChainStep.PLAN, status="in_progress"),
+            }
+        )
+        assert state.steps[ChainStep.PLAN].status == "in_progress"
+
+    def test_last_step_in_progress_after_all_prior_succeeded_is_valid(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        steps = {
+            s: _make_step_record(s, status="succeeded")
+            for s in (
+                ChainStep.SPECIFY,
+                ChainStep.CLARIFY,
+                ChainStep.PLAN,
+                ChainStep.TASKS,
+            )
+        }
+        steps[ChainStep.ANALYZE] = _make_step_record(ChainStep.ANALYZE, status="in_progress")
+        state = _make_chain_state(steps=steps)
+        assert state.steps[ChainStep.ANALYZE].status == "in_progress"
+
+    def test_in_progress_step_with_missing_prior_step_raises(self) -> None:
+        """CLARIFY in_progress but SPECIFY has no record at all (never
+        attempted) violates the invariant just as much as an explicit
+        pending/failed prior step."""
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        with pytest.raises(ValidationError):
+            _make_chain_state(
+                steps={
+                    ChainStep.CLARIFY: _make_step_record(ChainStep.CLARIFY, status="in_progress")
+                }
+            )
+
+    def test_in_progress_step_with_pending_prior_step_raises(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        with pytest.raises(ValidationError):
+            _make_chain_state(
+                steps={
+                    ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="pending"),
+                    ChainStep.CLARIFY: _make_step_record(ChainStep.CLARIFY, status="in_progress"),
+                }
+            )
+
+    def test_in_progress_step_with_failed_prior_step_raises(self) -> None:
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        with pytest.raises(ValidationError):
+            _make_chain_state(
+                steps={
+                    ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="succeeded"),
+                    ChainStep.CLARIFY: _make_step_record(ChainStep.CLARIFY, status="failed"),
+                    ChainStep.PLAN: _make_step_record(ChainStep.PLAN, status="in_progress"),
+                }
+            )
+
+    def test_two_steps_in_progress_simultaneously_raises(self) -> None:
+        """A second in_progress entry whose predecessor is itself only
+        in_progress (not succeeded) violates the invariant."""
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        with pytest.raises(ValidationError):
+            _make_chain_state(
+                steps={
+                    ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="in_progress"),
+                    ChainStep.CLARIFY: _make_step_record(ChainStep.CLARIFY, status="in_progress"),
+                }
+            )
+
+    def test_halted_chain_with_failed_step_and_skipped_tail_is_valid(self) -> None:
+        """Contract (chain-state.md, FR-009): steps[CLARIFY].status ==
+        "failed" => status == "halted" and plan/tasks/analyze remain
+        pending/skipped. No step is in_progress here, so the invariant
+        does not block it."""
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        state = _make_chain_state(
+            status="halted",
+            steps={
+                ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="succeeded"),
+                ChainStep.CLARIFY: _make_step_record(ChainStep.CLARIFY, status="failed"),
+                ChainStep.PLAN: _make_step_record(ChainStep.PLAN, status="skipped"),
+                ChainStep.TASKS: _make_step_record(ChainStep.TASKS, status="skipped"),
+                ChainStep.ANALYZE: _make_step_record(ChainStep.ANALYZE, status="skipped"),
+            },
+        )
+        assert state.status == "halted"
+
+    def test_succeeded_then_untouched_pending_is_valid(self) -> None:
+        """Steps may be succeeded up to some point with the rest untouched
+        (pending) as long as nothing is in_progress out of order."""
+        from maverick.workflows.spec_chain.constants import ChainStep
+
+        state = _make_chain_state(
+            steps={
+                ChainStep.SPECIFY: _make_step_record(ChainStep.SPECIFY, status="succeeded"),
+                ChainStep.CLARIFY: _make_step_record(ChainStep.CLARIFY, status="pending"),
+            }
+        )
+        assert state.steps[ChainStep.CLARIFY].status == "pending"
+
+
+# ===========================================================================
+# ClarifyDecision — frozen dataclass
+# ===========================================================================
+
+
+class TestClarifyDecision:
+    def _make(self, **overrides: Any) -> Any:
+        from maverick.assumptions.models import Severity
+        from maverick.workflows.spec_chain.models import ClarifyDecision
+
+        defaults: dict[str, Any] = {
+            "question": "Should the API support pagination?",
+            "adopted_answer": "Yes, cursor-based pagination.",
+            "alternatives": ("Offset-based pagination", "No pagination"),
+            "severity": Severity.LOW,
+            "severity_defaulted": False,
+            "path": "interception",
+            "ledger_bead_id": None,
+        }
+        defaults.update(overrides)
+        return ClarifyDecision(**defaults)
+
+    def test_construction_all_fields(self) -> None:
+        from maverick.workflows.spec_chain.models import ClarifyDecision
+
+        decision = self._make()
+        assert isinstance(decision, ClarifyDecision)
+
+    def test_fields_accessible(self) -> None:
+        decision = self._make()
+        assert decision.question == "Should the API support pagination?"
+        assert decision.adopted_answer == "Yes, cursor-based pagination."
+        assert decision.path == "interception"
+
+    def test_severity_uses_shared_assumption_ledger_enum(self) -> None:
+        """Field type is maverick.assumptions.models.Severity (spec 049) —
+        not a locally-defined duplicate."""
+        from maverick.assumptions.models import Severity
+
+        decision = self._make(severity=Severity.HIGH)
+        assert decision.severity is Severity.HIGH
+
+    def test_severity_defaulted_flag_is_independent_of_severity_value(self) -> None:
+        """FR-007a: default severity is LOW when the harness has no clear
+        signal; severity_defaulted records that fact."""
+        from maverick.assumptions.models import Severity
+
+        decision = self._make(severity=Severity.LOW, severity_defaulted=True)
+        assert decision.severity is Severity.LOW
+        assert decision.severity_defaulted is True
+
+    def test_alternatives_is_tuple(self) -> None:
+        decision = self._make(alternatives=("a", "b"))
+        assert isinstance(decision.alternatives, tuple)
+
+    def test_alternatives_may_be_empty_on_fallback_path(self) -> None:
+        decision = self._make(alternatives=(), path="non_interactive")
+        assert decision.alternatives == ()
+
+    def test_path_accepts_interception(self) -> None:
+        decision = self._make(path="interception")
+        assert decision.path == "interception"
+
+    def test_path_accepts_non_interactive(self) -> None:
+        decision = self._make(path="non_interactive")
+        assert decision.path == "non_interactive"
+
+    def test_ledger_bead_id_defaults_to_none(self) -> None:
+        """ "ledger_bead_id | str | None | filled after filing" — absent
+        at creation time, before record_standalone_assumption runs."""
+        from maverick.workflows.spec_chain.models import ClarifyDecision
+
+        decision = ClarifyDecision(
+            question="Q",
+            adopted_answer="A",
+            alternatives=(),
+            severity=self._make().severity,
+            severity_defaulted=False,
+            path="interception",
+        )
+        assert decision.ledger_bead_id is None
+
+    def test_ledger_bead_id_filled_after_filing(self) -> None:
+        decision = self._make(ledger_bead_id="bd-abc123")
+        assert decision.ledger_bead_id == "bd-abc123"
+
+    def test_frozen_immutability(self) -> None:
+        decision = self._make()
+        with pytest.raises(FrozenInstanceError):
+            decision.question = "changed"  # type: ignore[misc]
+
+
+# ===========================================================================
+# StepReport (+ ReportedQuestion / ReportedFinding) — structured-output
+# schema for SpecChainAgent.
+# ===========================================================================
+
+
+class TestReportedQuestion:
+    def test_construction(self) -> None:
+        from maverick.workflows.spec_chain.models import ReportedQuestion
+
+        question = ReportedQuestion(
+            question="Should X?",
+            adopted_answer="Yes",
+            alternatives=["No", "Maybe"],
+        )
+        assert question.question == "Should X?"
+        assert question.adopted_answer == "Yes"
+        assert question.alternatives == ["No", "Maybe"]
+
+    def test_alternatives_defaults_to_empty(self) -> None:
+        from maverick.workflows.spec_chain.models import ReportedQuestion
+
+        question = ReportedQuestion(question="Q", adopted_answer="A")
+        assert list(question.alternatives) == []
+
+
+class TestReportedFinding:
+    def test_construction_all_fields(self) -> None:
+        from maverick.workflows.spec_chain.models import ReportedFinding
+
+        finding = ReportedFinding(
+            title="Ambiguous auth requirement",
+            category="ambiguity",
+            severity_hint="medium",
+            location="spec.md#FR-003",
+            summary="FR-003 doesn't specify token lifetime.",
+        )
+        assert finding.title == "Ambiguous auth requirement"
+        assert finding.category == "ambiguity"
+        assert finding.severity_hint == "medium"
+        assert finding.location == "spec.md#FR-003"
+        assert finding.summary == "FR-003 doesn't specify token lifetime."
+
+
+class TestStepReport:
+    def _make(self, **overrides: Any) -> Any:
+        from maverick.workflows.spec_chain.models import StepReport
+
+        defaults: dict[str, Any] = {
+            "status": "completed",
+            "artifacts": ["specs/001-foo/spec.md"],
+            "questions": [],
+            "findings": [],
+            "detail": "Spec written from PRD.",
+        }
+        defaults.update(overrides)
+        return StepReport(**defaults)
+
+    def test_construction(self) -> None:
+        from maverick.workflows.spec_chain.models import StepReport
+
+        report = self._make()
+        assert isinstance(report, StepReport)
+
+    @pytest.mark.parametrize("status", ["completed", "blocked", "failed"])
+    def test_valid_status_values(self, status: str) -> None:
+        report = self._make(status=status)
+        assert report.status == status
+
+    def test_invalid_status_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            self._make(status="not-a-real-status")
+
+    def test_artifacts_is_list_of_str(self) -> None:
+        report = self._make(artifacts=["specs/001-foo/spec.md", "specs/001-foo/plan.md"])
+        assert isinstance(report.artifacts, list)
+
+    def test_questions_default_empty(self) -> None:
+        report = self._make(questions=[])
+        assert list(report.questions) == []
+
+    def test_findings_default_empty(self) -> None:
+        report = self._make(findings=[])
+        assert list(report.findings) == []
+
+    def test_questions_carries_reported_question_instances(self) -> None:
+        from maverick.workflows.spec_chain.models import ReportedQuestion
+
+        report = self._make(
+            status="blocked",
+            questions=[
+                ReportedQuestion(question="Q1", adopted_answer="A1", alternatives=["B1"]),
+            ],
+        )
+        assert report.questions[0].question == "Q1"
+
+    def test_findings_carries_reported_finding_instances(self) -> None:
+        from maverick.workflows.spec_chain.models import ReportedFinding
+
+        report = self._make(
+            status="completed",
+            findings=[
+                ReportedFinding(
+                    title="Missing edge case",
+                    category="coverage-gap",
+                    severity_hint="low",
+                    location="spec.md#FR-010",
+                    summary="No handling for empty PRD.",
+                ),
+            ],
+        )
+        assert report.findings[0].title == "Missing edge case"
+
+    def test_questions_accept_plain_dicts(self) -> None:
+        """StepReport backs SpecChainAgent's format=json_schema structured
+        output — OpenCode responses arrive as parsed JSON and are validated
+        via model_validate, so plain dicts must coerce to ReportedQuestion."""
+        report = self._make(
+            status="blocked",
+            questions=[{"question": "Q?", "adopted_answer": "A", "alternatives": []}],
+        )
+        assert report.questions[0].question == "Q?"
+
+    def test_findings_accept_plain_dicts(self) -> None:
+        report = self._make(
+            status="completed",
+            findings=[
+                {
+                    "title": "Gap",
+                    "category": "coverage-gap",
+                    "severity_hint": "low",
+                    "location": "spec.md",
+                    "summary": "summary",
+                }
+            ],
+        )
+        assert report.findings[0].title == "Gap"
+
+    def test_json_schema_has_expected_top_level_fields(self) -> None:
+        """StepReport is the schema OpenCode's format=json_schema forces the
+        model to satisfy — it must expose all five top-level fields."""
+        from maverick.workflows.spec_chain.models import StepReport
+
+        schema = StepReport.model_json_schema()
+        assert set(schema["properties"]) >= {
+            "status",
+            "artifacts",
+            "questions",
+            "findings",
+            "detail",
+        }
+
+
+# ===========================================================================
+# AnalyzeFinding -> remediation bead
+# ===========================================================================
+
+
+class TestAnalyzeFinding:
+    def _make(self, **overrides: Any) -> Any:
+        from maverick.workflows.spec_chain.models import AnalyzeFinding
+
+        defaults: dict[str, Any] = {
+            "title": "Ambiguous auth requirement",
+            "category": "ambiguity",
+            "severity_hint": "medium",
+            "location": "spec.md#FR-003",
+            "summary": "FR-003 doesn't specify token lifetime.",
+            "feature_dir": "specs/051-headless-spec-chain",
+        }
+        defaults.update(overrides)
+        return AnalyzeFinding(**defaults)
+
+    def test_construction_all_fields(self) -> None:
+        from maverick.workflows.spec_chain.models import AnalyzeFinding
+
+        finding = self._make()
+        assert isinstance(finding, AnalyzeFinding)
+
+    def test_fields_accessible(self) -> None:
+        finding = self._make()
+        assert finding.title == "Ambiguous auth requirement"
+        assert finding.category == "ambiguity"
+        assert finding.severity_hint == "medium"
+        assert finding.location == "spec.md#FR-003"
+        assert finding.summary == "FR-003 doesn't specify token lifetime."
+        assert finding.feature_dir == "specs/051-headless-spec-chain"
+
+    def test_frozen_immutability(self) -> None:
+        finding = self._make()
+        with pytest.raises(FrozenInstanceError):
+            finding.title = "changed"  # type: ignore[misc]
+
+    # --- speckit_feature / remediation_source bead-state keys ---
+
+    def test_feature_dir_is_the_speckit_feature_key_value(self) -> None:
+        """Bead state key "speckit_feature" = <NNN-feature> directory name
+        (adoption key, matches refuel delta key)."""
+        finding = self._make(feature_dir="specs/051-headless-spec-chain")
+        assert finding.feature_dir == "specs/051-headless-spec-chain"
+
+    # --- finding_fingerprint idempotency contract ---
+
+    def test_fingerprint_is_sha256_hex_digest(self) -> None:
+        finding = self._make()
+        fingerprint = finding.fingerprint
+        assert isinstance(fingerprint, str)
+        assert len(fingerprint) == 64
+        int(fingerprint, 16)  # raises ValueError if not valid hex
+
+    def test_fingerprint_is_deterministic(self) -> None:
+        """Idempotency contract: rerunning analyze on the same finding must
+        produce the same fingerprint so remediation beads don't duplicate."""
+        first = self._make().fingerprint
+        second = self._make().fingerprint
+        assert first == second
+
+    def test_fingerprint_differs_when_title_changes(self) -> None:
+        base = self._make().fingerprint
+        changed = self._make(title="A completely different finding title").fingerprint
+        assert base != changed
+
+    def test_fingerprint_differs_when_location_changes(self) -> None:
+        base = self._make().fingerprint
+        changed = self._make(location="tasks.md#T012").fingerprint
+        assert base != changed
+
+    def test_fingerprint_ignores_non_identity_fields(self) -> None:
+        """Only title + location feed the fingerprint (data-model.md:
+        "finding_fingerprint = sha256 of normalized title + location") —
+        category/severity_hint/summary must not perturb it, otherwise the
+        same underlying finding re-reported with slightly different prose
+        would spuriously create a duplicate remediation bead."""
+        base = self._make().fingerprint
+        same_identity = self._make(
+            category="different-category",
+            severity_hint="high",
+            summary="Completely different summary text.",
+        ).fingerprint
+        assert base == same_identity
+
+    def test_fingerprint_normalizes_case_and_whitespace(self) -> None:
+        """ "normalized" title/location means trivial formatting differences
+        (case, surrounding whitespace) must not change the fingerprint —
+        otherwise cosmetic wording drift across analyze runs would create
+        duplicate remediation beads."""
+        base = self._make(
+            title="Ambiguous auth requirement", location="spec.md#FR-003"
+        ).fingerprint
+        cosmetic = self._make(
+            title="  AMBIGUOUS auth REQUIREMENT  ",
+            location="  SPEC.MD#FR-003  ",
+        ).fingerprint
+        assert base == cosmetic
+
+
+# ===========================================================================
+# constants.py: labels / state-key constants for the remediation bead
+# (T007's contract — "AnalyzeFinding -> remediation bead" table).
+# ===========================================================================
+
+
+class TestSpecRemediationConstants:
+    def test_spec_remediation_label(self) -> None:
+        from maverick.workflows.spec_chain.constants import SPEC_REMEDIATION_LABEL
+
+        assert SPEC_REMEDIATION_LABEL == "spec-remediation"
+
+    def test_remediation_source_value(self) -> None:
+        from maverick.workflows.spec_chain.constants import REMEDIATION_SOURCE_ANALYZE
+
+        assert REMEDIATION_SOURCE_ANALYZE == "spec-chain:analyze"
+
+    def test_state_key_names(self) -> None:
+        from maverick.workflows.spec_chain.constants import (
+            KEY_FINDING_FINGERPRINT,
+            KEY_REMEDIATION_SOURCE,
+            KEY_SPECKIT_FEATURE,
+        )
+
+        assert KEY_SPECKIT_FEATURE == "speckit_feature"
+        assert KEY_REMEDIATION_SOURCE == "remediation_source"
+        assert KEY_FINDING_FINGERPRINT == "finding_fingerprint"
+
+    def test_analyze_finding_carries_enough_to_build_bead_state(self) -> None:
+        """AnalyzeFinding + the constants above together must be enough to
+        build the three bead state keys from the "AnalyzeFinding ->
+        remediation bead" table without any other input."""
+        from maverick.workflows.spec_chain.constants import REMEDIATION_SOURCE_ANALYZE
+        from maverick.workflows.spec_chain.models import AnalyzeFinding
+
+        finding = AnalyzeFinding(
+            title="Ambiguous auth requirement",
+            category="ambiguity",
+            severity_hint="medium",
+            location="spec.md#FR-003",
+            summary="FR-003 doesn't specify token lifetime.",
+            feature_dir="specs/051-headless-spec-chain",
+        )
+        state = {
+            "speckit_feature": finding.feature_dir,
+            "remediation_source": REMEDIATION_SOURCE_ANALYZE,
+            "finding_fingerprint": finding.fingerprint,
+        }
+        assert state["speckit_feature"] == "specs/051-headless-spec-chain"
+        assert state["remediation_source"] == "spec-chain:analyze"
+        assert len(state["finding_fingerprint"]) == 64

--- a/tests/unit/workflows/spec_chain/test_remediation.py
+++ b/tests/unit/workflows/spec_chain/test_remediation.py
@@ -1,0 +1,251 @@
+"""Tests for `maverick.library.actions.beads.create_remediation_beads` (R6)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from maverick.beads.client import BeadClient
+from maverick.beads.models import BeadDetails, BeadSummary
+from maverick.library.actions.beads import create_remediation_beads
+from maverick.workflows.spec_chain.constants import (
+    KEY_FINDING_FINGERPRINT,
+    KEY_REMEDIATION_SOURCE,
+    KEY_SPECKIT_FEATURE,
+    REMEDIATION_SOURCE_ANALYZE,
+    SPEC_REMEDIATION_LABEL,
+)
+from maverick.workflows.spec_chain.models import AnalyzeFinding
+
+
+def _finding(**overrides: object) -> AnalyzeFinding:
+    defaults: dict[str, object] = {
+        "title": "Ambiguous auth requirement",
+        "category": "ambiguity",
+        "severity_hint": "medium",
+        "location": "spec.md#FR-003",
+        "summary": "FR-003 doesn't specify token lifetime.",
+        "feature_dir": "050-headless-spec-chain",
+    }
+    defaults.update(overrides)
+    return AnalyzeFinding(**defaults)  # type: ignore[arg-type]
+
+
+class TestBeadShape:
+    @pytest.mark.asyncio
+    async def test_created_unparented_with_expected_state(self) -> None:
+        finding = _finding()
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+        create_bead_mock = AsyncMock(return_value=created)
+
+        with (
+            patch.object(BeadClient, "query", new=AsyncMock(return_value=[])),
+            patch.object(BeadClient, "create_bead", new=create_bead_mock),
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+        ):
+            result = await create_remediation_beads([finding], cwd=Path("/tmp/repo"))
+
+        assert result.created_bead_ids == ("dea-1",)
+        assert result.skipped_duplicate_fingerprints == ()
+        assert result.errors == ()
+
+        definition = create_bead_mock.await_args.args[0]
+        parent_id = create_bead_mock.await_args.kwargs.get("parent_id")
+        assert parent_id is None
+        assert SPEC_REMEDIATION_LABEL in definition.labels
+        assert "Ambiguous auth requirement" in definition.title
+
+        state_dict = mock_set_state.await_args.args[1]
+        assert state_dict[KEY_SPECKIT_FEATURE] == "050-headless-spec-chain"
+        assert state_dict[KEY_REMEDIATION_SOURCE] == REMEDIATION_SOURCE_ANALYZE
+        assert state_dict[KEY_FINDING_FINGERPRINT] == finding.fingerprint
+
+    @pytest.mark.asyncio
+    async def test_severity_hint_in_description_not_priority(self) -> None:
+        finding = _finding(severity_hint="high")
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+        create_bead_mock = AsyncMock(return_value=created)
+
+        with (
+            patch.object(BeadClient, "query", new=AsyncMock(return_value=[])),
+            patch.object(BeadClient, "create_bead", new=create_bead_mock),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+        ):
+            await create_remediation_beads([finding], cwd=Path("/tmp/repo"))
+
+        definition = create_bead_mock.await_args.args[0]
+        assert "high" in definition.description
+        # priority is a fixed advisory constant, not derived from severity.
+        assert definition.priority == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_findings_creates_nothing(self) -> None:
+        create_bead_mock = AsyncMock()
+        with patch.object(BeadClient, "create_bead", new=create_bead_mock):
+            result = await create_remediation_beads([], cwd=Path("/tmp/repo"))
+        create_bead_mock.assert_not_awaited()
+        assert result.created_bead_ids == ()
+
+
+class TestFingerprintIdempotency:
+    @pytest.mark.asyncio
+    async def test_existing_fingerprint_is_skipped_not_duplicated(self) -> None:
+        finding = _finding()
+
+        existing_bead = BeadDetails(
+            id="dea-existing",
+            title="Spec remediation: Ambiguous auth requirement",
+            bead_type="task",
+            status="open",
+            labels=[SPEC_REMEDIATION_LABEL],
+            state={KEY_FINDING_FINGERPRINT: finding.fingerprint},
+        )
+
+        async def fake_query(self: BeadClient, expr: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(
+                    id="dea-existing", title=existing_bead.title, status="open", bead_type="task"
+                )
+            ]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return existing_bead
+
+        create_bead_mock = AsyncMock()
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "create_bead", new=create_bead_mock),
+        ):
+            result = await create_remediation_beads([finding], cwd=Path("/tmp/repo"))
+
+        create_bead_mock.assert_not_awaited()
+        assert result.created_bead_ids == ()
+        assert result.skipped_duplicate_fingerprints == (finding.fingerprint,)
+
+    @pytest.mark.asyncio
+    async def test_non_remediation_beads_are_ignored_by_fingerprint_scan(self) -> None:
+        finding = _finding()
+
+        unrelated_bead = BeadDetails(
+            id="dea-unrelated",
+            title="Assumption: something else",
+            bead_type="task",
+            status="open",
+            labels=["assumption"],
+            state={},
+        )
+
+        async def fake_query(self: BeadClient, expr: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(
+                    id="dea-unrelated",
+                    title=unrelated_bead.title,
+                    status="open",
+                    bead_type="task",
+                )
+            ]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return unrelated_bead
+
+        created = type("CreatedBead", (), {"bd_id": "dea-new"})()
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+        ):
+            result = await create_remediation_beads([finding], cwd=Path("/tmp/repo"))
+
+        assert result.created_bead_ids == ("dea-new",)
+
+    @pytest.mark.asyncio
+    async def test_two_findings_one_duplicate_one_new(self) -> None:
+        dup_finding = _finding(title="Already reported")
+        new_finding = _finding(title="Brand new finding", location="tasks.md#T005")
+
+        existing_bead = BeadDetails(
+            id="dea-existing",
+            title="Spec remediation: Already reported",
+            bead_type="task",
+            status="open",
+            labels=[SPEC_REMEDIATION_LABEL],
+            state={KEY_FINDING_FINGERPRINT: dup_finding.fingerprint},
+        )
+
+        async def fake_query(self: BeadClient, expr: str) -> list[BeadSummary]:
+            return [
+                BeadSummary(
+                    id="dea-existing", title=existing_bead.title, status="open", bead_type="task"
+                )
+            ]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return existing_bead
+
+        created = type("CreatedBead", (), {"bd_id": "dea-new"})()
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+        ):
+            result = await create_remediation_beads(
+                [dup_finding, new_finding], cwd=Path("/tmp/repo")
+            )
+
+        assert result.created_bead_ids == ("dea-new",)
+        assert result.skipped_duplicate_fingerprints == (dup_finding.fingerprint,)
+
+
+class TestBestEffortPerFinding:
+    @pytest.mark.asyncio
+    async def test_one_finding_failure_does_not_sink_the_others(self) -> None:
+        failing_finding = _finding(title="Fails to create")
+        ok_finding = _finding(title="Succeeds", location="plan.md#L10")
+
+        call_count = {"n": 0}
+
+        async def flaky_create_bead(
+            self: BeadClient, definition: object, parent_id: object = None
+        ):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("bd create failed")
+            return type("CreatedBead", (), {"bd_id": "dea-ok"})()
+
+        with (
+            patch.object(BeadClient, "query", new=AsyncMock(return_value=[])),
+            patch.object(BeadClient, "create_bead", new=flaky_create_bead),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+        ):
+            result = await create_remediation_beads(
+                [failing_finding, ok_finding], cwd=Path("/tmp/repo")
+            )
+
+        assert result.created_bead_ids == ("dea-ok",)
+        assert len(result.errors) == 1
+        assert "Fails to create" in result.errors[0]
+
+    @pytest.mark.asyncio
+    async def test_query_failure_does_not_raise_treats_as_no_existing(self) -> None:
+        finding = _finding()
+        created = type("CreatedBead", (), {"bd_id": "dea-1"})()
+
+        async def failing_query(self: BeadClient, expr: str) -> list:
+            raise RuntimeError("bd query failed")
+
+        with (
+            patch.object(BeadClient, "query", new=failing_query),
+            patch.object(BeadClient, "create_bead", new=AsyncMock(return_value=created)),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+        ):
+            result = await create_remediation_beads([finding], cwd=Path("/tmp/repo"))
+
+        assert result.created_bead_ids == ("dea-1",)

--- a/tests/unit/workflows/spec_chain/test_state.py
+++ b/tests/unit/workflows/spec_chain/test_state.py
@@ -1,0 +1,440 @@
+"""Unit tests for spec-chain state persistence and resume discovery.
+
+Covers `maverick.workflows.spec_chain.state` (T009 — atomic save/load of
+`ChainState` to ``.maverick/runs/<run-id>/spec-chain.json``, plus
+``discover_resumable`` feature-keyed scan), per
+``specs/050-headless-spec-chain/contracts/chain-state.md``.
+
+At authorship time (T005) both ``maverick.workflows.spec_chain.models``
+(T008) and ``maverick.workflows.spec_chain.state`` (T009) are empty
+placeholder stubs, so this module is expected to fail at collection
+(``ImportError``) until those tasks land. That is the intended red state
+for TDD — do not "fix" this file to import around the stubs.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from maverick.assumptions.models import Severity
+from maverick.workflows.spec_chain.constants import ChainStep
+from maverick.workflows.spec_chain.models import ChainState, ClarifyDecision, StepRecord
+from maverick.workflows.spec_chain.state import (
+    discover_resumable,
+    load_chain_state,
+    save_chain_state,
+)
+
+RUNS_SUBDIR = Path(".maverick") / "runs"
+STATE_FILENAME = "spec-chain.json"
+
+
+# ---------------------------------------------------------------------------
+# Construction helpers
+# ---------------------------------------------------------------------------
+
+
+def _step_record(
+    step: ChainStep,
+    *,
+    status: str = "succeeded",
+    landed: bool = True,
+    attempts: int = 1,
+    error: str | None = None,
+) -> StepRecord:
+    now = datetime.now(tz=UTC)
+    return StepRecord(
+        step=step,
+        status=status,
+        attempts=attempts,
+        artifacts=[f"{step.value}.md"],
+        landed=landed,
+        error=error,
+        started_at=now,
+        finished_at=now if status in {"succeeded", "failed"} else None,
+    )
+
+
+def _clarify_decision(*, ledger_bead_id: str | None = None) -> ClarifyDecision:
+    return ClarifyDecision(
+        question="Should exports include archived widgets?",
+        adopted_answer="No, exclude archived widgets by default.",
+        alternatives=("Include all widgets", "Prompt per-run"),
+        severity=Severity.LOW,
+        severity_defaulted=True,
+        path="non_interactive",
+        ledger_bead_id=ledger_bead_id,
+    )
+
+
+def _chain_state(
+    *,
+    run_id: str = "run-00000000",
+    feature: str = "widget-export",
+    status: str = "running",
+    started_at: datetime | None = None,
+    updated_at: datetime | None = None,
+) -> ChainState:
+    started = started_at or datetime.now(tz=UTC)
+    updated = updated_at or started
+    return ChainState(
+        schema_version=1,
+        run_id=run_id,
+        feature=feature,
+        feature_dir=f"specs/050-{feature}",
+        prd_path="docs/widget-export-prd.md",
+        prd_digest="a" * 64,
+        workspace_path=(f"/home/user/.maverick/workspaces/proj/spec-chain/{feature}"),
+        status=status,
+        steps={
+            ChainStep.SPECIFY: _step_record(ChainStep.SPECIFY),
+            ChainStep.CLARIFY: _step_record(ChainStep.CLARIFY, status="in_progress", landed=False),
+        },
+        clarify_decisions=[_clarify_decision()],
+        remediation_bead_ids=["bead-123"],
+        started_at=started,
+        updated_at=updated,
+    )
+
+
+def _raw_state_json(
+    *,
+    run_id: str,
+    feature: str,
+    status: str,
+    updated_at: str,
+    started_at: str | None = None,
+) -> dict:
+    """Build a schema-conforming raw dict, bypassing save_chain_state entirely.
+
+    Used for discover_resumable tests so they don't depend on save()/the
+    model layer being correct — only on state.py's own read/scan/parse path.
+    """
+    started = started_at or updated_at
+    return {
+        "schema_version": 1,
+        "run_id": run_id,
+        "feature": feature,
+        "feature_dir": f"specs/050-{feature}",
+        "prd_path": "docs/prd.md",
+        "prd_digest": "0" * 64,
+        "workspace_path": f"/home/user/.maverick/workspaces/proj/spec-chain/{feature}",
+        "status": status,
+        "steps": {
+            "specify": {
+                "step": "specify",
+                "status": "succeeded",
+                "attempts": 1,
+                "artifacts": ["spec.md"],
+                "landed": True,
+                "error": None,
+                "started_at": started,
+                "finished_at": updated_at,
+            },
+        },
+        "clarify_decisions": [],
+        "remediation_bead_ids": [],
+        "started_at": started,
+        "updated_at": updated_at,
+    }
+
+
+def _write_raw_run(
+    base: Path,
+    *,
+    run_id: str,
+    feature: str,
+    status: str,
+    updated_at: str,
+    started_at: str | None = None,
+) -> Path:
+    run_dir = base / RUNS_SUBDIR / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    state_path = run_dir / STATE_FILENAME
+    state_path.write_text(
+        json.dumps(
+            _raw_state_json(
+                run_id=run_id,
+                feature=feature,
+                status=status,
+                updated_at=updated_at,
+                started_at=started_at,
+            )
+        ),
+        encoding="utf-8",
+    )
+    return state_path
+
+
+# ---------------------------------------------------------------------------
+# save_chain_state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_chain_state_writes_expected_file(temp_dir: Path) -> None:
+    state = _chain_state(run_id="run-save-1")
+
+    await save_chain_state(state, temp_dir)
+
+    state_path = temp_dir / RUNS_SUBDIR / "run-save-1" / STATE_FILENAME
+    assert state_path.is_file()
+    on_disk = json.loads(state_path.read_text(encoding="utf-8"))
+    assert on_disk["run_id"] == "run-save-1"
+    assert on_disk["feature"] == "widget-export"
+    assert on_disk["schema_version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_save_chain_state_is_atomic_no_leftover_tmp_files(temp_dir: Path) -> None:
+    state = _chain_state(run_id="run-save-atomic")
+
+    await save_chain_state(state, temp_dir)
+
+    run_dir = temp_dir / RUNS_SUBDIR / "run-save-atomic"
+    leftover_tmp = [p for p in run_dir.iterdir() if "tmp" in p.name.lower()]
+    assert leftover_tmp == []
+    assert (run_dir / STATE_FILENAME).is_file()
+
+
+@pytest.mark.asyncio
+async def test_save_chain_state_overwrites_existing_file(temp_dir: Path) -> None:
+    state = _chain_state(run_id="run-save-overwrite", status="running")
+    await save_chain_state(state, temp_dir)
+
+    updated = state.model_copy(update={"status": "halted"})
+    await save_chain_state(updated, temp_dir)
+
+    state_path = temp_dir / RUNS_SUBDIR / "run-save-overwrite" / STATE_FILENAME
+    on_disk = json.loads(state_path.read_text(encoding="utf-8"))
+    assert on_disk["status"] == "halted"
+
+
+# ---------------------------------------------------------------------------
+# load_chain_state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_chain_state_round_trips_saved_state(temp_dir: Path) -> None:
+    started = datetime(2026, 7, 1, 12, 0, 0, tzinfo=UTC)
+    updated = datetime(2026, 7, 1, 12, 30, 0, tzinfo=UTC)
+    state = _chain_state(
+        run_id="run-roundtrip",
+        feature="widget-export",
+        status="halted",
+        started_at=started,
+        updated_at=updated,
+    )
+
+    await save_chain_state(state, temp_dir)
+    loaded = await load_chain_state("run-roundtrip", temp_dir)
+
+    assert loaded is not None
+    assert loaded == state
+
+
+@pytest.mark.asyncio
+async def test_load_chain_state_round_trips_nested_steps_and_decisions(
+    temp_dir: Path,
+) -> None:
+    state = _chain_state(run_id="run-nested")
+
+    await save_chain_state(state, temp_dir)
+    loaded = await load_chain_state("run-nested", temp_dir)
+
+    assert loaded is not None
+    assert set(loaded.steps.keys()) == {ChainStep.SPECIFY, ChainStep.CLARIFY}
+    assert loaded.steps[ChainStep.SPECIFY].status == "succeeded"
+    assert loaded.steps[ChainStep.SPECIFY].landed is True
+    assert loaded.steps[ChainStep.CLARIFY].status == "in_progress"
+    assert loaded.steps[ChainStep.CLARIFY].landed is False
+    assert len(loaded.clarify_decisions) == 1
+    decision = loaded.clarify_decisions[0]
+    assert decision.question == "Should exports include archived widgets?"
+    assert decision.severity == Severity.LOW
+    assert decision.alternatives == ("Include all widgets", "Prompt per-run")
+    assert loaded.remediation_bead_ids == ["bead-123"]
+
+
+@pytest.mark.asyncio
+async def test_load_chain_state_missing_run_returns_none(temp_dir: Path) -> None:
+    loaded = await load_chain_state("does-not-exist", temp_dir)
+    assert loaded is None
+
+
+@pytest.mark.asyncio
+async def test_load_chain_state_missing_runs_dir_returns_none(temp_dir: Path) -> None:
+    # .maverick/runs doesn't exist at all under this base.
+    loaded = await load_chain_state("whatever", temp_dir)
+    assert loaded is None
+
+
+# ---------------------------------------------------------------------------
+# discover_resumable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discover_resumable_returns_newest_matching_status(
+    temp_dir: Path,
+) -> None:
+    base_time = datetime(2026, 7, 1, tzinfo=UTC)
+    _write_raw_run(
+        temp_dir,
+        run_id="run-older",
+        feature="widget-export",
+        status="halted",
+        updated_at=(base_time).isoformat(),
+    )
+    _write_raw_run(
+        temp_dir,
+        run_id="run-newer",
+        feature="widget-export",
+        status="running",
+        updated_at=(base_time + timedelta(hours=1)).isoformat(),
+    )
+
+    result = await discover_resumable("widget-export", temp_dir)
+
+    assert result is not None
+    assert result.run_id == "run-newer"
+    assert result.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_discover_resumable_ignores_non_matching_feature(temp_dir: Path) -> None:
+    base_time = datetime(2026, 7, 1, tzinfo=UTC)
+    _write_raw_run(
+        temp_dir,
+        run_id="run-other-feature",
+        feature="other-feature",
+        status="halted",
+        updated_at=base_time.isoformat(),
+    )
+
+    result = await discover_resumable("widget-export", temp_dir)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_discover_resumable_only_completed_chains_returns_none(
+    temp_dir: Path,
+) -> None:
+    base_time = datetime(2026, 7, 1, tzinfo=UTC)
+    _write_raw_run(
+        temp_dir,
+        run_id="run-completed",
+        feature="widget-export",
+        status="completed",
+        updated_at=base_time.isoformat(),
+    )
+    _write_raw_run(
+        temp_dir,
+        run_id="run-failed",
+        feature="widget-export",
+        status="failed",
+        updated_at=(base_time + timedelta(hours=1)).isoformat(),
+    )
+
+    result = await discover_resumable("widget-export", temp_dir)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_discover_resumable_prefers_running_or_halted_over_older_completed(
+    temp_dir: Path,
+) -> None:
+    base_time = datetime(2026, 7, 1, tzinfo=UTC)
+    # Newest run for the feature is completed (terminal) -- should be skipped
+    # in favor of the older, still-resumable halted run.
+    _write_raw_run(
+        temp_dir,
+        run_id="run-completed-newest",
+        feature="widget-export",
+        status="completed",
+        updated_at=(base_time + timedelta(hours=2)).isoformat(),
+    )
+    _write_raw_run(
+        temp_dir,
+        run_id="run-halted-older",
+        feature="widget-export",
+        status="halted",
+        updated_at=(base_time + timedelta(hours=1)).isoformat(),
+    )
+
+    result = await discover_resumable("widget-export", temp_dir)
+
+    assert result is not None
+    assert result.run_id == "run-halted-older"
+
+
+@pytest.mark.asyncio
+async def test_discover_resumable_tie_breaks_among_newest(temp_dir: Path) -> None:
+    tied_time = datetime(2026, 7, 1, 12, 0, 0, tzinfo=UTC).isoformat()
+    _write_raw_run(
+        temp_dir,
+        run_id="run-tie-a",
+        feature="widget-export",
+        status="halted",
+        updated_at=tied_time,
+    )
+    _write_raw_run(
+        temp_dir,
+        run_id="run-tie-b",
+        feature="widget-export",
+        status="running",
+        updated_at=tied_time,
+    )
+
+    result = await discover_resumable("widget-export", temp_dir)
+
+    # Contract only guarantees "newest first"; with an exact tie either
+    # candidate is an acceptable resume target, but one of them must win.
+    assert result is not None
+    assert result.run_id in {"run-tie-a", "run-tie-b"}
+    assert result.status in {"halted", "running"}
+
+
+@pytest.mark.asyncio
+async def test_discover_resumable_empty_runs_dir_returns_none(temp_dir: Path) -> None:
+    (temp_dir / RUNS_SUBDIR).mkdir(parents=True)
+
+    result = await discover_resumable("widget-export", temp_dir)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_discover_resumable_missing_runs_dir_returns_none(temp_dir: Path) -> None:
+    # temp_dir has no .maverick/runs at all.
+    result = await discover_resumable("widget-export", temp_dir)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_discover_resumable_skips_unparseable_state_files(temp_dir: Path) -> None:
+    """A corrupt/partial state file must not crash discovery of a valid one."""
+    corrupt_dir = temp_dir / RUNS_SUBDIR / "run-corrupt"
+    corrupt_dir.mkdir(parents=True)
+    (corrupt_dir / STATE_FILENAME).write_text("not valid json{{{", encoding="utf-8")
+
+    _write_raw_run(
+        temp_dir,
+        run_id="run-valid",
+        feature="widget-export",
+        status="halted",
+        updated_at=datetime(2026, 7, 1, tzinfo=UTC).isoformat(),
+    )
+
+    result = await discover_resumable("widget-export", temp_dir)
+
+    assert result is not None
+    assert result.run_id == "run-valid"

--- a/tests/unit/workflows/spec_chain/test_steps.py
+++ b/tests/unit/workflows/spec_chain/test_steps.py
@@ -1,0 +1,113 @@
+"""Tests for per-step prompt builders (`maverick.workflows.spec_chain.steps`)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from maverick.workflows.spec_chain.constants import ChainStep
+from maverick.workflows.spec_chain.steps import (
+    SLASH_COMMANDS,
+    build_step_prompt,
+    read_command_body,
+)
+
+
+class TestSlashCommands:
+    @pytest.mark.parametrize(
+        ("step", "command"),
+        [
+            (ChainStep.SPECIFY, "/speckit.specify"),
+            (ChainStep.CLARIFY, "/speckit.clarify"),
+            (ChainStep.PLAN, "/speckit.plan"),
+            (ChainStep.TASKS, "/speckit.tasks"),
+            (ChainStep.ANALYZE, "/speckit.analyze"),
+        ],
+    )
+    def test_slash_command_per_step(self, step: ChainStep, command: str) -> None:
+        assert SLASH_COMMANDS[step] == command
+
+    def test_every_chain_step_has_a_command(self) -> None:
+        assert set(SLASH_COMMANDS) == set(ChainStep)
+
+
+class TestReadCommandBody:
+    def test_returns_none_when_file_missing(self, tmp_path: Path) -> None:
+        assert read_command_body(tmp_path, ChainStep.SPECIFY) is None
+
+    def test_reads_command_file_body(self, tmp_path: Path) -> None:
+        commands_dir = tmp_path / ".claude" / "commands"
+        commands_dir.mkdir(parents=True)
+        (commands_dir / "speckit.specify.md").write_text(
+            "Do the specify thing.\n", encoding="utf-8"
+        )
+        body = read_command_body(tmp_path, ChainStep.SPECIFY)
+        assert body == "Do the specify thing.\n"
+
+    def test_reads_correct_file_per_step(self, tmp_path: Path) -> None:
+        commands_dir = tmp_path / ".claude" / "commands"
+        commands_dir.mkdir(parents=True)
+        (commands_dir / "speckit.clarify.md").write_text("clarify body", encoding="utf-8")
+        (commands_dir / "speckit.plan.md").write_text("plan body", encoding="utf-8")
+
+        assert read_command_body(tmp_path, ChainStep.CLARIFY) == "clarify body"
+        assert read_command_body(tmp_path, ChainStep.PLAN) == "plan body"
+        assert read_command_body(tmp_path, ChainStep.TASKS) is None
+
+
+class TestBuildStepPrompt:
+    def test_specify_prompt_includes_slash_command_and_feature(self, tmp_path: Path) -> None:
+        prompt = build_step_prompt(
+            ChainStep.SPECIFY,
+            workspace=tmp_path,
+            feature="widget-export",
+            prd_content="Build widget export.",
+        )
+        assert "/speckit.specify" in prompt
+        assert "widget-export" in prompt
+
+    def test_specify_prompt_injects_prd_content(self, tmp_path: Path) -> None:
+        prompt = build_step_prompt(
+            ChainStep.SPECIFY,
+            workspace=tmp_path,
+            feature="widget-export",
+            prd_content="UNIQUE PRD MARKER TEXT",
+        )
+        assert "UNIQUE PRD MARKER TEXT" in prompt
+
+    @pytest.mark.parametrize(
+        "step", [ChainStep.CLARIFY, ChainStep.PLAN, ChainStep.TASKS, ChainStep.ANALYZE]
+    )
+    def test_non_specify_prompts_ignore_prd_content(self, tmp_path: Path, step: ChainStep) -> None:
+        prompt = build_step_prompt(
+            step,
+            workspace=tmp_path,
+            feature="widget-export",
+            prd_content="UNIQUE PRD MARKER TEXT",
+        )
+        assert "UNIQUE PRD MARKER TEXT" not in prompt
+        assert SLASH_COMMANDS[step] in prompt
+
+    def test_prompt_includes_structured_report_instruction(self, tmp_path: Path) -> None:
+        prompt = build_step_prompt(ChainStep.PLAN, workspace=tmp_path, feature="widget-export")
+        assert "StructuredOutput" in prompt
+
+    def test_prompt_has_no_inline_fallback_when_command_file_absent(self, tmp_path: Path) -> None:
+        prompt = build_step_prompt(ChainStep.PLAN, workspace=tmp_path, feature="widget-export")
+        assert "own definition from this repository" not in prompt
+
+    def test_prompt_inlines_command_body_when_present(self, tmp_path: Path) -> None:
+        commands_dir = tmp_path / ".claude" / "commands"
+        commands_dir.mkdir(parents=True)
+        (commands_dir / "speckit.plan.md").write_text(
+            "UNIQUE PLAN COMMAND BODY MARKER", encoding="utf-8"
+        )
+        prompt = build_step_prompt(ChainStep.PLAN, workspace=tmp_path, feature="widget-export")
+        assert "UNIQUE PLAN COMMAND BODY MARKER" in prompt
+        assert "own definition from this repository" in prompt
+
+    def test_prompt_mentions_feature_for_every_step(self, tmp_path: Path) -> None:
+        for step in ChainStep:
+            prompt = build_step_prompt(step, workspace=tmp_path, feature="my-feature")
+            assert "my-feature" in prompt

--- a/tests/unit/workflows/spec_chain/test_workflow_methods.py
+++ b/tests/unit/workflows/spec_chain/test_workflow_methods.py
@@ -1,0 +1,225 @@
+"""Unit tests for `SpecChainWorkflow` helper methods added by code review.
+
+Covers two resume-path correctness fixes:
+
+* ``_reseed_workspace_from_checkout`` — a freshly-recreated hidden
+  workspace (the user cleared ``~/.maverick/workspaces`` between runs)
+  gets its landed upstream artifacts restored from the checkout, so
+  downstream steps don't run against an empty workspace.
+* ``_file_clarify_decisions`` idempotency — a resume that re-runs clarify
+  merges by normalized question instead of blindly appending, so the
+  audit list (and its derived counts) don't double.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from maverick.config import AgentBindingConfig, AgentsConfig, MaverickConfig
+from maverick.workflows.spec_chain.constants import ChainStep
+from maverick.workflows.spec_chain.models import ChainState, ClarifyDecision, StepRecord
+from maverick.workflows.spec_chain.workflow import SpecChainWorkflow
+
+
+def _config() -> MaverickConfig:
+    return MaverickConfig(
+        agents=AgentsConfig(generate=AgentBindingConfig(provider="claude", model_id="stub-model"))
+    )
+
+
+def _workflow() -> SpecChainWorkflow:
+    return SpecChainWorkflow(config=_config())
+
+
+def _base_state(*, feature_dir: str | None, **overrides: object) -> ChainState:
+    now = datetime.now(tz=UTC)
+    defaults: dict[str, object] = {
+        "run_id": "run-1",
+        "feature": "widget-export",
+        "feature_dir": feature_dir,
+        "prd_path": "docs/prd.md",
+        "prd_digest": "0" * 64,
+        "workspace_path": "/tmp/ws",
+        "status": "running",
+        "started_at": now,
+        "updated_at": now,
+    }
+    defaults.update(overrides)
+    return ChainState(**defaults)  # type: ignore[arg-type]
+
+
+class TestReseedWorkspaceFromCheckout:
+    def _landed_steps(self) -> dict[ChainStep, StepRecord]:
+        return {
+            ChainStep.SPECIFY: StepRecord(
+                step=ChainStep.SPECIFY,
+                status="succeeded",
+                landed=True,
+                artifacts=["spec.md"],
+            ),
+            ChainStep.PLAN: StepRecord(
+                step=ChainStep.PLAN,
+                status="succeeded",
+                landed=True,
+                artifacts=["plan.md"],
+            ),
+        }
+
+    def test_restores_landed_artifacts_into_empty_workspace(self, tmp_path: Path) -> None:
+        checkout = tmp_path / "checkout"
+        workspace = tmp_path / "workspace"
+        feature_dir = "001-widget-export"
+        checkout_feature = checkout / "specs" / feature_dir
+        checkout_feature.mkdir(parents=True)
+        (checkout_feature / "spec.md").write_text("spec body", encoding="utf-8")
+        (checkout_feature / "plan.md").write_text("plan body", encoding="utf-8")
+        (workspace / "specs").mkdir(parents=True)  # workspace exists but is empty
+
+        state = _base_state(feature_dir=f"specs/{feature_dir}", steps=self._landed_steps())
+
+        _workflow()._reseed_workspace_from_checkout(state, workspace=workspace, checkout=checkout)
+
+        ws_feature = workspace / "specs" / feature_dir
+        assert (ws_feature / "spec.md").read_text(encoding="utf-8") == "spec body"
+        assert (ws_feature / "plan.md").read_text(encoding="utf-8") == "plan body"
+
+    def test_noop_when_workspace_already_has_artifacts(self, tmp_path: Path) -> None:
+        checkout = tmp_path / "checkout"
+        workspace = tmp_path / "workspace"
+        feature_dir = "001-widget-export"
+        checkout_feature = checkout / "specs" / feature_dir
+        checkout_feature.mkdir(parents=True)
+        (checkout_feature / "spec.md").write_text("checkout spec", encoding="utf-8")
+        (checkout_feature / "plan.md").write_text("checkout plan", encoding="utf-8")
+
+        ws_feature = workspace / "specs" / feature_dir
+        ws_feature.mkdir(parents=True)
+        # Workspace already holds the landed artifacts (normal reuse path):
+        # the reseed must not clobber them with the checkout copies.
+        (ws_feature / "spec.md").write_text("workspace spec", encoding="utf-8")
+        (ws_feature / "plan.md").write_text("workspace plan", encoding="utf-8")
+
+        state = _base_state(feature_dir=f"specs/{feature_dir}", steps=self._landed_steps())
+
+        _workflow()._reseed_workspace_from_checkout(state, workspace=workspace, checkout=checkout)
+
+        assert (ws_feature / "spec.md").read_text(encoding="utf-8") == "workspace spec"
+        assert (ws_feature / "plan.md").read_text(encoding="utf-8") == "workspace plan"
+
+    def test_noop_when_no_feature_dir_yet(self, tmp_path: Path) -> None:
+        checkout = tmp_path / "checkout"
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        state = _base_state(feature_dir=None)
+
+        # Must not raise, must not create anything.
+        _workflow()._reseed_workspace_from_checkout(state, workspace=workspace, checkout=checkout)
+        assert not (workspace / "specs").exists()
+
+    def test_noop_when_checkout_feature_dir_absent(self, tmp_path: Path) -> None:
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        state = _base_state(feature_dir="specs/001-widget-export", steps=self._landed_steps())
+
+        _workflow()._reseed_workspace_from_checkout(state, workspace=workspace, checkout=checkout)
+        assert not (workspace / "specs").exists()
+
+    def test_reseeds_when_only_some_artifacts_present(self, tmp_path: Path) -> None:
+        """A partially-populated workspace (e.g. plan.md restored but
+        spec.md missing) still triggers a full reseed of the feature dir."""
+        checkout = tmp_path / "checkout"
+        workspace = tmp_path / "workspace"
+        feature_dir = "001-widget-export"
+        checkout_feature = checkout / "specs" / feature_dir
+        checkout_feature.mkdir(parents=True)
+        (checkout_feature / "spec.md").write_text("spec body", encoding="utf-8")
+        (checkout_feature / "plan.md").write_text("plan body", encoding="utf-8")
+
+        ws_feature = workspace / "specs" / feature_dir
+        ws_feature.mkdir(parents=True)
+        (ws_feature / "plan.md").write_text("stale plan", encoding="utf-8")  # spec.md missing
+
+        state = _base_state(feature_dir=f"specs/{feature_dir}", steps=self._landed_steps())
+
+        _workflow()._reseed_workspace_from_checkout(state, workspace=workspace, checkout=checkout)
+
+        assert (ws_feature / "spec.md").read_text(encoding="utf-8") == "spec body"
+        assert (ws_feature / "plan.md").read_text(encoding="utf-8") == "plan body"
+
+
+class TestFileClarifyDecisionsIdempotency:
+    def _spec_md(self) -> str:
+        return (
+            "# Spec\n\n## Clarifications\n\n### Session 2026-07-24\n\n"
+            "- Q: Should exports include archived widgets? "
+            "→ A: No, exclude archived widgets.\n"
+        )
+
+    def _existing_decision(self) -> ClarifyDecision:
+        from maverick.assumptions.models import Severity
+
+        return ClarifyDecision(
+            question="Should exports include archived widgets?",
+            adopted_answer="No, exclude archived widgets.",
+            alternatives=(),
+            severity=Severity.MEDIUM,
+            severity_defaulted=False,
+            path="non_interactive",
+            ledger_bead_id="dea-existing",
+        )
+
+    async def test_resume_rerun_does_not_double_decisions(self, tmp_path: Path) -> None:
+        feature_dir = "001-widget-export"
+        workspace = tmp_path / "workspace"
+        spec_dir = workspace / "specs" / feature_dir
+        spec_dir.mkdir(parents=True)
+        (spec_dir / "spec.md").write_text(self._spec_md(), encoding="utf-8")
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+
+        # State already carries the decision from the pre-halt clarify run.
+        state = _base_state(
+            feature_dir=f"specs/{feature_dir}",
+            clarify_decisions=[self._existing_decision()],
+        )
+
+        created = type("Record", (), {"bead_id": "dea-existing", "severity": None})()
+        with patch(
+            "maverick.workflows.spec_chain.workflow.record_standalone_assumption",
+            new=AsyncMock(return_value=created),
+        ):
+            new_state = await _workflow()._file_clarify_decisions(
+                state, workspace=workspace, checkout=checkout, feature_dir_name=feature_dir
+            )
+
+        # Same question re-parsed on resume must merge, not append.
+        assert len(new_state.clarify_decisions) == 1
+        questions = [d.question for d in new_state.clarify_decisions]
+        assert questions == ["Should exports include archived widgets?"]
+
+    async def test_fresh_run_records_the_decision(self, tmp_path: Path) -> None:
+        feature_dir = "001-widget-export"
+        workspace = tmp_path / "workspace"
+        spec_dir = workspace / "specs" / feature_dir
+        spec_dir.mkdir(parents=True)
+        (spec_dir / "spec.md").write_text(self._spec_md(), encoding="utf-8")
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+
+        state = _base_state(feature_dir=f"specs/{feature_dir}", clarify_decisions=[])
+
+        created = type("Record", (), {"bead_id": "dea-1", "severity": None})()
+        with patch(
+            "maverick.workflows.spec_chain.workflow.record_standalone_assumption",
+            new=AsyncMock(return_value=created),
+        ):
+            new_state = await _workflow()._file_clarify_decisions(
+                state, workspace=workspace, checkout=checkout, feature_dir_name=feature_dir
+            )
+
+        assert len(new_state.clarify_decisions) == 1
+        assert new_state.clarify_decisions[0].ledger_bead_id == "dea-1"

--- a/tests/unit/workspace/__init__.py
+++ b/tests/unit/workspace/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for hidden-workspace helpers."""

--- a/tests/unit/workspace/test_spec_chain_workspace.py
+++ b/tests/unit/workspace/test_spec_chain_workspace.py
@@ -9,15 +9,19 @@ Contract under test (`maverick.workspace.spec_chain.prepare_workspace`):
 - ``reuse=True`` (an active, resumable chain) reuses an existing on-disk
   workspace directory as-is: no ``workspace_add``, no ``workspace_forget``, no
   wipe.
-- ``reuse=False`` (a completed or freshly-started chain) starts clean: if a
-  stale directory is already on disk, it is forgotten (``workspace_forget``)
-  and removed before a fresh ``workspace_add`` recreates it. If nothing is on
-  disk yet, only ``workspace_add`` runs.
+- ``reuse=False`` (a completed or freshly-started chain) starts clean:
+  ``workspace_forget`` is always attempted first (best-effort — jj may still
+  track a workspace of this name even after its on-disk directory was cleared,
+  and ``workspace_add`` would fail on that lingering name collision), any
+  on-disk directory is then removed, and a fresh ``workspace_add`` recreates
+  it. A ``forget`` failure is tolerated (a never-registered name is not an
+  error); a real collision surfaces on ``workspace_add`` instead.
 - The PRD file (which may be untracked in the user's checkout) is always
   copied into the workspace, under ``<workspace>/inputs/<prd_path.name>``,
   before the function returns — regardless of which branch above ran.
-- ``JjError`` raised by the injected client surfaces as
-  ``SpecChainWorkspaceError``.
+- ``JjError`` raised by ``workspace_add`` surfaces as
+  ``SpecChainWorkspaceError``; a ``JjError`` from the best-effort
+  ``workspace_forget`` is swallowed.
 """
 
 from __future__ import annotations
@@ -110,9 +114,15 @@ class TestFreshRunCreation:
         assert result == expected
         mock_jj_client.workspace_add.assert_awaited_once_with(expected)
 
-    async def test_no_forget_or_rmtree_when_nothing_stale(
+    async def test_forget_is_attempted_best_effort_no_rmtree_when_nothing_stale(
         self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
     ) -> None:
+        """Even with nothing on disk, ``workspace_forget`` is attempted
+        best-effort to clear any jj-tracked name whose directory was
+        externally removed. No ``rmtree`` runs (there is nothing to wipe)."""
+        stale = _workspace_dir(home, checkout, "050-headless-spec-chain")
+        assert not stale.exists()
+
         await prepare_workspace(
             cwd=checkout,
             feature="050-headless-spec-chain",
@@ -122,7 +132,8 @@ class TestFreshRunCreation:
             home=home,
         )
 
-        mock_jj_client.workspace_forget.assert_not_awaited()
+        mock_jj_client.workspace_forget.assert_awaited_once_with("050-headless-spec-chain")
+        mock_jj_client.workspace_add.assert_awaited_once()
 
     async def test_workspace_path_is_outside_the_checkout(
         self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
@@ -175,7 +186,9 @@ class TestResumeReuseActiveChain:
     ) -> None:
         """reuse=True but nothing on disk (e.g. state says active but the
         directory vanished) — must still succeed by creating a workspace,
-        not raise or silently no-op."""
+        not raise or silently no-op. ``workspace_forget`` is attempted
+        best-effort first, because jj may still track the workspace name
+        even though its directory is gone."""
         expected = _workspace_dir(home, checkout, "050-headless-spec-chain")
         assert not expected.exists()
 
@@ -190,7 +203,7 @@ class TestResumeReuseActiveChain:
 
         assert result == expected
         mock_jj_client.workspace_add.assert_awaited_once_with(expected)
-        mock_jj_client.workspace_forget.assert_not_awaited()
+        mock_jj_client.workspace_forget.assert_awaited_once_with("050-headless-spec-chain")
 
 
 # ---------------------------------------------------------------------------
@@ -282,11 +295,12 @@ class TestForgetAndRecreateCompletedChain:
         assert observed_exists_at_add_time == [False]
         mock_jj_client.workspace_forget.assert_awaited_once_with("050-headless-spec-chain")
 
-    async def test_no_forget_when_nothing_stale_on_fresh_start(
+    async def test_forget_best_effort_then_add_on_fresh_start(
         self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
     ) -> None:
         """A freshly-started chain (never run before) has no stale directory
-        to forget — only workspace_add should run."""
+        to wipe, but ``workspace_forget`` is still attempted best-effort
+        before ``workspace_add`` to clear any lingering jj-tracked name."""
         await prepare_workspace(
             cwd=checkout,
             feature="050-headless-spec-chain",
@@ -296,7 +310,7 @@ class TestForgetAndRecreateCompletedChain:
             home=home,
         )
 
-        mock_jj_client.workspace_forget.assert_not_awaited()
+        mock_jj_client.workspace_forget.assert_awaited_once_with("050-headless-spec-chain")
         mock_jj_client.workspace_add.assert_awaited_once()
 
 
@@ -479,25 +493,33 @@ class TestWorkspaceCreationFailurePropagation:
                 home=home,
             )
 
-    async def test_jj_error_on_workspace_forget_becomes_spec_chain_workspace_error(
+    async def test_jj_error_on_workspace_forget_is_tolerated(
         self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
     ) -> None:
+        """``workspace_forget`` is best-effort: a failure (e.g. the name was
+        never registered) must NOT abort recreation — the workspace is still
+        wiped and recreated via ``workspace_add``."""
         stale = _workspace_dir(home, checkout, "050-headless-spec-chain")
         stale.mkdir(parents=True)
+        (stale / "leftover.txt").write_text("stale", encoding="utf-8")
 
         mock_jj_client.workspace_forget.side_effect = JjError(
             "jj workspace forget failed: unknown workspace"
         )
 
-        with pytest.raises(SpecChainWorkspaceError):
-            await prepare_workspace(
-                cwd=checkout,
-                feature="050-headless-spec-chain",
-                prd_path=prd_path,
-                reuse=False,
-                jj_client=mock_jj_client,
-                home=home,
-            )
+        result = await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        assert result == stale
+        mock_jj_client.workspace_add.assert_awaited_once_with(stale)
+        # The stale content was wiped despite the forget failure.
+        assert not (stale / "leftover.txt").exists()
 
     async def test_original_jj_error_is_chained(
         self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock

--- a/tests/unit/workspace/test_spec_chain_workspace.py
+++ b/tests/unit/workspace/test_spec_chain_workspace.py
@@ -1,0 +1,518 @@
+"""Unit tests for the hidden spec-chain jj workspace helper.
+
+Contract under test (`maverick.workspace.spec_chain.prepare_workspace`):
+
+- Location: ``<home>/.maverick/workspaces/<project-slug>/spec-chain/<feature>/`` —
+  per-feature, so two features never share a workspace directory.
+- Creation goes through the injected ``JjClient`` (``workspace_add`` /
+  ``workspace_forget``); the helper never shells out to jj itself.
+- ``reuse=True`` (an active, resumable chain) reuses an existing on-disk
+  workspace directory as-is: no ``workspace_add``, no ``workspace_forget``, no
+  wipe.
+- ``reuse=False`` (a completed or freshly-started chain) starts clean: if a
+  stale directory is already on disk, it is forgotten (``workspace_forget``)
+  and removed before a fresh ``workspace_add`` recreates it. If nothing is on
+  disk yet, only ``workspace_add`` runs.
+- The PRD file (which may be untracked in the user's checkout) is always
+  copied into the workspace, under ``<workspace>/inputs/<prd_path.name>``,
+  before the function returns — regardless of which branch above ran.
+- ``JjError`` raised by the injected client surfaces as
+  ``SpecChainWorkspaceError``.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from unittest.mock import AsyncMock, call
+
+import pytest
+
+from maverick.exceptions import JjError, SpecChainWorkspaceError
+from maverick.jj.client import JjClient
+from maverick.workspace.spec_chain import prepare_workspace
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def home(tmp_path: Path) -> Path:
+    """Fake ``~`` so tests never touch the real home directory."""
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir()
+    return fake_home
+
+
+@pytest.fixture
+def checkout(tmp_path: Path) -> Path:
+    """Fake user checkout (``cwd``) — just needs to exist and have a name."""
+    repo_dir = tmp_path / "checkouts" / "maverick"
+    repo_dir.mkdir(parents=True)
+    return repo_dir
+
+
+@pytest.fixture
+def prd_path(tmp_path: Path) -> Path:
+    """An untracked PRD file living in the user's checkout."""
+    prd = tmp_path / "prd-scratch" / "feature-prd.md"
+    prd.parent.mkdir(parents=True)
+    prd.write_text("# Feature PRD\n\nSome untracked content.\n", encoding="utf-8")
+    return prd
+
+
+@pytest.fixture
+def mock_jj_client() -> AsyncMock:
+    """A stubbed JjClient — no real jj repo involved in this unit test."""
+    client = AsyncMock(spec=JjClient)
+
+    # workspace_add should behave like the real client: return the resolved
+    # target path, and actually materialize the directory on disk (the way
+    # `jj workspace add` would), so downstream PRD-copy assertions can run
+    # against a real filesystem path.
+    async def _workspace_add(target: Path) -> Path:
+        target.mkdir(parents=True, exist_ok=False)
+        return target.resolve()
+
+    client.workspace_add.side_effect = _workspace_add
+    return client
+
+
+def _workspace_dir(home: Path, checkout: Path, feature: str) -> Path:
+    """Compute the expected workspace path per the R3 contract."""
+    return home / ".maverick" / "workspaces" / checkout.name / "spec-chain" / feature
+
+
+# ---------------------------------------------------------------------------
+# Fresh-run creation
+# ---------------------------------------------------------------------------
+
+
+class TestFreshRunCreation:
+    async def test_creates_workspace_via_workspace_add(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        expected = _workspace_dir(home, checkout, "050-headless-spec-chain")
+
+        result = await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        assert result == expected
+        mock_jj_client.workspace_add.assert_awaited_once_with(expected)
+
+    async def test_no_forget_or_rmtree_when_nothing_stale(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        mock_jj_client.workspace_forget.assert_not_awaited()
+
+    async def test_workspace_path_is_outside_the_checkout(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        result = await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        assert checkout not in result.parents
+        assert result.is_relative_to(home)
+
+
+# ---------------------------------------------------------------------------
+# Resume / reuse of an active chain
+# ---------------------------------------------------------------------------
+
+
+class TestResumeReuseActiveChain:
+    async def test_reuses_existing_directory_without_workspace_add(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        existing = _workspace_dir(home, checkout, "050-headless-spec-chain")
+        existing.mkdir(parents=True)
+        sentinel = existing / "specs" / "050-headless-spec-chain" / "spec.md"
+        sentinel.parent.mkdir(parents=True)
+        sentinel.write_text("already-written spec content", encoding="utf-8")
+
+        result = await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=True,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        assert result == existing
+        mock_jj_client.workspace_add.assert_not_awaited()
+        mock_jj_client.workspace_forget.assert_not_awaited()
+        # Existing content must survive untouched.
+        assert sentinel.read_text(encoding="utf-8") == "already-written spec content"
+
+    async def test_reuse_with_no_existing_directory_falls_back_to_creation(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        """reuse=True but nothing on disk (e.g. state says active but the
+        directory vanished) — must still succeed by creating a workspace,
+        not raise or silently no-op."""
+        expected = _workspace_dir(home, checkout, "050-headless-spec-chain")
+        assert not expected.exists()
+
+        result = await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=True,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        assert result == expected
+        mock_jj_client.workspace_add.assert_awaited_once_with(expected)
+        mock_jj_client.workspace_forget.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Forget + recreate of a completed (or stale) chain
+# ---------------------------------------------------------------------------
+
+
+class TestForgetAndRecreateCompletedChain:
+    async def test_forgets_then_recreates_in_order(
+        self,
+        home: Path,
+        checkout: Path,
+        prd_path: Path,
+        mock_jj_client: AsyncMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        stale = _workspace_dir(home, checkout, "050-headless-spec-chain")
+        stale.mkdir(parents=True)
+        (stale / "leftover.txt").write_text("stale", encoding="utf-8")
+
+        calls: list[str] = []
+
+        async def _forget(name: str) -> None:
+            calls.append(f"forget:{name}")
+
+        async def _add(target: Path) -> Path:
+            calls.append(f"add:{target}")
+            target.mkdir(parents=True, exist_ok=False)
+            return target.resolve()
+
+        mock_jj_client.workspace_forget.side_effect = _forget
+        mock_jj_client.workspace_add.side_effect = _add
+
+        real_rmtree = shutil.rmtree
+
+        def _tracking_rmtree(path: object, *args: object, **kwargs: object) -> None:
+            calls.append(f"rmtree:{path}")
+            real_rmtree(path, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr("maverick.workspace.spec_chain.shutil.rmtree", _tracking_rmtree)
+
+        result = await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        assert result == stale
+        # forget must precede rmtree must precede add — a fresh workspace_add
+        # cannot target a path jj still thinks is occupied, and rmtree must
+        # not delete a directory jj hasn't released yet.
+        forget_idx = calls.index("forget:050-headless-spec-chain")
+        rmtree_idx = next(i for i, c in enumerate(calls) if c.startswith("rmtree:"))
+        add_idx = next(i for i, c in enumerate(calls) if c.startswith("add:"))
+        assert forget_idx < rmtree_idx < add_idx
+
+        # The old content must be gone — workspace_add repopulated the dir
+        # from scratch via jj, not by preserving the stale leftovers.
+        assert not (stale / "leftover.txt").exists()
+
+    async def test_directory_does_not_exist_when_workspace_add_invoked(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        stale = _workspace_dir(home, checkout, "050-headless-spec-chain")
+        stale.mkdir(parents=True)
+        (stale / "leftover.txt").write_text("stale", encoding="utf-8")
+
+        observed_exists_at_add_time: list[bool] = []
+
+        async def _add(target: Path) -> Path:
+            observed_exists_at_add_time.append(target.exists())
+            target.mkdir(parents=True, exist_ok=False)
+            return target.resolve()
+
+        mock_jj_client.workspace_add.side_effect = _add
+
+        await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        assert observed_exists_at_add_time == [False]
+        mock_jj_client.workspace_forget.assert_awaited_once_with("050-headless-spec-chain")
+
+    async def test_no_forget_when_nothing_stale_on_fresh_start(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        """A freshly-started chain (never run before) has no stale directory
+        to forget — only workspace_add should run."""
+        await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        mock_jj_client.workspace_forget.assert_not_awaited()
+        mock_jj_client.workspace_add.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# PRD copy-in
+# ---------------------------------------------------------------------------
+
+
+class TestPrdCopyIn:
+    async def test_copies_prd_into_new_workspace(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        result = await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        copied = result / "inputs" / prd_path.name
+        assert copied.exists()
+        assert copied.read_text(encoding="utf-8") == prd_path.read_text(encoding="utf-8")
+
+    async def test_copies_prd_into_reused_workspace(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        existing = _workspace_dir(home, checkout, "050-headless-spec-chain")
+        existing.mkdir(parents=True)
+
+        result = await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=True,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        copied = result / "inputs" / prd_path.name
+        assert copied.exists()
+        assert copied.read_text(encoding="utf-8") == prd_path.read_text(encoding="utf-8")
+
+    async def test_prd_copy_reflects_current_content_on_reuse(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        """Even when reusing a workspace, the PRD copy must be refreshed —
+        the caller may resume with edited PRD content."""
+        existing = _workspace_dir(home, checkout, "050-headless-spec-chain")
+        existing.mkdir(parents=True)
+        stale_copy = existing / "inputs"
+        stale_copy.mkdir(parents=True)
+        (stale_copy / prd_path.name).write_text("old content", encoding="utf-8")
+
+        prd_path.write_text("brand new content", encoding="utf-8")
+
+        result = await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=True,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        copied = result / "inputs" / prd_path.name
+        assert copied.read_text(encoding="utf-8") == "brand new content"
+
+
+# ---------------------------------------------------------------------------
+# Per-feature path isolation
+# ---------------------------------------------------------------------------
+
+
+class TestPerFeatureIsolation:
+    async def test_different_features_get_different_paths(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        result_a = await prepare_workspace(
+            cwd=checkout,
+            feature="050-headless-spec-chain",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+        result_b = await prepare_workspace(
+            cwd=checkout,
+            feature="051-other-feature",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        assert result_a != result_b
+        assert "050-headless-spec-chain" in result_a.parts
+        assert "051-other-feature" in result_b.parts
+
+    async def test_halted_feature_a_untouched_by_fresh_run_of_feature_b(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        """A halted, resumable feature-A workspace must survive a completely
+        unrelated fresh run of feature B: no jj ops referencing feature A's
+        path, and its on-disk content is left alone."""
+        feature_a_dir = _workspace_dir(home, checkout, "feature-a")
+        feature_a_dir.mkdir(parents=True)
+        (feature_a_dir / "resumable-marker.txt").write_text("do not touch", encoding="utf-8")
+
+        await prepare_workspace(
+            cwd=checkout,
+            feature="feature-b",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        # feature A's directory and content are untouched.
+        assert (feature_a_dir / "resumable-marker.txt").read_text(
+            encoding="utf-8"
+        ) == "do not touch"
+
+        # No jj call ever referenced feature A's path or workspace name.
+        for c in mock_jj_client.workspace_add.await_args_list:
+            assert "feature-a" not in str(c)
+        for c in mock_jj_client.workspace_forget.await_args_list:
+            assert "feature-a" not in str(c)
+
+    async def test_two_features_produce_independent_jj_calls(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        expected_a = _workspace_dir(home, checkout, "feature-a")
+        expected_b = _workspace_dir(home, checkout, "feature-b")
+
+        await prepare_workspace(
+            cwd=checkout,
+            feature="feature-a",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+        await prepare_workspace(
+            cwd=checkout,
+            feature="feature-b",
+            prd_path=prd_path,
+            reuse=False,
+            jj_client=mock_jj_client,
+            home=home,
+        )
+
+        assert mock_jj_client.workspace_add.await_args_list == [
+            call(expected_a),
+            call(expected_b),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Workspace-creation failure propagation
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceCreationFailurePropagation:
+    async def test_jj_error_on_workspace_add_becomes_spec_chain_workspace_error(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        mock_jj_client.workspace_add.side_effect = JjError(
+            "jj workspace add failed: target exists"
+        )
+
+        with pytest.raises(SpecChainWorkspaceError):
+            await prepare_workspace(
+                cwd=checkout,
+                feature="050-headless-spec-chain",
+                prd_path=prd_path,
+                reuse=False,
+                jj_client=mock_jj_client,
+                home=home,
+            )
+
+    async def test_jj_error_on_workspace_forget_becomes_spec_chain_workspace_error(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        stale = _workspace_dir(home, checkout, "050-headless-spec-chain")
+        stale.mkdir(parents=True)
+
+        mock_jj_client.workspace_forget.side_effect = JjError(
+            "jj workspace forget failed: unknown workspace"
+        )
+
+        with pytest.raises(SpecChainWorkspaceError):
+            await prepare_workspace(
+                cwd=checkout,
+                feature="050-headless-spec-chain",
+                prd_path=prd_path,
+                reuse=False,
+                jj_client=mock_jj_client,
+                home=home,
+            )
+
+    async def test_original_jj_error_is_chained(
+        self, home: Path, checkout: Path, prd_path: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        underlying = JjError("boom")
+        mock_jj_client.workspace_add.side_effect = underlying
+
+        with pytest.raises(SpecChainWorkspaceError) as exc_info:
+            await prepare_workspace(
+                cwd=checkout,
+                feature="050-headless-spec-chain",
+                prd_path=prd_path,
+                reuse=False,
+                jj_client=mock_jj_client,
+                home=home,
+            )
+
+        assert exc_info.value.__cause__ is underlying


### PR DESCRIPTION
## Summary

Adds `maverick spec <feature> --from-prd <file>` — runs the target repo's own Spec Kit chain (**specify → clarify → plan → tasks → analyze**) headlessly inside a hidden jj workspace, invoking the repo's own `/speckit.*` commands via an airframe `SpecChainAgent`.

Key behaviors:
- **Clarify never blocks** — adopted answers are filed as standalone assumption-ledger entries with severity escalation by category.
- **Halt/resume semantics** — a failed/blocked clarify halts the chain; any other step failure halts the same way with downstream steps marked skipped; analyze failures degrade to a warning. State is checkpointed after every transition, enabling auto-resume from the first incomplete step (with landed-artifact re-verification and PRD-digest-change warnings) and graceful Ctrl-C handling.
- **Remediation loop** — analyze findings become standalone `spec-remediation` beads that `refuel --speckit` later adopts under its epic.
- **Init prereq** — `maverick init` gains an advisory Spec Kit prerequisite check with an install offer.

Amends CLAUDE.md Guardrail 0 and constitution.md Appendix E (v1.11.0) to document the hidden-workspace exception this feature requires (the one documented exception to the single-repo model).

Spec: `specs/050-headless-spec-chain/`.

## Commits

- `feat(spec)` — the headless Spec Kit chain feature (45/46 tasks; T045 is a live-provider smoke test, deferred).
- `fix(spec-chain)` — hardening from an xhigh code review: fail-fast retry predicate (only retry transient runtime errors), workspace-loss-on-resume recovery (`workspace_forget` best-effort before recreate + re-seed landed artifacts from checkout), and idempotent clarify-decision merging on resume.

## Testing

`make ci` green: **3872 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
