### PR TITLE
fix(burr): finish the BURR migration cleanup (#135)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,10 @@ Guidance for Claude Code when working in this repository.
 ## Project Overview
 
 Maverick is a Python CLI that orchestrates AI-powered development workflows
-on top of an OpenCode HTTP runtime. It runs PRD → plan → beads → implement →
-review → commit using an actor-mailbox architecture; mailbox actors return
-typed payloads via OpenCode's structured-output tool rather than per-agent
-MCP gateways.
+on top of the **airframe** agent-runtime abstraction. It runs PRD → plan →
+beads → implement → review → commit as **Burr** state machines; agents return
+typed Pydantic payloads via airframe's structured-output support rather than
+per-agent MCP gateways.
 
 ## Technology Stack
 
@@ -17,17 +17,16 @@ MCP gateways.
 | Language         | Python 3.11+                          | `from __future__ import annotations`        |
 | Package Manager  | uv                                    | reproducible via `uv.lock`                  |
 | Build            | Make                                  | AI-friendly minimal-noise targets           |
-| Agent runtime    | OpenCode HTTP (`opencode serve`)      | one server per workflow run                 |
-| HTTP client      | httpx                                 | `maverick.runtime.opencode.OpenCodeClient`  |
-| Actors           | xoscar                                | `n_process=0`, in-pool coroutines           |
-| Structured output| Pydantic + `format=json_schema`       | `maverick.payloads`                         |
+| Agent runtime    | airframe (`airframe.AgentRuntime`)    | `maverick.runtime.agent_factory`            |
+| Orchestration    | Burr state machines                   | `maverick.burr` + `workflows/*/burr_graph.py` |
+| Structured output| Pydantic result models                | `maverick.payloads`                         |
 | CLI              | Click + Rich                          | `maverick.cli.console`                      |
 | Validation       | Pydantic                              | config + data models                        |
 | Testing          | pytest + pytest-asyncio + xdist       | parallel via `-n auto`                      |
 | Lint / Type      | ruff / mypy (strict)                  | —                                           |
 | VCS writes       | Jujutsu (jj)                          | `maverick.jj.client.JjClient`               |
 | VCS reads        | GitPython                             | `maverick.git`                              |
-| Workspaces       | WorkspaceManager                      | hidden jj clones in `~/.maverick/workspaces/` |
+| Workspaces       | spec-chain only                       | `maverick.workspace.spec_chain`             |
 | GitHub API       | PyGithub                              | `maverick.utils.github_client`              |
 | Logging          | structlog                             | `maverick.logging.get_logger`               |
 | Retry            | tenacity                              | `AsyncRetrying`                             |
@@ -56,16 +55,18 @@ alternatives or hand-rolled equivalents.
 ```
 src/maverick/
 ├── main.py              # Click entrypoint
-├── config.py            # Pydantic config models (incl. ProviderTiersConfig)
+├── config.py            # Pydantic config models (agents:, actors:, tiers)
 ├── exceptions/          # MaverickError hierarchy
 ├── types.py / events.py / results.py / constants.py / payloads.py
-├── runtime/opencode/    # OpenCode HTTP client, server lifecycle, tiers
-├── actors/xoscar/       # supervisors + agent + deterministic actors
-├── agents/              # prompt builders (HOW)
-├── executor/            # StepExecutor protocol + OpenCode-backed default
+├── runtime/             # agent_factory (role → airframe runtime), registry
+├── burr/                # BurrWorkflowDriver + ProgressEventHook
+├── squadron/            # per-workflow agent sets + shared tier helpers
+├── agents/              # Agent subclasses: prompts + role (HOW)
+├── executor/            # StepConfig resolution
 ├── jj/ vcs/             # JjClient + VcsRepository protocol
-├── workspace/           # WorkspaceManager (hidden jj clones)
-├── workflows/           # plan_generate / refuel_maverick / fly_beads / ...
+├── workspace/           # spec-chain workspace (Guardrail 0's one exception)
+├── workflows/           # generate_flight_plan / refuel_maverick / fly_beads / ...
+│                        #   each: actions.py (@action fns) + burr_graph.py (wiring)
 ├── runners/             # CommandRunner, process_group, provider_health
 ├── library/actions/     # typed action layer (jj, git, beads, runway, ...)
 ├── runway/              # episodic + semantic knowledge store
@@ -74,20 +75,21 @@ src/maverick/
 
 ### Separation of concerns
 
-- **Actors** — `xo.Actor` subclasses owning state, exposing typed `async def`
-  methods. Agent actors hold a persistent OpenCode session; deterministic
-  actors wrap pure async Python.
-- **Supervisors** — `xo.Actor` with `@xo.generator run()` yielding
-  `ProgressEvent`s, plus typed domain methods child actors invoke.
-- **Agents** — know HOW (prompts, role). Don't own orchestration.
-- **Workflows** — know WHAT/WHEN. Create the actor pool (which spawns one
-  OpenCode server), send "start", wait for "complete".
-- **Structured output** — mailbox actors declare a `result_model` Pydantic
-  class; OpenCode's `format=json_schema` synthesizes a `StructuredOutput`
-  tool the model is forced to call. Payloads round-trip via
+- **Actions** — plain `async def` functions decorated with Burr's
+  `@action(reads=[...], writes=[...])`. They own one step of a workflow and
+  read/write only the state slots they declare.
+- **Burr graphs** — `build_*_application()` wires actions into a state
+  machine with explicit transitions. This is where control flow lives.
+- **Agents** — know HOW (prompts, role, result model). Don't own
+  orchestration.
+- **Squadrons** — per-run container owning every agent a workflow needs,
+  plus their airframe runtimes. Opened once per run, handed to the graph.
+- **Workflows** — know WHAT/WHEN. Open the squadron, build the app, drain
+  its events through `BurrWorkflowDriver`.
+- **Structured output** — agents declare a `result_model` Pydantic class;
+  airframe forces the model to return it. Payloads round-trip via
   `maverick.payloads.SubmitXxxPayload`.
 - **JjClient** — typed jj wrapper with retries/timeouts/error hierarchy.
-- **WorkspaceManager** — lifecycle for hidden jj workspaces.
 
 ### Three information types
 
@@ -151,204 +153,104 @@ acceptable.
 - **Only defer when truly blocked** (missing access, non-reproducible). When
   deferring, document what's blocked and the next concrete step.
 
-## OpenCode Runtime
+## Agent Runtime (airframe)
 
-All mailbox actors execute via the OpenCode HTTP runtime
-(`maverick.runtime.opencode`). One `opencode serve` subprocess runs per
-workflow run, spawned by the workflow's `Squadron`
-(`maverick.squadron.Squadron`) on a free port with HTTP Basic auth
-(username `opencode`, per-spawn random `OPENCODE_SERVER_PASSWORD`).
-Mailbox actors share that one server; each actor owns its own
-`OpenCodeClient` and session.
+Every LLM call goes through **airframe**, a provider-abstraction layer.
+`maverick.runtime.agent_factory.runtime_for_agent(role, ...)` maps a role
+name to a constructed `airframe.AgentRuntime` plus its resolved
+`(provider, model_id)` binding. There is no long-lived HTTP server and no
+per-workflow subprocess to manage.
 
-### Three-layer composition: Squadron + Agent + Actor
+Roles are fixed: `implement`, `review`, `briefing`, `decompose`,
+`generate` (`agent_factory.KNOWN_ROLES`). Each maps to an `agents.<role>`
+block in `maverick.yaml`. A role with no binding raises at squadron-open
+rather than silently picking a model the user never authorised — the
+same reason `runtime_for_agent` validates the binding against the
+adapter before returning.
 
-LLM-backed work flows through three layers:
+### Two-layer composition: Squadron + Agent
 
-1. **`Squadron`** (`src/maverick/squadron/`) — per-workflow lifecycle
-   container. Spawns the OpenCode server, validates every tier
-   binding it will use against `GET /provider` at startup (collapsing
-   the silent bad-modelID landmine to one place), and exposes the
-   typed agents the workflow's actors need. Per-workflow subclasses:
-   `FlySquadron`, `RefuelSquadron`, `PlanSquadron`.
-2. **`Agent`** + 3. **Actor** — see below.
+1. **`Squadron`** (`src/maverick/squadron/`) — per-run lifecycle
+   container. Builds one runtime per agent role, opens every agent, and
+   closes them all on exit. Per-workflow subclasses: `FlySquadron`,
+   `RefuelSquadron`, `PlanSquadron`, `ReconcileSquadron`.
+2. **`Agent`** (`src/maverick/agents/`) — owns its runtime scope,
+   structured-output validation, and cost telemetry. Subclass `Agent`,
+   declare `result_model` / `provider_tier` / `persona_name`, add domain
+   methods (`coder.implement(prompt)`).
 
 ```python
 async with FlySquadron(cwd=cwd, config=config, cost_sink=sink) as squadron:
-    async with actor_pool(
-        opencode_handle=squadron.handle,
-        provider_tiers=squadron.tier_overrides,
-        cost_sink=squadron.cost_sink,
-    ) as (pool, address):
-        # ...create supervisor, drain events...
-```
-
-The pool no longer owns the OpenCode lifecycle — it just registers
-the squadron's handle/tier-overrides/cost-sink against its address so
-the existing `opencode_handle_for(self.address)` lookups in agent
-construction keep working unchanged.
-
-### Two-layer agent model
-
-LLM-backed work flows through two layers:
-
-1. **`Agent`** (`src/maverick/agents/`) — owns the OpenCode session,
-   tier cascade, structured-output validation, cost telemetry. Subclass
-   `Agent`, declare `result_model` / `provider_tier` / `opencode_agent`,
-   add domain methods (`coder.implement(prompt, *, bead_id)`).
-   Independent of xoscar; can be used directly from scripts or tests.
-2. **Actor** (`src/maverick/actors/xoscar/`) — xoscar mailbox shell.
-   Holds an `Agent` instance built by a `_make_agent()` factory hook,
-   forwards supervisor calls to agent methods, classifies errors into
-   `PromptError` / `payload_parse_error` for the supervisor.
-
-```python
-# Layer 1: Agent
-class CodingAgent(Agent):
-    result_model: ClassVar = SubmitImplementationPayload
-    provider_tier: ClassVar[str] = "implement"
-    opencode_agent: ClassVar[str | None] = "maverick.implementer"
-
-    async def implement(self, prompt: str, *, bead_id: str) -> SubmitImplementationPayload:
+    app = build_fly_application(squadron=squadron, event_queue=queue, ...)
+    driver = BurrWorkflowDriver(app, halt_after=FLY_TERMINAL_ACTIONS, event_queue=queue)
+    async for evt in driver.events():
         ...
-
-# Layer 2: Actor (thin shell)
-class ImplementerActor(xo.Actor):
-    def _make_agent(self) -> CodingAgent:
-        # Override in tests to inject a stubbed agent.
-        return CodingAgent(handle=opencode_handle_for(self.address), ...)
-
-    async def __post_create__(self) -> None:
-        self._agent = self._make_agent()
-        await self._agent.open()
+    _, _, state = driver.result
 ```
 
-Agent methods provided by the base class:
+Agent base-class helpers: `_execute_via_runtime()` (structured),
+`_execute_text_via_runtime()` (plain text), `rotate_session()` (fresh
+context between beads), `open()` / `close()` + `async with`.
 
-- `_send_structured(prompt, *, schema=None, timeout=...)` — `format=json_schema`,
-  cascade, validation, typed payload.
-- `_send_text(prompt, *, timeout=...)` — plain-text response.
-- `rotate_session()` — drop the OpenCode session for a fresh context
-  (called between beads).
-- `open()` / `close()` lifecycle, plus `async with` support.
+### Per-complexity tiers
 
-What the agent layer **doesn't** do (what the legacy ACP+MCP path had
-and the new path doesn't need): MCP tool registration, `on_tool_call`,
-two-turn self-nudge loop, JSON-in-text fallback. The
-`StructuredOutput` tool forces the model to return a typed payload on
-the first turn — the recovery loops are dead code.
+`actors.<workflow>.<actor>.tiers.<complexity>` routes work to a
+different provider/model by the decomposer-assigned `complexity`.
+Three actors support it: fly's `implementer` and `reviewer`, refuel's
+`decomposer`.
 
-### Three operational landmines (and their mitigations)
+- `maverick.config.lookup_tiers_config()` parses the block into its
+  typed model. Malformed blocks degrade to `None` with a warning — one
+  typo must not take down workflow startup.
+- `maverick.squadron.tiers` holds everything shared: `TIER_ORDER`,
+  the `DEFAULT_TIER` sentinel (`"_default"` — the role's base binding,
+  deliberately *not* a member of `TIER_ORDER`), `binding_for_complexity()`,
+  `defined_tiers()`, `escalation_ladder()`, `merge_tier_config()`.
+- **Escalation ladders come from the squadron, never hardcoded.** A rung
+  may only name a tier the squadron built a *distinct* binding for, so a
+  squadron with no `tiers:` config yields a one-rung ladder and nothing
+  escalates. Escalating to an identical binding is a retry in disguise,
+  and it hides the fact that the binding never varied.
+- `escalation_threshold` means different things on different models
+  ("escalation steps" on `DecomposerTiersConfig`, "fix rounds before
+  promoting" on `ImplementerTiersConfig`), so `escalation_ladder()` takes
+  an explicit `max_steps` instead of reading it. The implementer reading
+  is currently unimplemented.
 
-The OpenCode HTTP API has three sharp edges. Every mitigation is wired
-into `maverick.runtime.opencode` already; if you find yourself writing
-HTTP calls outside that module, you'll re-introduce one of these.
+### Burr orchestration
 
-1. **Async dispatch + bad `modelID` = persistent server crash loop.**
-   `POST /session/:id/prompt_async` with an invalid model returns
-   HTTP 200 but persists the user message to the on-disk DB and crashes
-   the server in the background. Restart replays it and crashes again.
-   *Mitigation:* always validate the model via `validate_model_id()`
-   before sending, and prefer `send_with_event_watch()` (synchronous)
-   over `send_message_async()` for load-bearing work. Recovery runbook
-   for an existing crash loop: `python /tmp/opencode-spike/purge_queued.py`.
+Each workflow is a package with `actions.py` (`@action` functions) and
+`burr_graph.py` (`build_*_application()` + transitions + terminal
+actions). `maverick.burr.BurrWorkflowDriver` runs the app and yields
+`ProgressEvent`s while it goes.
 
-2. **Errors are silent on the synchronous HTTP response.** A bad
-   `modelID`, bad provider auth, or context overflow returns HTTP 200
-   with an empty body. Errors only surface on the `/event` SSE stream as
-   `session.error` events. *Mitigation:*
-   `OpenCodeClient.send_with_event_watch()` joins the send call to a
-   parallel event-drain and raises classified exceptions
-   (`OpenCodeAuthError`, `OpenCodeModelNotFoundError`,
-   `OpenCodeContextOverflowError`, etc.) instead of returning empty
-   bodies. Don't bypass it.
+- **The driver defers exceptions.** An action that raises does *not*
+  interrupt `driver.events()`; the exception is stored and re-raised
+  when you touch `driver.result`. Tests that assert on a raising action
+  must drain the events first, then access `.result`.
+- Actions declare `reads` / `writes` explicitly. Adding a state slot
+  means adding it to the producing action's `writes`, every consumer's
+  `reads`, *and* the graph's `.with_state(...)` seed.
+- Keep actions pure functions of state plus injected collaborators
+  (`squadron`, `events`, config values) bound via `.bind(...)` in the
+  graph. Disk and network reads belong in one place — see
+  `refuel_maverick`'s `init_state`, which is the only action that reads
+  the refuel cache.
 
-3. **Claude wraps StructuredOutput payloads inconsistently.** Roughly 30%
-   of haiku-4.5 responses come back as `{input: {...}}`,
-   `{parameter: {...}}`, `{content: '<json-string>'}`, etc. *Mitigation:*
-   `_unwrap_envelope()` in `client.py` strips the wrapper before
-   `model_validate`. Treat it as a permanent client-side normalization
-   layer — always go through `structured_of(message)` rather than
-   reading `info["structured"]` directly.
-
-### Provider tiers + cascade
-
-Each actor's `provider_tier` is a role name (`"review"`, `"implement"`,
-`"briefing"`, `"decompose"`, `"generate"`). The runtime resolves the tier
-to an ordered list of `(provider_id, model_id)` bindings via
-`maverick.runtime.opencode.tiers.resolve_tier()`. Defaults live in
-`DEFAULT_TIERS`; users override per-tier in `maverick.yaml` under
-`provider_tiers:`.
-
-When a binding fails for a recoverable reason (auth /
-model-not-found / sustained transient / structured-output failure) the
-mixin's `_send_with_model` falls over to the next binding via
-`cascade_send`. Failed bindings stick — future sends on the same actor
-skip them without retry. Each successful send populates
-`self._last_cost_record` and emits an `opencode_actor.cost` structured
-log row.
-
-Context-overflow is intentionally NOT cascadable; it needs a bigger
-context model, not a different one. Callers handle it explicitly.
-
-### Actor-mailbox + xoscar runtime
-
-All workflows run on an **xoscar** pool
-(`maverick.actors.xoscar.pool.actor_pool()`) bound to `127.0.0.1:0` — so
-concurrent workflows coexist. Pool uses `n_process=0`, all actors run as
-coroutines on a shared event loop. The pool also spawns one OpenCode
-server (`with_opencode=True` is the default) and registers its handle
-plus any user-config tier overrides on the pool address.
-
-- Supervisor created via
-  `await xo.create_actor(Supervisor, inputs, address=address, uid=…)` and
-  drained via `self._drain_xoscar_supervisor(supervisor)`. Children are
-  created in `__post_create__` and destroyed in `__pre_destroy__`.
-- Wrap long-running child calls in **`xo.wait_for`** (not
-  `asyncio.wait_for` — xoscar has a documented pitfall where
-  `asyncio.wait_for` around a remote call can lose the timeout if the pool
-  hangs).
-- Async generators across actor refs require `@xo.generator` on the source
-  and `async for event in await ref.run(...)` (note `await` before the
-  loop) on the consumer.
-- `await xo.destroy_actor(ref)` runs `__pre_destroy__`. `await pool.stop()`
-  alone does NOT — supervisors destroy children explicitly on completion.
-- The parent process must keep its asyncio loop running:
-  `subprocess.Popen.communicate()` blocks the loop and starves the
-  OpenCode subprocess. Use `asyncio.create_subprocess_exec` instead.
-
-Standard mailbox-actor lifecycle:
-
-| Phase                | What happens                                              |
-| -------------------- | --------------------------------------------------------- |
-| `__post_create__`    | Build the agent via `_make_agent()` factory, call `agent.open()` (no network yet). |
-| First send           | `agent._build_client()` opens a `OpenCodeClient` against the registered handle and creates a session. |
-| Subsequent sends     | Reuse the same session.                                   |
-| New bead             | Actor calls `agent.rotate_session()`; the next send opens a new session. |
-| `__pre_destroy__`    | Actor calls `agent.close()` — delete session, close client. |
-
-### Adding a new agent + actor
+### Adding a new agent
 
 1. Define a payload model in `maverick.payloads` and register it in
-   `SUPERVISOR_TOOL_PAYLOAD_MODELS` (the dict keys are kept stable for
-   the briefing agent's per-instance schema lookup).
+   `SUPERVISOR_TOOL_PAYLOAD_MODELS` (keys are stable — the briefing
+   agent does a per-instance schema lookup against them).
 2. Add an `Agent` subclass under `src/maverick/agents/<role>.py`:
-   - Declare `result_model`, `provider_tier`, `opencode_agent` class vars.
-   - Implement domain methods that call `_send_structured(prompt, ...)`
-     and return the typed payload.
-3. Add an actor shell under `src/maverick/actors/xoscar/<role>.py`:
-   - Subclass `xo.Actor`.
-   - Implement `_make_agent()` factory returning your agent instance,
-     wired with handle/cwd/step_config/tier_overrides/cost_sink from
-     the pool registries (`opencode_handle_for(self.address)` etc.).
-   - In `__post_create__`: `self._agent = self._make_agent(); await self._agent.open()`.
-   - In `__pre_destroy__`: `await self._agent.close()`.
-   - Implement supervisor-facing methods (`send_review`, `send_fix`,
-     etc.) — forward to agent methods, classify errors into
-     `PromptError`, route typed payloads to supervisor RPCs.
-4. Decorate methods reverse-called by the supervisor with `@xo.no_lock`
-   (so they don't deadlock against the actor lock held by the in-flight
-   `send_*`).
+   declare `result_model` / `provider_tier` / `persona_name`, and
+   implement domain methods that call `_execute_via_runtime(...)` and
+   return the typed payload.
+3. Build it in the workflow's `Squadron` subclass via
+   `runtime_for_agent(<role>, agents_config=self._config.agents)`,
+   and make sure `_all_agents()` yields it so `close()` tears it down.
+4. Call it from an `@action` in the workflow's `actions.py`, and wire
+   that action into `burr_graph.py`.
 
 ## CLI Output
 
@@ -542,7 +444,7 @@ Beads-only workflow model. All development is driven by beads (`bd` CLI).
 | `maverick spec <feature> --from-prd <file>`          | Headless Spec Kit chain from a PRD   |
 | `maverick refuel <plan-name>`                        | Decompose plan into beads            |
 | `maverick refuel <feature> --speckit [--dry-run\|--enrich]` | Deterministic Spec Kit ingestion |
-| `maverick fly --epic <id>`                           | Implement beads (actor-mailbox)      |
+| `maverick fly --epic <id>`                           | Implement beads (Burr drain loop)    |
 | `maverick land [--eject\|--finalize] [--status] [--json]` | Curate history and merge, or query the frontier |
 | `maverick reconcile [--dry-run] [--json]`            | Reapply changed human answers into jj history |
 | `maverick workspace status\|clean`                   | Manage hidden workspace              |
@@ -601,11 +503,10 @@ existing epic — no duplicate epics. See
 ### fly
 
 Iterates over ready beads. Drain loop is Burr-driven end to end
-(`workflows/fly_beads/burr_graph.py`; the earlier xoscar-actor
-`FlySupervisor` is retired) — each ready bead flows through the state
-machine: `Implementer → Gate → Reviewer → (fix loop if needed) →
-Commit`. Implementer + reviewer share persistent OpenCode sessions
-across fix rounds (rotated per bead via `_rotate_session()`). Options:
+(`workflows/fly_beads/burr_graph.py`) — each ready bead flows through
+the state machine: `Implementer → Gate → Reviewer → (fix loop if
+needed) → Commit`. Implementer + reviewer share a persistent runtime
+scope across fix rounds (rotated per bead via `rotate_session()`). Options:
 `--epic`, `--max-beads` (default 30), `--auto-commit`. Ctrl-C is a
 two-stage signal: first sets a graceful stop flag (finishes current
 bead, exits cleanly); second cancels the run.
@@ -813,10 +714,12 @@ for its full behavioral contract.
 
 - [uv](https://docs.astral.sh/uv/) for dependencies (`uv sync`).
 - [Make](https://www.gnu.org/software/make/) for development commands.
-- [opencode](https://opencode.ai) — agent runtime; pinned to v1.14.x.
-  `opencode auth login <provider>` populates
-  `~/.local/share/opencode/auth.json` so OpenCode can route to live
-  models. The runtime spawns one server per workflow run.
+- **airframe** — the agent-runtime abstraction every LLM call goes
+  through. Providers (Claude Code, Copilot, OpenCode, OpenRouter,
+  Bedrock, Kimi, …) are selected per role in `maverick.yaml` under
+  `agents:`; `maverick init` discovers which are authenticated locally.
+  Each provider carries its own auth step — e.g. `opencode auth login
+  <provider>` for the OpenCode-backed adapters.
 - [GitHub CLI](https://cli.github.com/) (`gh`) for PRs/issues outside the
   PyGithub-covered surface.
 - Optional: [CodeRabbit CLI](https://coderabbit.ai/), [ntfy](https://ntfy.sh).

--- a/src/maverick/agents/__init__.py
+++ b/src/maverick/agents/__init__.py
@@ -5,7 +5,7 @@ All agentic execution flows through airframe-runtime-backed
 
 * Per-role mailbox agents (``CodingAgent``, ``ReviewerAgent``,
   ``BriefingAgent``, ``DecomposerAgent``, ``GeneratorAgent``) — driven
-  by xoscar actor shells; one ``provider_tier`` class var per role.
+  by the workflows' Burr graphs; one ``provider_tier`` class var per role.
 * One-shot persona agents (``maverick.agents.personas``) — wrappers
   around bundled persona prompts (consolidator, curator, validation-
   fixer, runway-seed, flight-plan-generator); used by CLI commands and

--- a/src/maverick/burr/driver.py
+++ b/src/maverick/burr/driver.py
@@ -14,9 +14,9 @@ spikes:
 * After the consumer finishes iterating, ``result`` exposes the tuple
   returned by ``Application.arun()`` for downstream use.
 
-This is the airframe-side analogue of the xoscar supervisor's
-``@xo.generator run()`` drain (see
-:meth:`maverick.workflows.base.PythonWorkflow._drain_xoscar_supervisor`).
+This is the single drain path for every workflow: the graph pushes
+``ProgressEvent``s onto a queue while it runs, and the consumer
+forwards them to the workflow's own event stream.
 """
 
 from __future__ import annotations

--- a/src/maverick/cli/lazy_group.py
+++ b/src/maverick/cli/lazy_group.py
@@ -1,7 +1,7 @@
 """Lazy Click group that defers command module imports.
 
 Top-level command modules (``fly``, ``refuel``, ``brief`` …) drag in
-workflows, the ACP SDK, the xoscar runtime, etc. — easily 400ms on
+workflows, Burr, the airframe runtime, etc. — easily 400ms on
 startup. The CLI entry point registers command *pointers* with
 :class:`LazyGroup`; the pointed-to module is imported only when that
 command is actually invoked, and ``maverick --help`` renders a stored

--- a/src/maverick/config.py
+++ b/src/maverick/config.py
@@ -38,6 +38,7 @@ __all__ = [
     "get_user_config_path",
     "load_config",
     "lookup_actor_config",
+    "lookup_tiers_config",
 ]
 
 logger = get_logger(__name__)
@@ -560,6 +561,70 @@ def lookup_actor_config(
     except ValidationError as exc:
         logger.warning(
             "actor_config_parse_failed",
+            workflow=workflow_name,
+            actor=actor_name,
+            error=str(exc),
+        )
+        return None
+
+
+#: ``(workflow_name, actor_name) -> tiers model`` for every actor that
+#: supports per-complexity provider/model routing. Adding an entry here is
+#: all that's needed to make a new role's ``tiers:`` block load.
+TIERS_MODEL_FOR_ACTOR: dict[tuple[str, str], type[BaseModel]] = {
+    ("fly-beads", "implementer"): ImplementerTiersConfig,
+    ("fly-beads", "reviewer"): ReviewerTiersConfig,
+    ("refuel-maverick", "decomposer"): DecomposerTiersConfig,
+}
+
+
+def lookup_tiers_config(
+    config: MaverickConfig,
+    workflow_name: str,
+    actor_name: str,
+) -> BaseModel | None:
+    """Parse ``actors.<workflow>.<actor>.tiers`` into its typed tiers model.
+
+    :class:`ActorConfig` accepts ``tiers`` as an untyped pass-through so a
+    user can keep top-level fields and tier overrides in one YAML block;
+    this is the resolver that gives it a type. It previously lived in the
+    per-workflow supervisors, which the Burr migration deleted — leaving
+    every ``tiers:`` block silently inert (#135).
+
+    Malformed blocks degrade to ``None`` with a warning rather than
+    raising: a typo in one tier must not take down workflow startup, and
+    the caller's no-tiers path is always a valid fallback.
+
+    Args:
+        config: Loaded :class:`MaverickConfig`.
+        workflow_name: Internal workflow name (e.g. ``"fly-beads"``).
+        actor_name: Actor name as known to the workflow code
+            (e.g. ``"implementer"``, ``"decomposer"``).
+
+    Returns:
+        The parsed tiers model when a ``tiers:`` block is present, valid,
+        and the actor supports tiering; ``None`` otherwise.
+    """
+    model_cls = TIERS_MODEL_FOR_ACTOR.get((workflow_name, actor_name))
+    if model_cls is None:
+        return None
+    actor_config = lookup_actor_config(config, workflow_name, actor_name)
+    if actor_config is None or actor_config.tiers is None:
+        return None
+    raw = actor_config.tiers
+    if not isinstance(raw, dict):
+        logger.warning(
+            "tiers_config_invalid_shape",
+            workflow=workflow_name,
+            actor=actor_name,
+            got=type(raw).__name__,
+        )
+        return None
+    try:
+        return model_cls.model_validate(raw)
+    except ValidationError as exc:
+        logger.warning(
+            "tiers_config_parse_failed",
             workflow=workflow_name,
             actor=actor_name,
             error=str(exc),

--- a/src/maverick/library/actions/__init__.py
+++ b/src/maverick/library/actions/__init__.py
@@ -11,10 +11,10 @@ Actions are organized by domain:
 - dry_run: Dry-run mode support
 
 The legacy ``review`` action surface (text-mode dual-reviewer + fix
-loop) was removed in the airframe migration; the live actor
-flow under :mod:`maverick.actors.xoscar.fly_supervisor` runs reviews
-via two parallel ReviewerActor instances and a structured-output
-fixer instead.
+loop) was removed in the airframe migration; the live flow in
+:mod:`maverick.workflows.fly_beads.actions` runs reviews via two
+parallel reviewer agents (correctness + completeness) and a
+structured-output fixer instead.
 """
 
 from __future__ import annotations

--- a/src/maverick/library/actions/decompose.py
+++ b/src/maverick/library/actions/decompose.py
@@ -277,7 +277,7 @@ def _format_briefing_section(briefing: Any) -> str:
 
     parts: list[str] = ["## Briefing Room Analysis", ""]
 
-    # Handle raw dict of per-agent results (post-migration xoscar shape)
+    # Handle raw dict of per-agent results (fan-out shape)
     if isinstance(briefing, dict):
         for agent_name, agent_data in briefing.items():
             label = agent_name.replace("_", " ").title()

--- a/src/maverick/squadron/__init__.py
+++ b/src/maverick/squadron/__init__.py
@@ -4,13 +4,17 @@ A Squadron is the substrate-aware container for a single workflow run.
 It builds one :class:`airframe.AgentRuntime` per agent role via
 :func:`maverick.runtime.agent_factory.runtime_for_agent` (driven by
 :class:`MaverickConfig.agents`), and exposes the typed agents the
-workflow's actors need.
+workflow's Burr graph needs.
 
-Workflows compose Squadron with the xoscar :func:`actor_pool`::
+A workflow opens its squadron for the length of the run and hands it to
+the graph builder::
 
     async with FlySquadron(cwd=cwd, config=config, cost_sink=sink) as squadron:
-        async with actor_pool(cost_sink=squadron.cost_sink) as (pool, address):
-            ...
+        app = build_fly_application(squadron=squadron, event_queue=queue, ...)
+        ...
+
+Per-complexity provider/model routing is shared across squadrons in
+:mod:`maverick.squadron.tiers`.
 """
 
 from __future__ import annotations

--- a/src/maverick/squadron/decomposer_pool.py
+++ b/src/maverick/squadron/decomposer_pool.py
@@ -1,10 +1,9 @@
 """``DecomposerAgentPool`` — per-tier LRU pool of :class:`DecomposerAgent`.
 
-Mirrors the legacy ``_DecomposerPool`` (which pooled
-:class:`DecomposerActor` xoscar refs) but at the agent layer. The
-RefuelSquadron exposes one of these so the actor pool — or any other
-caller in step 3+ — can acquire a tier-specific decomposer without
-each call paying for fresh runtime scope setup.
+The RefuelSquadron exposes one of these so the detail fan-out can
+acquire a decomposer bound to a specific tier's model without each
+call paying for fresh runtime scope setup. Tier names come from
+:meth:`RefuelSquadron.decomposer_escalation_ladder`.
 
 Behaviour:
 

--- a/src/maverick/squadron/fly.py
+++ b/src/maverick/squadron/fly.py
@@ -2,16 +2,13 @@
 
 When ``actors.fly.implementer.tiers`` / ``actors.fly.reviewer.tiers`` is
 configured, one agent per defined tier is built at startup. Each per-tier
-agent owns its own persistent runtime scope and provider/model
-binding. Bead routing (complexity → tier) and escalation policy
-(complex-bead-failed → retry on next-higher tier) stay in the supervisor;
-this layer just builds and hands out agents.
+agent owns its own persistent runtime scope and provider/model binding.
+Bead routing (complexity → tier) and escalation policy
+(complex-bead-failed → retry on next-higher tier) stay in the Burr fly
+graph; this layer just builds and hands out agents.
 
-The actor-pool wires each per-tier ``ImplementerActor`` / ``ReviewerActor``
-shell to a pre-built agent via the ``agent=`` constructor kwarg so the
-existing xoscar boundary stays in place (Path A). Tests and any
-no-tiers caller fall back to a single agent under the ``_DEFAULT_TIER``
-key — same shape as the supervisor's legacy single-actor path.
+Tests and any no-tiers caller fall back to a single agent under the
+:data:`~maverick.squadron.tiers.DEFAULT_TIER` key.
 """
 
 from __future__ import annotations
@@ -27,45 +24,20 @@ from maverick.agents.reviewer import ReviewerAgent
 from maverick.config import AgentBindingConfig
 from maverick.runtime.agent_factory import runtime_for_agent
 from maverick.squadron.base import Squadron
+from maverick.squadron.tiers import (
+    DEFAULT_TIER,
+    TIER_ORDER,
+    binding_for_complexity,
+    escalation_ladder,
+    merge_tier_config,
+)
+
+#: Back-compat alias — this module owned the helper before it was shared.
+_merge_tier_config = merge_tier_config
 
 if TYPE_CHECKING:
     from maverick.config import MaverickConfig
     from maverick.runtime.registry import CostSink
-
-#: Ordered tier names (low → high intelligence). Matches WorkUnitComplexity
-#: and the Burr fly graph's per-tier dispatch in
-#: ``maverick.workflows.fly_beads.actions``.
-TIER_ORDER: tuple[str, ...] = ("trivial", "simple", "moderate", "complex")
-
-#: Sentinel name for the single-agent fallback when no tiers are configured.
-DEFAULT_TIER: str = "_default"
-
-
-def _merge_tier_config(base: Any, override: Any) -> Any:
-    """Merge a per-tier override over a base ``StepConfig``.
-
-    Each field set on the override replaces the base. Fields left as
-    ``None`` on the override fall through to base. Returns a new
-    ``StepConfig`` (``StepConfig`` is frozen, so this is a ``model_copy``).
-    """
-    if base is None:
-        from maverick.executor.config import StepConfig
-
-        return StepConfig(
-            provider=override.provider,
-            model_id=override.model_id,
-            timeout=override.timeout,
-            max_tokens=override.max_tokens,
-            temperature=override.temperature,
-        )
-    updates: dict[str, Any] = {}
-    for field_name in ("provider", "model_id", "timeout", "max_tokens", "temperature"):
-        value = getattr(override, field_name, None)
-        if value is not None:
-            updates[field_name] = value
-    if not updates:
-        return base
-    return base.model_copy(update=updates)
 
 
 class FlySquadron(Squadron):
@@ -96,21 +68,8 @@ class FlySquadron(Squadron):
         self.completeness_reviewers = {}
 
     def _binding_for_complexity(self, tier_name: str, override: Any) -> AgentBindingConfig | None:
-        """Convert a per-complexity ``ImplementerTierConfig`` to a factory override.
-
-        The complexity-tier config is a Maverick-only shape with extra
-        fields (timeout / max_tokens / temperature) the airframe factory
-        doesn't consume; only ``provider`` + ``model_id`` flow through.
-        Returns ``None`` for the ``DEFAULT_TIER`` sentinel (no
-        complexity override) or when neither field is set.
-        """
-        if tier_name == DEFAULT_TIER or override is None:
-            return None
-        provider = getattr(override, "provider", None)
-        model_id = getattr(override, "model_id", None)
-        if not provider or not model_id:
-            return None
-        return AgentBindingConfig(provider=provider, model_id=model_id)
+        """Thin instance-level alias for :func:`binding_for_complexity`."""
+        return binding_for_complexity(tier_name, override)
 
     def _build_coder(self, tier_name: str, step_config: Any, override: Any = None) -> CodingAgent:
         suffix = "" if tier_name == DEFAULT_TIER else f".{tier_name}"
@@ -194,6 +153,20 @@ class FlySquadron(Squadron):
                 self._build_reviewer_pair(DEFAULT_TIER, reviewer_base)
 
         await asyncio.gather(*(a.open() for a in self._all_agents()))
+
+    def implementer_escalation_ladder(self) -> tuple[str, ...]:
+        """Tier names a transient-failing implementer escalates along.
+
+        Uncapped: ``ImplementerTiersConfig.escalation_threshold`` counts
+        *fix rounds before promoting*, not escalation steps, so it is not
+        a cap on this ladder. (It is currently consumed nowhere — see
+        #135.)
+        """
+        return escalation_ladder(self._implementer_tiers)
+
+    def reviewer_escalation_ladder(self) -> tuple[str, ...]:
+        """Tier names a transient-failing reviewer escalates along."""
+        return escalation_ladder(self._reviewer_tiers)
 
     def coder_for(self, tier_name: str) -> CodingAgent:
         """Look up the coder for ``tier_name``.

--- a/src/maverick/squadron/refuel.py
+++ b/src/maverick/squadron/refuel.py
@@ -1,21 +1,27 @@
 """``RefuelSquadron`` — agents the ``refuel`` workflow exercises.
 
 * Briefing agents (navigator, structuralist, recon, contrarian, plus
-  any pre-flight variants) — built on demand, since the supervisor
-  fans them out via ``asyncio.gather``.
+  any pre-flight variants) — built on demand, since the Burr graph fans
+  them out via ``asyncio.gather``.
 * Generator (flight-plan synthesizer).
 * Decomposer pool (per-tier, demand-driven LRU pool of decomposer agents).
+
+When ``actors.refuel.decomposer.tiers`` is configured, each tier the pool
+is asked for resolves to that tier's own provider/model binding; the
+detail fan-out escalates a failed unit along
+:meth:`RefuelSquadron.decomposer_escalation_ladder`.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
 from maverick.agents.base import Agent
+from maverick.config import lookup_tiers_config
 
 if TYPE_CHECKING:
     from maverick.config import MaverickConfig
@@ -26,6 +32,7 @@ from maverick.agents.generator import GeneratorAgent
 from maverick.runtime.agent_factory import runtime_for_agent
 from maverick.squadron.base import Squadron
 from maverick.squadron.decomposer_pool import DecomposerAgentPool
+from maverick.squadron.tiers import binding_for_complexity, escalation_ladder
 
 
 class RefuelSquadron(Squadron):
@@ -43,11 +50,18 @@ class RefuelSquadron(Squadron):
         decomposer_pool_cap: int = 3,
         detail_session_max_turns: int = 5,
         fix_session_max_turns: int = 1,
+        decomposer_tiers: Any = None,
     ) -> None:
         super().__init__(cwd=cwd, config=config, cost_sink=cost_sink)
         self._decomposer_pool_cap = decomposer_pool_cap
         self._detail_session_max_turns = detail_session_max_turns
         self._fix_session_max_turns = fix_session_max_turns
+        # ``None`` here is the "caller didn't decide" signal, so fall back
+        # to the user's config. An explicit value (including a config the
+        # caller built itself) always wins — that's what tests use.
+        if decomposer_tiers is None:
+            decomposer_tiers = lookup_tiers_config(config, "refuel-maverick", "decomposer")
+        self._decomposer_tiers = decomposer_tiers
         # Every briefing built via build_briefing_agent is tracked here so
         # Squadron.close() can guarantee its HTTP session is shut down.
         # Refuel runs 4+ briefings per fan-out; one forgotten close =
@@ -70,8 +84,34 @@ class RefuelSquadron(Squadron):
             factory=self._build_decomposer,
         )
 
+    def decomposer_escalation_ladder(self) -> tuple[str, ...]:
+        """Tier names a failed detail unit escalates along, in order.
+
+        Always starts at the base binding. Collapses to a single entry
+        when no tiers are configured — there is nothing to escalate *to*,
+        and re-running the identical binding under a different tier name
+        is a retry pretending to be an escalation.
+
+        Capped by ``DecomposerTiersConfig.escalation_threshold``, which on
+        *this* model means "escalation steps allowed per unit".
+        """
+        max_steps = getattr(self._decomposer_tiers, "escalation_threshold", None)
+        return escalation_ladder(self._decomposer_tiers, max_steps=max_steps)
+
     async def _build_decomposer(self, tier: str) -> DecomposerAgent:
-        decomposer_runtime, _ = runtime_for_agent("decompose", agents_config=self._config.agents)
+        """Build + open one pooled decomposer bound to ``tier``'s model.
+
+        ``tier`` is a key from :meth:`decomposer_escalation_ladder`; the
+        base-binding sentinel and any tier the user left undefined both
+        resolve ``binding_override=None``, i.e. the ``decompose`` role's
+        own binding.
+        """
+        override = getattr(self._decomposer_tiers, tier, None)
+        decomposer_runtime, _ = runtime_for_agent(
+            "decompose",
+            agents_config=self._config.agents,
+            binding_override=binding_for_complexity(tier, override),
+        )
         agent = DecomposerAgent(
             runtime=decomposer_runtime,
             cwd=str(self._cwd),

--- a/src/maverick/squadron/tiers.py
+++ b/src/maverick/squadron/tiers.py
@@ -1,0 +1,133 @@
+"""Shared per-complexity tier helpers for squadrons.
+
+A *tier* maps a work item's ``complexity`` (assigned by the decomposer at
+refuel time) to its own provider/model binding, so trivial work doesn't
+pay frontier prices and complex work doesn't suffer weak models. Three
+actors support tiering today — fly's implementer and reviewer, and
+refuel's decomposer — and every one of them needs the same three
+operations, so they live here rather than on any one squadron.
+
+The user-facing surface is ``actors.<workflow>.<actor>.tiers.<complexity>``;
+:func:`maverick.config.lookup_tiers_config` turns that block into a typed
+tiers model, and the functions below turn that model into the arguments a
+squadron needs to build agents.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from maverick.config import AgentBindingConfig
+
+#: Ordered tier names, cheapest → most capable. Matches ``WorkUnitComplexity``
+#: and the per-tier fields on every ``*TiersConfig`` model.
+TIER_ORDER: tuple[str, ...] = ("trivial", "simple", "moderate", "complex")
+
+#: Sentinel tier name for the single-agent fallback (no tiers configured).
+#: Deliberately not a member of :data:`TIER_ORDER`: it means "the role's
+#: base binding", which may sit anywhere on the capability scale.
+DEFAULT_TIER: str = "_default"
+
+__all__ = [
+    "DEFAULT_TIER",
+    "TIER_ORDER",
+    "binding_for_complexity",
+    "defined_tiers",
+    "escalation_ladder",
+    "merge_tier_config",
+]
+
+
+def merge_tier_config(base: Any, override: Any) -> Any:
+    """Merge a per-tier override over a base ``StepConfig``.
+
+    Each field set on the override replaces the base. Fields left as
+    ``None`` on the override fall through to base. Returns a new
+    ``StepConfig`` (``StepConfig`` is frozen, so this is a ``model_copy``).
+    """
+    if base is None:
+        from maverick.executor.config import StepConfig
+
+        return StepConfig(
+            provider=override.provider,
+            model_id=override.model_id,
+            timeout=override.timeout,
+            max_tokens=override.max_tokens,
+            temperature=override.temperature,
+        )
+    updates: dict[str, Any] = {}
+    for field_name in ("provider", "model_id", "timeout", "max_tokens", "temperature"):
+        value = getattr(override, field_name, None)
+        if value is not None:
+            updates[field_name] = value
+    if not updates:
+        return base
+    return base.model_copy(update=updates)
+
+
+def binding_for_complexity(tier_name: str, override: Any) -> AgentBindingConfig | None:
+    """Convert a per-complexity tier config to an agent-factory override.
+
+    The tier config is a Maverick-only shape with extra fields (timeout /
+    max_tokens / temperature) the airframe factory doesn't consume; only
+    ``provider`` + ``model_id`` flow through, and only when *both* are
+    set — a half-specified binding would silently pair one tier's
+    provider with another's model.
+
+    Returns ``None`` for the :data:`DEFAULT_TIER` sentinel (no complexity
+    override) or when the override doesn't fully specify a binding, which
+    the factory reads as "use the role's base binding".
+    """
+    if tier_name == DEFAULT_TIER or override is None:
+        return None
+    provider = getattr(override, "provider", None)
+    model_id = getattr(override, "model_id", None)
+    if not provider or not model_id:
+        return None
+    return AgentBindingConfig(provider=provider, model_id=model_id)
+
+
+def defined_tiers(tiers_config: Any) -> tuple[str, ...]:
+    """Tier names ``tiers_config`` actually defines, cheapest → most capable.
+
+    Sparse configs are normal and supported: defining only ``moderate``
+    and ``complex`` is a common shape. Returns ``()`` when the config is
+    absent or defines no tiers.
+    """
+    if tiers_config is None:
+        return ()
+    return tuple(name for name in TIER_ORDER if getattr(tiers_config, name, None) is not None)
+
+
+def escalation_ladder(tiers_config: Any, *, max_steps: int | None = None) -> tuple[str, ...]:
+    """Build the ordered tier ladder a failed work item escalates along.
+
+    The ladder always starts at :data:`DEFAULT_TIER` (the role's base
+    binding, which is where unescalated work runs) and then climbs
+    through the *defined* tiers in ascending capability order.
+
+    Tiers are only worth escalating to if they resolve to a **different**
+    binding, so a config with no tiers yields ``(DEFAULT_TIER,)`` — no
+    escalation at all. That is the point: escalating to an identical
+    binding is a retry wearing a costume, and it hid the fact that the
+    binding never varied at all (#135).
+
+    ``max_steps`` is deliberately an explicit argument rather than read
+    off ``tiers_config.escalation_threshold``: that field means
+    "escalation steps allowed" on :class:`DecomposerTiersConfig` but
+    "fix rounds before promoting" on :class:`ImplementerTiersConfig`, and
+    silently picking one reading for both would be wrong for one of them.
+
+    Args:
+        tiers_config: The typed tiers model, or ``None``.
+        max_steps: Cap on escalation steps above the base binding.
+            ``None`` means uncapped; ``0`` disables escalation.
+
+    Returns:
+        The ladder, always non-empty and always starting at
+        :data:`DEFAULT_TIER`.
+    """
+    tiers = defined_tiers(tiers_config)
+    if max_steps is not None:
+        tiers = tiers[: max(0, max_steps)]
+    return (DEFAULT_TIER, *tiers)

--- a/src/maverick/workflows/fly_beads/_implement.py
+++ b/src/maverick/workflows/fly_beads/_implement.py
@@ -1,8 +1,8 @@
 """Implement helpers for fly-beads.
 
-Snapshot/describe operations and verification-only detection.
-Agent implementation is now handled by ImplementerActor in the
-Thespian actor system.
+Snapshot/describe operations and verification-only detection. The agent
+implementation itself is driven by the Burr graph's ``implement`` action
+(:mod:`maverick.workflows.fly_beads.actions`), not from here.
 """
 
 from __future__ import annotations

--- a/src/maverick/workflows/fly_beads/_review.py
+++ b/src/maverick/workflows/fly_beads/_review.py
@@ -1,3 +1,0 @@
-"""Review step — now handled by ReviewerActor in the Thespian system."""
-
-from __future__ import annotations

--- a/src/maverick/workflows/fly_beads/_spec_check.py
+++ b/src/maverick/workflows/fly_beads/_spec_check.py
@@ -2,7 +2,7 @@
 
 Ports the rule engine from the pre-migration ``SpecCheckActor`` into a
 substrate-independent helper that the Burr ``spec_check`` action can
-call directly. No xoscar, no actor shell — just :mod:`subprocess` calls
+call directly. No agent, no LLM — just :mod:`subprocess` calls
 to ``git diff`` and ``grep``.
 
 Rust is the only project type with rules today (matches the legacy

--- a/src/maverick/workflows/fly_beads/actions.py
+++ b/src/maverick/workflows/fly_beads/actions.py
@@ -29,6 +29,7 @@ from maverick.events import (
     StepOutput,
 )
 from maverick.payloads import dump_supervisor_payload
+from maverick.squadron.tiers import DEFAULT_TIER as _DEFAULT_TIER
 
 if TYPE_CHECKING:
     from maverick.config import MaverickConfig
@@ -68,7 +69,9 @@ MAX_SPEC_FIX_ATTEMPTS: int = 2
 # many beads have completed in the current run.
 AGGREGATE_REVIEW_THRESHOLD: int = 2
 
-DEFAULT_TIER: str = "_default"
+#: Re-exported from the shared tier module so this module's tier keys
+#: can't drift from the names the squadron builds bindings for.
+DEFAULT_TIER: str = _DEFAULT_TIER
 
 _SOURCE = "fly-burr"
 
@@ -829,17 +832,30 @@ async def review(
     )
 
 
-_TIER_LADDER: tuple[str, ...] = (DEFAULT_TIER, "trivial", "simple", "moderate", "complex")
-_REVIEWER_TIER_LADDER: tuple[str, ...] = _TIER_LADDER
+def _ladder(squadron: FlySquadron, which: str) -> tuple[str, ...]:
+    """The escalation ladder ``squadron`` actually has distinct agents for.
+
+    Sourced from the squadron rather than hardcoded so a rung can never
+    name a tier whose binding the squadron wouldn't vary. A squadron with
+    no ``tiers:`` config yields ``(DEFAULT_TIER,)`` — escalating to an
+    identical binding is a retry in disguise (#135).
+
+    Falls back to the base-binding-only ladder for stub squadrons in
+    tests that don't model tiering.
+    """
+    getter = getattr(squadron, f"{which}_escalation_ladder", None)
+    if getter is None:
+        return (DEFAULT_TIER,)
+    return getter() or (DEFAULT_TIER,)
 
 
-def _tier_for_level(level: int) -> str:
-    """Resolve a tier name on :data:`_TIER_LADDER` for an escalation level."""
+def _tier_at(ladder: tuple[str, ...], level: int) -> str:
+    """Clamp ``level`` onto ``ladder`` and return that rung's tier name."""
     if level <= 0:
-        return _TIER_LADDER[0]
-    if level >= len(_TIER_LADDER):
-        return _TIER_LADDER[-1]
-    return _TIER_LADDER[level]
+        return ladder[0]
+    if level >= len(ladder):
+        return ladder[-1]
+    return ladder[level]
 
 
 async def _call_implementer_with_escalation(
@@ -864,10 +880,11 @@ async def _call_implementer_with_escalation(
 
     step_name = op
     level = max(0, initial_level)
-    max_level = len(_TIER_LADDER) - 1
+    ladder = _ladder(squadron, "implementer")
+    max_level = len(ladder) - 1
     last_transient = ""
     while True:
-        tier_name = _tier_for_level(level)
+        tier_name = _tier_at(ladder, level)
         coder = squadron.coder_for(tier_name)
         await events.put(AgentStarted(step_name=step_name, agent_name=label, provider=""))
         t0 = time.monotonic()
@@ -899,7 +916,7 @@ async def _call_implementer_with_escalation(
                 )
                 return None, level, last_transient
             next_level = level + 1
-            next_tier = _tier_for_level(next_level)
+            next_tier = _tier_at(ladder, next_level)
             await _put_output(
                 events,
                 step_name,
@@ -943,20 +960,6 @@ async def _call_implementer_with_escalation(
         return payload, level, ""
 
 
-def _reviewer_tier_for_level(level: int) -> str:
-    """Resolve the reviewer tier name for an escalation level.
-
-    Level ``0`` is the squadron default. Each transient failure bumps
-    one rung up :data:`_REVIEWER_TIER_LADDER`; once the top is reached
-    there are no further tiers to try.
-    """
-    if level <= 0:
-        return _REVIEWER_TIER_LADDER[0]
-    if level >= len(_REVIEWER_TIER_LADDER):
-        return _REVIEWER_TIER_LADDER[-1]
-    return _REVIEWER_TIER_LADDER[level]
-
-
 async def _review_round_with_escalation(
     *,
     squadron: FlySquadron,
@@ -982,9 +985,10 @@ async def _review_round_with_escalation(
 
     level = max(0, initial_level)
     last_transient_error = ""
-    max_level = len(_REVIEWER_TIER_LADDER) - 1
+    ladder = _ladder(squadron, "reviewer")
+    max_level = len(ladder) - 1
     while True:
-        tier_name = _reviewer_tier_for_level(level)
+        tier_name = _tier_at(ladder, level)
         correctness = squadron.correctness_reviewer_for(tier_name)
         completeness = squadron.completeness_reviewer_for(tier_name)
 
@@ -1043,7 +1047,7 @@ async def _review_round_with_escalation(
                     )
                     return None, level, last_transient_error
                 next_level = level + 1
-                next_tier = _reviewer_tier_for_level(next_level)
+                next_tier = _tier_at(ladder, next_level)
                 await _put_output(
                     events,
                     "review",
@@ -1574,7 +1578,7 @@ async def aggregate_review(
         )
 
     # Build "<id>: <title>" lines from the per-bead event ledger so the
-    # prompt mirrors the xoscar shape (titles are not on the
+    # prompt intentionally omits titles (they are not on the
     # completed_bead_ids list itself).
     bead_events: list[dict[str, Any]] = list(state.get("bead_events") or ())
     title_by_id: dict[str, str] = {e["bead_id"]: e.get("title", "") for e in bead_events}

--- a/src/maverick/workflows/fly_beads/workflow.py
+++ b/src/maverick/workflows/fly_beads/workflow.py
@@ -348,11 +348,12 @@ class FlyBeadsWorkflow(PythonWorkflow):
         # queue drains, polling for newly-ready beads every
         # ``watch_interval`` seconds up to a fixed idle cap.
         # ----------------------------------------------------------------
-        burr_result = await self._run_fly_with_burr(
+        burr_result = await _run_bead_loop(
+            self,
             epic_id=epic_id,
             cwd=cwd,
             max_beads=max_beads,
-            completed_bead_ids=completed_bead_ids,
+            completed_bead_ids=tuple(completed_bead_ids or ()),
             flight_plan_name=flight_plan_name,
             watch=watch,
             watch_interval=watch_interval,
@@ -398,42 +399,6 @@ class FlyBeadsWorkflow(PythonWorkflow):
         )
         return result.to_dict()
 
-    async def _run_fly_with_burr(
-        self,
-        *,
-        epic_id: str,
-        cwd: Path,
-        max_beads: int = MAX_BEADS,
-        completed_bead_ids: set[str] | None = None,
-        flight_plan_name: str = "",
-        watch: bool = False,
-        watch_interval: int = 30,
-        run_id: str = "",
-    ) -> dict[str, Any]:
-        """Run the fly bead loop via the Burr-backed driver.
-
-        Post-migration gaps are documented in
-        :mod:`maverick.workflows.fly_beads.actions`.
-
-        Args:
-            run_id: This run's own ``run_id`` (already minted by
-                :meth:`_run` before the bead loop starts) — threaded to
-                the mid-flight reconcile actions (052-conditional-landing)
-                so a triggered ``ReconcileWorkflow`` pass can exclude this
-                run from its own concurrent-fly guard.
-        """
-        return await _run_fly_with_burr_impl(
-            self,
-            epic_id=epic_id,
-            cwd=cwd,
-            max_beads=max_beads,
-            completed_bead_ids=tuple(completed_bead_ids or ()),
-            flight_plan_name=flight_plan_name,
-            watch=watch,
-            watch_interval=watch_interval,
-            run_id=run_id,
-        )
-
 
 def _cost_sink_for_cwd(cwd: Path) -> Any:
     """Return a :class:`CostSink` appender for the user repo's runway store.
@@ -454,7 +419,7 @@ def _cost_sink_for_cwd(cwd: Path) -> Any:
     return make_cost_sink(store)
 
 
-async def _run_fly_with_burr_impl(
+async def _run_bead_loop(
     workflow: Any,
     *,
     epic_id: str,
@@ -466,14 +431,22 @@ async def _run_fly_with_burr_impl(
     watch_interval: int = 30,
     run_id: str = "",
 ) -> dict[str, Any]:
-    """Drive the fly Burr application; return the same shape as xoscar.
+    """Drive the fly Burr application; return the aggregate bead counts.
 
     Lives outside the class so the import-cycle (squadron → workflow)
     stays manageable: callers pass ``self`` in as ``workflow``.
+
+    Args:
+        run_id: This run's own ``run_id`` (already minted by
+            :meth:`FlyBeadsWorkflow._run` before the bead loop starts) —
+            threaded to the mid-flight reconcile actions
+            (052-conditional-landing) so a triggered ``ReconcileWorkflow``
+            pass can exclude this run from its own concurrent-fly guard.
     """
     import asyncio as _asyncio
 
     from maverick.burr import BurrWorkflowDriver
+    from maverick.config import lookup_tiers_config
     from maverick.events import ProgressEvent
     from maverick.squadron.fly import FlySquadron
     from maverick.workflows.fly_beads.burr_graph import (
@@ -482,7 +455,17 @@ async def _run_fly_with_burr_impl(
     )
 
     cost_sink = _cost_sink_for_cwd(cwd)
-    async with FlySquadron(cwd=cwd, config=workflow._config, cost_sink=cost_sink) as squadron:
+    async with FlySquadron(
+        cwd=cwd,
+        config=workflow._config,
+        cost_sink=cost_sink,
+        # ``actors.fly.{implementer,reviewer}.tiers`` was parsed by the
+        # supervisors the Burr migration deleted, which left the whole
+        # tier surface inert (#135). The squadron has always accepted
+        # these; nothing was passing them.
+        implementer_tiers=lookup_tiers_config(workflow._config, "fly-beads", "implementer"),
+        reviewer_tiers=lookup_tiers_config(workflow._config, "fly-beads", "reviewer"),
+    ) as squadron:
         event_queue: _asyncio.Queue[ProgressEvent | None] = _asyncio.Queue()
         app = build_fly_application(
             squadron=squadron,

--- a/src/maverick/workflows/generate_flight_plan/actions.py
+++ b/src/maverick/workflows/generate_flight_plan/actions.py
@@ -50,7 +50,7 @@ _SOURCE = "plan-burr"
 
 
 #: ``(agent_name, display_label, mcp_tool, role_key)`` tuples — same
-#: layout as the xoscar ``PLAN_BRIEFING_CONFIG`` so per-role configuration
+#: layout as ``PLAN_BRIEFING_CONFIG`` so per-role configuration
 #: stays portable across the two drivers.
 BRIEFING_CONFIG: tuple[tuple[str, str, str, str], ...] = (
     ("scopist", "Scopist", "submit_scope", "scope"),

--- a/src/maverick/workflows/generate_flight_plan/workflow.py
+++ b/src/maverick/workflows/generate_flight_plan/workflow.py
@@ -192,7 +192,7 @@ class GenerateFlightPlanWorkflow(PythonWorkflow):
         # Steps 2-5: briefing, generation, validation, and writing —
         # driven by the Burr application built around the PlanSquadron.
         # ------------------------------------------------------------------
-        result = await self._generate_with_burr(
+        result = await self._generate_plan(
             prd_content=prd_content,
             name=name,
             plan_dir=plan_dir,
@@ -207,7 +207,7 @@ class GenerateFlightPlanWorkflow(PythonWorkflow):
             briefing_generated=result.get("briefing_path") is not None,
         ).to_dict()
 
-    async def _generate_with_burr(
+    async def _generate_plan(
         self,
         *,
         prd_content: str,
@@ -216,12 +216,11 @@ class GenerateFlightPlanWorkflow(PythonWorkflow):
         skip_briefing: bool,
         cwd: str,
     ) -> dict[str, Any]:
-        """Generate the flight plan via the Burr-backed driver.
+        """Run briefing → generation → validation → write via Burr.
 
-        Opt-in path behind ``MAVERICK_USE_BURR=plan``. Same return-dict
-        contract as :meth:`_generate_with_xoscar`. The squadron, agents,
-        provider labels, and step configs are sourced exactly as in the
-        xoscar path; only the orchestration substrate differs.
+        Kept as its own method rather than inlined into :meth:`_run` only
+        to keep that method readable; there is no alternative driver to
+        select between.
         """
         import asyncio
 

--- a/src/maverick/workflows/refuel_maverick/actions.py
+++ b/src/maverick/workflows/refuel_maverick/actions.py
@@ -1,35 +1,35 @@
 """Burr actions for the ``refuel_maverick`` workflow.
 
-The ``maverick refuel`` workflow runs through these actions exclusively
-as of Phase 4 of the xoscar → Burr migration.
+These actions *are* the ``maverick refuel`` workflow — there is no other
+driver and no flag to select one.
 
-Known gaps relative to the pre-migration supervisor (queued for
-follow-up):
+Behaviour worth knowing before changing anything here:
 
-* Detail fan-out: per-unit retry budget is ``MAX_DETAIL_RETRIES = 1``
-  at the current tier. On ``airframe.errors.RuntimeTransientError``
-  the unit escalates one rung on the decomposer tier ladder and
-  retries; timeouts and persistent no-payload outcomes stay
-  abandoned at the current tier (matching the pre-migration
-  ``_try_one_tier`` policy). True per-tier runtime bindings — so
-  the escalated tier maps to a *different* model — are wired
-  through ``runtime_for_agent("decompose")`` today and will
-  benefit from later substrate work to support per-tier overrides.
-* Cache write-back: the workflow now passes a per-plan
-  ``cache_dir = <cwd>/.maverick/plans/<plan>/refuel-cache/``; the
-  ``synthesize_briefing``, ``outline``, and ``detail_fan_out``
-  actions persist their results there (``briefings.json``,
-  ``outline.json``, ``details/<unit_id>.json``). The read side —
-  loading these on a subsequent run to short-circuit re-generation
-  — is a separate follow-up; today the cache is write-only and
-  exists for manual inspection / future resume.
-* Quota error special-handling: treated like any other failure for now.
-* Fix-round merge: merges both ``details`` and ``work_units`` from
-  the fix payload (handles the case where the fixer splits an
-  overloaded unit). New ``work_units`` returned by the fixer are
-  appended to the outline; existing ones are replaced by id.
-
-Default driver remains xoscar; opt in via ``MAVERICK_USE_BURR=refuel``.
+* **Detail fan-out retries.** Per-unit budget is
+  ``MAX_DETAIL_RETRIES = 1`` at the current tier, and a
+  ``RuntimeTransientError`` spends it before escalating. Timeouts and
+  persistent no-payload outcomes are final at the current tier — they
+  don't escalate.
+* **Tier escalation.** The ladder comes from the squadron
+  (:func:`_tier_ladder`), so a rung can only name a tier the squadron
+  built a distinct provider/model binding for. With no
+  ``actors.refuel.decomposer.tiers`` configured the ladder is a single
+  rung and nothing escalates, because there is nothing to escalate *to*.
+* **Quota.** A provider limit is not a model-quality problem, so it
+  neither retries nor escalates: the first unit to hit one aborts the
+  whole fan-out with :class:`ProviderQuotaError` rather than letting
+  every remaining unit re-hit the same wall and then building beads from
+  a truncated plan.
+* **Cache.** ``cache_dir = <cwd>/.maverick/plans/<plan>/refuel-cache/``
+  is both written and read. :func:`init_state` seeds briefs, outline,
+  and per-unit details from it; each producing action short-circuits on
+  an already-populated slot. Envelopes are versioned
+  (:data:`CACHE_SCHEMA_VERSION`) and fail closed — see
+  :func:`_read_cache_json`.
+* **Fix-round merge.** Merges both ``details`` and ``work_units`` from
+  the fix payload (handles the fixer splitting an overloaded unit). New
+  ``work_units`` are appended to the outline; existing ones are replaced
+  by id.
 """
 
 from __future__ import annotations
@@ -48,6 +48,7 @@ from maverick.events import (
     ProgressEvent,
     StepOutput,
 )
+from maverick.exceptions.quota import ProviderQuotaError, is_quota_error
 from maverick.payloads import (
     SUPERVISOR_TOOL_PAYLOAD_MODELS,
     SubmitDetailsPayload,
@@ -56,6 +57,7 @@ from maverick.payloads import (
     SupervisorInboxPayload,
     dump_supervisor_payload,
 )
+from maverick.squadron.tiers import DEFAULT_TIER
 
 if TYPE_CHECKING:
     from maverick.agents.decomposer import DecomposerAgent
@@ -86,7 +88,7 @@ MAX_DETAIL_RETRIES: int = 1
 
 
 #: ``(agent_name, display_label, mcp_tool, role_key)`` tuples — same
-#: layout as ``REFUEL_BRIEFING_CONFIG`` in the xoscar supervisor.
+#: layout as the legacy ``REFUEL_BRIEFING_CONFIG``.
 BRIEFING_CONFIG: tuple[tuple[str, str, str, str], ...] = (
     ("navigator", "Navigator", "submit_navigator_brief", "navigator"),
     ("structuralist", "Structuralist", "submit_structuralist_brief", "structuralist"),
@@ -169,23 +171,44 @@ async def _put_output(
     )
 
 
+#: Envelope version for every file under ``<plan>/refuel-cache/``.
+#:
+#: Bump whenever the *meaning* of a cached payload changes. A cache
+#: written by a different version is discarded rather than adapted —
+#: reusing a drifted brief or outline silently produces beads that don't
+#: match the plan, which is far worse than paying for regeneration.
+CACHE_SCHEMA_VERSION: int = 1
+
+#: ``kind`` discriminators, so a file that lands in the wrong slot (a
+#: copy-paste, a bad merge) is rejected instead of parsed as its neighbour.
+CACHE_KIND_BRIEFINGS = "briefings"
+CACHE_KIND_OUTLINE = "outline"
+CACHE_KIND_DETAIL = "detail"
+
+
 async def _write_cache_json(
     path: Path,
     payload: Any,
     *,
+    kind: str,
     events: asyncio.Queue[ProgressEvent | None] | None,
     label: str,
 ) -> None:
-    """Write ``payload`` to ``path`` as pretty-printed JSON.
+    """Write ``payload`` to ``path`` inside a versioned envelope.
 
     Best-effort: any ``OSError`` (or other filesystem hiccup) is
     logged as a warning via ``events`` and swallowed so the refuel
     run still completes. Creates parent directories on demand.
     """
+    envelope = {
+        "schema_version": CACHE_SCHEMA_VERSION,
+        "kind": kind,
+        "payload": payload,
+    }
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
-            json.dumps(payload, indent=2, default=str, sort_keys=True),
+            json.dumps(envelope, indent=2, default=str, sort_keys=True),
             encoding="utf-8",
         )
     except OSError as exc:
@@ -197,6 +220,60 @@ async def _write_cache_json(
                 level="warning",
                 metadata={"path": str(path), "label": label},
             )
+
+
+def _read_cache_json(path: Path, *, kind: str) -> Any | None:
+    """Read a versioned cache envelope, or ``None`` if it can't be trusted.
+
+    Fails closed on every ambiguity — missing file, unreadable file,
+    malformed JSON, non-object envelope, unknown ``schema_version``, or
+    a ``kind`` that doesn't match what the caller asked for. The cost of
+    a wrong answer here is a plan decomposed from stale evidence; the
+    cost of a false negative is one regeneration.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        envelope = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(envelope, dict):
+        return None
+    if envelope.get("schema_version") != CACHE_SCHEMA_VERSION:
+        return None
+    if envelope.get("kind") != kind:
+        return None
+    # A cached ``null`` is indistinguishable from "absent" downstream, so
+    # treat it as a miss rather than seeding a slot with nothing.
+    return envelope.get("payload")
+
+
+def _load_cached_details(cache_dir: Path) -> dict[str, dict[str, Any]]:
+    """Load every per-unit detail under ``<cache_dir>/details/``.
+
+    Returns ``{unit_id: detail}``. Individual unreadable or drifted files
+    are skipped, so a partially-corrupt cache degrades to regenerating
+    only the units it lost.
+    """
+    details_dir = cache_dir / "details"
+    try:
+        entries = sorted(details_dir.glob("*.json"))
+    except OSError:
+        return {}
+    loaded: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        payload = _read_cache_json(entry, kind=CACHE_KIND_DETAIL)
+        if not isinstance(payload, dict):
+            continue
+        # Trust the payload's own id over the filename: the filename is
+        # derived from it at write time, but only the payload is what
+        # downstream merging keys on.
+        unit_id = payload.get("id") or payload.get("unit_id") or entry.stem
+        if unit_id:
+            loaded[str(unit_id)] = payload
+    return loaded
 
 
 # ---------------------------------------------------------------------------
@@ -211,6 +288,7 @@ async def _write_cache_json(
         "briefing_markdown",
         "outline",
         "accumulated_details",
+        "cached_details",
         "specs",
         "fix_rounds",
         "validation_passed",
@@ -224,13 +302,59 @@ async def _write_cache_json(
         "abandoned_unit_ids",
     ],
 )
-async def init_state(state: State) -> tuple[dict[str, Any], State]:
-    """Seed scratch slots used by downstream actions."""
+async def init_state(
+    state: State,
+    *,
+    cache_dir: str = "",
+    events: asyncio.Queue[ProgressEvent | None] | None = None,
+) -> tuple[dict[str, Any], State]:
+    """Seed scratch slots used by downstream actions.
+
+    When ``cache_dir`` names a populated ``refuel-cache/`` from an
+    earlier run, its briefs / outline / per-unit details are loaded here
+    and the actions that would have produced them short-circuit. Doing
+    the disk read once, in one action, keeps every producer a pure
+    function of state.
+
+    Anything the cache can't vouch for is simply absent — see
+    :func:`_read_cache_json`.
+    """
+    briefs: dict[str, Any] = {}
+    outline_dict: dict[str, Any] | None = None
+    cached_details: dict[str, dict[str, Any]] = {}
+
+    if cache_dir:
+        root = Path(cache_dir)
+        cached_briefs = _read_cache_json(root / "briefings.json", kind=CACHE_KIND_BRIEFINGS)
+        if isinstance(cached_briefs, dict):
+            briefs = cached_briefs
+        cached_outline = _read_cache_json(root / "outline.json", kind=CACHE_KIND_OUTLINE)
+        if isinstance(cached_outline, dict):
+            outline_dict = cached_outline
+        cached_details = _load_cached_details(root)
+
+        if events is not None and (briefs or outline_dict is not None or cached_details):
+            await _put_output(
+                events,
+                "decompose",
+                (
+                    f"Reusing refuel cache: {len(briefs)} briefs, "
+                    f"outline {'hit' if outline_dict else 'miss'}, "
+                    f"{len(cached_details)} unit details"
+                ),
+                metadata={
+                    "brief_count": len(briefs),
+                    "outline_cached": outline_dict is not None,
+                    "detail_count": len(cached_details),
+                },
+            )
+
     return {}, state.update(
-        briefs={},
+        briefs=briefs,
         briefing_markdown="",
-        outline=None,
+        outline=outline_dict,
         accumulated_details=[],
+        cached_details=cached_details,
         specs=[],
         fix_rounds=0,
         validation_passed=False,
@@ -253,8 +377,23 @@ async def parallel_briefings(
     events: asyncio.Queue[ProgressEvent | None],
     max_concurrent: int,
 ) -> tuple[dict[str, Any], State]:
-    """Run navigator + structuralist + recon in parallel."""
+    """Run navigator + structuralist + recon in parallel.
+
+    Roles already present in ``briefs`` (seeded from cache by
+    :func:`init_state`) are skipped — a cached brief is the same
+    evidence at zero cost.
+    """
     provider_labels: dict[str, str] = state["provider_labels"]
+    existing: dict[str, Any] = dict(state["briefs"])
+    pending = [n for n in PARALLEL_BRIEFING_AGENTS if _ROLE_FOR[n] not in existing]
+    if not pending:
+        await _put_output(
+            events,
+            "briefing",
+            "Reusing cached briefings",
+            metadata={"cached_roles": sorted(existing)},
+        )
+        return {"briefs_collected": list(existing), "from_cache": True}, state
     sem = asyncio.Semaphore(max(1, max_concurrent))
 
     async def _bounded(name: str) -> tuple[str, dict[str, Any]]:
@@ -267,8 +406,8 @@ async def parallel_briefings(
                 provider_label=provider_labels.get(_LABEL_FOR[name], ""),
             )
 
-    results = await asyncio.gather(*(_bounded(n) for n in PARALLEL_BRIEFING_AGENTS))
-    briefs = dict(state["briefs"])
+    results = await asyncio.gather(*(_bounded(n) for n in pending))
+    briefs = existing
     for role_key, payload_dict in results:
         briefs[role_key] = payload_dict
     return {"briefs_collected": list(briefs)}, state.update(briefs=briefs)
@@ -284,10 +423,15 @@ async def contrarian_briefing(
     squadron: RefuelSquadron,
     events: asyncio.Queue[ProgressEvent | None],
 ) -> tuple[dict[str, Any], State]:
-    """Run the contrarian after the parallel briefings are in."""
+    """Run the contrarian after the parallel briefings are in.
+
+    Skipped entirely when a cached contrarian brief was seeded.
+    """
     from maverick.agents.briefing.prompts import build_contrarian_prompt
 
     briefs = state["briefs"]
+    if _ROLE_FOR["contrarian"] in briefs:
+        return {"contrarian_done": True, "from_cache": True}, state
     prompt = build_contrarian_prompt(
         flight_plan_content=state["raw_content"],
         navigator=briefs.get("navigator"),
@@ -333,7 +477,8 @@ async def synthesize_briefing(
     if cache_dir and briefs:
         await _write_cache_json(
             Path(cache_dir) / "briefings.json",
-            {"payloads": briefs},
+            briefs,
+            kind=CACHE_KIND_BRIEFINGS,
             events=events,
             label="briefings",
         )
@@ -345,7 +490,12 @@ async def synthesize_briefing(
 # ---------------------------------------------------------------------------
 
 
-_DEFAULT_TIER = "default"
+#: Re-exported so this module's pool keys can't drift from the tier
+#: names the squadron builds bindings for. It used to be a local
+#: ``"default"`` while every other tier surface used ``"_default"``;
+#: with real per-tier bindings that divergence would silently route a
+#: tier lookup to the wrong (or no) override.
+_DEFAULT_TIER = DEFAULT_TIER
 
 
 @action(
@@ -361,10 +511,20 @@ async def outline(
 ) -> tuple[dict[str, Any], State]:
     """Acquire a decomposer from the pool and run the outline pass.
 
-    When ``cache_dir`` is set, persists the outline payload to
-    ``<cache_dir>/outline.json`` after the agent returns. Cache
-    failures are non-fatal.
+    Short-circuits when :func:`init_state` already seeded an outline from
+    ``<cache_dir>/outline.json``. Otherwise persists the outline payload
+    there after the agent returns. Cache failures are non-fatal.
     """
+    if state["outline"] is not None:
+        cached_units = len(state["outline"].get("work_units", ()))
+        await _put_output(
+            events,
+            "decompose",
+            f"Reusing cached outline ({cached_units} work units)",
+            metadata={"work_unit_count": cached_units, "from_cache": True},
+        )
+        return {"work_unit_count": cached_units, "from_cache": True}, state
+
     await _put_output(events, "decompose", "Requesting outline")
     decomposer: DecomposerAgent = await squadron.decomposer_pool.acquire(_DEFAULT_TIER)
     await events.put(AgentStarted(step_name="decompose", agent_name="outline", provider=""))
@@ -401,29 +561,25 @@ async def outline(
     if cache_dir:
         await _write_cache_json(
             Path(cache_dir) / "outline.json",
-            {"payload": outline_dict},
+            outline_dict,
+            kind=CACHE_KIND_OUTLINE,
             events=events,
             label="outline",
         )
     return {"work_unit_count": unit_count}, state.update(outline=outline_dict)
 
 
-_REFUEL_TIER_LADDER: tuple[str, ...] = (
-    _DEFAULT_TIER,
-    "trivial",
-    "simple",
-    "moderate",
-    "complex",
-)
+def _tier_ladder(squadron: RefuelSquadron) -> tuple[str, ...]:
+    """The tier names a failed unit escalates along, cheapest-first.
 
-
-def _refuel_tier_for_level(level: int) -> str:
-    """Pick the decomposer tier name for an escalation level."""
-    if level <= 0:
-        return _REFUEL_TIER_LADDER[0]
-    if level >= len(_REFUEL_TIER_LADDER):
-        return _REFUEL_TIER_LADDER[-1]
-    return _REFUEL_TIER_LADDER[level]
+    Sourced from the squadron so the ladder can never name a tier whose
+    binding the squadron wouldn't actually vary. Falls back to the
+    base-binding-only ladder for stub squadrons in tests.
+    """
+    ladder = getattr(squadron, "decomposer_escalation_ladder", None)
+    if ladder is None:
+        return (_DEFAULT_TIER,)
+    return ladder() or (_DEFAULT_TIER,)
 
 
 async def _run_one_detail(
@@ -439,8 +595,15 @@ async def _run_one_detail(
     one of ``""`` (success), ``"timeout"``, ``"transient"``, or
     ``"no_payload"``. ``transient`` lets the caller escalate to the
     next tier; the others propagate up as abandon.
+
+    Transient errors consume the same-tier retry budget before they are
+    reported. They used to short-circuit it and rely on the escalation
+    ladder for a second attempt, which only worked because every tier
+    resolved to the same binding; now that the ladder climbs real
+    bindings (and is empty when none are configured), the same-binding
+    retry a network blip needs has to happen here.
     """
-    from airframe.errors import RuntimeTransientError
+    from airframe.errors import RuntimeBudgetExceededError, RuntimeTransientError
 
     label = unit_id
     await events.put(AgentStarted(step_name="decompose", agent_name=label, provider=""))
@@ -449,33 +612,56 @@ async def _run_one_detail(
     last_payload: dict[str, Any] | None = None
     failure_kind = "no_payload"
     last_error: str | None = None
-    for attempt in range(attempts):
-        try:
-            payload = await decomposer.detail(unit_ids=(unit_id,))
-        except TimeoutError:
-            if attempt + 1 >= attempts:
-                failure_kind = "timeout"
-                last_error = "timed out"
+    try:
+        for attempt in range(attempts):
+            try:
+                payload = await decomposer.detail(unit_ids=(unit_id,))
+            except TimeoutError:
+                if attempt + 1 >= attempts:
+                    failure_kind = "timeout"
+                    last_error = "timed out"
+                    break
+                continue
+            except RuntimeBudgetExceededError as exc:
+                raise ProviderQuotaError(str(exc), agent_name=f"decomposer:{unit_id}") from exc
+            except RuntimeTransientError as exc:
+                # Some providers report a hard quota as a transient
+                # 429/5xx. Retrying or escalating that burns wall-clock
+                # against a limit that won't move until it resets.
+                if is_quota_error(str(exc)):
+                    raise ProviderQuotaError(str(exc), agent_name=f"decomposer:{unit_id}") from exc
+                failure_kind = "transient"
+                last_error = str(exc)
+                if attempt + 1 >= attempts:
+                    break
+                continue
+            if not isinstance(payload, SubmitDetailsPayload):
+                raise TypeError(
+                    f"decomposer.detail returned {type(payload).__name__}, "
+                    f"expected SubmitDetailsPayload"
+                )
+            payload_dict = dump_supervisor_payload(payload)
+            details = payload_dict.get("details", []) or []
+            matching = [d for d in details if (d.get("id") or d.get("unit_id")) == unit_id]
+            if matching:
+                last_payload = matching[0]
+                failure_kind = ""
                 break
-            continue
-        except RuntimeTransientError as exc:
-            failure_kind = "transient"
-            last_error = str(exc)
-            break
-        if not isinstance(payload, SubmitDetailsPayload):
-            raise TypeError(
-                f"decomposer.detail returned {type(payload).__name__}, "
-                f"expected SubmitDetailsPayload"
+            if attempt + 1 >= attempts:
+                break
+    except ProviderQuotaError as exc:
+        # Close out the agent's progress row before unwinding, or the
+        # UI leaves a spinner running for a unit that will never finish.
+        await events.put(
+            AgentCompleted(
+                step_name="decompose",
+                agent_name=label,
+                duration_seconds=time.monotonic() - t0,
+                success=False,
+                error=str(exc),
             )
-        payload_dict = dump_supervisor_payload(payload)
-        details = payload_dict.get("details", []) or []
-        matching = [d for d in details if (d.get("id") or d.get("unit_id")) == unit_id]
-        if matching:
-            last_payload = matching[0]
-            failure_kind = ""
-            break
-        if attempt + 1 >= attempts:
-            break
+        )
+        raise
 
     await events.put(
         AgentCompleted(
@@ -498,18 +684,21 @@ async def _run_detail_with_escalation(
 ) -> dict[str, Any] | None:
     """Run one unit's detail pass with per-unit tier escalation.
 
-    On ``RuntimeTransientError``, bumps to the next tier on
-    :data:`_REFUEL_TIER_LADDER` and re-acquires a decomposer from the
-    pool for that tier. Returns the unit's detail payload on success
-    or ``None`` once the ladder is exhausted (or a non-transient
-    failure terminates the loop). Timeouts and persistent
-    no-payload outcomes are treated as final at the current tier —
-    they don't escalate.
+    On ``RuntimeTransientError`` that survives the same-tier retry
+    budget, moves to the next tier on the squadron's ladder
+    (:func:`_tier_ladder`) and re-acquires a decomposer bound to that
+    tier's model. Returns the unit's detail payload on success or
+    ``None`` once the ladder is exhausted (or a non-transient failure
+    terminates the loop). Timeouts and persistent no-payload outcomes
+    are treated as final at the current tier — they don't escalate.
+
+    :class:`ProviderQuotaError` propagates untouched: a exhausted
+    provider limit is not a model-quality problem, so climbing the tier
+    ladder just spends wall-clock re-hitting the same wall. The caller
+    aborts the run.
     """
-    level = 0
-    max_level = len(_REFUEL_TIER_LADDER) - 1
-    while True:
-        tier = _refuel_tier_for_level(level)
+    ladder = _tier_ladder(squadron)
+    for level, tier in enumerate(ladder):
         decomposer = await squadron.decomposer_pool.acquire(tier)
         try:
             detail, failure = await _run_one_detail(
@@ -522,9 +711,9 @@ async def _run_detail_with_escalation(
             await squadron.decomposer_pool.release(decomposer, tier)
         if detail is not None:
             return detail
-        if failure != "transient" or level >= max_level:
+        if failure != "transient" or level + 1 >= len(ladder):
             return None
-        next_tier = _refuel_tier_for_level(level + 1)
+        next_tier = ladder[level + 1]
         await _put_output(
             events,
             "decompose",
@@ -532,11 +721,11 @@ async def _run_detail_with_escalation(
             level="warning",
             metadata={"unit_id": unit_id, "from_tier": tier, "to_tier": next_tier},
         )
-        level += 1
+    return None
 
 
 @action(
-    reads=["outline"],
+    reads=["outline", "cached_details"],
     writes=["accumulated_details", "abandoned_unit_ids"],
 )
 async def detail_fan_out(
@@ -554,7 +743,10 @@ async def detail_fan_out(
     :func:`_run_detail_with_escalation`. When ``cache_dir`` is set,
     each successful unit detail is persisted to
     ``<cache_dir>/details/<unit_id>.json`` immediately so a
-    partially-successful fan-out is recoverable.
+    partially-successful fan-out is recoverable — and units already
+    present in ``cached_details`` are not requested again. Cache reuse
+    is per unit, so a run that abandoned half its units re-requests only
+    those.
     """
     outline_dict = state["outline"]
     if outline_dict is None:
@@ -564,21 +756,63 @@ async def detail_fan_out(
     if not unit_ids:
         return {"unit_count": 0}, state
 
-    await _put_output(events, "decompose", f"Requesting details for {len(unit_ids)} units")
+    cached: dict[str, dict[str, Any]] = state.get("cached_details") or {}
+    # Only reuse details for units this outline still contains — a
+    # regenerated outline may have dropped or renamed a unit, and a
+    # detail for a unit that no longer exists must not enter the merge.
+    reused = [cached[uid] for uid in unit_ids if uid in cached]
+    pending_ids = [uid for uid in unit_ids if uid not in cached]
+
+    if reused:
+        await _put_output(
+            events,
+            "decompose",
+            f"Reusing {len(reused)} cached unit details",
+            metadata={"reused": len(reused), "pending": len(pending_ids)},
+        )
+    if not pending_ids:
+        return (
+            {"completed_count": len(reused), "abandoned_count": 0, "from_cache": True},
+            state.update(accumulated_details=list(reused), abandoned_unit_ids=[]),
+        )
+
+    await _put_output(events, "decompose", f"Requesting details for {len(pending_ids)} units")
     sem = asyncio.Semaphore(max(1, pool_size))
-    accumulated: list[dict[str, Any]] = []
+    accumulated: list[dict[str, Any]] = list(reused)
     abandoned: list[str] = []
     lock = asyncio.Lock()
     details_dir = Path(cache_dir) / "details" if cache_dir else None
 
+    # Set by the first unit to hit a provider limit. Once it is set,
+    # every other in-flight and queued unit gives up immediately: the
+    # limit is account-wide, so the remaining requests would each burn a
+    # round-trip to be told the same thing.
+    quota_error: ProviderQuotaError | None = None
+
     async def _one(unit_id: str) -> None:
+        nonlocal quota_error
+        if quota_error is not None:
+            async with lock:
+                abandoned.append(unit_id)
+            return
         async with sem:
-            detail = await _run_detail_with_escalation(
-                unit_id=unit_id,
-                squadron=squadron,
-                retries_remaining=MAX_DETAIL_RETRIES,
-                events=events,
-            )
+            if quota_error is not None:
+                async with lock:
+                    abandoned.append(unit_id)
+                return
+            try:
+                detail = await _run_detail_with_escalation(
+                    unit_id=unit_id,
+                    squadron=squadron,
+                    retries_remaining=MAX_DETAIL_RETRIES,
+                    events=events,
+                )
+            except ProviderQuotaError as exc:
+                async with lock:
+                    if quota_error is None:
+                        quota_error = exc
+                    abandoned.append(unit_id)
+                return
         async with lock:
             if detail is None:
                 abandoned.append(unit_id)
@@ -588,11 +822,39 @@ async def detail_fan_out(
             await _write_cache_json(
                 details_dir / f"{unit_id}.json",
                 detail,
+                kind=CACHE_KIND_DETAIL,
                 events=events,
                 label=f"detail/{unit_id}",
             )
 
-    await asyncio.gather(*(_one(u) for u in unit_ids))
+    await asyncio.gather(*(_one(u) for u in pending_ids))
+
+    if quota_error is not None:
+        reset_hint = (
+            f" Provider limit resets {quota_error.reset_time}." if quota_error.reset_time else ""
+        )
+        await _put_output(
+            events,
+            "decompose",
+            (
+                f"Provider quota exhausted during detail fan-out; aborting refuel. "
+                f"{len(accumulated)} unit details were cached and will be reused on "
+                f"re-run.{reset_hint}"
+            ),
+            level="error",
+            metadata={
+                "quota_exhausted": True,
+                "cached_details": len(accumulated),
+                "abandoned": len(abandoned),
+                "reset_time": quota_error.reset_time,
+            },
+        )
+        # Abort rather than proceeding to validate/create_beads: a plan
+        # decomposed from a truncated fan-out would produce beads that
+        # silently omit most of the work. Everything completed so far is
+        # already on disk under the refuel cache, so a re-run after the
+        # limit resets picks up where this left off.
+        raise quota_error
 
     await _put_output(
         events,
@@ -638,7 +900,7 @@ async def validate(
     expected_sc_refs: tuple[str, ...] = (),
     sc_count: int = 0,
 ) -> tuple[dict[str, Any], State]:
-    """Run the same deterministic validator the xoscar workflow uses."""
+    """Run the deterministic decomposition validator."""
     from maverick.library.actions.decompose import validate_decomposition
     from maverick.workflows.refuel_maverick.models import WorkUnitSpec
 
@@ -650,7 +912,7 @@ async def validate(
     # ``validate_decomposition`` returns a list of gap strings on
     # success (empty == passed) and *raises* ``ValueError`` /
     # ``SCCoverageError`` on schema-level issues (cycles, dangling
-    # depends_on, uncovered SCs). Mirror the xoscar supervisor's
+    # depends_on, uncovered SCs). Mirror the legacy supervisor's
     # behaviour and surface either path as ``validation_warnings``.
     gaps: list[str] = []
     try:

--- a/src/maverick/workflows/refuel_maverick/burr_graph.py
+++ b/src/maverick/workflows/refuel_maverick/burr_graph.py
@@ -17,8 +17,10 @@ that mirrors the legacy ``RefuelSupervisor`` shape:
 When ``skip_briefing=True`` the briefing actions are skipped and the
 graph routes ``init_state → outline``.
 
-Phase 2 simplifications (documented in :mod:`actions`): single-tier
-decomposer dispatch, no escalation, no cache write-back.
+``init_state`` also seeds briefs / outline / per-unit details from
+``<cache_dir>/`` when an earlier run left one, and every producing
+action short-circuits on an already-populated slot — so a re-run after
+a mid-flight failure resumes rather than re-pays.
 """
 
 from __future__ import annotations
@@ -97,7 +99,10 @@ def build_refuel_application(
     builder: Any = (
         ApplicationBuilder()
         .with_actions(
-            init_state=refuel_actions.init_state,
+            init_state=refuel_actions.init_state.bind(
+                cache_dir=cache_dir,
+                events=event_queue,
+            ),
             parallel_briefings=refuel_actions.parallel_briefings.bind(
                 squadron=squadron,
                 events=event_queue,
@@ -153,6 +158,7 @@ def build_refuel_application(
             briefing_markdown="",
             outline=None,
             accumulated_details=[],
+            cached_details={},
             specs=[],
             fix_rounds=0,
             validation_passed=False,

--- a/src/maverick/workflows/refuel_maverick/workflow.py
+++ b/src/maverick/workflows/refuel_maverick/workflow.py
@@ -464,7 +464,7 @@ class RefuelMaverickWorkflow(PythonWorkflow):
         # Steps 2b-4: Briefing + Decompose + Validate — driven by the
         # Burr application built around the RefuelSquadron.
         # ------------------------------------------------------------------
-        decomposition = await self._run_with_burr(
+        decomposition = await self._run_decomposition(
             flight_plan=flight_plan,
             raw_content=raw_content,
             codebase_context=codebase_context,
@@ -558,14 +558,13 @@ class RefuelMaverickWorkflow(PythonWorkflow):
         # ------------------------------------------------------------------
         # Steps 6-7: Consume the supervisor's bead-creation outputs.
         #
-        # ``RefuelSupervisor._run_decompose`` already created the epic +
-        # work beads via :class:`BeadCreatorActor` and wired
-        # ``depends_on`` deps inside the same call. Re-running
-        # ``create_beads`` here would fabricate a duplicate epic with
-        # identical children — that was the historical bug. Instead, we
-        # adopt the supervisor's outputs from ``ctx`` (stashed in
-        # ``_run_with_burr``) and only run the post-creation
-        # bookkeeping the supervisor doesn't own (run-meta update,
+        # The Burr graph's ``create_beads`` action already created the
+        # epic + work beads and wired ``depends_on`` deps inside the same
+        # call. Re-running bead creation here would fabricate a duplicate
+        # epic with identical children — that was the historical bug.
+        # Instead, we adopt the graph's outputs from ``ctx`` (stashed in
+        # :meth:`_run_decomposition`) and only run the post-creation
+        # bookkeeping the graph doesn't own (run-meta update,
         # ``flight_plan_name`` state attachment, cross-epic dep wiring).
         # ------------------------------------------------------------------
         supervisor_epic: dict[str, Any] | None = ctx.get("supervisor_epic")
@@ -824,7 +823,7 @@ class RefuelMaverickWorkflow(PythonWorkflow):
         )
         return result.to_dict()
 
-    async def _run_with_burr(
+    async def _run_decomposition(
         self,
         *,
         flight_plan: Any,
@@ -836,12 +835,11 @@ class RefuelMaverickWorkflow(PythonWorkflow):
         ctx: dict[str, Any] | None = None,
         ws_cwd: Path,
     ) -> Any:
-        """Run briefing + decomposition via the Burr-backed driver.
+        """Run briefing + decomposition via Burr.
 
-        Post-Burr-migration: single-tier decomposer dispatch, no
-        escalation, no cache write-back. Cache reads still pass through
-        when prior runs left a cache on disk; restoring cache writes is
-        queued behind the rest of the post-migration gaps.
+        Kept as its own method rather than inlined into :meth:`_run` only
+        to keep that method readable; there is no alternative driver to
+        select between.
         """
         from maverick.agents.briefing.prompts import build_briefing_prompt
         from maverick.burr import BurrWorkflowDriver
@@ -880,6 +878,8 @@ class RefuelMaverickWorkflow(PythonWorkflow):
             cost_sink=cost_sink,
             decomposer_pool_cap=self._config.parallel.decomposer_pool_size,
         ) as squadron:
+            # ``decomposer_tiers`` is resolved from config inside the
+            # squadron; nothing to thread here.
             event_queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
             # Per-plan refuel cache under
             # ``<cwd>/.maverick/plans/<plan>/refuel-cache/`` so a

--- a/tests/unit/squadron/test_tiers.py
+++ b/tests/unit/squadron/test_tiers.py
@@ -1,0 +1,198 @@
+"""Shared per-complexity tier helpers (:mod:`maverick.squadron.tiers`).
+
+Covers the invariant #135 was really about: a tier is only worth
+escalating to if it resolves to a *different* provider/model binding.
+Before this module existed, every ladder was a hardcoded five-name list
+and every name resolved to the same binding, so "escalation" was a retry
+with extra logging.
+"""
+
+from __future__ import annotations
+
+from maverick.config import (
+    DecomposerTiersConfig,
+    ImplementerTierConfig,
+    ImplementerTiersConfig,
+    ReviewerTiersConfig,
+)
+from maverick.squadron.tiers import (
+    DEFAULT_TIER,
+    TIER_ORDER,
+    binding_for_complexity,
+    defined_tiers,
+    escalation_ladder,
+    merge_tier_config,
+)
+
+
+def _tier(**kwargs: object) -> ImplementerTierConfig:
+    return ImplementerTierConfig(**kwargs)  # type: ignore[arg-type]
+
+
+class TestTierOrder:
+    def test_default_sentinel_is_not_a_real_tier(self) -> None:
+        """``_default`` means "the role's base binding", which may sit
+        anywhere on the capability scale — treating it as a rung would
+        make ordering claims that aren't true."""
+        assert DEFAULT_TIER not in TIER_ORDER
+
+    def test_order_is_cheapest_first(self) -> None:
+        assert TIER_ORDER == ("trivial", "simple", "moderate", "complex")
+
+
+class TestBindingForComplexity:
+    def test_full_binding_flows_through(self) -> None:
+        binding = binding_for_complexity(
+            "complex", _tier(provider="anthropic", model_id="claude-opus-5")
+        )
+
+        assert binding is not None
+        assert binding.provider == "anthropic"
+        assert binding.model_id == "claude-opus-5"
+
+    def test_default_sentinel_never_overrides(self) -> None:
+        """The base binding is the role's own; a tier override would be
+        a contradiction in terms."""
+        assert (
+            binding_for_complexity(
+                DEFAULT_TIER, _tier(provider="anthropic", model_id="claude-opus-5")
+            )
+            is None
+        )
+
+    def test_none_override(self) -> None:
+        assert binding_for_complexity("complex", None) is None
+
+    def test_half_specified_binding_is_rejected(self) -> None:
+        """Provider without model (or vice versa) must not be pieced
+        together with the role default — that silently pairs one tier's
+        provider with another tier's model."""
+        assert binding_for_complexity("complex", _tier(provider="anthropic")) is None
+        assert binding_for_complexity("complex", _tier(model_id="claude-opus-5")) is None
+
+    def test_non_binding_fields_do_not_make_a_binding(self) -> None:
+        """timeout/max_tokens/temperature are Maverick-only knobs the
+        agent factory doesn't consume."""
+        assert binding_for_complexity("complex", _tier(timeout=90, max_tokens=1000)) is None
+
+
+class TestDefinedTiers:
+    def test_none_config(self) -> None:
+        assert defined_tiers(None) == ()
+
+    def test_empty_config(self) -> None:
+        assert defined_tiers(ImplementerTiersConfig()) == ()
+
+    def test_sparse_config_keeps_capability_order(self) -> None:
+        """Sparse configs are the documented common case — declaring
+        only the two tiers you care about must not reorder them."""
+        config = ImplementerTiersConfig(
+            complex=_tier(provider="anthropic", model_id="opus"),
+            trivial=_tier(provider="anthropic", model_id="haiku"),
+        )
+
+        assert defined_tiers(config) == ("trivial", "complex")
+
+    def test_all_tiers(self) -> None:
+        config = ImplementerTiersConfig(
+            trivial=_tier(model_id="a"),
+            simple=_tier(model_id="b"),
+            moderate=_tier(model_id="c"),
+            complex=_tier(model_id="d"),
+        )
+
+        assert defined_tiers(config) == TIER_ORDER
+
+
+class TestEscalationLadder:
+    def test_no_config_yields_no_escalation(self) -> None:
+        """The #135 invariant: with one binding there is nowhere to
+        escalate *to*, so the ladder must not manufacture rungs."""
+        assert escalation_ladder(None) == (DEFAULT_TIER,)
+
+    def test_empty_config_yields_no_escalation(self) -> None:
+        assert escalation_ladder(ImplementerTiersConfig()) == (DEFAULT_TIER,)
+
+    def test_ladder_starts_at_base_binding(self) -> None:
+        """Unescalated work runs on the role's own binding, so that is
+        always rung zero."""
+        config = ImplementerTiersConfig(complex=_tier(provider="anthropic", model_id="opus"))
+
+        assert escalation_ladder(config)[0] == DEFAULT_TIER
+
+    def test_ladder_climbs_only_defined_tiers(self) -> None:
+        config = ImplementerTiersConfig(
+            simple=_tier(provider="anthropic", model_id="haiku"),
+            complex=_tier(provider="anthropic", model_id="opus"),
+        )
+
+        assert escalation_ladder(config) == (DEFAULT_TIER, "simple", "complex")
+
+    def test_max_steps_caps_the_ladder(self) -> None:
+        config = DecomposerTiersConfig(
+            trivial=_tier(model_id="a"),
+            simple=_tier(model_id="b"),
+            moderate=_tier(model_id="c"),
+        )
+
+        assert escalation_ladder(config, max_steps=1) == (DEFAULT_TIER, "trivial")
+
+    def test_max_steps_zero_disables_escalation(self) -> None:
+        config = DecomposerTiersConfig(complex=_tier(model_id="opus"))
+
+        assert escalation_ladder(config, max_steps=0) == (DEFAULT_TIER,)
+
+    def test_max_steps_beyond_defined_tiers_is_not_padded(self) -> None:
+        """Asking for more steps than there are tiers must not repeat or
+        invent rungs."""
+        config = DecomposerTiersConfig(complex=_tier(model_id="opus"))
+
+        assert escalation_ladder(config, max_steps=5) == (DEFAULT_TIER, "complex")
+
+    def test_escalation_threshold_is_not_read_implicitly(self) -> None:
+        """The field means "escalation steps" on DecomposerTiersConfig but
+        "fix rounds before promoting" on ImplementerTiersConfig. Reading
+        it here would silently apply one meaning to both.
+        """
+        config = DecomposerTiersConfig(
+            trivial=_tier(model_id="a"),
+            simple=_tier(model_id="b"),
+            escalation_threshold=1,
+        )
+
+        # Uncapped unless the caller passes max_steps explicitly.
+        assert escalation_ladder(config) == (DEFAULT_TIER, "trivial", "simple")
+
+    def test_reviewer_tiers_have_no_threshold_field(self) -> None:
+        """Reviewers are documented as non-escalating by config, but the
+        ladder shape itself is still well-defined."""
+        config = ReviewerTiersConfig(complex=_tier(model_id="opus"))
+
+        assert escalation_ladder(config) == (DEFAULT_TIER, "complex")
+
+
+class TestMergeTierConfig:
+    def test_none_base_builds_from_override(self) -> None:
+        merged = merge_tier_config(None, _tier(provider="anthropic", model_id="opus", timeout=42))
+
+        assert merged.provider == "anthropic"
+        assert merged.model_id == "opus"
+        assert merged.timeout == 42
+
+    def test_set_fields_replace_base(self) -> None:
+        from maverick.executor.config import StepConfig
+
+        base = StepConfig(provider="openai", model_id="gpt", timeout=10)
+        merged = merge_tier_config(base, _tier(model_id="opus"))
+
+        assert merged.model_id == "opus"
+        # Unset override fields fall through rather than clearing base.
+        assert merged.provider == "openai"
+        assert merged.timeout == 10
+
+    def test_all_none_override_returns_base_identity(self) -> None:
+        from maverick.executor.config import StepConfig
+
+        base = StepConfig(provider="openai", model_id="gpt")
+
+        assert merge_tier_config(base, _tier()) is base

--- a/tests/unit/test_tiers_config_resolution.py
+++ b/tests/unit/test_tiers_config_resolution.py
@@ -1,0 +1,215 @@
+"""``actors.<workflow>.<actor>.tiers`` is parsed and reaches the squadrons.
+
+The Burr migration deleted the per-workflow supervisors, and with them
+the only code that parsed the ``tiers:`` block. :class:`ActorConfig`
+kept accepting the key as an untyped pass-through, so a configured
+``tiers:`` block loaded, validated, and did nothing at all — for all
+three tierable actors (#135).
+
+These tests pin both halves: the resolver reads the block, and the
+production call sites actually pass what it returns.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from maverick.config import (
+    DecomposerTiersConfig,
+    ImplementerTiersConfig,
+    MaverickConfig,
+    ReviewerTiersConfig,
+    lookup_tiers_config,
+)
+
+
+def _config(actors: dict[str, Any]) -> MaverickConfig:
+    return MaverickConfig(actors=actors)
+
+
+_TIER_BLOCK = {
+    "trivial": {"provider": "anthropic", "model_id": "claude-haiku-4-5-20251001"},
+    "complex": {"provider": "anthropic", "model_id": "claude-opus-5"},
+}
+
+
+class TestLookupTiersConfig:
+    def test_implementer_tiers_parsed(self) -> None:
+        config = _config({"fly": {"implementer": {"tiers": _TIER_BLOCK}}})
+
+        tiers = lookup_tiers_config(config, "fly-beads", "implementer")
+
+        assert isinstance(tiers, ImplementerTiersConfig)
+        assert tiers.trivial is not None
+        assert tiers.trivial.model_id == "claude-haiku-4-5-20251001"
+        assert tiers.complex is not None
+        assert tiers.complex.model_id == "claude-opus-5"
+        # Undeclared tiers stay undeclared — no silent filling-in.
+        assert tiers.simple is None
+
+    def test_reviewer_tiers_parsed(self) -> None:
+        config = _config({"fly": {"reviewer": {"tiers": _TIER_BLOCK}}})
+
+        tiers = lookup_tiers_config(config, "fly-beads", "reviewer")
+
+        assert isinstance(tiers, ReviewerTiersConfig)
+
+    def test_decomposer_tiers_parsed(self) -> None:
+        config = _config({"refuel": {"decomposer": {"tiers": _TIER_BLOCK}}})
+
+        tiers = lookup_tiers_config(config, "refuel-maverick", "decomposer")
+
+        assert isinstance(tiers, DecomposerTiersConfig)
+
+    def test_tiers_coexist_with_top_level_actor_fields(self) -> None:
+        """The whole reason ``tiers`` is a pass-through on ActorConfig is
+        so one YAML block can carry both."""
+        config = _config(
+            {
+                "fly": {
+                    "implementer": {
+                        "provider": "anthropic",
+                        "model_id": "claude-sonnet-5",
+                        "tiers": _TIER_BLOCK,
+                    }
+                }
+            }
+        )
+
+        tiers = lookup_tiers_config(config, "fly-beads", "implementer")
+
+        assert tiers is not None
+        assert tiers.complex is not None  # type: ignore[union-attr]
+
+    def test_absent_block_returns_none(self) -> None:
+        config = _config({"fly": {"implementer": {"model_id": "claude-sonnet-5"}}})
+
+        assert lookup_tiers_config(config, "fly-beads", "implementer") is None
+
+    def test_absent_actor_returns_none(self) -> None:
+        assert lookup_tiers_config(_config({}), "fly-beads", "implementer") is None
+
+    def test_untierable_actor_returns_none(self) -> None:
+        """Only actors in the registry support tiering; a ``tiers:`` block
+        on anything else is inert by design, not by accident."""
+        config = _config({"plan": {"scopist": {"tiers": _TIER_BLOCK}}})
+
+        assert lookup_tiers_config(config, "generate-flight-plan", "scopist") is None
+
+    def test_malformed_tiers_degrade_to_none(self) -> None:
+        """A typo in one tier must not take down workflow startup — the
+        caller's no-tiers path is always a valid fallback."""
+        config = _config(
+            {"fly": {"implementer": {"tiers": {"trivial": {"timeout": -5}}}}},
+        )
+
+        assert lookup_tiers_config(config, "fly-beads", "implementer") is None
+
+    def test_non_dict_tiers_degrade_to_none(self) -> None:
+        config = _config({"fly": {"implementer": {"tiers": ["trivial"]}}})
+
+        assert lookup_tiers_config(config, "fly-beads", "implementer") is None
+
+
+class TestSquadronsReceiveTiers:
+    """The resolver existing isn't enough — it has to be *called*."""
+
+    def test_refuel_squadron_reads_tiers_from_config(self) -> None:
+        """``RefuelSquadron`` resolves its own tiers, so the workflow has
+        nothing to thread and can't forget to."""
+        from maverick.squadron.refuel import RefuelSquadron
+        from maverick.squadron.tiers import DEFAULT_TIER
+
+        config = _config({"refuel": {"decomposer": {"tiers": _TIER_BLOCK}}})
+        squadron = RefuelSquadron(cwd=Path("."), config=config)
+
+        # Capped at one escalation step by DecomposerTiersConfig's
+        # default ``escalation_threshold``.
+        assert squadron.decomposer_escalation_ladder() == (DEFAULT_TIER, "trivial")
+
+    def test_refuel_squadron_without_tiers_does_not_escalate(self) -> None:
+        from maverick.squadron.refuel import RefuelSquadron
+        from maverick.squadron.tiers import DEFAULT_TIER
+
+        squadron = RefuelSquadron(cwd=Path("."), config=_config({}))
+
+        assert squadron.decomposer_escalation_ladder() == (DEFAULT_TIER,)
+
+    def test_explicit_decomposer_tiers_beat_config(self) -> None:
+        """An explicit argument is the caller deciding; only ``None``
+        means "go look at the config"."""
+        from maverick.squadron.refuel import RefuelSquadron
+        from maverick.squadron.tiers import DEFAULT_TIER
+
+        config = _config({"refuel": {"decomposer": {"tiers": _TIER_BLOCK}}})
+        squadron = RefuelSquadron(
+            cwd=Path("."),
+            config=config,
+            decomposer_tiers=DecomposerTiersConfig(),
+        )
+
+        assert squadron.decomposer_escalation_ladder() == (DEFAULT_TIER,)
+
+    async def test_fly_bead_loop_passes_both_tier_blocks(self) -> None:
+        """Regression for the exact #135 gap: ``FlySquadron`` has always
+        accepted ``implementer_tiers``/``reviewer_tiers``; the production
+        call site was passing neither, so the whole surface was inert.
+
+        Asserting on the constructor kwargs rather than on a manually
+        built squadron is the point — a squadron that resolves tiers
+        correctly is worthless if nothing hands them over.
+        """
+        from maverick.squadron.tiers import DEFAULT_TIER
+        from maverick.workflows.fly_beads import workflow as wf
+
+        config = _config(
+            {
+                "fly": {
+                    "implementer": {"tiers": _TIER_BLOCK},
+                    "reviewer": {"tiers": _TIER_BLOCK},
+                }
+            }
+        )
+        captured: dict[str, Any] = {}
+
+        class _StopHereError(RuntimeError):
+            pass
+
+        def _capture(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            raise _StopHereError
+
+        class _Workflow:
+            _config = config
+
+        # ``_run_bead_loop`` imports FlySquadron lazily, so patch it at
+        # its definition site rather than on the workflow module.
+        with (
+            patch("maverick.squadron.fly.FlySquadron", _capture),
+            patch.object(wf, "_cost_sink_for_cwd", lambda _cwd: None),
+        ):
+            try:
+                await wf._run_bead_loop(
+                    _Workflow(),
+                    epic_id="e-1",
+                    cwd=Path("."),
+                    max_beads=1,
+                    completed_bead_ids=(),
+                )
+            except _StopHereError:
+                pass
+
+        from maverick.squadron.tiers import escalation_ladder
+
+        assert escalation_ladder(captured["implementer_tiers"]) == (
+            DEFAULT_TIER,
+            "trivial",
+            "complex",
+        )
+        assert escalation_ladder(captured["reviewer_tiers"]) == (
+            DEFAULT_TIER,
+            "trivial",
+            "complex",
+        )

--- a/tests/unit/workflows/fly_beads/test_burr_graph.py
+++ b/tests/unit/workflows/fly_beads/test_burr_graph.py
@@ -27,6 +27,7 @@ from maverick.payloads import (
     SubmitImplementationPayload,
     SubmitReviewPayload,
 )
+from maverick.squadron.tiers import DEFAULT_TIER
 from maverick.workflows.fly_beads.burr_graph import (
     FLY_TERMINAL_ACTIONS,
     build_fly_application,
@@ -65,7 +66,11 @@ class StubFlySquadron:
         coders_by_tier: dict[str, StubCodingAgent] | None = None,
         correctness_by_tier: dict[str, StubReviewerAgent] | None = None,
         completeness_by_tier: dict[str, StubReviewerAgent] | None = None,
+        escalation_ladder: tuple[str, ...] | None = None,
     ) -> None:
+        # ``None`` mirrors a squadron with no ``tiers:`` config: one
+        # binding, so nothing to escalate to.
+        self._escalation_ladder = escalation_ladder or (DEFAULT_TIER,)
         self.coder = coder or StubCodingAgent(
             implement_payloads=[SubmitImplementationPayload(summary="stub impl")],
             fix_payloads=[SubmitFixResultPayload(summary="stub fix") for _ in range(5)],
@@ -81,6 +86,12 @@ class StubFlySquadron:
         self.coders_by_tier: dict[str, StubCodingAgent] = coders_by_tier or {}
         self.correctness_by_tier: dict[str, StubReviewerAgent] = correctness_by_tier or {}
         self.completeness_by_tier: dict[str, StubReviewerAgent] = completeness_by_tier or {}
+
+    def implementer_escalation_ladder(self) -> tuple[str, ...]:
+        return self._escalation_ladder
+
+    def reviewer_escalation_ladder(self) -> tuple[str, ...]:
+        return self._escalation_ladder
 
     def coder_for(self, tier: str) -> StubCodingAgent:
         return self.coders_by_tier.get(tier, self.coder)
@@ -657,7 +668,10 @@ class TestFlyBurrImplementerTransientEscalation:
 
         squadron = StubFlySquadron(
             coder=escalated_coder,
-            coders_by_tier={"_default": default_coder},
+            coders_by_tier={DEFAULT_TIER: default_coder},
+            # One configured tier above the base binding — escalation is
+            # only meaningful when the next rung is a *different* model.
+            escalation_ladder=(DEFAULT_TIER, "complex"),
         )
 
         queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
@@ -699,7 +713,7 @@ class TestFlyBurrImplementerTransientEscalation:
         assert any(c[0] == "implement" for c in escalated_coder.calls)
 
     async def test_implement_transient_exhausts_aborts_bead(self, tmp_path: Path) -> None:
-        """Every tier raises transient → bead is abandoned, level pinned at 4."""
+        """Every rung raises transient → bead abandoned at the top rung."""
         from airframe.errors import RuntimeTransientError
 
         from maverick.workflows.fly_beads.graceful_stop import reset_graceful_stop
@@ -720,7 +734,9 @@ class TestFlyBurrImplementerTransientEscalation:
                 raise RuntimeTransientError(f"upstream fix fault #{self.fix_calls}")
 
         always_raising = _AlwaysRaisingCoder()
-        squadron = StubFlySquadron()
+        squadron = StubFlySquadron(
+            escalation_ladder=(DEFAULT_TIER, "moderate", "complex"),
+        )
         squadron.coder_for = lambda _tier: always_raising  # type: ignore[assignment]
 
         queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
@@ -741,13 +757,13 @@ class TestFlyBurrImplementerTransientEscalation:
             await _collect(driver)
 
         _, _, state = driver.result
-        # All 5 rungs walked, bead aborted (not aggregated — only 1 bead
-        # so aggregate is below threshold and doesn't fire).
-        assert state["implementer_escalation_level"] == 4
+        # All 3 configured rungs walked, bead aborted (not aggregated —
+        # only 1 bead, so aggregate is below threshold and doesn't fire).
+        assert state["implementer_escalation_level"] == 2
         assert state["implement_ok"] is False
         assert state["bead_aborted"] is True
         assert state["failed_count"] == 1
-        assert always_raising.implement_calls == 5
+        assert always_raising.implement_calls == 3
 
 
 class TestFlyBurrReviewerTransientEscalation:
@@ -782,8 +798,9 @@ class TestFlyBurrReviewerTransientEscalation:
                 review_kind="completeness",
                 review_payloads=[SubmitReviewPayload(approved=True, findings=())],
             ),
-            correctness_by_tier={"_default": default_correctness},
-            completeness_by_tier={"_default": default_completeness},
+            correctness_by_tier={DEFAULT_TIER: default_correctness},
+            completeness_by_tier={DEFAULT_TIER: default_completeness},
+            escalation_ladder=(DEFAULT_TIER, "complex"),
         )
 
         queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
@@ -827,7 +844,7 @@ class TestFlyBurrReviewerTransientEscalation:
     async def test_transient_failure_exhausts_escalation_marks_human_review(
         self, tmp_path: Path
     ) -> None:
-        """Every tier raises transient → needs-human-review with error message."""
+        """Every configured rung raises transient → needs-human-review."""
         from airframe.errors import RuntimeTransientError
 
         from maverick.workflows.fly_beads.graceful_stop import reset_graceful_stop
@@ -861,7 +878,9 @@ class TestFlyBurrReviewerTransientEscalation:
         correctness_always = _AlwaysRaising("correctness")
         completeness_always = _AlwaysRaising("completeness")
 
-        squadron = StubFlySquadron()
+        squadron = StubFlySquadron(
+            escalation_ladder=(DEFAULT_TIER, "moderate", "complex"),
+        )
         # Override the tier-dispatch methods to always return the
         # raising stubs.
         squadron.correctness_reviewer_for = lambda _tier: correctness_always  # type: ignore[assignment]
@@ -899,14 +918,14 @@ class TestFlyBurrReviewerTransientEscalation:
             await _collect(driver)
 
         _, _, state = driver.result
-        # Climbed all 5 ladder rungs (level 0..4) and then exited.
-        assert state["reviewer_escalation_level"] == 4
+        # Climbed all 3 configured rungs (level 0..2) and then exited.
+        assert state["reviewer_escalation_level"] == 2
         assert state["needs_human_review"] is True
         assert state["approved"] is False
-        # Each rung tried once → 5 correctness attempts; completeness
+        # Each rung tried once → 3 correctness attempts; completeness
         # may be cancelled mid-flight by the gather, so we only assert
         # the lower bound for it.
-        assert correctness_always.calls == 5
+        assert correctness_always.calls == 3
         # Finding text carries the exhaustion reason.
         finding_text = " ".join(state["last_review_findings"])
         assert "exhausted escalation" in finding_text

--- a/tests/unit/workflows/generate_flight_plan/test_workflow.py
+++ b/tests/unit/workflows/generate_flight_plan/test_workflow.py
@@ -64,7 +64,7 @@ def _make_supervisor_result(
     plan_dir: Path,
     output: FlightPlanOutput | None = None,
 ) -> dict[str, Any]:
-    """Build a dict matching what _generate_with_burr returns.
+    """Build a dict matching what _generate_plan returns.
 
     Also writes the flight plan file to disk so tests that check file
     existence continue to work.
@@ -73,7 +73,7 @@ def _make_supervisor_result(
     today = __import__("datetime").date.today()
     plan = _convert_output_to_flight_plan(fp_output, today)
 
-    # Write the flight plan file (thespian actors do this in production)
+    # Write the flight plan file (the Burr graph does this in production)
     from maverick.flight.serializer import serialize_flight_plan
 
     plan_dir.mkdir(parents=True, exist_ok=True)
@@ -200,14 +200,14 @@ class TestGenerateFlightPlanWorkflowHappyPath:
         mock_config: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """read_prd step produces a StepCompleted event (other steps run inside Thespian)."""
+        """read_prd produces a StepCompleted event (other steps run inside the Burr graph)."""
         plan_dir = tmp_path / "test-plan"
         supervisor_result = _make_supervisor_result(plan_dir)
 
         workflow = _make_workflow(mock_config)
         with patch.object(
             workflow,
-            "_generate_with_burr",
+            "_generate_plan",
             new=AsyncMock(return_value=supervisor_result),
         ):
             events = await _collect_events(
@@ -237,7 +237,7 @@ class TestGenerateFlightPlanWorkflowHappyPath:
         workflow = _make_workflow(mock_config)
         with patch.object(
             workflow,
-            "_generate_with_burr",
+            "_generate_plan",
             new=AsyncMock(return_value=supervisor_result),
         ):
             events = await _collect_events(
@@ -266,7 +266,7 @@ class TestGenerateFlightPlanWorkflowHappyPath:
         workflow = _make_workflow(mock_config)
         with patch.object(
             workflow,
-            "_generate_with_burr",
+            "_generate_plan",
             new=AsyncMock(return_value=supervisor_result),
         ):
             events = await _collect_events(
@@ -289,14 +289,14 @@ class TestGenerateFlightPlanWorkflowHappyPath:
         mock_config: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Thespian actor system writes the flight plan file to disk."""
+        """The Burr graph writes the flight plan file to disk."""
         plan_dir = tmp_path / "test-plan"
         supervisor_result = _make_supervisor_result(plan_dir)
 
         workflow = _make_workflow(mock_config)
         with patch.object(
             workflow,
-            "_generate_with_burr",
+            "_generate_plan",
             new=AsyncMock(return_value=supervisor_result),
         ):
             await _collect_events(
@@ -328,7 +328,7 @@ class TestGenerateFlightPlanWorkflowHappyPath:
         workflow = _make_workflow(mock_config)
         with patch.object(
             workflow,
-            "_generate_with_burr",
+            "_generate_plan",
             new=AsyncMock(return_value=supervisor_result),
         ):
             await _collect_events(
@@ -373,11 +373,11 @@ class TestGenerateFlightPlanWorkflowErrors:
         mock_config: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Agent returning no output causes Thespian to report failure."""
+        """Agent returning no output causes the Burr graph to report failure."""
         workflow = _make_workflow(mock_config)
         with patch.object(
             workflow,
-            "_generate_with_burr",
+            "_generate_plan",
             new=AsyncMock(
                 side_effect=WorkflowError("Plan generation failed: no output from agent")
             ),

--- a/tests/unit/workflows/refuel_maverick/conftest.py
+++ b/tests/unit/workflows/refuel_maverick/conftest.py
@@ -226,10 +226,10 @@ def patch_decompose_supervisor(
     bead_result: BeadCreationResult | None = None,
     dep_result: DependencyWiringResult | None = None,
 ) -> Any:
-    """Return a context manager that patches _run_with_burr.
+    """Return a context manager that patches _run_decomposition.
 
     The xoscar actor path is now the only decomposition path AND the
-    only bead-creation path. The real ``_run_with_burr`` populates
+    only bead-creation path. The real ``_run_decomposition`` populates
     ``ctx`` with the supervisor's bead-creation outputs (epic, work
     beads, created_map, dependencies) so the workflow's downstream
     steps can adopt them instead of re-running ``create_beads``. The
@@ -243,7 +243,7 @@ def patch_decompose_supervisor(
     if dep_result is None:
         dep_result = make_wire_result()
 
-    async def _fake_run_with_burr(
+    async def _fake_run_decomposition(
         self: Any,
         *args: Any,
         ctx: dict[str, Any] | None = None,
@@ -261,8 +261,8 @@ def patch_decompose_supervisor(
         return decomp
 
     return patch(
-        "maverick.workflows.refuel_maverick.workflow.RefuelMaverickWorkflow._run_with_burr",
-        new=_fake_run_with_burr,
+        "maverick.workflows.refuel_maverick.workflow.RefuelMaverickWorkflow._run_decomposition",
+        new=_fake_run_decomposition,
     )
 
 

--- a/tests/unit/workflows/refuel_maverick/test_burr_graph.py
+++ b/tests/unit/workflows/refuel_maverick/test_burr_graph.py
@@ -33,6 +33,8 @@ from maverick.payloads import (
     WorkUnitDetailPayload,
     WorkUnitOutlinePayload,
 )
+from maverick.squadron.tiers import DEFAULT_TIER
+from maverick.workflows.refuel_maverick.actions import CACHE_SCHEMA_VERSION
 from maverick.workflows.refuel_maverick.burr_graph import (
     REFUEL_TERMINAL_ACTIONS,
     build_refuel_application,
@@ -140,7 +142,11 @@ class StubRefuelSquadron:
         detail_payloads: list[SubmitDetailsPayload] | None = None,
         fix_payloads: list[SubmitFixPayload] | None = None,
         briefing_payloads: dict[str, Any] | None = None,
+        escalation_ladder: tuple[str, ...] | None = None,
     ) -> None:
+        # ``None`` mirrors an unconfigured squadron: the base binding is
+        # the only rung, so there is nothing to escalate to.
+        self._escalation_ladder = escalation_ladder or (DEFAULT_TIER,)
         outline = outline_payload or _make_outline()
         # Each per-unit detail call returns details for *one* unit;
         # the fan-out makes one decomposer call per unit by default.
@@ -156,6 +162,9 @@ class StubRefuelSquadron:
         self.decomposer_pool = _StubDecomposerPool(self._decomposer)
         self._briefing_payloads = dict(briefing_payloads or _BRIEF_PAYLOADS)
         self.built_briefings: list[StubBriefingAgent] = []
+
+    def decomposer_escalation_ladder(self) -> tuple[str, ...]:
+        return self._escalation_ladder
 
     def build_briefing_agent(self, *, agent_name: str, result_model: Any) -> StubBriefingAgent:
         payload = self._briefing_payloads.get(agent_name)
@@ -199,6 +208,20 @@ def _make_bead_result() -> BeadCreationResult:
         },
         errors=(),
     )
+
+
+def _raise_budget(message: str) -> None:
+    """Raise airframe's budget error with its required metadata."""
+    from airframe.errors import RuntimeBudgetExceededError
+
+    raise RuntimeBudgetExceededError(message, cap=10.0, current=10.5, kind="usd")
+
+
+def _dump(payload: Any) -> dict[str, Any]:
+    """Serialize a payload the way the cache writer does."""
+    from maverick.payloads import dump_supervisor_payload
+
+    return dump_supervisor_payload(payload)
 
 
 def _make_wire_result() -> DependencyWiringResult:
@@ -371,13 +394,21 @@ class TestRefuelBurrGraphHappyPath:
 
 
 class TestRefuelBurrDetailEscalation:
-    async def test_transient_on_default_tier_escalates_and_succeeds(self, tmp_path: Path) -> None:
-        """Detail call raises transient → next tier acquired → unit succeeds."""
+    async def test_transient_retries_on_same_tier_when_no_tiers_configured(
+        self, tmp_path: Path
+    ) -> None:
+        """Transient → same-binding retry inside the budget → unit succeeds.
+
+        With no ``tiers:`` config there is no second binding to escalate
+        to, so resilience against a transient blip has to come from the
+        same-tier retry budget rather than from walking a ladder of
+        aliases for one model (#135).
+        """
         from airframe.errors import RuntimeTransientError
 
         outline = _make_outline(unit_ids=("u-1",))
-        # The first ``detail()`` call raises transient; the retry on
-        # the escalated tier succeeds. ``outline()`` must still work.
+        # The first ``detail()`` call raises transient; the retry
+        # succeeds. ``outline()`` must still work.
         squadron = StubRefuelSquadron(
             outline_payload=outline,
             detail_payloads=[_make_details(("u-1",))],
@@ -424,13 +455,80 @@ class TestRefuelBurrDetailEscalation:
         # Detail eventually landed and the unit was not abandoned.
         assert state["abandoned_unit_ids"] == []
         assert any(d.get("id") == "u-1" for d in state["accumulated_details"])
-        # The pool was acquired for the outline + the failed default
-        # tier + the escalated trivial tier. Release count matches.
+        # One acquire for the outline + one for the detail unit. The
+        # retry happens *within* that acquire, so no second checkout.
         acquired = squadron.decomposer_pool.acquire_calls
-        assert acquired == ["default", "default", "trivial"]
+        assert acquired == [DEFAULT_TIER, DEFAULT_TIER]
         assert squadron.decomposer_pool.release_calls == acquired
-        # The escalation actually re-ran ``detail``.
+        # The retry actually re-ran ``detail``.
         assert detail_calls["n"] == 2
+
+    async def test_transient_escalates_through_configured_tiers(self, tmp_path: Path) -> None:
+        """A configured ladder is walked in order, one acquire per rung.
+
+        This is the behaviour that was missing: before per-tier bindings
+        existed, every rung resolved to the same model, so "escalation"
+        bought nothing.
+        """
+        from airframe.errors import RuntimeTransientError
+
+        outline = _make_outline(unit_ids=("u-1",))
+        squadron = StubRefuelSquadron(
+            outline_payload=outline,
+            detail_payloads=[_make_details(("u-1",))],
+            escalation_ladder=(DEFAULT_TIER, "moderate", "complex"),
+        )
+        original_detail = squadron._decomposer.detail
+        detail_calls = {"n": 0}
+
+        # Fail every attempt on the first two rungs (the retry budget
+        # gives 2 attempts per rung), then succeed on "complex".
+        async def _fail_until_complex(**kwargs: Any) -> SubmitDetailsPayload:
+            detail_calls["n"] += 1
+            if detail_calls["n"] <= 4:
+                raise RuntimeTransientError("rate limited")
+            return await original_detail(**kwargs)
+
+        squadron._decomposer.detail = _fail_until_complex  # type: ignore[assignment]
+
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.create_beads",
+                new=AsyncMock(return_value=_make_bead_result()),
+            ),
+            patch(
+                "maverick.library.actions.beads.wire_dependencies",
+                new=AsyncMock(return_value=_make_wire_result()),
+            ),
+        ):
+            app = build_refuel_application(
+                squadron=squadron,
+                event_queue=queue,
+                raw_content="x",
+                briefing_prompt="x",
+                codebase_context=_empty_codebase_context(),
+                open_bead_context=None,
+                runway_context_text=None,
+                plan_name="p",
+                plan_objective="o",
+                cwd=str(tmp_path),
+                skip_briefing=True,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=REFUEL_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+
+        _, _, state = driver.result
+        assert state["abandoned_unit_ids"] == []
+        assert any(d.get("id") == "u-1" for d in state["accumulated_details"])
+        # Outline on the base tier, then one acquire per ladder rung —
+        # and critically, the *configured* rungs, not a fixed list.
+        assert squadron.decomposer_pool.acquire_calls == [
+            DEFAULT_TIER,
+            DEFAULT_TIER,
+            "moderate",
+            "complex",
+        ]
 
     async def test_transient_exhausts_ladder_abandons_unit(self, tmp_path: Path) -> None:
         """Every tier raises transient → unit is abandoned, no detail recorded."""
@@ -453,7 +551,10 @@ class TestRefuelBurrDetailEscalation:
                 raise AssertionError("fix should not be called when all details fail")
 
         always_raising = _AlwaysRaisingDecomposer()
-        squadron = StubRefuelSquadron(outline_payload=outline)
+        squadron = StubRefuelSquadron(
+            outline_payload=outline,
+            escalation_ladder=(DEFAULT_TIER, "moderate", "complex"),
+        )
         # Outline still uses the stub agent; only swap the agent the
         # pool hands out *after* the outline action has run. Easiest:
         # leave outline alone and route subsequent acquires to the
@@ -464,7 +565,7 @@ class TestRefuelBurrDetailEscalation:
             await original_acquire(tier)  # records the call
             if (
                 always_raising.detail_calls == 0
-                and tier == "default"
+                and tier == DEFAULT_TIER
                 and (outline_acquired["n"] == 0)
             ):
                 outline_acquired["n"] = 1
@@ -502,18 +603,17 @@ class TestRefuelBurrDetailEscalation:
             await _collect(driver)
 
         _, _, state = driver.result
-        # All 5 rungs of the ladder tried (transients escalate
-        # immediately, so each tier sees exactly one call).
-        assert always_raising.detail_calls == 5
+        # 3 rungs x 2 attempts each (the same-tier retry budget) — the
+        # ladder is exhausted only after every rung has spent its budget.
+        assert always_raising.detail_calls == 6
         assert "u-1" in state["abandoned_unit_ids"]
         assert all(d.get("id") != "u-1" for d in state["accumulated_details"])
-        # Outline acquired once on "default" + each of the 5 detail
-        # tiers acquired once = 6 total.
-        assert len(squadron.decomposer_pool.acquire_calls) == 6
-        assert len(squadron.decomposer_pool.release_calls) == 6
-        # The detail-side calls cycled through the full tier ladder.
+        # Outline acquired once + one acquire per rung = 4 total.
+        assert len(squadron.decomposer_pool.acquire_calls) == 4
+        assert len(squadron.decomposer_pool.release_calls) == 4
+        # The detail-side calls walked the configured ladder in order.
         detail_tiers = squadron.decomposer_pool.acquire_calls[1:]
-        assert detail_tiers == ["default", "trivial", "simple", "moderate", "complex"]
+        assert detail_tiers == [DEFAULT_TIER, "moderate", "complex"]
 
 
 class TestRefuelBurrCacheWriteBack:
@@ -561,12 +661,18 @@ class TestRefuelBurrCacheWriteBack:
         assert u2_path.exists()
 
         outline_doc = _json.loads(outline_path.read_text())
-        assert "payload" in outline_doc
-        unit_ids = {u["id"] for u in outline_doc["payload"].get("work_units") or ()}
+        # Versioned envelope — a drifted or mis-filed cache must be
+        # rejectable on read without parsing the payload.
+        assert outline_doc["schema_version"] == CACHE_SCHEMA_VERSION
+        assert outline_doc["kind"] == "outline"
+        outline_doc = outline_doc["payload"]
+        unit_ids = {u["id"] for u in outline_doc.get("work_units") or ()}
         assert unit_ids == {"u-1", "u-2"}
 
         u1_doc = _json.loads(u1_path.read_text())
-        assert u1_doc.get("id") == "u-1"
+        assert u1_doc["schema_version"] == CACHE_SCHEMA_VERSION
+        assert u1_doc["kind"] == "detail"
+        assert u1_doc["payload"].get("id") == "u-1"
 
     async def test_briefings_written_to_cache_dir(self, tmp_path: Path) -> None:
         """``briefings.json`` lands alongside the outline/details files."""
@@ -615,7 +721,10 @@ class TestRefuelBurrCacheWriteBack:
         briefings_path = cache_dir / "briefings.json"
         assert briefings_path.exists()
         doc = _json.loads(briefings_path.read_text())
-        assert set(doc.get("payloads", {}).keys()) == {
+        assert doc["schema_version"] == CACHE_SCHEMA_VERSION
+        assert doc["kind"] == "briefings"
+        doc = doc["payload"]
+        assert set(doc.keys()) == {
             "navigator",
             "structuralist",
             "recon",
@@ -655,6 +764,362 @@ class TestRefuelBurrCacheWriteBack:
             await _collect(driver)
 
         assert not cache_dir.exists()
+
+
+class TestRefuelBurrCacheReadBack:
+    """A populated ``refuel-cache/`` short-circuits regeneration (#135).
+
+    The write side landed first and nothing consumed it, so every re-run
+    paid full agent cost for evidence already sitting on disk.
+    """
+
+    @staticmethod
+    def _write(path: Path, kind: str, payload: Any, *, version: int | None = None) -> None:
+        import json as _json
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            _json.dumps(
+                {
+                    "schema_version": CACHE_SCHEMA_VERSION if version is None else version,
+                    "kind": kind,
+                    "payload": payload,
+                }
+            )
+        )
+
+    async def _run(
+        self, squadron: StubRefuelSquadron, tmp_path: Path, cache_dir: Path, **kwargs: Any
+    ) -> Any:
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.create_beads",
+                new=AsyncMock(return_value=_make_bead_result()),
+            ),
+            patch(
+                "maverick.library.actions.beads.wire_dependencies",
+                new=AsyncMock(return_value=_make_wire_result()),
+            ),
+        ):
+            app = build_refuel_application(
+                squadron=squadron,
+                event_queue=queue,
+                raw_content="x",
+                briefing_prompt="x",
+                codebase_context=_empty_codebase_context(),
+                open_bead_context=None,
+                runway_context_text=None,
+                plan_name="p",
+                plan_objective="o",
+                cwd=str(tmp_path),
+                cache_dir=str(cache_dir),
+                **kwargs,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=REFUEL_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+        return driver.result[2]
+
+    async def test_cached_outline_and_details_skip_the_decomposer(self, tmp_path: Path) -> None:
+        outline = _make_outline(unit_ids=("u-1", "u-2"))
+        cache_dir = tmp_path / "refuel-cache"
+        self._write(
+            cache_dir / "outline.json",
+            "outline",
+            _dump(outline),
+        )
+        for uid in ("u-1", "u-2"):
+            self._write(
+                cache_dir / "details" / f"{uid}.json",
+                "detail",
+                {"id": uid, "instructions": f"cached {uid}", "acceptance_criteria": []},
+            )
+
+        squadron = StubRefuelSquadron(outline_payload=outline)
+        state = await self._run(squadron, tmp_path, cache_dir, skip_briefing=True)
+
+        # Zero decomposer checkouts: neither the outline nor any detail
+        # needed an agent.
+        assert squadron.decomposer_pool.acquire_calls == []
+        assert state["abandoned_unit_ids"] == []
+        assert {d["id"] for d in state["accumulated_details"]} == {"u-1", "u-2"}
+        assert any("cached u-1" in d.get("instructions", "") for d in state["accumulated_details"])
+
+    async def test_partial_detail_cache_regenerates_only_the_gap(self, tmp_path: Path) -> None:
+        """A run that abandoned half its units re-requests only those."""
+        outline = _make_outline(unit_ids=("u-1", "u-2"))
+        cache_dir = tmp_path / "refuel-cache"
+        self._write(cache_dir / "outline.json", "outline", _dump(outline))
+        self._write(
+            cache_dir / "details" / "u-1.json",
+            "detail",
+            {"id": "u-1", "instructions": "cached u-1", "acceptance_criteria": []},
+        )
+
+        squadron = StubRefuelSquadron(
+            outline_payload=outline,
+            detail_payloads=[_make_details(("u-2",))],
+        )
+        state = await self._run(squadron, tmp_path, cache_dir, skip_briefing=True)
+
+        # Exactly one detail checkout — for the uncached unit.
+        assert squadron.decomposer_pool.acquire_calls == [DEFAULT_TIER]
+        assert {d["id"] for d in state["accumulated_details"]} == {"u-1", "u-2"}
+
+    async def test_cached_briefs_skip_all_four_briefing_agents(self, tmp_path: Path) -> None:
+        cache_dir = tmp_path / "refuel-cache"
+        self._write(
+            cache_dir / "briefings.json",
+            "briefings",
+            {role: {"summary": f"cached {role}"} for role in _BRIEF_PAYLOADS},
+        )
+
+        squadron = StubRefuelSquadron()
+        state = await self._run(squadron, tmp_path, cache_dir, skip_briefing=False)
+
+        # No briefing agent was ever built, let alone called.
+        assert squadron.built_briefings == []
+        assert set(state["briefs"]) == set(_BRIEF_PAYLOADS)
+        # The markdown is still rendered — it's a pure function of briefs.
+        assert state["briefing_markdown"]
+
+    async def test_stale_schema_version_fails_closed(self, tmp_path: Path) -> None:
+        """A cache from a different schema is discarded, not adapted.
+
+        Regenerating costs budget; reusing a drifted outline silently
+        produces beads that don't match the plan.
+        """
+        outline = _make_outline(unit_ids=("u-1",))
+        cache_dir = tmp_path / "refuel-cache"
+        self._write(
+            cache_dir / "outline.json",
+            "outline",
+            _dump(outline),
+            version=CACHE_SCHEMA_VERSION + 1,
+        )
+
+        squadron = StubRefuelSquadron(outline_payload=outline)
+        await self._run(squadron, tmp_path, cache_dir, skip_briefing=True)
+
+        # Two checkouts — one to regenerate the outline, one for the
+        # single unit's detail. A cache hit would have made it one.
+        assert squadron.decomposer_pool.acquire_calls == [DEFAULT_TIER, DEFAULT_TIER]
+
+    async def test_wrong_kind_fails_closed(self, tmp_path: Path) -> None:
+        """A detail file sitting in the outline slot must not be parsed
+        as an outline."""
+        outline = _make_outline(unit_ids=("u-1",))
+        cache_dir = tmp_path / "refuel-cache"
+        self._write(cache_dir / "outline.json", "detail", _dump(outline))
+
+        squadron = StubRefuelSquadron(outline_payload=outline)
+        await self._run(squadron, tmp_path, cache_dir, skip_briefing=True)
+
+        # Outline regenerated (2 checkouts, not 1) — see the
+        # stale-schema case for the same reasoning.
+        assert squadron.decomposer_pool.acquire_calls == [DEFAULT_TIER, DEFAULT_TIER]
+
+    async def test_corrupt_json_fails_closed(self, tmp_path: Path) -> None:
+        outline = _make_outline(unit_ids=("u-1",))
+        cache_dir = tmp_path / "refuel-cache"
+        (cache_dir).mkdir(parents=True, exist_ok=True)
+        (cache_dir / "outline.json").write_text("{not json")
+
+        squadron = StubRefuelSquadron(outline_payload=outline)
+        await self._run(squadron, tmp_path, cache_dir, skip_briefing=True)
+
+        # Outline regenerated (2 checkouts, not 1) — see the
+        # stale-schema case for the same reasoning.
+        assert squadron.decomposer_pool.acquire_calls == [DEFAULT_TIER, DEFAULT_TIER]
+
+    async def test_detail_for_a_dropped_unit_is_not_merged(self, tmp_path: Path) -> None:
+        """A regenerated outline may drop a unit; its stale cached detail
+        must not leak into the merge."""
+        outline = _make_outline(unit_ids=("u-1",))
+        cache_dir = tmp_path / "refuel-cache"
+        self._write(cache_dir / "outline.json", "outline", _dump(outline))
+        for uid in ("u-1", "u-obsolete"):
+            self._write(
+                cache_dir / "details" / f"{uid}.json",
+                "detail",
+                {"id": uid, "instructions": f"cached {uid}", "acceptance_criteria": []},
+            )
+
+        squadron = StubRefuelSquadron(outline_payload=outline)
+        state = await self._run(squadron, tmp_path, cache_dir, skip_briefing=True)
+
+        assert {d["id"] for d in state["accumulated_details"]} == {"u-1"}
+
+
+class TestRefuelBurrQuotaHandling:
+    """Provider quota aborts the run; it does not walk the tier ladder (#135).
+
+    Quota exhaustion is account-wide and time-bound: no other model,
+    tier, or retry makes it go away before the limit resets. Treating it
+    like an ordinary failure meant every remaining unit paid a full
+    round-trip to be told the same thing, and then beads were created
+    from a truncated fan-out.
+    """
+
+    @staticmethod
+    async def _run_expecting_quota(
+        squadron: StubRefuelSquadron, tmp_path: Path, **kwargs: Any
+    ) -> BaseException | None:
+        queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        with (
+            patch(
+                "maverick.library.actions.beads.create_beads",
+                new=AsyncMock(return_value=_make_bead_result()),
+            ),
+            patch(
+                "maverick.library.actions.beads.wire_dependencies",
+                new=AsyncMock(return_value=_make_wire_result()),
+            ),
+        ):
+            app = build_refuel_application(
+                squadron=squadron,
+                event_queue=queue,
+                raw_content="x",
+                briefing_prompt="x",
+                codebase_context=_empty_codebase_context(),
+                open_bead_context=None,
+                runway_context_text=None,
+                plan_name="p",
+                plan_objective="o",
+                cwd=str(tmp_path),
+                skip_briefing=True,
+                **kwargs,
+            )
+            driver = BurrWorkflowDriver(app, halt_after=REFUEL_TERMINAL_ACTIONS, event_queue=queue)
+            await _collect(driver)
+            # The driver defers an action's exception to ``.result`` so
+            # the event stream always drains cleanly first.
+            try:
+                _ = driver.result
+            except BaseException as exc:  # noqa: BLE001 — the assertion subject
+                return exc
+        return None
+
+    async def test_budget_exceeded_aborts_without_climbing_the_ladder(
+        self, tmp_path: Path
+    ) -> None:
+
+        from maverick.exceptions.quota import ProviderQuotaError
+
+        outline = _make_outline(unit_ids=("u-1",))
+        squadron = StubRefuelSquadron(
+            outline_payload=outline,
+            escalation_ladder=(DEFAULT_TIER, "moderate", "complex"),
+        )
+        calls = {"n": 0}
+
+        async def _quota(**_kw: Any) -> SubmitDetailsPayload:
+            calls["n"] += 1
+            _raise_budget("monthly usage limit exceeded")
+
+        squadron._decomposer.detail = _quota  # type: ignore[assignment]
+
+        exc = await self._run_expecting_quota(squadron, tmp_path)
+
+        assert isinstance(exc, ProviderQuotaError)
+        # One attempt total: no same-tier retry, no escalation to
+        # "moderate" or "complex".
+        assert calls["n"] == 1
+        assert squadron.decomposer_pool.acquire_calls == [DEFAULT_TIER, DEFAULT_TIER]
+
+    async def test_quota_reported_as_transient_is_not_retried(self, tmp_path: Path) -> None:
+        """Some providers dress a hard limit up as a 429/5xx.
+
+        Classifying by message keeps those off the retry-and-escalate
+        path that a genuine transient belongs on.
+        """
+        from airframe.errors import RuntimeTransientError
+
+        from maverick.exceptions.quota import ProviderQuotaError
+
+        outline = _make_outline(unit_ids=("u-1",))
+        squadron = StubRefuelSquadron(
+            outline_payload=outline,
+            escalation_ladder=(DEFAULT_TIER, "complex"),
+        )
+        calls = {"n": 0}
+
+        async def _quota_as_transient(**_kw: Any) -> SubmitDetailsPayload:
+            calls["n"] += 1
+            raise RuntimeTransientError("429: usage limit reached, resets 6am UTC")
+
+        squadron._decomposer.detail = _quota_as_transient  # type: ignore[assignment]
+
+        exc = await self._run_expecting_quota(squadron, tmp_path)
+
+        assert isinstance(exc, ProviderQuotaError)
+        assert calls["n"] == 1
+        # The reset hint is parsed off the message for the operator.
+        assert exc.reset_time is not None
+        assert "6am" in exc.reset_time
+
+    async def test_genuine_transient_still_retries_and_escalates(self, tmp_path: Path) -> None:
+        """Guard the other side: the quota check must not swallow real
+        transients, which *do* deserve the ladder."""
+        from airframe.errors import RuntimeTransientError
+
+        outline = _make_outline(unit_ids=("u-1",))
+        squadron = StubRefuelSquadron(
+            outline_payload=outline,
+            detail_payloads=[_make_details(("u-1",))],
+            escalation_ladder=(DEFAULT_TIER, "complex"),
+        )
+        original_detail = squadron._decomposer.detail
+        calls = {"n": 0}
+
+        async def _transient_then_ok(**kwargs: Any) -> SubmitDetailsPayload:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeTransientError("503 service unavailable")
+            return await original_detail(**kwargs)
+
+        squadron._decomposer.detail = _transient_then_ok  # type: ignore[assignment]
+
+        exc = await self._run_expecting_quota(squadron, tmp_path)
+
+        assert exc is None
+        assert calls["n"] == 2
+
+    async def test_completed_units_are_cached_before_the_abort(self, tmp_path: Path) -> None:
+        """The abort is only tolerable because progress survives it.
+
+        Units that finished before the limit hit are on disk, so the
+        re-run after reset resumes instead of starting over.
+        """
+
+        outline = _make_outline(unit_ids=("u-1", "u-2"))
+        cache_dir = tmp_path / "refuel-cache"
+        squadron = StubRefuelSquadron(outline_payload=outline)
+        original_detail = squadron._decomposer.detail
+        seen: list[str] = []
+
+        async def _one_then_quota(**kwargs: Any) -> SubmitDetailsPayload:
+            unit_ids = kwargs.get("unit_ids") or ()
+            seen.extend(unit_ids)
+            if len(seen) > 1:
+                _raise_budget("you have no quota left")
+            return await original_detail(**kwargs)
+
+        squadron._decomposer.detail = _one_then_quota  # type: ignore[assignment]
+
+        from maverick.exceptions.quota import ProviderQuotaError
+
+        # pool_size=1 so the two units are strictly ordered.
+        exc = await self._run_expecting_quota(
+            squadron, tmp_path, cache_dir=str(cache_dir), decomposer_pool_size=1
+        )
+
+        # The run aborted rather than creating beads from a fan-out that
+        # only covered half the plan...
+        assert isinstance(exc, ProviderQuotaError)
+        # ...and the half that did complete survived the abort.
+        cached = sorted(p.name for p in (cache_dir / "details").glob("*.json"))
+        assert cached == ["u-1.json"]
 
 
 class TestRefuelBurrGraphValidationLoop:

--- a/tests/unit/workflows/refuel_maverick/test_workflow.py
+++ b/tests/unit/workflows/refuel_maverick/test_workflow.py
@@ -85,7 +85,7 @@ class TestRefuelMaverickWorkflowHappyPath:
                 {"flight_plan_path": str(fp), "skip_briefing": True},
             )
 
-        # StepStarted events for outer steps (decompose/validate run inside Thespian)
+        # StepStarted events for outer steps (decompose/validate run inside the Burr graph)
         started_names = [e.step_name for e in events if isinstance(e, StepStarted)]
         for step in _OUTER_STEPS:
             assert step in started_names, f"Expected StepStarted for {step}"

--- a/tests/unit/workflows/refuel_maverick/test_workflow_edge_cases.py
+++ b/tests/unit/workflows/refuel_maverick/test_workflow_edge_cases.py
@@ -253,7 +253,7 @@ class TestErrorHandling:
             ),
             patch.object(
                 workflow,
-                "_run_with_burr",
+                "_run_decomposition",
                 new=AsyncMock(
                     side_effect=WorkflowError("Circular dependency detected in decomposition")
                 ),
@@ -406,7 +406,7 @@ Test objective.
             # the agent would successfully decompose and the workflow
             # would not fail — defeating the test's intent.
             patch(
-                f"{_MODULE}.RefuelMaverickWorkflow._run_with_burr",
+                f"{_MODULE}.RefuelMaverickWorkflow._run_decomposition",
                 new=AsyncMock(side_effect=RuntimeError("ACP prompt failed after retries")),
             ),
         ):
@@ -462,7 +462,7 @@ Test objective.
                 ),
             ),
             patch(
-                f"{_MODULE}.RefuelMaverickWorkflow._run_with_burr",
+                f"{_MODULE}.RefuelMaverickWorkflow._run_decomposition",
                 new=_fake_supervisor,
             ),
         ):
@@ -554,7 +554,7 @@ class TestParallelGroups:
         tmp_path: Path,
     ) -> None:
         """Parallel decomposition has named parallel groups in work units."""
-        # Validation now runs inside _run_with_burr (Thespian).
+        # Validation now runs inside _run_decomposition (the Burr graph).
         # Verify that the decomposition output itself contains parallel groups.
         parallel_decomp = _make_parallel_decomp()
         group_units = [wu for wu in parallel_decomp.work_units if wu.parallel_group]

--- a/tests/unit/workflows/test_fly_beads_workflow.py
+++ b/tests/unit/workflows/test_fly_beads_workflow.py
@@ -27,7 +27,6 @@ from maverick.library.actions.types import (
 _WF_MOD = "maverick.workflows.fly_beads.workflow"
 _STEPS_MOD = "maverick.workflows.fly_beads.steps"
 _IMPL_MOD = "maverick.workflows.fly_beads._implement"
-_REVIEW_MOD = "maverick.workflows.fly_beads._review"
 _RUNWAY_MOD = "maverick.workflows.fly_beads._runway"
 _COMMIT_MOD = "maverick.workflows.fly_beads._commit"
 
@@ -118,7 +117,7 @@ def _make_mock_actions(
             "error": None,
         },
         "mark_complete_return": mark_complete,
-        "xoscar_return": {
+        "bead_loop_return": {
             "beads_completed": 1,
             "completed_bead_ids": ["b1"],
             "beads_failed": 0,
@@ -184,9 +183,9 @@ _PATCH_SPECS: list[tuple[str, str, str | None, str]] = [
         _RV,
     ),
     (
-        "xoscar",
-        f"{_WF_MOD}.FlyBeadsWorkflow._run_fly_with_burr",
-        "xoscar_return",
+        "bead_loop",
+        f"{_WF_MOD}._run_bead_loop",
+        "bead_loop_return",
         _RV,
     ),
 ]
@@ -335,9 +334,9 @@ class TestFlyBeadsWorkflow:
     async def test_bead_failure_reported_in_result(
         self, fly_workflow: Any, tmp_path: Path
     ) -> None:
-        """When Thespian reports bead failures, they appear in the result."""
+        """When the bead loop reports failures, they appear in the result."""
         mv = _make_mock_actions()
-        mv["xoscar_return"] = {
+        mv["bead_loop_return"] = {
             "beads_completed": 0,
             "completed_bead_ids": [],
             "beads_failed": 1,
@@ -348,7 +347,7 @@ class TestFlyBeadsWorkflow:
                 fly_workflow, {"epic_id": "", "max_beads": 5, "cwd": str(tmp_path)}
             )
 
-        mocks["xoscar"].assert_called_once()
+        mocks["bead_loop"].assert_called_once()
 
         completed = next(e for e in events if isinstance(e, WorkflowCompleted))
         assert completed.success is True
@@ -375,22 +374,22 @@ class TestFlyBeadsWorkflow:
         completed = next(e for e in events if isinstance(e, WorkflowCompleted))
         assert completed.success is False
 
-    async def test_xoscar_path_invoked(self, fly_workflow: Any, tmp_path: Path) -> None:
-        """Thespian path is invoked for execution."""
+    async def test_bead_loop_invoked(self, fly_workflow: Any, tmp_path: Path) -> None:
+        """The Burr bead loop is invoked for execution."""
         with _patch_all_actions() as mocks:
             await _collect_events(
                 fly_workflow, {"epic_id": "", "max_beads": 5, "cwd": str(tmp_path)}
             )
 
-        mocks["xoscar"].assert_called_once()
+        mocks["bead_loop"].assert_called_once()
         mocks["select"].assert_not_called()
 
-    async def test_human_review_items_come_from_xoscar_events(
+    async def test_human_review_items_come_from_bead_loop_events(
         self, fly_workflow: Any, tmp_path: Path
     ) -> None:
-        """Needs-human-review beads are derived from Thespian bead events."""
+        """Needs-human-review beads are derived from the loop's bead events."""
         mv = _make_mock_actions()
-        mv["xoscar_return"] = {
+        mv["bead_loop_return"] = {
             "beads_completed": 1,
             "completed_bead_ids": ["b1"],
             "beads_failed": 0,
@@ -422,7 +421,7 @@ class TestFlyBeadsWorkflow:
         ]
 
     async def test_max_beads_limit(self, fly_workflow: Any, tmp_path: Path) -> None:
-        """Thespian result beads_completed used for final count."""
+        """The bead loop's beads_completed is used for the final count."""
         select_side_effect = [
             _make_select_result(bead_id=f"b{i}", title=f"Bead {i}", done=False) for i in range(10)
         ]
@@ -430,7 +429,7 @@ class TestFlyBeadsWorkflow:
             select_side_effect=select_side_effect,
         )
 
-        mv["xoscar_return"] = {
+        mv["bead_loop_return"] = {
             "beads_completed": 3,
             "completed_bead_ids": ["b1", "b2", "b3"],
             "beads_failed": 0,
@@ -446,9 +445,9 @@ class TestFlyBeadsWorkflow:
         assert final["beads_succeeded"] == 3
 
     async def test_multiple_beads_processed(self, fly_workflow: Any, tmp_path: Path) -> None:
-        """Multiple beads reported by Thespian appear in result."""
+        """Multiple beads reported by the bead loop appear in the result."""
         mv = _make_mock_actions()
-        mv["xoscar_return"] = {
+        mv["bead_loop_return"] = {
             "beads_completed": 2,
             "completed_bead_ids": ["b1", "b2"],
             "beads_failed": 0,
@@ -463,15 +462,15 @@ class TestFlyBeadsWorkflow:
         assert fly_workflow.result.final_output["beads_succeeded"] == 2
 
     async def test_epic_id_passed_to_supervisor(self, fly_workflow: Any, tmp_path: Path) -> None:
-        """Epic ID is passed to the Thespian path for processing."""
+        """Epic ID is passed to the bead loop for processing."""
         with _patch_all_actions() as mocks:
             async for _ in fly_workflow.execute(
                 {"epic_id": "epic-99", "max_beads": 5, "cwd": str(tmp_path)}
             ):
                 pass
 
-        mocks["xoscar"].assert_called_once()
-        call_kwargs = mocks["xoscar"].call_args[1]
+        mocks["bead_loop"].assert_called_once()
+        call_kwargs = mocks["bead_loop"].call_args[1]
         assert call_kwargs["epic_id"] == "epic-99"
 
     async def test_epic_not_closed_when_children_still_open(


### PR DESCRIPTION
Closes the post-migration debt tracked in #135. Five of the six subtasks are done; one is blocked and documented below.

## (3) Per-tier bindings — the gap was bigger than the issue reported

The issue described the decomposer resolving every tier to the same model, and suggested mirroring how `FlySquadron` already handles implementer/reviewer tiers.

**That pattern was itself dead code.** `implementer_tiers` / `reviewer_tiers` are `FlySquadron` constructor params that *nothing in production ever passed* — the code that parsed `actors.<workflow>.<actor>.tiers` lived in the per-workflow supervisors the Burr migration deleted. `ActorConfig` kept accepting `tiers` as an untyped pass-through, so a configured block loaded, validated, and did nothing at all. Every `tiers:` block a user wrote was inert, for all three tierable actors — not just the decomposer.

- `config.lookup_tiers_config()` restores the parse. Malformed blocks degrade to `None` with a warning; one typo must not take down workflow startup.
- New `squadron/tiers.py` holds what fly and refuel both need: `TIER_ORDER`, the `DEFAULT_TIER` sentinel, `binding_for_complexity()`, `defined_tiers()`, `escalation_ladder()`, `merge_tier_config()`.
- **Escalation ladders now come from the squadron**, not a hardcoded five-name list, so a rung can only name a tier the squadron built a *distinct* binding for. An unconfigured squadron gets a one-rung ladder — escalating to an identical binding is a retry in disguise, and it's precisely what hid this bug.

Two consequences worth flagging:

1. Collapsing the ladder would have removed the only thing giving transient failures a second attempt, so **transient errors now spend the same-tier retry budget before escalating.** They previously short-circuited it and leaned on the ladder, which only worked because every rung was the same model.
2. The old ladder started `_default → trivial`. With real bindings that **downgrades** the model on first failure. Fly had the identical bug, and wiring fly's bindings would have made it live — so both are fixed here.

I also found `escalation_threshold` documented with two different meanings — "escalation steps" on `DecomposerTiersConfig`, "fix rounds before promoting" on `ImplementerTiersConfig` — and consumed nowhere. `escalation_ladder()` takes an explicit `max_steps` rather than silently applying one reading to both. The implementer reading stays unimplemented; that's pre-existing and a separate decision.

## (2) Inline the `_*_with_burr` wrappers

Fly had a genuine double layer (method → module-level impl); the pass-through method is gone and `_run` calls `_run_bead_loop` directly.

Generate and refuel had a single helper each, which is decomposition rather than indirection. I renamed those to substrate-neutral names (`_generate_plan`, `_run_decomposition`) and fixed docstrings claiming they were "opt-in behind `MAVERICK_USE_BURR`" with a `_with_xoscar` counterpart — neither has existed for some time.

**I did not textually inline their 90–120 line bodies into `_run`.** That would push those methods well past the module's own size guidance, trading one vestige for a worse one. Flagging it since the issue asked for a literal inline.

## (4a) Refuel cache read side

`init_state` seeds briefs, outline, and per-unit details from `refuel-cache/`; each producing action short-circuits on a populated slot. Doing the disk read in one place keeps every producer a pure function of state.

Envelopes carry `schema_version` + `kind` and **fail closed** on any ambiguity — missing file, bad JSON, wrong version, wrong kind. Reusing a drifted outline silently produces beads that don't match the plan; regenerating just costs budget. Detail reuse is per unit and filtered against the current outline, so a dropped unit's stale detail can't re-enter the merge.

## (4b) Refuel quota handling

A provider limit is account-wide and time-bound, so it now neither retries nor escalates. The first unit to hit one aborts the fan-out with `ProviderQuotaError` rather than letting every remaining unit burn a round-trip to be told the same thing and then building beads from a truncated plan. Providers that dress a hard limit up as a 429/5xx are caught by message via the existing `is_quota_error`. Completed units are already cached, so the re-run after reset resumes.

## (1) Stale references

`grep -rn xoscar src/` now returns only explicitly-historical mentions ("retired", "earlier"), per the issue's done definition.

**CLAUDE.md needed more than the issue described.** It documented an OpenCode HTTP runtime and an xoscar actor pool as the architecture — but `src/maverick/actors/` and `runtime/opencode/` are both gone, and OpenCode is now one provider among many behind airframe. Since CLAUDE.md loads into every agent session, it was actively misleading future work. Those sections are rewritten around airframe + Burr, including `BurrWorkflowDriver`'s deferred-exception behaviour (an action that raises doesn't interrupt `.events()`; the exception surfaces at `.result`) — easy to get wrong in tests, and I got it wrong once while writing these.

Also deleted `fly_beads/_review.py`: an empty module whose only content was a docstring claiming a retired substrate handled reviews, imported by nothing.

## (5) E2E smoke against sample-maverick-project — BLOCKED

Needs live model calls. This environment has no `opencode` binary, no provider auth (`~/.local/share/opencode/auth.json` absent), and no API keys.

**Next step:** on a box with a provider authenticated, run `maverick init` → `plan generate` → `refuel` → `fly --epic <id> --max-beads 3` against sample-maverick-project, and file a follow-up bug per regression rather than fixing in-line. Leaving #135 open for this box only.

## Testing

`make ci-coverage` (the exact CI target): **4436 passed, 1 xfailed**, coverage 85.58%.

New coverage:
- `tests/unit/squadron/test_tiers.py` — 23 tests over the shared tier helpers.
- `tests/unit/test_tiers_config_resolution.py` — the resolver *and* that production call sites actually pass what it returns. A squadron that resolves tiers correctly is worthless if nothing hands them over.
- Refuel cache read-back and quota classes in `test_burr_graph.py`.

Every new regression test was confirmed to fail against the pre-fix code. Two of my fail-closed assertions were initially too weak — `DEFAULT_TIER in acquire_calls` is trivially true because detail fan-out acquires regardless of the outline cache — so they were tightened to exact call sequences and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012av72R5SPCc84chsUNjhLC
