### PR TITLE
fix(tests): apply integration marker and timeout defaults per directory

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,8 +13,13 @@ Two things every test under ``tests/integration/`` gets automatically:
    scheduling. Under ``-n auto`` they compete with every other worker and
    routinely take several times their serial runtime — the global 30s
    default in ``pyproject.toml`` (right for pure-Python unit tests) left
-   too little headroom and produced intermittent CI failures that passed
-   on re-run and in isolation (issue #163).
+   too little headroom and produced intermittent failures that passed on
+   re-run and in isolation (issue #163).
+
+   Those failures show up in *local* full-suite runs, not CI: GitHub
+   Actions installs ``jj`` but not ``bd``, so the modules in question
+   skip at collection there. ``make ci`` on a dev box is the documented
+   pre-push gate (CLAUDE.md), which is exactly where they bit.
 
 Both are applied only where a test hasn't already said otherwise, so an
 explicit ``@pytest.mark.timeout(...)`` still wins.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,61 @@
+"""Directory-scoped defaults for the integration suite.
+
+Two things every test under ``tests/integration/`` gets automatically:
+
+1. **The ``integration`` marker.** This used to be a module-level
+   ``pytestmark = pytest.mark.integration`` — which does nothing in a
+   ``conftest.py``: pytest only honours ``pytestmark`` in test *modules*,
+   so only the four files that happened to declare it themselves were ever
+   marked, and ``-m integration`` silently missed the other thirteen.
+
+2. **A generous default timeout.** These tests shell out to real ``jj``,
+   ``bd``, and ``git``, so their wall-clock is dominated by subprocess
+   scheduling. Under ``-n auto`` they compete with every other worker and
+   routinely take several times their serial runtime — the global 30s
+   default in ``pyproject.toml`` (right for pure-Python unit tests) left
+   too little headroom and produced intermittent CI failures that passed
+   on re-run and in isolation (issue #163).
+
+Both are applied only where a test hasn't already said otherwise, so an
+explicit ``@pytest.mark.timeout(...)`` still wins.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
 import pytest
 
-# Apply integration marker to all tests in this directory
-pytestmark = pytest.mark.integration
+_INTEGRATION_DIR = Path(__file__).parent
+
+#: Default per-test timeout (seconds) for the integration suite.
+#:
+#: Sized from measurement, not guesswork: the slowest offender in #163
+#: (``test_scenario_2_rollback_on_gate_failure``) runs ~20s serially on an
+#: idle 8-core box, so it needed only a ~1.5x contention slowdown to breach
+#: a 30s budget. 120s absorbs a ~6x slowdown while still failing a
+#: genuinely hung test in bounded time. Tests that legitimately need longer
+#: keep their own explicit marker.
+INTEGRATION_TIMEOUT_SECONDS = 120
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Apply the ``integration`` marker and default timeout to this suite.
+
+    A ``conftest.py`` hook is invoked for the whole session, not just its
+    own subtree, so items are filtered to this directory explicitly.
+    """
+    for item in items:
+        item_path = getattr(item, "path", None)
+        # Compare paths rather than substring-matching the nodeid, so a
+        # checkout living under a directory named "integration" doesn't
+        # sweep the unit suite in too.
+        if item_path is None or not item_path.is_relative_to(_INTEGRATION_DIR):
+            continue
+
+        item.add_marker(pytest.mark.integration)
+
+        # Explicit per-test timeouts win — several tests in this suite
+        # already carry 60/90/150s overrides.
+        if item.get_closest_marker("timeout") is None:
+            item.add_marker(pytest.mark.timeout(INTEGRATION_TIMEOUT_SECONDS))

--- a/tests/unit/test_integration_suite_defaults.py
+++ b/tests/unit/test_integration_suite_defaults.py
@@ -1,0 +1,126 @@
+"""The integration suite's directory-scoped defaults actually apply (#163).
+
+``tests/integration/conftest.py`` previously used a module-level
+``pytestmark``, which pytest ignores in a ``conftest.py`` — so the
+``integration`` marker silently covered only the handful of files that
+declared it themselves, and nothing supplied the longer timeout those
+real-subprocess tests need. Both failures were invisible: the suite
+still passed, just with the wrong marks and too little headroom.
+
+These tests run pytest in-process against the real integration tree via
+``--collect-only`` (no integration test is executed) and assert on the
+marks that come out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.integration.conftest import INTEGRATION_TIMEOUT_SECONDS
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INTEGRATION_DIR = _REPO_ROOT / "tests" / "integration"
+
+
+def _collect_marks(*targets: str) -> dict[str, dict[str, object]]:
+    """Collect *targets* and return ``{nodeid: {"timeout": ..., "integration": ...}}``."""
+    collected: dict[str, dict[str, object]] = {}
+
+    class _Recorder:
+        def pytest_collection_modifyitems(self, items: list[pytest.Item]) -> None:
+            for item in items:
+                timeout = item.get_closest_marker("timeout")
+                collected[item.nodeid] = {
+                    "timeout": timeout.args[0] if timeout else None,
+                    "integration": item.get_closest_marker("integration") is not None,
+                }
+
+    pytest.main(
+        ["--collect-only", "-q", "-p", "no:randomly", "--timeout=30", *targets],
+        plugins=[_Recorder()],
+    )
+    return collected
+
+
+class TestIntegrationMarker:
+    def test_applied_to_files_that_do_not_declare_it(self) -> None:
+        """The regression that made ``-m integration`` under-collect.
+
+        ``test_json_verbs_scenario.py`` carries no ``pytestmark`` of its
+        own, so under the old conftest it was collected without the
+        marker.
+        """
+        target = str(_INTEGRATION_DIR / "cli" / "test_json_verbs_scenario.py")
+        marks = _collect_marks(target)
+
+        assert marks, "collected nothing — check the target path"
+        assert all(m["integration"] for m in marks.values())
+
+    def test_every_integration_test_is_marked(self) -> None:
+        """`-m integration` must select the whole directory, not a subset."""
+        all_marks = _collect_marks(str(_INTEGRATION_DIR))
+        unmarked = [nodeid for nodeid, m in all_marks.items() if not m["integration"]]
+
+        assert not unmarked, (
+            f"{len(unmarked)} integration tests missing the marker: {unmarked[:5]}"
+        )
+
+    def test_unit_tests_are_not_swept_in(self) -> None:
+        """The conftest hook sees every item in the session — it must filter."""
+        target = str(_REPO_ROOT / "tests" / "unit" / "test_workflow_errors.py")
+        marks = _collect_marks(target)
+
+        assert marks
+        assert not any(m["integration"] for m in marks.values())
+
+
+class TestIntegrationTimeoutDefault:
+    def test_default_applied_to_the_flaky_offenders(self) -> None:
+        """The three tests from #163 get real headroom, not the global 30s."""
+        marks = _collect_marks(
+            str(_INTEGRATION_DIR / "workflows" / "test_reconcile_jj.py"),
+            str(_INTEGRATION_DIR / "test_assumption_ledger_flow.py"),
+        )
+        offenders = [
+            "test_scenario_2_rollback_on_gate_failure",
+            "test_scenario_1_clean_retroactive_application",
+            "test_record_commit_stamp_flow",
+        ]
+
+        for name in offenders:
+            matching = [m for nodeid, m in marks.items() if nodeid.endswith(f"::{name}")]
+            assert matching, f"{name} was not collected"
+            assert matching[0]["timeout"] == INTEGRATION_TIMEOUT_SECONDS
+
+    def test_explicit_per_test_override_still_wins(self) -> None:
+        """A test that asked for a longer budget keeps it."""
+        marks = _collect_marks(str(_INTEGRATION_DIR / "test_assumption_ledger_flow.py"))
+        overridden = {
+            "test_low_severity_blocks_frontier_until_bulk_waived": 150,
+            "test_full_provenance_round_trip_report": 60,
+        }
+
+        for name, expected in overridden.items():
+            matching = [m for nodeid, m in marks.items() if nodeid.endswith(f"::{name}")]
+            assert matching, f"{name} was not collected"
+            assert matching[0]["timeout"] == expected
+
+    def test_unit_tests_keep_the_global_default(self) -> None:
+        """The longer budget must not leak out of the integration tree."""
+        target = str(_REPO_ROOT / "tests" / "unit" / "test_workflow_errors.py")
+        marks = _collect_marks(target)
+
+        assert marks
+        assert all(m["timeout"] is None for m in marks.values())
+
+    def test_default_exceeds_the_slowest_measured_serial_runtime(self) -> None:
+        """Guard the sizing rationale in the conftest docstring.
+
+        The slowest offender measured ~20s serially; the default must
+        leave room for several-fold contention slowdown, not a hair.
+        """
+        slowest_measured_serial = 20
+        minimum_contention_headroom = slowest_measured_serial * 5
+        assert minimum_contention_headroom <= INTEGRATION_TIMEOUT_SECONDS

--- a/tests/unit/test_integration_suite_defaults.py
+++ b/tests/unit/test_integration_suite_defaults.py
@@ -10,6 +10,14 @@ still passed, just with the wrong marks and too little headroom.
 These tests run pytest in-process against the real integration tree via
 ``--collect-only`` (no integration test is executed) and assert on the
 marks that come out.
+
+**Environment independence**: several integration modules call
+``pytest.skip(..., allow_module_level=True)`` when ``bd``/``jj`` are
+absent, which prevents collection entirely — CI installs ``jj`` but not
+``bd``, so a different set of tests collects there than on a dev box.
+Assertions below are therefore stated as invariants over *whatever*
+collected, never over named tests, with targeted checks skipping
+explicitly when their subject isn't present.
 """
 
 from __future__ import annotations
@@ -44,64 +52,94 @@ def _collect_marks(*targets: str) -> dict[str, dict[str, object]]:
     return collected
 
 
+@pytest.fixture(scope="module")
+def integration_marks() -> dict[str, dict[str, object]]:
+    """Marks for every integration test collectable in this environment."""
+    marks = _collect_marks(str(_INTEGRATION_DIR))
+    if not marks:  # pragma: no cover — would mean the whole suite is unreachable
+        pytest.skip("no integration tests collected in this environment")
+    return marks
+
+
 class TestIntegrationMarker:
-    def test_applied_to_files_that_do_not_declare_it(self) -> None:
-        """The regression that made ``-m integration`` under-collect.
+    def test_every_collected_integration_test_is_marked(
+        self, integration_marks: dict[str, dict[str, object]]
+    ) -> None:
+        """`-m integration` must select the whole directory, not a subset.
 
-        ``test_json_verbs_scenario.py`` carries no ``pytestmark`` of its
-        own, so under the old conftest it was collected without the
-        marker.
+        The original bug: only files carrying their own ``pytestmark``
+        were marked, so `-m integration` under-collected everything else.
         """
-        target = str(_INTEGRATION_DIR / "cli" / "test_json_verbs_scenario.py")
-        marks = _collect_marks(target)
-
-        assert marks, "collected nothing — check the target path"
-        assert all(m["integration"] for m in marks.values())
-
-    def test_every_integration_test_is_marked(self) -> None:
-        """`-m integration` must select the whole directory, not a subset."""
-        all_marks = _collect_marks(str(_INTEGRATION_DIR))
-        unmarked = [nodeid for nodeid, m in all_marks.items() if not m["integration"]]
+        unmarked = [nodeid for nodeid, m in integration_marks.items() if not m["integration"]]
 
         assert not unmarked, (
             f"{len(unmarked)} integration tests missing the marker: {unmarked[:5]}"
         )
 
+    def test_covers_files_that_do_not_declare_the_marker(
+        self, integration_marks: dict[str, dict[str, object]]
+    ) -> None:
+        """Guards specifically against the old per-module-only behavior.
+
+        ``cli/test_json_verbs_scenario.py`` has no ``pytestmark`` of its
+        own and no tooling guard, so it collects everywhere — making it a
+        reliable witness that the marker now comes from the conftest.
+        """
+        witness = [n for n in integration_marks if "test_json_verbs_scenario.py" in n]
+
+        assert witness, "witness file was not collected — did it move?"
+        assert all(integration_marks[n]["integration"] for n in witness)
+
     def test_unit_tests_are_not_swept_in(self) -> None:
         """The conftest hook sees every item in the session — it must filter."""
-        target = str(_REPO_ROOT / "tests" / "unit" / "test_workflow_errors.py")
-        marks = _collect_marks(target)
+        marks = _collect_marks(str(_REPO_ROOT / "tests" / "unit" / "test_workflow_errors.py"))
 
         assert marks
         assert not any(m["integration"] for m in marks.values())
 
 
 class TestIntegrationTimeoutDefault:
-    def test_default_applied_to_the_flaky_offenders(self) -> None:
-        """The three tests from #163 get real headroom, not the global 30s."""
-        marks = _collect_marks(
-            str(_INTEGRATION_DIR / "workflows" / "test_reconcile_jj.py"),
-            str(_INTEGRATION_DIR / "test_assumption_ledger_flow.py"),
+    def test_no_integration_test_falls_through_to_the_global_default(
+        self, integration_marks: dict[str, dict[str, object]]
+    ) -> None:
+        """The invariant behind #163.
+
+        Every integration test must carry an explicit budget; a ``None``
+        here means it silently inherits the 30s global default sized for
+        pure-Python unit tests.
+        """
+        unbudgeted = [nodeid for nodeid, m in integration_marks.items() if m["timeout"] is None]
+
+        assert not unbudgeted, (
+            f"{len(unbudgeted)} tests fall back to the 30s global: {unbudgeted[:5]}"
         )
-        offenders = [
-            "test_scenario_2_rollback_on_gate_failure",
-            "test_scenario_1_clean_retroactive_application",
-            "test_record_commit_stamp_flow",
+
+    def test_default_is_actually_reachable(
+        self, integration_marks: dict[str, dict[str, object]]
+    ) -> None:
+        """At least one test picks up the directory default (not all overridden)."""
+        defaulted = [
+            nodeid
+            for nodeid, m in integration_marks.items()
+            if m["timeout"] == INTEGRATION_TIMEOUT_SECONDS
         ]
 
-        for name in offenders:
-            matching = [m for nodeid, m in marks.items() if nodeid.endswith(f"::{name}")]
-            assert matching, f"{name} was not collected"
-            assert matching[0]["timeout"] == INTEGRATION_TIMEOUT_SECONDS
+        assert defaulted, "nothing received the conftest default — is the hook filtering wrongly?"
 
     def test_explicit_per_test_override_still_wins(self) -> None:
-        """A test that asked for a longer budget keeps it."""
+        """A test that asked for a longer budget keeps it.
+
+        Subject lives in a module guarded on ``bd``, which CI does not
+        install — skip rather than fail where it can't be collected.
+        """
         marks = _collect_marks(str(_INTEGRATION_DIR / "test_assumption_ledger_flow.py"))
+        if not marks:
+            pytest.skip("test_assumption_ledger_flow.py not collectable (bd absent)")
+
         overridden = {
             "test_low_severity_blocks_frontier_until_bulk_waived": 150,
             "test_full_provenance_round_trip_report": 60,
         }
-
         for name, expected in overridden.items():
             matching = [m for nodeid, m in marks.items() if nodeid.endswith(f"::{name}")]
             assert matching, f"{name} was not collected"
@@ -109,8 +147,7 @@ class TestIntegrationTimeoutDefault:
 
     def test_unit_tests_keep_the_global_default(self) -> None:
         """The longer budget must not leak out of the integration tree."""
-        target = str(_REPO_ROOT / "tests" / "unit" / "test_workflow_errors.py")
-        marks = _collect_marks(target)
+        marks = _collect_marks(str(_REPO_ROOT / "tests" / "unit" / "test_workflow_errors.py"))
 
         assert marks
         assert all(m["timeout"] is None for m in marks.values())


### PR DESCRIPTION
Closes #163.

## The flakiness

Three integration tests intermittently timed out under `-n auto` and passed in isolation. Not a hang — insufficient headroom against the global 30s default in `pyproject.toml`. Serial runtimes on an idle 8-core box:

| Test | Serial | Headroom |
| --- | --- | --- |
| `test_scenario_2_rollback_on_gate_failure` | 19.9s | 10.1s |
| `test_scenario_1_clean_retroactive_application` | 9.2s | 20.8s |
| `test_record_commit_stamp_flow` | 6.2s | 23.8s |

`test_scenario_2` needed only a ~1.5x contention slowdown to breach the budget. These tests shell out to real `jj`/`bd`/`git`, so under seven competing xdist workers that's routine.

**Where they bite**: local full-suite runs, not CI. GitHub Actions installs `jj` but not `bd`, and both modules `pytest.skip(allow_module_level=True)` without their tooling — so they never run here. `make ci` on a dev box is the documented pre-push gate (CLAUDE.md), which is where they failed. (I had this wrong in the first draft of this PR and in the conftest docstring; corrected in 3ef9746.)

## A second bug found while fixing it

`tests/integration/conftest.py` applied its marker via a module-level `pytestmark` — which pytest **ignores in a conftest**; it only honours `pytestmark` in test *modules*. So the `integration` marker only ever covered the four files that happened to declare it themselves, and `-m integration` silently under-collected the other thirteen. Anyone running `-m integration` or `-m "not integration"` has been getting wrong results.

Both are the same root cause — the directory had no working mechanism for applying defaults — so both are fixed by the same replacement: a `pytest_collection_modifyitems` hook that applies the marker *and* a default timeout, filtered to this directory and skipped wherever a test already said otherwise.

`-m integration` now collects 113 tests.

## Sizing

120s, chosen from the measurements above rather than picked round: it absorbs a ~6x contention slowdown over the slowest observed test while still failing a genuinely hung test in bounded time. Explicit per-test overrides already in the tree (60s, 90s, 150s) still win — verified.

## Not doing

The issue also suggested adding `@pytest.mark.slow` to integration tests over ~5s "so `make test-fast` excludes them consistently". Checking the Makefile, `test-fast` runs `tests/unit/` by path — integration tests are already excluded regardless of markers. That suggestion was unfounded and is skipped.

## Verification

`make ci-coverage` (the exact CI target): **4388 passed, 1 xfailed**, coverage 85.45%.

New `tests/unit/test_integration_suite_defaults.py` covers the conftest itself, since both bugs here were the invisible kind — the suite passed the whole time, just with the wrong marks and too little headroom. It asserts marker coverage, that no integration test falls through to the 30s global, that explicit overrides win, and that nothing leaks into the unit suite.

Two things I checked rather than assumed:
- The tests genuinely catch the regression — restored the old conftest and watched 3 of them fail.
- They're environment-independent — first version named specific tests and broke in CI for the collection reason above; rewritten as invariants over whatever collects, and verified by running with `bd` removed from `PATH` (7 passed, 1 skipped with a stated reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012av72R5SPCc84chsUNjhLC
