### PR TITLE
fix(refuel): seven defects found by the first live walkthrough

### DIFF
--- a/src/maverick/library/actions/decompose.py
+++ b/src/maverick/library/actions/decompose.py
@@ -973,10 +973,17 @@ def validate_decomposition(
             if ref not in covered_refs:
                 gap = f"{ref} not explicitly covered by any work unit"
                 gaps.append(gap)
-                logger.warning("sc_not_covered", ref=ref)
+                # debug, not warning: the gap is already carried on the
+                # raised exception, so warning level only duplicated it —
+                # while putting a raw structlog row on stderr per
+                # uncovered ref, which lands in the user's terminal
+                # interleaved with the Rich output the CLI rules say is
+                # the only thing they should see. A live run emitted 16
+                # of them in one validation pass (#135 subtask 5).
+                logger.debug("sc_not_covered", ref=ref)
 
     if gaps:
-        raise SCCoverageError(
+        raise SCTraceabilityError(
             f"Incomplete SC coverage: {len(gaps)} success criteria not traced — {'; '.join(gaps)}",
             gaps=gaps,
         )
@@ -1058,7 +1065,7 @@ def validate_decomposition(
 
 
 class SCCoverageError(ValueError):
-    """Raised when success criteria are not fully covered by work units.
+    """Raised when success-criteria coverage is structurally wrong.
 
     Attributes:
         gaps: List of uncovered SC references.
@@ -1067,3 +1074,32 @@ class SCCoverageError(ValueError):
     def __init__(self, message: str, gaps: list[str]) -> None:
         super().__init__(message)
         self.gaps = gaps
+
+
+class SCTraceabilityError(SCCoverageError):
+    """Some success criteria are not traced by any work unit.
+
+    Split out from :class:`SCCoverageError` because it is **advisory**,
+    unlike its sibling case (an overloaded work unit), which the fixer
+    can act on by splitting the unit.
+
+    A criterion is untraced for one of two very different reasons, and
+    the check cannot tell them apart:
+
+    * The decomposition genuinely missed a feature — worth fixing.
+    * The criterion is a **cross-cutting constraint** and no single work
+      unit can ever carry it: "total source lines stay under 500",
+      "``ruff check`` passes", "the package installs and ``--help``
+      works". These are quality gates over the finished codebase, not
+      units of work.
+
+    Treating the second kind as a hard failure is unrecoverable, and
+    expensive: the fix loop cannot close the gap no matter how many
+    rounds it spends, and the fixer — asked to make a work unit cover
+    "total LOC ≤ 500" — invents work units trying. A live run of the
+    sample project turned 7 work units into 33 across three rounds,
+    every one of them wasted (#135 subtask 5).
+
+    So callers should record these gaps and show them to the human, but
+    must not fail validation or drive the fix loop on them alone.
+    """

--- a/src/maverick/workflows/refuel_maverick/actions.py
+++ b/src/maverick/workflows/refuel_maverick/actions.py
@@ -151,6 +151,34 @@ async def _run_one_briefing(
     return _ROLE_FOR[agent_name], dump_supervisor_payload(payload)
 
 
+async def _briefing_failed(
+    events: asyncio.Queue[ProgressEvent | None],
+    agent_name: str,
+    exc: BaseException,
+) -> None:
+    """Report a briefing agent failure without aborting the workflow.
+
+    Briefings are evidence-gathering, and every downstream consumer
+    already treats each brief as optional —
+    :func:`~maverick.preflight_briefing.serializer.serialize_briefs_to_markdown`
+    takes all four as ``| None``. So one agent failing should cost its
+    brief, not the run.
+
+    It used to cost the run: a contrarian that could not produce valid
+    structured output ("max structured output retries") aborted refuel
+    outright, discarding three briefs that had already succeeded (#135
+    subtask 5). That is the exact case Core Principle 3 — "one agent
+    failing must not crash the workflow" — exists to prevent.
+    """
+    await _put_output(
+        events,
+        "briefing",
+        f"Briefing agent {agent_name!r} failed; continuing without its brief: {exc}",
+        level="warning",
+        metadata={"agent": agent_name, "error": str(exc)},
+    )
+
+
 async def _put_output(
     events: asyncio.Queue[ProgressEvent | None],
     step_name: str,
@@ -220,6 +248,30 @@ async def _write_cache_json(
                 level="warning",
                 metadata={"path": str(path), "label": label},
             )
+
+
+async def _write_briefings_cache(
+    briefs: dict[str, Any],
+    *,
+    cache_dir: str,
+    events: asyncio.Queue[ProgressEvent | None] | None,
+) -> None:
+    """Persist whatever briefs exist so far.
+
+    Called after *each* briefing phase rather than once at the end. The
+    cache's whole purpose is to make a failed run cheap to retry, and a
+    single write at the end of the briefing sequence cannot do that — a
+    contrarian failure discarded three completed briefs (#135 subtask 5).
+    """
+    if not cache_dir or not briefs:
+        return
+    await _write_cache_json(
+        Path(cache_dir) / "briefings.json",
+        briefs,
+        kind=CACHE_KIND_BRIEFINGS,
+        events=events,
+        label="briefings",
+    )
 
 
 def _read_cache_json(path: Path, *, kind: str) -> Any | None:
@@ -378,6 +430,7 @@ async def parallel_briefings(
     squadron: RefuelSquadron,
     events: asyncio.Queue[ProgressEvent | None],
     max_concurrent: int,
+    cache_dir: str = "",
 ) -> tuple[dict[str, Any], State]:
     """Run navigator + structuralist + recon in parallel.
 
@@ -398,20 +451,33 @@ async def parallel_briefings(
         return {"briefs_collected": list(existing), "from_cache": True}, state
     sem = asyncio.Semaphore(max(1, max_concurrent))
 
-    async def _bounded(name: str) -> tuple[str, dict[str, Any]]:
+    async def _bounded(name: str) -> tuple[str, dict[str, Any]] | None:
         async with sem:
-            return await _run_one_briefing(
-                agent_name=name,
-                prompt=state["briefing_prompt"],
-                squadron=squadron,
-                events=events,
-                provider_label=provider_labels.get(_LABEL_FOR[name], ""),
-            )
+            try:
+                return await _run_one_briefing(
+                    agent_name=name,
+                    prompt=state["briefing_prompt"],
+                    squadron=squadron,
+                    events=events,
+                    provider_label=provider_labels.get(_LABEL_FOR[name], ""),
+                )
+            except Exception as exc:  # noqa: BLE001 — see _briefing_failed
+                await _briefing_failed(events, name, exc)
+                return None
 
     results = await asyncio.gather(*(_bounded(n) for n in pending))
     briefs = existing
-    for role_key, payload_dict in results:
+    for result in results:
+        if result is None:
+            continue
+        role_key, payload_dict = result
         briefs[role_key] = payload_dict
+
+    # Persist as soon as the parallel phase lands, not after the
+    # contrarian: the contrarian is a separate agent that can fail on its
+    # own, and when it did, three successful briefs (290s of work) were
+    # thrown away because the only cache write sat downstream of it.
+    await _write_briefings_cache(briefs, cache_dir=cache_dir, events=events)
     return {"briefs_collected": list(briefs)}, state.update(briefs=briefs)
 
 
@@ -424,6 +490,7 @@ async def contrarian_briefing(
     *,
     squadron: RefuelSquadron,
     events: asyncio.Queue[ProgressEvent | None],
+    cache_dir: str = "",
 ) -> tuple[dict[str, Any], State]:
     """Run the contrarian after the parallel briefings are in.
 
@@ -440,15 +507,21 @@ async def contrarian_briefing(
         structuralist=briefs.get("structuralist"),
         recon=briefs.get("recon"),
     )
-    role_key, payload_dict = await _run_one_briefing(
-        agent_name="contrarian",
-        prompt=prompt,
-        squadron=squadron,
-        events=events,
-        provider_label=state["provider_labels"].get("Contrarian", ""),
-    )
+    try:
+        role_key, payload_dict = await _run_one_briefing(
+            agent_name="contrarian",
+            prompt=prompt,
+            squadron=squadron,
+            events=events,
+            provider_label=state["provider_labels"].get("Contrarian", ""),
+        )
+    except Exception as exc:  # noqa: BLE001 — see _briefing_failed
+        await _briefing_failed(events, "contrarian", exc)
+        return {"contrarian_done": False, "failed": True}, state
+
     new_briefs = dict(briefs)
     new_briefs[role_key] = payload_dict
+    await _write_briefings_cache(new_briefs, cache_dir=cache_dir, events=events)
     return {"contrarian_done": True}, state.update(briefs=new_briefs)
 
 

--- a/src/maverick/workflows/refuel_maverick/actions.py
+++ b/src/maverick/workflows/refuel_maverick/actions.py
@@ -293,6 +293,7 @@ def _load_cached_details(cache_dir: Path) -> dict[str, dict[str, Any]]:
         "fix_rounds",
         "validation_passed",
         "validation_warnings",
+        "untraced_criteria",
         "epic_id",
         "epic",
         "work_beads",
@@ -359,6 +360,7 @@ async def init_state(
         fix_rounds=0,
         validation_passed=False,
         validation_warnings=[],
+        untraced_criteria=[],
         epic_id="",
         epic=None,
         work_beads=[],
@@ -891,7 +893,7 @@ def _merge_to_specs(
 
 @action(
     reads=["outline", "accumulated_details"],
-    writes=["specs", "validation_passed", "validation_warnings"],
+    writes=["specs", "validation_passed", "validation_warnings", "untraced_criteria"],
 )
 async def validate(
     state: State,
@@ -908,13 +910,22 @@ async def validate(
     if outline_dict is None:
         raise RuntimeError("validate ran without an outline")
 
+    from maverick.library.actions.decompose import SCTraceabilityError
+
     specs = _merge_to_specs(outline_dict, state["accumulated_details"])
-    # ``validate_decomposition`` returns a list of gap strings on
-    # success (empty == passed) and *raises* ``ValueError`` /
-    # ``SCCoverageError`` on schema-level issues (cycles, dangling
-    # depends_on, uncovered SCs). Mirror the legacy supervisor's
-    # behaviour and surface either path as ``validation_warnings``.
+    # ``validate_decomposition`` returns a list of soft warnings on
+    # success (empty == passed) and *raises* on schema-level issues.
+    # Two classes of raise, deliberately handled differently:
+    #
+    # * ``SCTraceabilityError`` — untraced success criteria. Advisory:
+    #   cross-cutting constraints ("total LOC <= 500", "lint passes")
+    #   can never be traced to one work unit, so failing on them sends
+    #   the fix loop after a gap it cannot close. Recorded and shown,
+    #   but does not fail validation.
+    # * Everything else (cycles, dangling depends_on, overloaded units)
+    #   — genuinely fixable, so it still fails and drives the fix loop.
     gaps: list[str] = []
+    advisory: list[str] = []
     try:
         spec_models = [WorkUnitSpec.model_validate(s) for s in specs]
         result = validate_decomposition(
@@ -923,9 +934,26 @@ async def validate(
             expected_sc_refs=list(expected_sc_refs) if expected_sc_refs else None,
         )
         gaps = list(result)
+    except SCTraceabilityError as exc:
+        advisory = list(exc.gaps)
     except ValueError as exc:
         gaps = [str(exc)]
     passed = not gaps
+
+    if advisory:
+        # Name the criteria. The count alone told an operator nothing —
+        # and cost two live debugging sessions to work around (#135).
+        await _put_output(
+            events,
+            "decompose",
+            (
+                f"{len(advisory)} success criterion/criteria not traced to a work unit "
+                f"(not blocking — cross-cutting constraints usually can't be): "
+                + "; ".join(advisory)
+            ),
+            level="warning",
+            metadata={"untraced_count": len(advisory), "untraced": advisory},
+        )
 
     if passed:
         await _put_output(events, "decompose", "Validation passed", level="success")
@@ -933,15 +961,20 @@ async def validate(
         await _put_output(
             events,
             "decompose",
-            f"Validation found {len(gaps)} gap(s)",
+            f"Validation found {len(gaps)} gap(s): " + "; ".join(gaps),
             level="warning",
-            metadata={"gap_count": len(gaps)},
+            metadata={"gap_count": len(gaps), "gaps": gaps},
         )
 
     return {"passed": passed, "gap_count": len(gaps)}, state.update(
         specs=specs,
         validation_passed=passed,
+        # Kept separate from ``untraced_criteria`` on purpose:
+        # ``request_fix`` builds the fixer's prompt from this slot, and
+        # advisory gaps must never reach it — that is precisely how the
+        # fixer ends up chasing an uncloseable criterion.
         validation_warnings=list(gaps),
+        untraced_criteria=list(advisory),
     )
 
 

--- a/src/maverick/workflows/refuel_maverick/burr_graph.py
+++ b/src/maverick/workflows/refuel_maverick/burr_graph.py
@@ -163,6 +163,7 @@ def build_refuel_application(
             fix_rounds=0,
             validation_passed=False,
             validation_warnings=[],
+            untraced_criteria=[],
             validation_complete=False,
             epic_id="",
             epic=None,

--- a/src/maverick/workflows/refuel_maverick/burr_graph.py
+++ b/src/maverick/workflows/refuel_maverick/burr_graph.py
@@ -107,10 +107,12 @@ def build_refuel_application(
                 squadron=squadron,
                 events=event_queue,
                 max_concurrent=max_briefing_agents,
+                cache_dir=cache_dir,
             ),
             contrarian_briefing=refuel_actions.contrarian_briefing.bind(
                 squadron=squadron,
                 events=event_queue,
+                cache_dir=cache_dir,
             ),
             synthesize_briefing=refuel_actions.synthesize_briefing.bind(
                 cache_dir=cache_dir,

--- a/src/maverick/workflows/refuel_maverick/workflow.py
+++ b/src/maverick/workflows/refuel_maverick/workflow.py
@@ -512,6 +512,7 @@ class RefuelMaverickWorkflow(PythonWorkflow):
             skip_briefing=skip_briefing,
             ctx=ctx,
             ws_cwd=ws_cwd,
+            plan_dir=flight_plan_path.parent,
         )
         briefing_path_str: str | None = None
         suggested_deps: tuple[str, ...] = ()
@@ -526,8 +527,15 @@ class RefuelMaverickWorkflow(PythonWorkflow):
         if decomposition is None:
             raise WorkflowError("Decomposition loop exited without producing a result")
 
-        # Determine output directory (colocated with flight plan in workspace)
-        work_units_dir = ws_cwd / ".maverick" / "plans" / flight_plan.name
+        # Colocate work units with the flight plan they came from.
+        #
+        # Derived from the plan's own path, not ``flight_plan.name``: the
+        # generator writes the plan to ``plans/<cli-name>/`` but is free
+        # to put a different ``name:`` in the frontmatter (it picked
+        # "greet-cli-mvp" for a plan generated as "greet-cli"), which
+        # scattered the outputs into a second directory that had no
+        # flight plan in it (#135 subtask 5).
+        work_units_dir = flight_plan_path.parent
 
         # Convert specs to WorkUnit models
         work_units = convert_specs_to_work_units(
@@ -873,6 +881,7 @@ class RefuelMaverickWorkflow(PythonWorkflow):
         skip_briefing: bool = False,
         ctx: dict[str, Any] | None = None,
         ws_cwd: Path,
+        plan_dir: Path,
     ) -> Any:
         """Run briefing + decomposition via Burr.
 
@@ -919,11 +928,12 @@ class RefuelMaverickWorkflow(PythonWorkflow):
             # later resume can read the raw artifacts. The actions
             # treat ``cache_dir`` as advisory — empty disables writes
             # and any OSError is swallowed with a warning.
-            cache_dir = (
-                str(ws_cwd / ".maverick" / "plans" / plan_name / "refuel-cache")
-                if plan_name
-                else ""
-            )
+            # Keyed off the plan's own directory, not ``flight_plan.name``
+            # — see the note on ``work_units_dir``. Caches written by an
+            # older build under ``plans/<frontmatter-name>/`` are simply
+            # not found, which is the correct outcome: they belong to a
+            # directory with no flight plan in it.
+            cache_dir = str(plan_dir / "refuel-cache")
             app = build_refuel_application(
                 squadron=squadron,
                 event_queue=event_queue,

--- a/src/maverick/workflows/refuel_maverick/workflow.py
+++ b/src/maverick/workflows/refuel_maverick/workflow.py
@@ -112,6 +112,45 @@ def _outline_cache_key(
     return h.hexdigest()[:16]
 
 
+def success_criteria_refs(flight_plan: Any) -> tuple[tuple[str, ...], int]:
+    """Split a flight plan's success criteria into ``(ref_ids, count)``.
+
+    Only *real* ref identifiers are returned. The markdown flight-plan
+    format stores each criterion as prose —
+    :class:`~maverick.flight.models.SuccessCriterion` has ``text`` and
+    ``checked``, no id — so ``ref_ids`` is normally empty and
+    :func:`~maverick.library.actions.decompose.validate_decomposition`
+    falls back to sequential ``SC-001..SC-NNN``, which is exactly what the
+    decomposer emits as ``trace_ref``.
+
+    That falsiness is load-bearing. This used to read ``sc.id`` /
+    ``sc.description``, neither of which exists on that model, producing
+    one empty string per criterion — and a tuple of empty strings is
+    truthy, so it suppressed the fallback and left the validator
+    comparing ``""`` against every ``trace_ref``. Nothing ever matched,
+    so every refuel reported all criteria uncovered, spent its whole fix
+    budget on a gap no edit could close, and let the fixer invent
+    redundant work units chasing criteria it could not name (a live run
+    turned 7 work units into 18, with duplicates).
+
+    Args:
+        flight_plan: Any object exposing ``success_criteria``; a missing
+            attribute is treated as "no criteria" rather than an error,
+            since older plan objects predate the field.
+
+    Returns:
+        ``(ref_ids, count)``. ``count`` covers every criterion, including
+        those contributing no ref — it is what sizes the fallback.
+    """
+    criteria = tuple(getattr(flight_plan, "success_criteria", ()) or ())
+    refs = tuple(
+        ref
+        for sc in criteria
+        if (ref := str(getattr(sc, "id", None) or getattr(sc, "ref", None) or "").strip())
+    )
+    return refs, len(criteria)
+
+
 class RefuelMaverickWorkflow(PythonWorkflow):
     """Workflow that decomposes a Maverick Flight Plan into work units and beads.
 
@@ -861,13 +900,7 @@ class RefuelMaverickWorkflow(PythonWorkflow):
             open_bead_context=open_bead_result,
         )
 
-        # Extract success-criteria refs from the FlightPlan so the
-        # validator can check coverage.
-        sc_refs: tuple[str, ...] = tuple(
-            (getattr(sc, "id", None) or getattr(sc, "description", "") or "")
-            for sc in (getattr(flight_plan, "success_criteria", ()) or ())
-        )
-        sc_count = len(sc_refs)
+        sc_refs, sc_count = success_criteria_refs(flight_plan)
         plan_name = str(getattr(flight_plan, "name", "") or "")
         plan_objective = str(getattr(flight_plan, "objective", "") or "")
 

--- a/tests/unit/workflows/refuel_maverick/test_burr_graph.py
+++ b/tests/unit/workflows/refuel_maverick/test_burr_graph.py
@@ -1124,23 +1124,32 @@ class TestRefuelBurrQuotaHandling:
 
 class TestRefuelBurrGraphValidationLoop:
     async def test_fix_loop_runs_when_validation_fails_then_passes(self, tmp_path: Path) -> None:
-        """First validate produces gaps → request_fix → validate (passes)."""
-        # Outline has one unit with no AC, first detail leaves AC empty,
-        # fix delivers a corrected detail.
+        """First validate produces gaps → request_fix → validate (passes).
+
+        Driven by an *overloaded* work unit rather than untraced success
+        criteria. Untraced criteria are advisory now — they are routinely
+        cross-cutting constraints no work unit can carry — so they no
+        longer reach the fix loop. Overload still does, and it is the one
+        the fixer can actually act on: split the unit.
+        """
         outline = _make_outline(unit_ids=("u-1",))
-        # First detail call: AC without trace_ref → coverage gap.
+        # First detail call: one unit claiming 13 SC refs — over the
+        # hard limit of 12, so validation fails.
         empty_details = SubmitDetailsPayload(
             details=(
                 WorkUnitDetailPayload(
                     id="u-1",
                     instructions="todo",
-                    acceptance_criteria=(AcceptanceCriterionPayload(text="todo ac"),),
+                    acceptance_criteria=tuple(
+                        AcceptanceCriterionPayload(text=f"ac-{i}", trace_ref=f"SC-{i:03d}")
+                        for i in range(1, 14)
+                    ),
                     verification=("pytest -k todo",),
                     test_specification="",
                 ),
             )
         )
-        # Fix delivers AC with the expected trace_ref so coverage closes.
+        # Fix delivers a slimmed-down unit that is back under the limit.
         fix_payload = SubmitFixPayload(
             work_units=(),
             details=(
@@ -1148,7 +1157,7 @@ class TestRefuelBurrGraphValidationLoop:
                     id="u-1",
                     instructions="done",
                     acceptance_criteria=(
-                        AcceptanceCriterionPayload(text="ac-1", trace_ref="SC-1"),
+                        AcceptanceCriterionPayload(text="ac-1", trace_ref="SC-001"),
                     ),
                     verification=("pytest",),
                     test_specification="",
@@ -1185,10 +1194,10 @@ class TestRefuelBurrGraphValidationLoop:
                 plan_objective="o",
                 cwd=str(tmp_path),
                 skip_briefing=True,
-                # Pass non-zero sc_count so the validator notices the
-                # missing acceptance criteria in the first detail pass.
+                # sc_count drives the overload check's ref accounting;
+                # the trigger is the 13-ref unit, not coverage.
                 success_criteria_count=1,
-                expected_sc_refs=("SC-1",),
+                expected_sc_refs=("SC-001",),
             )
             driver = BurrWorkflowDriver(app, halt_after=REFUEL_TERMINAL_ACTIONS, event_queue=queue)
             events = await _collect(driver)
@@ -1211,12 +1220,18 @@ class TestRefuelBurrGraphValidationLoop:
         should contain both units so downstream actions see the split.
         """
         outline = _make_outline(unit_ids=("u-1",))
+        # Overloaded unit (13 SC refs > the hard limit of 12) — the one
+        # coverage failure the fixer can genuinely act on, and the
+        # scenario this test is named for.
         empty_details = SubmitDetailsPayload(
             details=(
                 WorkUnitDetailPayload(
                     id="u-1",
                     instructions="todo",
-                    acceptance_criteria=(AcceptanceCriterionPayload(text="todo ac"),),
+                    acceptance_criteria=tuple(
+                        AcceptanceCriterionPayload(text=f"ac-{i}", trace_ref=f"SC-{i:03d}")
+                        for i in range(1, 14)
+                    ),
                     verification=("pytest -k todo",),
                     test_specification="",
                 ),
@@ -1242,11 +1257,22 @@ class TestRefuelBurrGraphValidationLoop:
         fix_payload = SubmitFixPayload(
             work_units=(new_unit_a, new_unit_b),
             details=(
+                # The split also slims the original unit; without this
+                # u-1 would still carry 13 refs and fail again.
+                WorkUnitDetailPayload(
+                    id="u-1",
+                    instructions="slimmed",
+                    acceptance_criteria=(
+                        AcceptanceCriterionPayload(text="ac-1", trace_ref="SC-001"),
+                    ),
+                    verification=("pytest",),
+                    test_specification="",
+                ),
                 WorkUnitDetailPayload(
                     id="u-1-a",
                     instructions="done a",
                     acceptance_criteria=(
-                        AcceptanceCriterionPayload(text="ac-a", trace_ref="SC-1"),
+                        AcceptanceCriterionPayload(text="ac-a", trace_ref="SC-001"),
                     ),
                     verification=("pytest",),
                     test_specification="",
@@ -1255,7 +1281,7 @@ class TestRefuelBurrGraphValidationLoop:
                     id="u-1-b",
                     instructions="done b",
                     acceptance_criteria=(
-                        AcceptanceCriterionPayload(text="ac-b", trace_ref="SC-1"),
+                        AcceptanceCriterionPayload(text="ac-b", trace_ref="SC-001"),
                     ),
                     verification=("pytest",),
                     test_specification="",
@@ -1293,7 +1319,7 @@ class TestRefuelBurrGraphValidationLoop:
                 cwd=str(tmp_path),
                 skip_briefing=True,
                 success_criteria_count=1,
-                expected_sc_refs=("SC-1",),
+                expected_sc_refs=("SC-001",),
             )
             driver = BurrWorkflowDriver(app, halt_after=REFUEL_TERMINAL_ACTIONS, event_queue=queue)
             await _collect(driver)

--- a/tests/unit/workflows/refuel_maverick/test_sc_refs.py
+++ b/tests/unit/workflows/refuel_maverick/test_sc_refs.py
@@ -273,3 +273,56 @@ class TestArtifactsColocateWithThePlan:
         # The frontmatter name must not reappear as a directory key.
         assert '"plans" / flight_plan.name' not in src
         assert '"plans" / plan_name' not in src
+
+
+class TestBriefingFailuresAreSurvivable:
+    """A failed briefing agent costs its brief, not the run (#135 subtask 5).
+
+    A live refuel died outright when the contrarian could not produce
+    valid structured output after 5 attempts. Navigator, Structuralist
+    and Recon had all already succeeded — 290 seconds of agent work —
+    and every bit of it was discarded, because the only briefings cache
+    write sat downstream of the contrarian.
+
+    Two separate defects, both fixed here: the failure was fatal, and the
+    cache could not help with the one failure mode it most needed to.
+    """
+
+    def test_all_briefs_are_optional_downstream(self) -> None:
+        """The premise the graceful path relies on."""
+        import inspect
+
+        from maverick.preflight_briefing.serializer import serialize_briefs_to_markdown
+
+        sig = inspect.signature(serialize_briefs_to_markdown)
+        for name in ("scope", "analysis", "criteria", "challenge"):
+            assert sig.parameters[name].default is None, (
+                f"{name} must be optional for a missing brief to be survivable"
+            )
+
+    def test_briefing_actions_do_not_let_one_agent_kill_the_run(self) -> None:
+        import inspect
+
+        from maverick.workflows.refuel_maverick import actions as acts
+
+        for fn in (acts.parallel_briefings, acts.contrarian_briefing):
+            src = inspect.getsource(getattr(fn, "_action", fn) if hasattr(fn, "_action") else fn)
+            assert "_briefing_failed" in src, (
+                f"{fn} must degrade on agent failure, not propagate it"
+            )
+
+    def test_cache_is_written_before_the_contrarian_runs(self) -> None:
+        """The ordering that made the cache useless for this failure."""
+        import inspect
+
+        from maverick.workflows.refuel_maverick import actions as acts
+
+        src = inspect.getsource(acts)
+        parallel_at = src.index("async def parallel_briefings")
+        contrarian_at = src.index("async def contrarian_briefing")
+        first_write = src.index("_write_briefings_cache(", parallel_at)
+
+        assert parallel_at < first_write < contrarian_at, (
+            "the parallel phase must persist its briefs before the "
+            "contrarian gets a chance to fail"
+        )

--- a/tests/unit/workflows/refuel_maverick/test_sc_refs.py
+++ b/tests/unit/workflows/refuel_maverick/test_sc_refs.py
@@ -1,0 +1,142 @@
+"""Success-criteria refs forwarded to the decomposition validator.
+
+Found by the first live walkthrough (#135 subtask 5). The extraction read
+``sc.id`` / ``sc.description``, neither of which exists on
+:class:`~maverick.flight.models.SuccessCriterion` — it has ``text`` and
+``checked``. Every criterion therefore produced an empty string.
+
+The damage was not the empty strings themselves but that a tuple of them
+is *truthy*: ``validate_decomposition`` treats a non-empty
+``expected_sc_refs`` as authoritative and skips its ``SC-001..SC-NNN``
+fallback. So the validator compared ``""`` against every ``trace_ref``,
+matched nothing, and reported all criteria uncovered on every run —
+which burned the entire fix budget on an unfixable gap and let the fixer
+invent redundant work units chasing criteria it could not name.
+
+A live run turned 7 work units into 18, with confirmed duplicates.
+"""
+
+from __future__ import annotations
+
+from maverick.workflows.refuel_maverick.workflow import (
+    success_criteria_refs as _extract,
+)
+
+
+class TestSuccessCriteriaRefExtraction:
+    def test_prose_criteria_yield_no_refs_but_a_real_count(self) -> None:
+        """The shape the markdown flight-plan format actually produces.
+
+        ``SuccessCriterion`` carries prose, not identifiers — so refs must
+        come back empty (letting the validator fall back to SC-001..N)
+        while the count still reflects every criterion.
+        """
+        from maverick.flight.models import SuccessCriterion
+
+        class _Plan:
+            success_criteria = tuple(
+                SuccessCriterion(text=f"criterion {i}", checked=False) for i in range(1, 17)
+            )
+
+        refs, count = _extract(_Plan())
+
+        assert refs == ()
+        assert count == 16
+
+    def test_empty_refs_do_not_suppress_the_validator_fallback(self) -> None:
+        """The actual defect, stated as the validator sees it.
+
+        A tuple of empty strings is truthy; an empty tuple is not. That
+        single distinction is what decides whether ``SC-001..N`` is used.
+        """
+        from maverick.flight.models import SuccessCriterion
+
+        class _Plan:
+            success_criteria = (SuccessCriterion(text="does a thing", checked=False),)
+
+        refs, _ = _extract(_Plan())
+
+        # The pre-fix expression produced ("",) here — truthy, so the
+        # validator skipped its fallback and compared "" to every ref.
+        assert refs == ()
+        assert not refs, "a falsy refs tuple is what lets SC-001..N apply"
+
+    def test_real_ref_ids_are_forwarded(self) -> None:
+        """Plans that *do* carry ref ids must still override the fallback."""
+
+        class _Criterion:
+            def __init__(self, id_: str) -> None:
+                self.id = id_
+
+        class _Plan:
+            success_criteria = (_Criterion("SC-B1-default"), _Criterion("SC-B1-linux"))
+
+        refs, count = _extract(_Plan())
+
+        assert refs == ("SC-B1-default", "SC-B1-linux")
+        assert count == 2
+
+    def test_blank_and_whitespace_refs_are_dropped_not_forwarded(self) -> None:
+        """A half-populated plan must not poison the fallback either."""
+
+        class _Criterion:
+            def __init__(self, id_: str) -> None:
+                self.id = id_
+
+        class _Plan:
+            success_criteria = (_Criterion("SC-01"), _Criterion("   "), _Criterion(""))
+
+        refs, count = _extract(_Plan())
+
+        assert refs == ("SC-01",)
+        # Count stays honest even though two criteria contributed no ref.
+        assert count == 3
+
+    def test_no_criteria_at_all(self) -> None:
+        class _Plan:
+            success_criteria = ()
+
+        assert _extract(_Plan()) == ((), 0)
+
+    def test_missing_attribute_is_tolerated(self) -> None:
+        """Older/partial plan objects must not raise here."""
+
+        class _Plan:
+            pass
+
+        assert _extract(_Plan()) == ((), 0)
+
+
+class TestValidatorFallbackContract:
+    """The half of the contract that lives in ``validate_decomposition``."""
+
+    def test_empty_refs_select_sequential_fallback(self) -> None:
+        """Pin the truthiness behaviour the extraction depends on."""
+        expected_sc_refs: tuple[str, ...] = ()
+        success_criteria_count = 3
+
+        expected = (
+            list(expected_sc_refs)
+            if expected_sc_refs
+            else [f"SC-{i:03d}" for i in range(1, success_criteria_count + 1)]
+        )
+
+        assert expected == ["SC-001", "SC-002", "SC-003"]
+
+    def test_tuple_of_blanks_would_have_suppressed_it(self) -> None:
+        """Documents why the old expression was harmful, not merely wrong.
+
+        If this ever starts returning the fallback, the extraction fix
+        stops being load-bearing and this whole class can go.
+        """
+        expected_sc_refs = ("", "", "")
+        success_criteria_count = 3
+
+        expected = (
+            list(expected_sc_refs)
+            if expected_sc_refs
+            else [f"SC-{i:03d}" for i in range(1, success_criteria_count + 1)]
+        )
+
+        assert expected == ["", "", ""]
+        assert "SC-001" not in expected

--- a/tests/unit/workflows/refuel_maverick/test_sc_refs.py
+++ b/tests/unit/workflows/refuel_maverick/test_sc_refs.py
@@ -14,6 +14,12 @@ which burned the entire fix budget on an unfixable gap and let the fixer
 invent redundant work units chasing criteria it could not name.
 
 A live run turned 7 work units into 18, with confirmed duplicates.
+
+Fixing the extraction alone was *not* enough, and made this workload
+worse before it made it better: with a precise-but-impossible target
+(``SC-015: total source lines stay under 500``) the fixer tried harder
+and produced 33 units instead of 18. See
+:class:`TestUntracedCriteriaAreAdvisory` for the second half of the fix.
 """
 
 from __future__ import annotations
@@ -140,3 +146,130 @@ class TestValidatorFallbackContract:
 
         assert expected == ["", "", ""]
         assert "SC-001" not in expected
+
+
+class TestUntracedCriteriaAreAdvisory:
+    """Untraced criteria must not drive the fix loop (#135 subtask 5).
+
+    A criterion goes untraced for two incompatible reasons and the check
+    cannot distinguish them: the decomposition genuinely missed a
+    feature, or the criterion is a cross-cutting constraint no single
+    work unit can carry ("total LOC <= 500", "ruff check passes",
+    "the package installs"). Failing on the second kind is unrecoverable
+    — and expensive. Two live runs each spent their whole 3-round fix
+    budget on it, and the fixer, told to make a work unit cover a
+    codebase-wide LOC budget, invented units trying: 7 became 18 on one
+    run and 33 on the other.
+    """
+
+    def test_traceability_error_is_distinguishable_from_overload(self) -> None:
+        """Both used to be one exception type, so callers could not tell
+        the uncloseable case from the one the fixer can act on."""
+        from maverick.library.actions.decompose import (
+            SCCoverageError,
+            SCTraceabilityError,
+        )
+
+        assert issubclass(SCTraceabilityError, SCCoverageError)
+        # Overload still raises the base class, so `except
+        # SCTraceabilityError` cannot swallow it.
+        assert not issubclass(SCCoverageError, SCTraceabilityError)
+
+    def test_untraced_criteria_raise_traceability_error(self) -> None:
+        from maverick.library.actions.decompose import (
+            SCTraceabilityError,
+            validate_decomposition,
+        )
+        from maverick.workflows.refuel_maverick.models import WorkUnitSpec
+
+        spec = WorkUnitSpec.model_validate(
+            {
+                "id": "u-1",
+                "task": "do a thing",
+                "sequence": 1,
+                "depends_on": [],
+                "file_scope": {},
+                "complexity": "simple",
+                "instructions": "go",
+                "acceptance_criteria": [{"text": "ac", "trace_ref": "SC-001"}],
+                "verification": ["pytest"],
+                "test_specification": "",
+            }
+        )
+
+        try:
+            validate_decomposition([spec], success_criteria_count=2)
+        except SCTraceabilityError as exc:
+            # SC-002 is uncovered; SC-001 is fine.
+            assert any("SC-002" in g for g in exc.gaps)
+        else:  # pragma: no cover - the gap must be detected
+            raise AssertionError("expected SCTraceabilityError")
+
+    def test_overload_still_raises_the_hard_error(self) -> None:
+        """The fixer *can* split an overloaded unit, so it must keep
+        failing validation."""
+        from maverick.library.actions.decompose import (
+            SCCoverageError,
+            SCTraceabilityError,
+            validate_decomposition,
+        )
+        from maverick.workflows.refuel_maverick.models import WorkUnitSpec
+
+        spec = WorkUnitSpec.model_validate(
+            {
+                "id": "u-1",
+                "task": "do everything",
+                "sequence": 1,
+                "depends_on": [],
+                "file_scope": {},
+                "complexity": "complex",
+                "instructions": "go",
+                "acceptance_criteria": [
+                    {"text": f"ac-{i}", "trace_ref": f"SC-{i:03d}"} for i in range(1, 14)
+                ],
+                "verification": ["pytest"],
+                "test_specification": "",
+            }
+        )
+
+        try:
+            validate_decomposition([spec], success_criteria_count=13)
+        except SCCoverageError as exc:
+            assert not isinstance(exc, SCTraceabilityError), (
+                "overload must stay hard-failing, or the fixer never splits the unit"
+            )
+            assert "Split into smaller units" in str(exc)
+        else:  # pragma: no cover
+            raise AssertionError("expected SCCoverageError for the overloaded unit")
+
+
+class TestArtifactsColocateWithThePlan:
+    """Refuel writes next to the flight plan, not to ``<frontmatter name>``.
+
+    ``plan generate <name>`` writes ``plans/<name>/flight-plan.md``, but
+    the generator chooses the frontmatter ``name:`` freely — a plan
+    generated as ``greet-cli`` came back named ``greet-cli-mvp``. Refuel
+    used to key its work-unit and cache directories off that frontmatter
+    name, so a live run left the flight plan in ``plans/greet-cli/`` and
+    everything refuel produced in ``plans/greet-cli-mvp/`` (#135
+    subtask 5).
+    """
+
+    def test_work_units_and_cache_derive_from_the_plan_path(self) -> None:
+        """Pin the derivation as source, since exercising the real
+        workflow needs a squadron and a live Burr app."""
+        import inspect
+
+        from maverick.workflows.refuel_maverick import workflow as wf
+
+        src = inspect.getsource(wf.RefuelMaverickWorkflow)
+
+        assert "work_units_dir = flight_plan_path.parent" in src, (
+            "work units must colocate with the flight plan"
+        )
+        assert 'cache_dir = str(plan_dir / "refuel-cache")' in src, (
+            "the refuel cache must colocate with the flight plan"
+        )
+        # The frontmatter name must not reappear as a directory key.
+        assert '"plans" / flight_plan.name' not in src
+        assert '"plans" / plan_name' not in src


### PR DESCRIPTION
Seven defects in `refuel_maverick`, all found by the first live walkthrough of the sample project (#135 subtask 5). Every one of them was reachable on a clean, ordinary refuel — none needed an edge case to trigger.

## Read the three commits as one change

`5f2d082` alone makes this workload **worse**, and should not land without `ceff42a` on top. Measured on the sample project, same plan both times:

| state | work units | gaps reported |
| --- | --- | --- |
| before any fix | 7 → 18 | 16 blank |
| refs fix only (`5f2d082`) | 7 → 33 | 1 real (`SC-015`) |
| both fixes | 7 → 7 | 1 advisory, 0 fix rounds |

Naming the criterion correctly gave the fixer a *precise but impossible* target, and it tried harder than sixteen unparseable blanks had provoked it to (+12, +8, +6 units per round). The fix is only complete once uncloseable criteria stop driving the loop at all.

## What was wrong

1. **SC refs read fields that don't exist.** `_run_decomposition` built `expected_sc_refs` from `sc.id` / `sc.description`; `SuccessCriterion` carries `text` / `checked`. Every criterion produced `""` — and a tuple of empty strings is *truthy*, so `validate_decomposition` treated it as authoritative and skipped its `SC-001..N` fallback. Validation therefore failed on **every refuel of any markdown flight plan**, burning the full 3-round fix budget on a gap no edit could close: ~33 minutes, 59% of the observed 55-minute run.
2. **Constraint criteria can never be traced.** `SC-015` is "total source lines stay at or below 500" — a quality gate over the finished codebase, not work any single unit carries. Untraced criteria now raise `SCTraceabilityError` (new, subclass of `SCCoverageError`) and `validate` treats it as advisory. Overloaded units keep raising the base class and keep failing hard, because splitting a unit is something the fixer genuinely can do.
3. **A failed briefing agent killed the run.** The contrarian returned `error_max_structured_output_retries` and took the refuel down after Navigator, Structuralist and Recon had all succeeded — 290 seconds of completed agent work discarded. Core Principle 3 says one agent failing must not crash the workflow, and every consumer already treats each brief as optional (`serialize_briefs_to_markdown` takes all four as `| None`).
4. **The cache couldn't help with the failure it most needed to.** `briefings.json` was written only by `synthesize_briefing`, downstream of the contrarian. A cache whose purpose is making failures cheap must persist before the next thing that can fail. **This one was mine** — I added the read side in #135 without noticing the writer sat behind the most likely failure.
5. **Split plan directories.** Refuel keyed its work-unit and cache dirs off the frontmatter `name:`, which the generator picks freely — a plan generated as `greet-cli` came back named `greet-cli-mvp`, so refuel's output landed in a second directory with no flight plan in it. Both now derive from the plan's own path.
6. **`sc_not_covered` logged at warning level** — 16 raw structlog rows on stderr per validation pass, interleaved with Rich output. It duplicated data already on the exception; now `debug`. (`5f2d082`'s message says these go to *stdout* and defers the fix. Both wrong — stderr, and fixed here in `ceff42a`.)
7. **Validation reported a gap count with no gap text.** Cost two live debugging sessions. Gaps are now named in the message.

## Advisory gaps get their own state slot

`untraced_criteria`, not `validation_warnings` — `request_fix` builds the fixer's prompt from the latter, and that is precisely the path by which an uncloseable criterion reached it.

## Verification

- `make ci`: **4451 passed, 1 xfailed, 85.57% coverage**.
- 15 new tests in `tests/unit/workflows/refuel_maverick/test_sc_refs.py`, each confirmed to fail against the pre-fix code (temporarily reverted, observed red, restored).
- **Verified live**, against the exact failure that killed the previous run: `briefings.json` written at the corrected path containing `['navigator','recon','structuralist']` *before* the contrarian ran, and the log line `∟ Briefing agent 'contrarian' failed; continuing without its brief:` — confirming 3, 4 and 5.
- **Not verified live:** the advisory-gap change (1 and 2). It has unit tests and a verified replay against the recorded artifacts from the live run — same decomposition, same `trace_ref`s, one advisory gap, zero fix rounds — but the confirming run was stopped before it reached validation. The 7-unit prediction in the table above is a replay result, not an end-to-end observation.

## Scope

All seven are confined to the legacy `refuel_maverick` path. The Spec Kit path (`refuel_speckit`) shares none of this code and is unaffected — it has never been validated end-to-end, which is filed as #168. Also filed from this walkthrough: #166 (contrarian structured-output flake), #167 (the fixer inventing units — the trigger is removed here, the behaviour is not, and it stays reachable via the overload and dangling-deps paths), #169.

Part of #135 (subtask 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSKj2NnUpCysHvK5ZGt7BA
