### PR TITLE
ci: install jj so spec-chain integration tests can run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,21 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      - name: Install jj (Jujutsu)
+        # The spec-chain integration tests build a real jj-colocated repo
+        # and exercise genuine `jj workspace` behavior, so they need the
+        # actual binary (other suites mock JjClient). Pinned to match the
+        # dev container's jujutsu feature.
+        env:
+          JJ_VERSION: v0.43.0
+        run: |
+          curl -fsSL \
+            "https://github.com/jj-vcs/jj/releases/download/${JJ_VERSION}/jj-${JJ_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            -o /tmp/jj.tar.gz
+          tar -xzf /tmp/jj.tar.gz -C /tmp ./jj
+          sudo install -m 0755 /tmp/jj /usr/local/bin/jj
+          jj --version
+
       - name: Run CI checks (lint, typecheck, test)
         run: make ci-coverage
 


### PR DESCRIPTION
## Problem

`main` went red after #157 merged: every spec-chain integration test ERRORs at fixture setup with `FileNotFoundError: [Errno 2] No such file or directory: 'jj'`. The `build_speckit_repo` fixture shells out to real `jj git init --colocate` / `jj commit`, but the CI workflow never installed jj. Local `make ci` passed only because the dev container ships jj via its jujutsu feature.

## Fix

Add a pinned jj install step (v0.43.0, matching the dev container) before the test run. These tests validate genuine `jj workspace` finalization behavior, so running them against the real binary — rather than skip-guarding when jj is absent — is the intent.

## Testing

YAML validated; jj release asset + tarball layout (`./jj`) confirmed against `jj-vcs/jj` v0.43.0. The real check is this PR's own CI run going green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)