### PR TITLE
chore(devcontainer): install beads, specify, and gh-actions tools

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,12 +14,13 @@
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {},
     "ghcr.io/get2knowio/devcontainer-features/ai-clis:2": {
-	"install": "claudeCode,codex,copilot"
+      "install": "claudeCode,codex,copilot,beads,specifyCli"
     },
     "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools:2": {},
     "ghcr.io/get2knowio/devcontainer-features/python-tools:2": {
       "omit": "poetry"
-    }
+    },
+    "ghcr.io/get2knowio/devcontainer-features/github-actions-tools:2": {}
   },
   "remoteEnv": {
     "GH_PAGER": ""
@@ -55,5 +56,5 @@
     "source=${localWorkspaceFolder}/../sample-maverick-project,target=/workspaces/sample-maverick-project,type=bind,consistency=cached",
     "source=${localWorkspaceFolder}/../site,target=/workspaces/site,type=bind,consistency=cached"
   ],
-  "postCreateCommand": "python3 --version && uv --version && node --version"
+  "postCreateCommand": "python3 --version && uv --version && node --version && jj --version && command -v bd && command -v specify"
 }


### PR DESCRIPTION
## Summary

Aligns the dev container's `ai-clis` feature with what Maverick actually depends on. The feature was restricted to `claudeCode,codex,copilot`, which silently omitted:

- **`beads`** — the `bd` CLI drives the entire Maverick workflow (refuel → fly → land, the assumption ledger, spec-remediation beads). It was **not on PATH** in the container.
- **`specifyCli`** — used by the new `maverick spec` chain and `maverick init`'s Spec Kit prerequisite check.

Also:
- Adds the **`github-actions-tools`** feature (`actionlint` + `act`) — it's in the reference `python-agentic` template this config derives from, and directly useful for validating CI workflow changes (e.g. the recent `jj`-install fix).
- Extends `postCreateCommand` to smoke-test `jj`, `bd`, and `specify` so a failed feature install surfaces at container build rather than mid-task.

## Not changed / intentionally excluded

- **jj** — already installed; `modern-cli-tools` ships jujutsu by default.
- **`openCode` CLI feature** — `opencode` / `opencode-go` / `opencode-zen` are airframe **cloud provider IDs**, not the local `opencode` binary. The airframe-agents runtime replaced the old `opencode serve` subprocess model, so the CLI isn't needed.
- **`geminiCli`** (unused) and **`codeRabbit`** (optional per CLAUDE.md) — omitted to avoid over-provisioning.

## Testing

`devcontainer.json` validated as JSON. Full verification is a container rebuild (the added `postCreateCommand` checks assert `bd` and `specify` land on PATH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)