### PR TITLE
feat(spec-chain): tear down completed workspaces, sweep abandoned ones

### DIFF
--- a/docs/bead-cost-and-workspace-plan.md
+++ b/docs/bead-cost-and-workspace-plan.md
@@ -1,7 +1,7 @@
 # Workspace leaks, event-bead bloat, and write amplification — plan
 
 **Audience:** Maverick maintainers; the implementation plan for the three cost defects filed from the first live Spec Kit walkthrough.
-**Status:** Proposed. Not yet implemented. Supersedes the "Not in this PR" section of #175.
+**Status:** In progress — PR 1 done (#177), PRs 2 and 3 not started. Supersedes the "Not in this PR" section of #175.
 **Date:** 2026-07-27.
 **Author:** derived from the live walkthrough of `spec → refuel --speckit → fly → land` against `sample-maverick-project` (#168).
 
@@ -69,7 +69,22 @@ could not be proven read-only. **Verify before writing any translator code** —
 throwaway `bd init` directory, run a two-node plan and confirm both the `ids` map and that
 `bd dep tree` shows `a` blocking `b`, not the reverse.
 
-## PR 1 — Workspace teardown and sweep
+## PR 1 — Workspace teardown and sweep — **DONE (#177)**
+
+Landed as planned. Two things worth recording for PRs 2 and 3:
+
+- **`jj op restore` reverts more than the rollback section assumed.** During the sample
+  project cleanup it un-did a `mv` of `.maverick/plans/greet-cli` on its own, because that
+  directory was a *tracked* working-copy addition rather than an ignored file. The manual
+  un-park step in [Verification](#verification) is unnecessary. What it does *not* touch
+  held exactly as written: gitignored files, `.maverick/runs/`, and `.beads/embeddeddolt/`
+  all needed removing or restoring by hand.
+- **One existing test had to be rewritten rather than deleted.**
+  `test_deleted_workspace_is_reseeded_from_checkout` asserted on workspace contents *after*
+  a completed run — precisely what teardown removes. Its intent stayed valid, so it now
+  observes during the `tasks` step. Expect the same shape in PR 2, where
+  `TestMidCreationFailure` asserts partial-bead semantics that atomic graph creation
+  eliminates.
 
 Self-contained; no bd involvement.
 

--- a/src/maverick/workflows/spec_chain/state.py
+++ b/src/maverick/workflows/spec_chain/state.py
@@ -15,7 +15,12 @@ from maverick.logging import get_logger
 from maverick.utils.atomic import atomic_write_text
 from maverick.workflows.spec_chain.models import ChainState
 
-__all__ = ["discover_resumable", "load_chain_state", "save_chain_state"]
+__all__ = [
+    "discover_resumable",
+    "load_chain_state",
+    "resumable_features",
+    "save_chain_state",
+]
 
 logger = get_logger(__name__)
 
@@ -55,25 +60,53 @@ async def discover_resumable(feature: str, base: Path) -> ChainState | None:
     ``feature == feature`` and ``status in {"halted", "running"}``.
     Corrupt or unparseable sibling state files are skipped, not fatal.
     """
+    candidates = [
+        state
+        for state in await _load_all_states(base)
+        if state.feature == feature and state.status in _RESUMABLE_STATUSES
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda s: s.updated_at)
+
+
+async def resumable_features(base: Path) -> set[str]:
+    """Every feature under *base* with a halted or still-running chain.
+
+    The complement of this set is safe to collect: a completed chain's hidden
+    workspace cannot be resumed at all (re-running the feature hits the CLI's
+    spec-dir collision check), so nothing durable is lost by removing it.
+    Shares :func:`_load_all_states` with :func:`discover_resumable` so the two
+    can never disagree about what "resumable" means — they gate the same
+    decision from opposite directions.
+    """
+    return {
+        state.feature
+        for state in await _load_all_states(base)
+        if state.status in _RESUMABLE_STATUSES
+    }
+
+
+async def _load_all_states(base: Path) -> list[ChainState]:
+    """Parse every readable ``.maverick/runs/*/spec-chain.json`` under *base*.
+
+    Corrupt or unparseable siblings are skipped, not fatal — one bad file
+    must not hide every other run's state.
+    """
     runs_dir = base / _RUNS_SUBDIR
     if not await asyncio.to_thread(runs_dir.is_dir):
-        return None
+        return []
 
     run_dirs = await asyncio.to_thread(lambda: list(runs_dir.iterdir()))
-    candidates: list[ChainState] = []
+    states: list[ChainState] = []
     for run_dir in run_dirs:
         state_path = run_dir / _STATE_FILENAME
         if not await asyncio.to_thread(state_path.is_file):
             continue
         try:
             text = await asyncio.to_thread(state_path.read_text, encoding="utf-8")
-            state = ChainState.model_validate(json.loads(text))
+            states.append(ChainState.model_validate(json.loads(text)))
         except Exception as exc:
             logger.debug("spec_chain_state_unreadable", path=str(state_path), error=str(exc))
             continue
-        if state.feature == feature and state.status in _RESUMABLE_STATUSES:
-            candidates.append(state)
-
-    if not candidates:
-        return None
-    return max(candidates, key=lambda s: s.updated_at)
+    return states

--- a/src/maverick/workflows/spec_chain/workflow.py
+++ b/src/maverick/workflows/spec_chain/workflow.py
@@ -62,9 +62,17 @@ from maverick.workflows.spec_chain.models import (
     StepStatus,
     is_valid_feature_slug,
 )
-from maverick.workflows.spec_chain.state import load_chain_state, save_chain_state
+from maverick.workflows.spec_chain.state import (
+    load_chain_state,
+    resumable_features,
+    save_chain_state,
+)
 from maverick.workflows.spec_chain.steps import build_step_prompt
-from maverick.workspace.spec_chain import prepare_workspace
+from maverick.workspace.spec_chain import (
+    prepare_workspace,
+    sweep_stale_workspaces,
+    teardown_workspace,
+)
 
 __all__ = ["WORKFLOW_NAME", "SpecChainWorkflow"]
 
@@ -287,9 +295,43 @@ class SpecChainWorkflow(PythonWorkflow):
         if state.status == "running":
             state = state.model_copy(update={"status": "completed", "updated_at": _utcnow()})
             await save_chain_state(state, cwd)
+            # Completed only. A halted or interrupted chain keeps its
+            # workspace: it holds the failing step's partial output, and
+            # resume reuses it. A completed chain's cannot even be resumed —
+            # re-running the feature hits the CLI's spec-dir collision check —
+            # so it is pure garbage, and left alone it would strand a stray
+            # anonymous head in the user's own commit graph forever.
+            # Checkpointed first: cleanup is best-effort and must never be
+            # able to lose the record that the chain finished.
+            await teardown_workspace(
+                cwd=cwd, feature=feature, jj_client=JjClient(cwd=cwd), home=home
+            )
 
         logger.info("spec_chain_finished", run_id=run_id, feature=feature, status=state.status)
         return _build_report(state).to_dict()
+
+    async def _sweep_stale_workspaces(
+        self, *, cwd: Path, feature: str, jj_client: JjClient, home: Path | None
+    ) -> None:
+        """Collect workspaces left behind by chains that never completed.
+
+        Teardown-on-completion never fires for a chain the user abandoned
+        with Ctrl-C, which is the realistic leak, so the sweep is what
+        actually bounds growth.
+
+        The keep-set is this layer's policy call, which is why it is computed
+        here rather than inside ``workspace/``: resumability is a property of
+        ``.maverick/runs`` state, not of the filesystem. *feature* is always
+        kept — on a fresh run ``prepare_workspace`` is about to recreate it,
+        on a resume it is in active use.
+        """
+        try:
+            keep = await resumable_features(cwd)
+        except Exception as exc:  # noqa: BLE001 — never block a run on cleanup
+            logger.warning("spec_chain_workspace_sweep_skipped", error=str(exc))
+            return
+        keep.add(feature)
+        await sweep_stale_workspaces(cwd=cwd, jj_client=jj_client, keep=keep, home=home)
 
     async def _start_fresh(
         self,
@@ -306,6 +348,9 @@ class SpecChainWorkflow(PythonWorkflow):
         prd_digest = hashlib.sha256(prd_content.encode("utf-8")).hexdigest()
 
         jj_client = JjClient(cwd=cwd)
+        await self._sweep_stale_workspaces(
+            cwd=cwd, feature=feature, jj_client=jj_client, home=home
+        )
         workspace_path = await prepare_workspace(
             cwd=cwd,
             feature=feature,
@@ -366,6 +411,9 @@ class SpecChainWorkflow(PythonWorkflow):
                 )
 
         jj_client = JjClient(cwd=cwd)
+        await self._sweep_stale_workspaces(
+            cwd=cwd, feature=feature, jj_client=jj_client, home=home
+        )
         workspace_path = await prepare_workspace(
             cwd=cwd,
             feature=feature,

--- a/src/maverick/workspace/spec_chain.py
+++ b/src/maverick/workspace/spec_chain.py
@@ -12,6 +12,7 @@ See specs/050-headless-spec-chain/research.md R3.
 from __future__ import annotations
 
 import shutil
+from collections.abc import Container
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -21,13 +22,17 @@ from maverick.logging import get_logger
 if TYPE_CHECKING:
     from maverick.jj.client import JjClient
 
-__all__ = ["prepare_workspace"]
+__all__ = ["prepare_workspace", "sweep_stale_workspaces", "teardown_workspace"]
 
 logger = get_logger(__name__)
 
 
+def _workspace_root(*, home: Path, cwd: Path) -> Path:
+    return home / ".maverick" / "workspaces" / cwd.name / "spec-chain"
+
+
 def _workspace_dir(*, home: Path, cwd: Path, feature: str) -> Path:
-    return home / ".maverick" / "workspaces" / cwd.name / "spec-chain" / feature
+    return _workspace_root(home=home, cwd=cwd) / feature
 
 
 async def prepare_workspace(
@@ -100,3 +105,108 @@ async def prepare_workspace(
         reused=reuse and workspace_dir.exists(),
     )
     return workspace_dir
+
+
+async def teardown_workspace(
+    *,
+    cwd: Path,
+    feature: str,
+    jj_client: JjClient,
+    home: Path | None = None,
+) -> None:
+    """Un-register and delete *feature*'s hidden workspace.
+
+    Safe by construction: the workspace holds nothing durable. Landing copies
+    workspace -> checkout after every step, nothing is ever committed inside
+    it, and ``_reseed_workspace_from_checkout`` rebuilds a fresh one from the
+    checkout on resume. Resume depends on the checkpoint and the landed
+    artifacts, never on this directory surviving.
+
+    Call only for a *completed* chain. A halted or interrupted one keeps its
+    workspace: it is the only copy of the failing step's partial output, and
+    resume reuses it.
+
+    ``workspace_forget`` must precede the removal. Deleting the directory
+    first leaves jj still tracking the name — which both blocks a later
+    ``workspace_add`` and strands the workspace's working-copy commit as an
+    anonymous head in the *user's* commit graph, visible in their ``jj log``
+    forever.
+
+    Best-effort throughout: every failure is logged and swallowed. A chain
+    that did all five steps must not be reported as failed because cleanup
+    could not finish.
+
+    Args:
+        cwd: The user's checkout — names the per-project workspace root.
+        feature: Feature slug; also the jj workspace name.
+        jj_client: Injected :class:`JjClient` bound to *cwd*.
+        home: Override for ``~`` (tests only).
+    """
+    home = home or Path.home()
+    workspace_dir = _workspace_dir(home=home, cwd=cwd, feature=feature)
+
+    try:
+        await jj_client.workspace_forget(workspace_dir.name)
+    except Exception as exc:  # noqa: BLE001 — cleanup must never sink a completed chain
+        logger.debug(
+            "spec_chain_workspace_forget_failed",
+            workspace=str(workspace_dir),
+            error=str(exc),
+        )
+
+    try:
+        if workspace_dir.exists():
+            shutil.rmtree(workspace_dir)
+    except OSError as exc:
+        logger.warning(
+            "spec_chain_workspace_remove_failed",
+            workspace=str(workspace_dir),
+            error=str(exc),
+        )
+        return
+
+    logger.info("spec_chain_workspace_torn_down", feature=feature, workspace=str(workspace_dir))
+
+
+async def sweep_stale_workspaces(
+    *,
+    cwd: Path,
+    jj_client: JjClient,
+    keep: Container[str],
+    home: Path | None = None,
+) -> None:
+    """Collect this project's workspaces whose features are not in *keep*.
+
+    Teardown-on-completion alone does not bound growth: it never fires for a
+    chain the user abandoned with Ctrl-C, which is the realistic leak. This
+    sweeps whatever is left over from previous runs.
+
+    Scoped to *cwd*'s own workspace root — another checkout's workspaces are
+    not ours to collect, and their resumable state lives in a different
+    ``.maverick/runs``.
+
+    Args:
+        cwd: The user's checkout — names the per-project workspace root.
+        jj_client: Injected :class:`JjClient` bound to *cwd*.
+        keep: Feature names to preserve. The caller owns this policy; pass
+            ``state.resumable_features(cwd)`` plus whatever the current run
+            is about to use.
+        home: Override for ``~`` (tests only).
+    """
+    home = home or Path.home()
+    root = _workspace_root(home=home, cwd=cwd)
+    if not root.is_dir():
+        return
+
+    try:
+        entries = sorted(p for p in root.iterdir() if p.is_dir())
+    except OSError as exc:
+        logger.warning("spec_chain_workspace_sweep_unreadable", root=str(root), error=str(exc))
+        return
+
+    for entry in entries:
+        if entry.name in keep:
+            continue
+        # Per-entry isolation: one undeletable workspace must not strand
+        # every later one.
+        await teardown_workspace(cwd=cwd, feature=entry.name, jj_client=jj_client, home=home)

--- a/tests/integration/spec_chain/test_halt.py
+++ b/tests/integration/spec_chain/test_halt.py
@@ -231,3 +231,65 @@ class TestAnalyzeFailureIsAWarningNotAHalt:
         report = workflow.result.final_output
         assert report["status"] == "completed"
         assert report["resume_hint"] is None
+
+
+class TestWorkspaceLifecycleAcrossOutcomes:
+    """Teardown is gated on the chain *completing*, not on it finishing.
+
+    A halted chain's hidden workspace is the only copy of the failing step's
+    partial output — landing only ever copies out artifacts a step declared,
+    and a step that failed declared none. Resume also reuses it. Collecting
+    it would destroy the evidence the run exists to produce.
+    """
+
+    async def test_halted_chain_keeps_its_workspace(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        stub_runtime_factory(monkeypatch, step_handlers={ChainStep.PLAN: _blocked_handler})
+        await _run_workflow(speckit_repo, fake_home, run_id="halt-keeps-workspace")
+
+        state = await load_chain_state("halt-keeps-workspace", speckit_repo)
+        assert state is not None
+        assert state.status == "halted"
+
+        workspace = fake_home / ".maverick" / "workspaces" / "repo" / "spec-chain" / FEATURE
+        assert workspace.is_dir(), "a halted chain must keep its workspace to resume from"
+
+    async def test_completed_chain_tears_its_workspace_down(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        stub_runtime_factory(monkeypatch)
+        await _run_workflow(speckit_repo, fake_home, run_id="complete-tears-down")
+
+        state = await load_chain_state("complete-tears-down", speckit_repo)
+        assert state is not None
+        assert state.status == "completed"
+
+        workspace = fake_home / ".maverick" / "workspaces" / "repo" / "spec-chain" / FEATURE
+        assert not workspace.exists()
+
+    async def test_stale_workspace_from_an_abandoned_feature_is_swept(
+        self,
+        speckit_repo: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        bd_stubs: list[str],
+    ) -> None:
+        """The realistic leak: a chain the user Ctrl-C'd, whose state never
+        reached a terminal status the CLI would resume from."""
+        root = fake_home / ".maverick" / "workspaces" / "repo" / "spec-chain"
+        abandoned = root / "some-other-feature"
+        abandoned.mkdir(parents=True)
+
+        stub_runtime_factory(monkeypatch)
+        await _run_workflow(speckit_repo, fake_home, run_id="sweep-run")
+
+        assert not abandoned.exists(), "a workspace with no resumable state must be swept"

--- a/tests/integration/spec_chain/test_resume.py
+++ b/tests/integration/spec_chain/test_resume.py
@@ -170,17 +170,36 @@ class TestWorkspaceReseedOnResume:
 
         # Run 2 (resume): workspace is recreated fresh, then reseeded with
         # the landed upstream artifacts before tasks re-runs.
-        stub_runtime_factory(monkeypatch)
+        #
+        # Observed *during* the run rather than after it: the reseed is only
+        # visible while the workspace exists, and a chain that completes now
+        # tears its workspace down (a completed chain cannot be resumed, so
+        # keeping it would strand a stray head in the user's commit graph).
+        seen_at_tasks: dict[str, bool] = {}
+
+        def _record_workspace(feature_path: Path, _runtime: Any) -> dict[str, Any]:
+            seen_at_tasks["spec.md"] = (feature_path / "spec.md").is_file()
+            seen_at_tasks["plan.md"] = (feature_path / "plan.md").is_file()
+            (feature_path / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
+            return {
+                "status": "completed",
+                "artifacts": ["tasks.md"],
+                "questions": [],
+                "findings": [],
+                "detail": "ok",
+            }
+
+        stub_runtime_factory(monkeypatch, step_handlers={ChainStep.TASKS: _record_workspace})
         await _run_once(speckit_repo, fake_home, run_id=run_id)
 
-        # The reseed restored upstream artifacts into the fresh workspace.
-        ws_feature = workspace_root / "specs" / FEATURE_DIR
-        assert (ws_feature / "spec.md").is_file()
-        assert (ws_feature / "plan.md").is_file()
+        assert seen_at_tasks == {"spec.md": True, "plan.md": True}, (
+            "reseed did not restore landed upstream artifacts before tasks re-ran"
+        )
 
         final_state = await load_chain_state(run_id, speckit_repo)
         assert final_state is not None
         assert final_state.status == "completed"
+        assert not workspace_root.exists(), "a completed chain must not leave its workspace behind"
 
 
 class TestPrdDigestMismatchWarns:

--- a/tests/unit/workflows/spec_chain/test_state.py
+++ b/tests/unit/workflows/spec_chain/test_state.py
@@ -438,3 +438,72 @@ async def test_discover_resumable_skips_unparseable_state_files(temp_dir: Path) 
 
     assert result is not None
     assert result.run_id == "run-valid"
+
+
+class TestResumableFeatures:
+    """`resumable_features` names every feature a sweep must not delete.
+
+    The hidden workspace of a halted or still-running chain is that chain's
+    only copy of the failing step's partial output, and resume reuses it. A
+    completed chain's workspace is pure garbage -- it cannot even be resumed,
+    since re-running the feature hits the CLI's collision check.
+    """
+
+    async def test_returns_features_with_resumable_status(self, tmp_path: Path) -> None:
+        from maverick.workflows.spec_chain.state import resumable_features
+
+        await save_chain_state(
+            _chain_state(run_id="r1", feature="halted-one", status="halted"), tmp_path
+        )
+        await save_chain_state(
+            _chain_state(run_id="r2", feature="running-one", status="running"), tmp_path
+        )
+
+        assert await resumable_features(tmp_path) == {"halted-one", "running-one"}
+
+    async def test_completed_features_are_not_resumable(self, tmp_path: Path) -> None:
+        from maverick.workflows.spec_chain.state import resumable_features
+
+        await save_chain_state(
+            _chain_state(run_id="r1", feature="done", status="completed"), tmp_path
+        )
+        await save_chain_state(
+            _chain_state(run_id="r2", feature="live", status="halted"), tmp_path
+        )
+
+        assert await resumable_features(tmp_path) == {"live"}
+
+    async def test_missing_runs_dir_is_empty_not_an_error(self, tmp_path: Path) -> None:
+        from maverick.workflows.spec_chain.state import resumable_features
+
+        assert await resumable_features(tmp_path / "no-such-checkout") == set()
+
+    async def test_corrupt_state_file_is_skipped(self, tmp_path: Path) -> None:
+        from maverick.workflows.spec_chain.state import resumable_features
+
+        await save_chain_state(
+            _chain_state(run_id="good", feature="live", status="halted"), tmp_path
+        )
+        bad = tmp_path / ".maverick" / "runs" / "bad"
+        bad.mkdir(parents=True)
+        (bad / "spec-chain.json").write_text("{not json", encoding="utf-8")
+
+        assert await resumable_features(tmp_path) == {"live"}
+
+    async def test_agrees_with_discover_resumable(self, tmp_path: Path) -> None:
+        """The two must never disagree -- they gate the same decision."""
+        from maverick.workflows.spec_chain.state import resumable_features
+
+        for run_id, feature, status in (
+            ("r1", "halted-one", "halted"),
+            ("r2", "done-one", "completed"),
+            ("r3", "running-one", "running"),
+        ):
+            await save_chain_state(
+                _chain_state(run_id=run_id, feature=feature, status=status), tmp_path
+            )
+
+        features = await resumable_features(tmp_path)
+        for feature in ("halted-one", "done-one", "running-one"):
+            found = await discover_resumable(feature, tmp_path)
+            assert (found is not None) == (feature in features), feature

--- a/tests/unit/workspace/test_spec_chain_workspace.py
+++ b/tests/unit/workspace/test_spec_chain_workspace.py
@@ -538,3 +538,160 @@ class TestWorkspaceCreationFailurePropagation:
             )
 
         assert exc_info.value.__cause__ is underlying
+
+
+# ---------------------------------------------------------------------------
+# Teardown and sweep
+# ---------------------------------------------------------------------------
+
+
+class TestTeardownWorkspace:
+    """A completed chain's workspace is garbage and must not survive.
+
+    Regression for the first live Spec Kit walkthrough: nothing ever tore a
+    workspace down. `prepare_workspace(reuse=False)` only wipes on the *next*
+    run of the same feature, and a completed feature can never be re-run (the
+    CLI's collision check exits 2) -- so every feature ever specced leaked a
+    directory, a registered jj workspace, and a stray anonymous head in the
+    user's own commit graph.
+    """
+
+    async def test_forgets_then_removes(
+        self, home: Path, checkout: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        from maverick.workspace.spec_chain import teardown_workspace
+
+        ws = _workspace_dir(home, checkout, "050-feature")
+        ws.mkdir(parents=True)
+        (ws / "specs").mkdir()
+
+        await teardown_workspace(
+            cwd=checkout, feature="050-feature", jj_client=mock_jj_client, home=home
+        )
+
+        mock_jj_client.workspace_forget.assert_awaited_once_with("050-feature")
+        assert not ws.exists()
+
+    async def test_forget_precedes_removal(
+        self, home: Path, checkout: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        """Order is load-bearing: removing first leaves jj tracking a ghost."""
+        from maverick.workspace.spec_chain import teardown_workspace
+
+        ws = _workspace_dir(home, checkout, "050-feature")
+        ws.mkdir(parents=True)
+        seen: list[bool] = []
+
+        async def _forget(_name: str) -> None:
+            seen.append(ws.exists())
+
+        mock_jj_client.workspace_forget.side_effect = _forget
+
+        await teardown_workspace(
+            cwd=checkout, feature="050-feature", jj_client=mock_jj_client, home=home
+        )
+        assert seen == [True], "workspace_forget ran after the directory was removed"
+
+    async def test_jj_error_is_tolerated_and_directory_still_removed(
+        self, home: Path, checkout: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        from maverick.workspace.spec_chain import teardown_workspace
+
+        ws = _workspace_dir(home, checkout, "050-feature")
+        ws.mkdir(parents=True)
+        mock_jj_client.workspace_forget.side_effect = JjError("no such workspace")
+
+        await teardown_workspace(
+            cwd=checkout, feature="050-feature", jj_client=mock_jj_client, home=home
+        )
+        assert not ws.exists()
+
+    async def test_missing_directory_is_not_an_error(
+        self, home: Path, checkout: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        from maverick.workspace.spec_chain import teardown_workspace
+
+        await teardown_workspace(
+            cwd=checkout, feature="never-created", jj_client=mock_jj_client, home=home
+        )
+        mock_jj_client.workspace_forget.assert_awaited_once_with("never-created")
+
+    async def test_never_raises_so_a_completed_chain_cannot_fail_on_cleanup(
+        self, home: Path, checkout: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        from maverick.workspace.spec_chain import teardown_workspace
+
+        mock_jj_client.workspace_forget.side_effect = RuntimeError("catastrophe")
+        await teardown_workspace(
+            cwd=checkout, feature="050-feature", jj_client=mock_jj_client, home=home
+        )
+
+
+class TestSweepStaleWorkspaces:
+    """Teardown-on-completion alone does not bound growth.
+
+    It never fires for an abandoned Ctrl-C chain -- which is the realistic
+    leak -- so a sweep has to collect anything with no resumable state behind
+    it.
+    """
+
+    async def test_removes_workspaces_not_in_keep(
+        self, home: Path, checkout: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        from maverick.workspace.spec_chain import sweep_stale_workspaces
+
+        stale = _workspace_dir(home, checkout, "abandoned")
+        live = _workspace_dir(home, checkout, "halted-chain")
+        stale.mkdir(parents=True)
+        live.mkdir(parents=True)
+
+        await sweep_stale_workspaces(
+            cwd=checkout, jj_client=mock_jj_client, keep={"halted-chain"}, home=home
+        )
+
+        assert not stale.exists()
+        assert live.exists()
+        mock_jj_client.workspace_forget.assert_awaited_once_with("abandoned")
+
+    async def test_scoped_to_this_project(
+        self, home: Path, checkout: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        """Another checkout's workspaces are not ours to collect."""
+        from maverick.workspace.spec_chain import sweep_stale_workspaces
+
+        ours = _workspace_dir(home, checkout, "abandoned")
+        theirs = home / ".maverick" / "workspaces" / "other-project" / "spec-chain" / "abandoned"
+        ours.mkdir(parents=True)
+        theirs.mkdir(parents=True)
+
+        await sweep_stale_workspaces(cwd=checkout, jj_client=mock_jj_client, keep=set(), home=home)
+
+        assert not ours.exists()
+        assert theirs.exists()
+
+    async def test_missing_root_is_a_no_op(
+        self, home: Path, checkout: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        from maverick.workspace.spec_chain import sweep_stale_workspaces
+
+        await sweep_stale_workspaces(cwd=checkout, jj_client=mock_jj_client, keep=set(), home=home)
+        mock_jj_client.workspace_forget.assert_not_awaited()
+
+    async def test_one_failure_does_not_stop_the_sweep(
+        self, home: Path, checkout: Path, mock_jj_client: AsyncMock
+    ) -> None:
+        from maverick.workspace.spec_chain import sweep_stale_workspaces
+
+        first = _workspace_dir(home, checkout, "aaa-bad")
+        second = _workspace_dir(home, checkout, "zzz-good")
+        first.mkdir(parents=True)
+        second.mkdir(parents=True)
+
+        async def _forget(name: str) -> None:
+            if name == "aaa-bad":
+                raise JjError("boom")
+
+        mock_jj_client.workspace_forget.side_effect = _forget
+
+        await sweep_stale_workspaces(cwd=checkout, jj_client=mock_jj_client, keep=set(), home=home)
+        assert not second.exists()


### PR DESCRIPTION
PR 1 of 3 from `docs/bead-cost-and-workspace-plan.md` (#176).

The hidden spec-chain workspace was never removed. `prepare_workspace(reuse=False)` only wipes on the *next* run of the same feature, and a completed feature can never be re-run — the CLI's spec-dir collision check exits 2 first. So every feature ever specced leaked, permanently: a ~349K directory, a registered jj workspace, and **a stray anonymous head in the user's own commit graph**, visible in their `jj log` forever.

## Why this is small

Teardown is safe by construction. The workspace holds nothing durable — landing copies workspace → checkout after every step, nothing is ever committed inside it, and `_reseed_workspace_from_checkout` already rebuilds one from the checkout on resume. Resume depends on the checkpoint and the landed artifacts, never on the directory surviving; `prepare_workspace` has always treated a missing directory as ordinary.

## Changes

- **`teardown_workspace()`** — `workspace_forget` then `rmtree`, in that order. A test pins the ordering rather than trusting the comment: removing first leaves jj tracking the name, which both blocks a later `workspace_add` and is what strands the head. Best-effort throughout — a chain that completed all five steps must never be reported failed because cleanup could not finish.
- **`sweep_stale_workspaces()`** — teardown-on-completion alone does not bound growth. It never fires for a chain the user Ctrl-C'd, which is the realistic leak, so the sweep is what actually collects. Scoped to this project's root; per-entry isolated so one undeletable workspace cannot strand the rest.
- **`state.resumable_features()`** — factored `_load_all_states` out of `discover_resumable` so both share one scan. They gate the same decision from opposite directions and must never disagree about what resumable means.

## Gated on completing, not on finishing

A halted or interrupted chain **keeps** its workspace. Landing only copies out artifacts a step *declared*, and a step that failed declared none — so that directory is the only copy of the failing step's partial output. Collecting it would destroy the evidence the run exists to produce. Both directions are tested.

The keep-set is computed in the workflow layer, not `workspace/`: resumability is a property of `.maverick/runs` state, not of the filesystem, and keeping `workspace/` a dumb filesystem+jj module avoids an upward import into `workflows/`.

## One test rewritten, not deleted

`test_deleted_workspace_is_reseeded_from_checkout` asserted on workspace contents *after* a completed run — precisely what no longer exists. Its intent (reseed restores landed upstream artifacts) is still valid, so it now observes during the `tasks` step, where the reseed is visible, and additionally asserts the workspace is gone at the end.

## Verification

- `make ci`: **4483 passed, 1 xfailed**.
- Tests written first. The two asserting new behaviour were observed failing against unfixed code by disabling both call sites, per Principle V.
- `test_halted_chain_keeps_its_workspace` passes either way by construction — it is a guard against a future regression, not evidence of this fix. Calling that out rather than implying three red-then-green tests.

Part of #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSKj2NnUpCysHvK5ZGt7BA