### PR TITLE
fix(speckit): four defects from the first live Spec Kit walkthrough + assumption harvest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,19 @@ jobs:
           sudo install -m 0755 /tmp/jj /usr/local/bin/jj
           jj --version
 
+      - name: Install ripgrep
+        # Spec Kit ingestion *generates* `rg --files -g '<path>'` verification
+        # commands that fly's AC check later executes, so rg is a de-facto
+        # runtime dependency of that path. One test runs an emitted command
+        # for real to prove the no-file-scope fallback is satisfiable — the
+        # defect that once drove the fixer to fabricate a file to match an
+        # unmatchable glob. It skips without rg, so CI must supply it or that
+        # regression could land green.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends ripgrep
+          rg --version
+
       - name: Run CI checks (lint, typecheck, test)
         run: make ci-coverage
 

--- a/src/maverick/cli/workflow_executor.py
+++ b/src/maverick/cli/workflow_executor.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 import click
 from rich.live import Live
+from rich.markup import escape
 from rich.spinner import Spinner
 from rich.table import Table
 
@@ -273,7 +274,7 @@ async def render_workflow_events(
             console_obj.print(f"  [green]✓[/] [bold]{event.name}[/]")
 
         elif isinstance(event, PreflightCheckFailed):
-            console_obj.print(f"  [red]✗[/] [bold]{event.name}[/]: {event.message}")
+            console_obj.print(f"  [red]✗[/] [bold]{event.name}[/]: {escape(event.message)}")
             if event.remediation:
                 console_obj.print(f"    [dim]Hint: {event.remediation}[/]")
 
@@ -333,7 +334,7 @@ async def render_workflow_events(
                 console_obj.print()
                 _agent_streaming = False
 
-            label = event.display_label or _current_label or _display_name(event.step_name)
+            label = escape(event.display_label or _current_label or _display_name(event.step_name))
             dur = f"{event.duration_ms / 1000:.2f}s"
             icon = "[green]✓[/]" if event.success else "[red]✗[/]"
 
@@ -346,7 +347,7 @@ async def render_workflow_events(
                 if _first_interim:
                     style = _level_styles.get("info", "[cyan]")
                     console_obj.print(f"  {style}∟[/] {_first_interim}")
-                console_obj.print(f"{icon} {label}: {event.error} [dim]({dur})[/]")
+                console_obj.print(f"{icon} {label}: {escape(event.error)} [dim]({dur})[/]")
             elif not _header_printed:
                 # No interims at all — just show the label
                 console_obj.print(f"{icon} {label} [dim]({dur})[/]")
@@ -392,10 +393,10 @@ async def render_workflow_events(
 
         elif isinstance(event, StepOutput):
             if _agent_tracker is not None and _agent_tracker.active:
-                _agent_tracker.add_message(event.message)
+                _agent_tracker.add_message(escape(event.message))
             elif not _header_printed and not _first_interim:
                 # Buffer first interim — enables collapsing for simple steps
-                _first_interim = event.message
+                _first_interim = escape(event.message)
             else:
                 # Check for progress-counter messages (e.g., "Detail 3/45 complete")
                 # and render as a single updating line instead of 45 separate lines.
@@ -436,7 +437,7 @@ async def render_workflow_events(
                         _first_interim = None
                     _ensure_header()
                     style = _level_styles.get(event.level, "[cyan]")
-                    console_obj.print(f"  {style}∟[/] {event.message}")
+                    console_obj.print(f"  {style}∟[/] {escape(event.message)}")
 
         elif isinstance(event, RollbackStarted):
             console_obj.print(f"[yellow]  ↩ Rolling back: {event.step_name}...[/]")
@@ -449,7 +450,7 @@ async def render_workflow_events(
                 console_obj.print(f"[red]  ✗ Rollback failed: {event.step_name}{error_detail}[/]")
 
         elif isinstance(event, LoopIterationStarted):
-            label = event.item_label or f"iteration {event.iteration_index + 1}"
+            label = escape(event.item_label or f"iteration {event.iteration_index + 1}")
             total = event.total_iterations
             idx = event.iteration_index + 1
             console_obj.print(f"\n[cyan]── [{idx}/{total}] {label} ──[/]")

--- a/src/maverick/speckit/build.py
+++ b/src/maverick/speckit/build.py
@@ -279,7 +279,13 @@ def _build_verification_lines(task: SpeckitTask, feature: SpeckitFeature) -> lis
         # Fallback: confirm the source feature directory itself exists —
         # a trivially-true but non-empty check (D8: never leave the AC-check
         # gate with nothing to run).
-        lines.append(f"rg --files -g '{feature.feature_name}'")
+        #
+        # The glob must name the directory's *contents*. Globbing the bare
+        # feature name matches nothing (no file is called "001-greet-cli";
+        # the directory is "specs/001-greet-cli/"), which turned this
+        # supposedly-trivial check into an AC gate no fix could close — and
+        # the fixer closed it by fabricating a file with that exact name.
+        lines.append(f"rg --files -g 'specs/{feature.feature_name}/*'")
     return lines
 
 

--- a/src/maverick/speckit/parser.py
+++ b/src/maverick/speckit/parser.py
@@ -60,8 +60,15 @@ def _extract_file_paths(text: str) -> tuple[str, ...]:
     """
     paths: list[str] = []
     for raw_tok in text.split():
-        tok = raw_tok.strip(".,;:()[]{}'\"")
+        tok = raw_tok.strip(".,;:()[]{}'\"`")
         if "/" not in tok:
+            continue
+        # Markup left *inside* the token means this was never one path --
+        # e.g. "`[tool.mypy]`/`[tool.ruff]`" is two inline code spans. Emitting
+        # it would produce a glob that cannot match, and an unmatchable
+        # verification command is what routes a task into an AC check no fix
+        # can close.
+        if any(ch in tok for ch in "`[]{}()"):
             continue
         if tok.endswith("/") or re.search(r"\.[A-Za-z0-9_]+$", tok):
             paths.append(tok)
@@ -190,6 +197,27 @@ def parse_tasks_md(
             continue
 
         if current_phase is None:
+            # A checkbox line carrying a real T### id outside every phase is
+            # lost work, not prose. Dropping it silently is how a stock
+            # "## Phase N: Polish" placeholder rendered as "## Final Phase:"
+            # discarded a feature's entire quality-gate task with no signal
+            # anywhere downstream. Free-form checkbox prose has no id and
+            # stays benign.
+            orphan_m = _TASK_LINE_RE.match(line)
+            if orphan_m:
+                raise SpeckitParseError(
+                    f"{file}:{line_number}: task {orphan_m.group(2)} appears outside "
+                    f"any phase section: {line!r}",
+                    file=file,
+                    line=line_number,
+                    expected="every task to sit under a '## Phase <n>' heading",
+                    suggestion=(
+                        "rename the enclosing heading to '## Phase <n>: <title>' "
+                        "(a numbered phase); headings such as '## Final Phase' or "
+                        "'## Phase N' are not recognised and would silently drop "
+                        "their tasks"
+                    ),
+                )
             continue
 
         stripped = line.strip()

--- a/src/maverick/workflows/spec_chain/clarify.py
+++ b/src/maverick/workflows/spec_chain/clarify.py
@@ -37,6 +37,7 @@ from maverick.workflows.spec_chain.models import ClarifyDecision
 __all__ = [
     "ESCALATION_SIGNALS",
     "assess_severity",
+    "assumptions_from_spec_md",
     "decisions_from_interception",
     "decisions_from_spec_md",
     "supports_interception",
@@ -62,6 +63,16 @@ ESCALATION_SIGNALS: dict[str, tuple[str, ...]] = {
 }
 
 _CLARIFICATION_BULLET_RE = re.compile(r"^-\s+Q:\s*(.+?)\s*\u2192\s*A:\s*(.+)$")
+
+#: ``## Assumptions`` opens the section; any other H2 closes it.
+_ASSUMPTIONS_HEADING_RE = re.compile(r"^##\s+Assumptions\s*$", re.IGNORECASE)
+_OTHER_H2_RE = re.compile(r"^##\s+")
+
+#: Spec Kit writes ``- **Topic**: decision``. The bold topic is optional —
+#: a plain ``- Topic: decision`` bullet carries the same information.
+_ASSUMPTION_BULLET_RE = re.compile(
+    r"^-\s+(?:\*\*(?P<bold>.+?)\*\*|(?P<plain>[^:]+?))\s*:\s*(?P<decision>.+)$"
+)
 
 
 def assess_severity(question: str) -> tuple[Severity, bool]:
@@ -154,6 +165,60 @@ def decisions_from_spec_md(spec_md_content: str) -> list[ClarifyDecision]:
                 severity=severity,
                 severity_defaulted=defaulted,
                 path="non_interactive",
+                ledger_bead_id=None,
+            )
+        )
+    return decisions
+
+
+def assumptions_from_spec_md(spec_md_content: str) -> list[ClarifyDecision]:
+    """Harvest ``## Assumptions`` — what specify decided without being asked.
+
+    Spec Kit's specify step resolves an underspecified PRD by *documenting
+    an assumption* rather than emitting ``[NEEDS CLARIFICATION]``. Those
+    entries are adopted answers in every sense the ledger cares about
+    (question, adopted answer, no human in the loop), but they are written
+    by a different step than clarify and in a different shape, so
+    :func:`decisions_from_spec_md` never sees them.
+
+    Leaving them unharvested means the land gate — whose whole purpose is
+    to make a human look at what was decided on their behalf — silently
+    skips the decisions with the widest blast radius, including "defer
+    this capability entirely".
+
+    Severity is assessed over the topic *and* the decision, because the
+    escalating signal usually lives in the answer ("out of scope for this
+    release"), not in the topic ("Retry budget").
+    """
+    decisions: list[ClarifyDecision] = []
+    in_section = False
+    for raw_line in spec_md_content.splitlines():
+        line = raw_line.rstrip()
+        if _ASSUMPTIONS_HEADING_RE.match(line):
+            in_section = True
+            continue
+        if in_section and _OTHER_H2_RE.match(line):
+            break
+        if not in_section:
+            continue
+
+        m = _ASSUMPTION_BULLET_RE.match(line.strip())
+        if not m:
+            continue
+        topic = (m.group("bold") or m.group("plain") or "").strip()
+        decision = m.group("decision").strip()
+        if not topic or not decision:
+            continue
+
+        severity, defaulted = assess_severity(f"{topic} {decision}")
+        decisions.append(
+            ClarifyDecision(
+                question=topic,
+                adopted_answer=decision,
+                alternatives=(),
+                severity=severity,
+                severity_defaulted=defaulted,
+                path="assumptions_section",
                 ledger_bead_id=None,
             )
         )

--- a/src/maverick/workflows/spec_chain/constants.py
+++ b/src/maverick/workflows/spec_chain/constants.py
@@ -18,6 +18,7 @@ __all__ = [
     "KEY_SOURCE_REF",
     "KEY_SPECKIT_FEATURE",
     "REMEDIATION_SOURCE_ANALYZE",
+    "SOURCE_REF_ASSUMPTIONS",
     "SOURCE_REF_CLARIFY",
     "SPEC_REMEDIATION_LABEL",
     "STEP_TIMEOUT_SECONDS",
@@ -73,6 +74,11 @@ KEY_SOURCE_REF = "source_ref"
 
 #: ``source_ref`` value stamped on clarify-derived ledger entries.
 SOURCE_REF_CLARIFY = "spec-chain:clarify"
+
+#: Provenance for entries harvested from specify's ``## Assumptions``
+#: section, distinct from clarify's own answers so a reviewer can tell
+#: "the model was asked and answered" from "the model decided unasked".
+SOURCE_REF_ASSUMPTIONS = "spec-chain:assumptions"
 
 # ---------------------------------------------------------------------------
 # Timeouts

--- a/src/maverick/workflows/spec_chain/models.py
+++ b/src/maverick/workflows/spec_chain/models.py
@@ -97,7 +97,7 @@ class ClarifyDecision:
     alternatives: tuple[str, ...]
     severity: Severity
     severity_defaulted: bool
-    path: Literal["interception", "non_interactive"]
+    path: Literal["interception", "non_interactive", "assumptions_section"]
     ledger_bead_id: str | None = None
 
 

--- a/src/maverick/workflows/spec_chain/workflow.py
+++ b/src/maverick/workflows/spec_chain/workflow.py
@@ -37,9 +37,13 @@ from maverick.logging import get_logger
 from maverick.payloads import AssumptionPayload
 from maverick.squadron.spec_chain import SpecChainSquadron
 from maverick.workflows.base import PythonWorkflow
-from maverick.workflows.spec_chain.clarify import decisions_from_spec_md
+from maverick.workflows.spec_chain.clarify import (
+    assumptions_from_spec_md,
+    decisions_from_spec_md,
+)
 from maverick.workflows.spec_chain.constants import (
     CHAIN_STEP_ORDER,
+    SOURCE_REF_ASSUMPTIONS,
     SOURCE_REF_CLARIFY,
     ChainStep,
 )
@@ -624,7 +628,19 @@ class SpecChainWorkflow(PythonWorkflow):
         if not spec_md_path.is_file():
             return state
         spec_content = await _read_text(spec_md_path)
+        # Two sources, one ledger. `## Clarifications` holds what clarify was
+        # asked and answered; `## Assumptions` holds what specify decided
+        # unasked. Both are adopted answers with no human in the loop, so both
+        # belong in front of the land gate. Clarify wins a tie: if the same
+        # topic appears in both, its bullet is the more deliberate record.
         parsed_decisions = decisions_from_spec_md(spec_content)
+        seen = {_normalize_question(d.question) for d in parsed_decisions}
+        assumption_decisions = [
+            d
+            for d in assumptions_from_spec_md(spec_content)
+            if _normalize_question(d.question) not in seen
+        ]
+        parsed_decisions.extend(assumption_decisions)
         if not parsed_decisions:
             return state
 
@@ -643,7 +659,11 @@ class SpecChainWorkflow(PythonWorkflow):
                     bead_client,
                     payload=payload,
                     owner_spec=feature_dir_name,
-                    source_ref=SOURCE_REF_CLARIFY,
+                    source_ref=(
+                        SOURCE_REF_ASSUMPTIONS
+                        if decision.path == "assumptions_section"
+                        else SOURCE_REF_CLARIFY
+                    ),
                 )
             except Exception as exc:  # noqa: BLE001 — one bad entry must not sink clarify
                 logger.warning(

--- a/tests/unit/cli/test_workflow_executor.py
+++ b/tests/unit/cli/test_workflow_executor.py
@@ -80,3 +80,47 @@ class TestExecutePythonWorkflow:
 
         assert RecordingWorkflow.last_workflow_name == WORKFLOW_NAME
         mock_render.assert_awaited_once()
+
+
+class TestStepOutputMarkupSafety:
+    """Workflow text is data, not Rich markup.
+
+    Regression for the first live Spec Kit walkthrough: a Spec Kit task
+    description mentioning ``[project.scripts]`` and ``[tool.mypy]`` had
+    those tokens silently eaten by Rich's markup parser on the way to the
+    terminal, and a description containing ``[/]`` raises ``MarkupError``
+    outright. Neither is markup the workflow authored -- both come from a
+    file Maverick parsed.
+    """
+
+    @staticmethod
+    async def _render(messages: list[str]) -> str:
+        import io
+
+        from rich.console import Console
+
+        from maverick.cli.workflow_executor import render_workflow_events
+        from maverick.events import StepOutput
+
+        async def _events() -> AsyncIterator[Any]:
+            for msg in messages:
+                yield StepOutput(step_name="create_beads", message=msg)
+
+        buf = io.StringIO()
+        await render_workflow_events(_events(), Console(file=buf, width=200, no_color=True))
+        return buf.getvalue()
+
+    async def test_bracketed_tokens_survive_rendering(self) -> None:
+        out = await self._render(
+            [
+                "first interim",
+                "T001: create `[project.scripts]` and `[tool.mypy]`/`[tool.ruff]` sections",
+            ]
+        )
+        assert "[project.scripts]" in out
+        assert "[tool.mypy]" in out
+        assert "[tool.ruff]" in out
+
+    async def test_closing_tag_in_message_does_not_raise(self) -> None:
+        out = await self._render(["first interim", "T002: handle the `[/]` route"])
+        assert "[/]" in out

--- a/tests/unit/speckit/test_build_plan.py
+++ b/tests/unit/speckit/test_build_plan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -255,8 +256,15 @@ class TestVerificationFallback:
         )
         assert any("specs/001-greet-cli/" in ln for ln in lines), lines
 
+    @pytest.mark.skipif(shutil.which("rg") is None, reason="requires ripgrep on PATH")
     def test_fallback_actually_matches_on_a_real_tree(self, tmp_path: Path) -> None:
-        """Run the emitted command for real -- the point is that it passes."""
+        """Run the emitted command for real -- the point is that it passes.
+
+        Guarded rather than reimplemented: asserting against our own glob
+        expansion would test a copy of the thing under test, and the whole
+        defect was that a command nobody executed could not match. CI installs
+        ripgrep so this runs there; the skip is for contributors without it.
+        """
         import shlex
         import subprocess
 

--- a/tests/unit/speckit/test_build_plan.py
+++ b/tests/unit/speckit/test_build_plan.py
@@ -208,3 +208,65 @@ class TestValidationBeforeWrite:
         )
         _plan, warnings = build_ingestion_plan(feature)
         assert any("Success Criteria" in w for w in warnings)
+
+
+class TestVerificationFallback:
+    """The no-file-scope fallback must be a check a fix can actually close.
+
+    Regression for the first live walkthrough: a task with no extractable
+    file paths got ``rg --files -g '<feature_name>'``. ``build.py`` calls
+    that "trivially-true", but nothing in a repository is *named*
+    ``001-greet-cli`` -- the directory is ``specs/001-greet-cli/``. The
+    check therefore always failed, routed the bead into an AC fix round no
+    edit could close, and the fixer satisfied it by fabricating and
+    committing a junk file named ``specs/001-greet-cli/001-greet-cli``.
+    """
+
+    TASKS = """\
+## Phase 1: Setup
+
+- [ ] T001 Draft the rollout narrative for stakeholders
+"""
+
+    SPEC = """\
+# Feature Specification: Greet
+
+## Success Criteria
+
+- **SC-001**: It works.
+"""
+
+    def _verification_lines(self, tmp_path: Path) -> list[str]:
+        feature_dir = tmp_path / "specs" / "001-greet-cli"
+        feature_dir.mkdir(parents=True)
+        feature = _feature_from_fixture(feature_dir, self.TASKS, self.SPEC)
+        plan, _ = build_ingestion_plan(feature)
+        body = plan.new_tasks[0].definition.description
+        section = body.split("## Verification", 1)[1]
+        return [
+            ln.strip("- ").strip() for ln in section.splitlines() if ln.strip().startswith("-")
+        ]
+
+    def test_fallback_targets_the_feature_directory_not_a_bare_name(self, tmp_path: Path) -> None:
+        lines = self._verification_lines(tmp_path)
+        assert lines, "the AC gate must never be left with nothing to run"
+        assert "rg --files -g '001-greet-cli'" not in lines, (
+            "a bare feature name matches no file; this check can never pass"
+        )
+        assert any("specs/001-greet-cli/" in ln for ln in lines), lines
+
+    def test_fallback_actually_matches_on_a_real_tree(self, tmp_path: Path) -> None:
+        """Run the emitted command for real -- the point is that it passes."""
+        import shlex
+        import subprocess
+
+        feature_dir = tmp_path / "specs" / "001-greet-cli"
+        lines = self._verification_lines(tmp_path)
+        (feature_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
+        (feature_dir / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
+
+        proc = subprocess.run(shlex.split(lines[0]), cwd=tmp_path, capture_output=True, text=True)
+        assert proc.stdout.strip(), (
+            f"fallback {lines[0]!r} matched nothing in {tmp_path}; "
+            "an unmatchable check is an AC gate no fix can close"
+        )

--- a/tests/unit/speckit/test_parser_tasks.py
+++ b/tests/unit/speckit/test_parser_tasks.py
@@ -62,6 +62,41 @@ class TestHappyPath:
         assert "tests/test_feature_a.py" in by_id["T007"].file_paths
         assert by_id["T001"].file_paths == ()
 
+    def test_backtick_wrapped_paths_extracted(self) -> None:
+        """Spec Kit writes every path in backticks -- the common real shape.
+
+        Regression for the first live walkthrough: 26 of 28 generated tasks
+        extracted zero paths because ``_extract_file_paths`` stripped
+        ``.,;:()[]{}'"`` but not backticks. Empty file scope then routed
+        every task into ``_build_verification_lines``' fallback glob.
+        """
+        content = """\
+## Phase 1: Setup
+
+- [ ] T001 Create `src/greet/renderers/__init__.py` to establish the sub-package
+- [ ] T002 Update `get_console()` in `src/greet/output.py` and `src/greet/core.py`
+"""
+        phases, _ = parse_tasks_md(content)
+        by_id = {t.task_id: t for phase in phases for t in phase.tasks}
+        assert by_id["T001"].file_paths == ("src/greet/renderers/__init__.py",)
+        assert by_id["T002"].file_paths == ("src/greet/output.py", "src/greet/core.py")
+
+    def test_adjacent_inline_code_spans_are_not_a_path(self) -> None:
+        """``\\`[tool.mypy]\\`/\\`[tool.ruff]\\``` is two code spans, not a path.
+
+        Stripping only the outer delimiters leaves markup characters inside
+        the token; emitting it as a file path yields a glob that can never
+        match, which is what routes a task into an uncloseable AC check.
+        """
+        content = """\
+## Phase 1: Setup
+
+- [ ] T001 Create `pyproject.toml` with `[tool.mypy]`/`[tool.ruff]` sections
+"""
+        phases, _ = parse_tasks_md(content)
+        paths = phases[0].tasks[0].file_paths
+        assert paths == (), f"expected no path tokens, got {paths!r}"
+
     def test_fenced_code_block_is_skipped(self, full_tasks_md: str) -> None:
         phases, _ = parse_tasks_md(full_tasks_md)
         all_ids = {t.task_id for phase in phases for t in phase.tasks}
@@ -147,6 +182,57 @@ more prose
         phases, _ = parse_tasks_md(content)
         assert phases[0].tasks == ()
         assert phases[1].tasks[0].task_id == "T001"
+
+
+class TestOrphanedTasks:
+    """A real T### task outside any phase must never be discarded silently.
+
+    Regression for the first live Spec Kit walkthrough: ``/speckit.tasks``
+    rendered the stock template's ``## Phase N: Polish & Cross-Cutting
+    Concerns`` placeholder as ``## Final Phase: ...``. That heading misses
+    :data:`_PHASE_HEADING_RE`, so the three tasks beneath it were dropped
+    with no error anywhere in the pipeline -- including the only task that
+    ran the quality gates.
+    """
+
+    FINAL_PHASE = """\
+## Phase 1: Setup
+
+- [ ] T001 Do a thing
+
+## Final Phase: Polish & Cross-Cutting Concerns
+
+- [ ] T026 [P] Add a fallback in `src/greet/output.py`
+- [ ] T028 Run full quality gate suite
+"""
+
+    def test_task_under_unrecognized_phase_heading_is_not_dropped(self) -> None:
+        with pytest.raises(SpeckitParseError):
+            parse_tasks_md(self.FINAL_PHASE, file="tasks.md")
+
+    def test_orphan_error_names_the_lost_task_and_its_line(self) -> None:
+        with pytest.raises(SpeckitParseError) as exc_info:
+            parse_tasks_md(self.FINAL_PHASE, file="tasks.md")
+        err = exc_info.value
+        assert "T026" in str(err), "the error must name the task that would be lost"
+        assert err.file == "tasks.md"
+        assert err.line == 7
+        assert err.suggestion
+
+    def test_checkbox_prose_outside_a_phase_is_still_ignored(self) -> None:
+        """Free-form checkbox lines carry no task ID and must stay benign."""
+        content = """\
+## Phase 1: Setup
+
+- [ ] T001 Do a thing
+
+## Notes
+
+- [ ] this is prose, not a task
+"""
+        phases, _ = parse_tasks_md(content)
+        assert [p.number for p in phases] == [1]
+        assert phases[0].tasks[0].task_id == "T001"
 
 
 class TestHardErrors:

--- a/tests/unit/workflows/spec_chain/test_clarify.py
+++ b/tests/unit/workflows/spec_chain/test_clarify.py
@@ -186,3 +186,79 @@ class TestDecisionsFromSpecMd:
         decisions = decisions_from_spec_md(content)
         assert decisions[0].severity is Severity.LOW
         assert decisions[0].severity_defaulted is True
+
+
+class TestAssumptionsFromSpecMd:
+    """`## Assumptions` is where specify records what it decided unasked.
+
+    From the first live Spec Kit walkthrough: specify resolved all three of
+    the PRD's explicit Open Questions into this section and emitted zero
+    `[NEEDS CLARIFICATION]` markers, so clarify had nothing left to ask.
+    Six adopted decisions -- including "defer this feature entirely" --
+    reached no ledger entry and therefore never reached the land gate.
+    """
+
+    LIVE = """\
+# Feature Specification: Greet CLI
+
+## Clarifications
+
+### Session 2026-07-27
+
+- Q: What is the minimum supported Python version? → A: Python 3.10+.
+
+## Assumptions
+
+- **`--random` behavior**: Selects exactly one language per invocation.
+- **Grid/all-at-once layout**: Deferred entirely; output is always sequential.
+- **RTL language rendering**: Banner rendered left-to-right; no bidi reflow.
+
+## Success Criteria
+
+- **SC-001**: A user sees output within 60 seconds.
+"""
+
+    def test_parses_each_assumption_bullet(self) -> None:
+        from maverick.workflows.spec_chain.clarify import assumptions_from_spec_md
+
+        decisions = assumptions_from_spec_md(self.LIVE)
+        assert [d.question for d in decisions] == [
+            "`--random` behavior",
+            "Grid/all-at-once layout",
+            "RTL language rendering",
+        ]
+        assert decisions[1].adopted_answer.startswith("Deferred entirely")
+
+    def test_section_ends_at_the_next_heading(self) -> None:
+        """SC-001 lives under Success Criteria and is not an assumption."""
+        from maverick.workflows.spec_chain.clarify import assumptions_from_spec_md
+
+        decisions = assumptions_from_spec_md(self.LIVE)
+        assert all("SC-001" not in d.question for d in decisions)
+        assert len(decisions) == 3
+
+    def test_clarification_bullets_are_not_assumptions(self) -> None:
+        from maverick.workflows.spec_chain.clarify import assumptions_from_spec_md
+
+        decisions = assumptions_from_spec_md(self.LIVE)
+        assert all("minimum supported Python" not in d.question for d in decisions)
+
+    def test_path_records_how_the_decision_was_captured(self) -> None:
+        from maverick.workflows.spec_chain.clarify import assumptions_from_spec_md
+
+        decisions = assumptions_from_spec_md(self.LIVE)
+        assert {d.path for d in decisions} == {"assumptions_section"}
+
+    def test_severity_assessed_over_question_and_answer(self) -> None:
+        """A scope signal in the *decision* must escalate, not just in the topic."""
+        from maverick.workflows.spec_chain.clarify import assumptions_from_spec_md
+
+        content = "## Assumptions\n\n- **Retry budget**: Out of scope for this release.\n"
+        decisions = assumptions_from_spec_md(content)
+        assert decisions[0].severity is Severity.MEDIUM
+        assert decisions[0].severity_defaulted is False
+
+    def test_no_assumptions_section_yields_nothing(self) -> None:
+        from maverick.workflows.spec_chain.clarify import assumptions_from_spec_md
+
+        assert assumptions_from_spec_md("# Spec\n\n## Requirements\n\n- FR-001\n") == []


### PR DESCRIPTION
First end-to-end run of the path the constitution now calls default (#168): PRD → `maverick spec` → `refuel --speckit` → `fly` → `land`, against `sample-maverick-project`. Four defects, all reachable on an ordinary run of a stock Spec Kit repo, plus the assumption-harvest gap the run exposed.

## The chain that matters

Three of the four defects are one causal chain, and it ends somewhere I did not expect:

`_extract_file_paths` strips `` .,;:()[]{}'" `` but **not backticks** — and Spec Kit writes every path in backticks. So **26 of 28 generated tasks (93%) extracted zero file paths**. Empty file scope falls through to `_build_verification_lines`' fallback, `rg --files -g '<feature_name>'`, which `build.py` calls *"trivially-true"*. It is reliably **false**: nothing is *named* `001-greet-cli`; the directory is `specs/001-greet-cli/`. The check therefore always failed and routed the bead into an AC-check fix round no edit could close.

The fixer closed it by **fabricating `specs/001-greet-cli/001-greet-cli`** — a file no task asked for, not part of the Spec Kit contract, invented purely to make a glob match — and it was **committed into the T003 bead commit**. It then made the check pass for the remaining 25 tasks, so the defect concealed itself after the first bead. Observed cost before it went quiet: **320s of agent time on bead 1**.

The agent's own ledger entry from that fix round reads:

> *"Where should the file named `001-greet-cli` live?"*

This is constitution Guardrail X.10 — *"Validation MUST NOT fail on conditions no fix can close"* — reappearing on the Spec Kit path. The classic path made the fixer invent work units (`44cfa4e`); this one makes it invent files.

## Silent task loss

`/speckit.tasks` rendered the stock template's `## Phase N: Polish & Cross-Cutting Concerns` placeholder as `## Final Phase: …`. That misses `_PHASE_HEADING_RE`, so `_OTHER_H2_RE` closed the phase and the tasks beneath it hit the `current_phase is None` guard at `parser.py:192` — which sits **before** the malformed-line raise at `:203`. That ordering is what made the loss silent.

**3 of 28 tasks (11%) discarded, including T028 — the only task that ran the quality gates.** `--dry-run` printed 25 tasks and looked entirely healthy; there was no signal anywhere downstream.

A task id outside every phase now raises and names it. Checkbox *prose* outside a phase still parses as before — that distinction is the fix boundary, and the pre-existing test for it still passes.

## Rich markup ate workflow text

Task descriptions reached the console unescaped, so `[project.scripts]` and `[tool.mypy]` were silently stripped from progress output, and a description containing `[/]` raises `MarkupError` outright. Both come from a file Maverick parsed, not markup any workflow authored. Escaped at every render point — messages, errors, step labels, and the `fly` per-bead loop header, which carries bead titles. No emitter embeds intentional markup, so the escape is total. Stored bead titles were never affected; this was display-only.

## Assumption harvest

The ledger exists so a human sees what the machine decided on their behalf before landing. It was seeing a third of it.

Specify resolves an underspecified PRD by *documenting an assumption* rather than emitting `[NEEDS CLARIFICATION]`. Those are adopted answers in every sense the ledger cares about, but they live in `## Assumptions` — a different step, a different shape — so `decisions_from_spec_md` never saw them.

Live: specify emitted **zero** `[NEEDS CLARIFICATION]` markers and resolved all three of the PRD's explicit Open Questions into `## Assumptions`. Three decisions reached the land gate; seven did not, including **"Grid/all-at-once layout: Deferred entirely"** — a decision to drop a requested capability. Against that same spec.md this takes the gate from **3 entries to 10**.

Severity is assessed over topic *and* decision, since the escalating signal usually sits in the answer. A distinct `SOURCE_REF_ASSUMPTIONS` stamp lets a reviewer tell "the model was asked and answered" from "the model decided unasked".

**Known gap, deliberately left:** every harvested entry lands `low`, including that deferral, because `ESCALATION_SIGNALS["scope"]` has no `defer` keyword. Adding one changes clarify's severities too — a product call, not a drive-by.

## What the walkthrough validated

Worth recording, since none of it had run live before: hidden-workspace cwd binding (workspace gets `specs/` first, checkout follows via landing — confirmed by ordering), per-step landing, checkpointing, clarify's non-interactive convention, analyze → 15 remediation beads, deterministic ingest (28 tasks, 51 edges, correct phase barrier), remediation adoption, no-op re-run idempotence, and `fly`'s full implement → gate-fix → AC-fix → review → commit cycle with correct `bead(<id>):` subjects and `Bead:` trailers.

Two predictions in the plan were **wrong** and are worth correcting: the clarify interactive-stall predicted as the primary finding did not reproduce (it filed 3 entries correctly), and the cwd-binding risk was over-weighted — airframe's Claude adapter builds its client inside `execute()`, within the `os.chdir` window.

## Verification

- `make ci`: **4466 passed, 1 xfailed**.
- Every test was written first and **observed failing against the unfixed code**, per Principle V. The `build.py` fallback test *executes the emitted `rg` command* rather than asserting on a copy of the string.
- Defects 1–3 were caught by a pre-ingest gate running the real parser against the generated `tasks.md` before any bead was written; defect 3's full consequence was observed live during `fly`.
- One CI run flaked on `test_full_provenance_round_trip_report` (`@pytest.mark.timeout(60)`, 21.8s in isolation — load-sensitive). It imports nothing this PR touches; green on re-run. Its cost is `bd` subprocess time, which is the subject of the next item.

## Not in this PR

Filed as follow-ups rather than fixed here:

- **The spec-chain jj workspace is never torn down.** It leaks *permanently, one per feature ever specced* — `prepare_workspace(reuse=False)` only wipes on the next run of the same feature, and a completed feature can never be re-run (collision check). Each leaves a stray anonymous head in the user's own `jj log`.
- **`bd set-state` is a state-machine primitive used for immutable provenance** — an event bead recording "T001 became T001". 160 event beads for ~50 real ones this run. `bd create -l 'key:value,…'` produces identical labels in one subprocess with no event bead, and `BeadClient.show` already reads them back.
- **The phase barrier is a full cross-product** (`S×R` per boundary): 28 tasks → 51 edges, but a 136-task spec → ~688, each its own subprocess. Ingestion now exceeds its own SC-001 30s bound.

Part of #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSKj2NnUpCysHvK5ZGt7BA
