### PR TITLE
docs: competitive analysis of agent orchestration platforms + specify-prompt roadmap

### DIFF
--- a/docs/competitive-analysis-orchestration-platforms.md
+++ b/docs/competitive-analysis-orchestration-platforms.md
@@ -1,0 +1,608 @@
+# Competitive Analysis: Agent Orchestration Platforms
+
+**Date**: 2026-08-05
+**Scope**: The full landscape of agent orchestration for software development — spec-driven
+methodology layers, plan-first orchestration products, parallel-agent runners, in-process
+multi-agent harnesses, cloud async agents, durable-execution frameworks, and human-in-the-loop
+infrastructure — mapped against Maverick, airframe, and remo.
+**Method**: Public product documentation, vendor sites, independent tool comparisons, and
+practitioner write-ups reviewed 2026-08-05, alongside a survey of this repository,
+`get2knowio/airframe`, and `get2knowio/remo`.
+
+> **Naming note**: one competitor — the plan-first desktop/IDE product analyzed in depth in §2.2 —
+> is referred to as **the reference platform** at the requester's instruction. Every other product
+> is named. If this reads inconsistently, the name can be restored in a single edit.
+
+---
+
+## 1. Executive summary
+
+Three things are true at once:
+
+1. **The category has converged on a shared diagnosis.** Across every serious entrant, the same
+   sentence appears in different words: *the bottleneck is no longer code generation, it is
+   verification and intent*. Everyone is building upward from the coding agent, not competing with
+   it.
+2. **Nobody has assembled the specific combination you're describing.** Spec-driven tools stop at
+   the spec handoff. Fleet orchestrators run many agents but treat human input as a blocking
+   interrupt. Human-in-the-loop infrastructure batches approvals but has no spec model and no
+   memory of what was decided. **The three-way intersection — deterministic spec substrate ×
+   heterogeneous multi-model execution × batched, schedule-respecting human input — is open.**
+3. **We already own the hardest piece of it, and don't market it as such.** The assumption ledger
+   plus `reconcile` is the primitive that makes non-blocking parallel execution *safe*. Everyone
+   else either blocks the agent on a question or lets it guess silently. We record the guess, keep
+   flying, surface it on the human's schedule, and can retroactively fold the correction back into
+   history. No competitor documentation describes anything equivalent.
+
+The gap is not intelligence or architecture. It is **parallelism** (Guardrail 0 forbids the
+isolation everyone else uses), **residency** (our state dies with the process), and **scheduling**
+(we have the queue but no delivery mechanism).
+
+---
+
+## 2. The landscape
+
+### 2.1 Segment map
+
+| Segment | What it owns | Representative entrants |
+|---|---|---|
+| **A. Spec-driven methodology** | *What to build* — structured intent artifacts | GitHub Spec Kit, OpenSpec, AWS Kiro, Tessl, BMAD-METHOD, Spec Kitty |
+| **B. Plan-first orchestration products** | Plan → handoff → verify loop over third-party agents | The reference platform (§2.2), HumanLayer/CodeLayer, Intent |
+| **C. Local parallel-agent runners** | Fleet execution with isolation + a board UI | Conductor (Melty Labs), Vibe Kanban, Sculptor (Imbue), Claude Squad, Crystal/Nimbalyst, Emdash, Composio Agent Orchestrator, Spec Kitty orchestrator |
+| **D. In-process multi-agent** | Coordination *inside* one harness | Claude Agent Teams, Claude Code subagents, Oh My OpenAgent (OmO/Sisyphus), Google Antigravity |
+| **E. Cloud async agents** | Fire-and-forget; PR is the return value | Google Jules, OpenAI Codex Web, GitHub Copilot coding agent, Claude Code Web, Devin, Cursor Cloud Agents |
+| **F. Durable execution / SDK** | The plumbing under all of the above | LangGraph, Temporal, OpenAI Agents SDK, CrewAI, Google ADK, Strands, **Burr** (ours) |
+| **G. Human-in-the-loop infrastructure** | Approval queues as runtime | HumanLayer API, async-approval libraries, OpenAI Agents SDK HITL flow |
+
+**Where we sit today**: A (consume Spec Kit) + B (plan→verify loop) + F (Burr) + a proprietary slice
+of G. **We are absent from C, D, and E** — which is precisely the parallelism gap.
+
+### 2.2 Segment B deep dive — the reference platform
+
+Analyzed in full previously; retained here in compressed form since it remains the most complete
+implementation of the plan-first thesis.
+
+- **Architecture**: resident host daemon (owns workspace, files, git diffs, terminals, agent
+  processes, provider detection; local or remote, OS-service installable) + desktop/IDE client +
+  full CLI + cloud (credits, sync, sharing).
+- **Task container**: 1..n workspace folders, each independently choosing run location (in-place /
+  new worktree / existing worktree), holding panels, canvas tabs, and artifacts.
+- **Artifacts**: Spec / Ticket / Story / Review. Tickets and stories carry status + assignee; specs
+  and reviews deliberately do not, because they are *shared context, not work units*.
+- **Four modes**: single-PR planning, phased planning (with intent clarification and user-editable
+  phases), standalone agentic review, and a collaborative board mode.
+- **Verification** — the distinguishing mechanic: compares implementation against *the plan it
+  issued*, emitting Critical / Major / Minor / **Outdated** findings, with re-verify (cheap,
+  iterative) vs. fresh-verify (unbiased) modes.
+- **Execution records**: every handoff captured with plan, verification results, commits, status.
+- **Autonomy**: fixed mode (config chosen upfront) and adaptive mode (mutates specs and tickets from
+  implementation discoveries, re-selects agent/model per ticket, runs tickets in parallel).
+- **Config surfaces**: per-step model profiles with a cost calculator; Handlebars-style prompt
+  templates; user-defined slash-invocable workflows.
+- **Weakness**: autonomy is desktop-tethered — pauses on sleep or IDE disconnect. Monetizes its own
+  planning inference via credits.
+
+### 2.3 Segment A — spec-driven methodology layers
+
+The layer we already build on. An independent February 2026 evaluation across 13 scoring categories
+found **no universal winner** — rankings shift entirely with priorities.
+
+| Tool | Model | Strength | Weakness |
+|---|---|---|---|
+| **GitHub Spec Kit** | OSS, model-agnostic, constitution-driven | Greenfield; battle-tested; what we build on | **No worktree automation**; struggles with iterative modification of existing specs |
+| **OpenSpec** | MIT | **Delta format** (`ADDED` / `MODIFIED` / `REMOVED`) purpose-built for brownfield; tight `propose → apply → sync → archive` loop | Manual spec-drift management |
+| **AWS Kiro** | Proprietary, GA March 2026, Code OSS + Claude via Bedrock | `requirements.md`/`design.md`/`tasks.md` as the unit of work; **agent hooks** (event-driven automation on save/create/delete) and **steering files** (per-folder behavioral rules) | AWS-centric; overkill for small changes |
+| **Tessl** | Proprietary | **Spec-as-source** — edit only specs, regenerate code; `.tessl/` tiles teach MCP-compatible agents the workflow | Most opinionated; furthest from how teams work today |
+| **BMAD-METHOD** | OSS | 21 specialized agents, enterprise workflow coverage | Sledgehammer overhead |
+| **Spec Kitty** | OSS | **Spec Kit + built-in worktree orchestration** + live Kanban + auto-merge + an `orchestrator-api` for external providers | Young; smaller ecosystem |
+
+**Two findings matter directly to us:**
+
+1. **The modification problem.** Spec Kit's identified weakness is exactly the brownfield case —
+   iterating on an existing spec rather than authoring a new one. OpenSpec's delta format is the
+   field's answer. Our `refuel --speckit` delta re-runs solve this at the *bead* level (append new
+   tasks under the existing epic) but not at the *spec* level. Worth evaluating a delta layer over
+   `spec.md`.
+2. **Spec Kitty is our closest structural competitor.** It is literally Spec Kit + worktrees +
+   Kanban + a multi-agent orchestrator API, keeping specs, plans, work packages, acceptance
+   criteria, review state, and merge decisions *in the repository*. Same substrate, same in-repo
+   philosophy, and it already has the parallelism we lack. It has no assumption-ledger equivalent
+   and no history curation — but it is the tool to watch.
+
+### 2.4 Segment C — local parallel-agent runners
+
+The fastest-moving segment, and the one we are entirely absent from. The universal pattern:
+**one isolated working copy per agent, a board UI over the fleet, human reviews diffs.**
+
+- **Conductor** (Melty Labs) — Mac app, parallel Claude Code + Codex agents in isolated git
+  worktrees. Widely cited as the lowest-friction entry point.
+- **Sculptor** (Imbue) — the outlier: each agent runs in its own **Docker container** with a full
+  repo copy, not a worktree. Stronger isolation; "Pairing Mode" for switching into an agent's
+  workspace. Free in beta.
+- **Vibe Kanban** — task cards with diff review; Kanban as the primary interface.
+- **Composio Agent Orchestrator** (OSS) — pushes furthest into autonomy: fleets in isolated
+  worktrees, each with its own PR, fixing CI failures and review comments, supervised from one
+  dashboard.
+- **Claude Squad / Crystal / Emdash / Switchboard** — session managers over multiple Claude Code
+  instances.
+- **Spec Kitty orchestrator** — discovers ready work packages via a host API, runs agents in
+  worktrees, transitions through review lanes, auto-merges on accept. 3–10 agents.
+
+**Isolation is table stakes in this segment.** Guardrail 0 puts us on the opposite side of that
+consensus. See §5.1 — this is the central architectural tension in your thesis.
+
+### 2.5 Segment D — in-process multi-agent
+
+- **Claude Agent Teams** (shipped with Opus 4.6, 5 Feb 2026) — your session becomes the *lead*;
+  teammates are independent Claude Code instances with their own context windows, tool access, and
+  permissions, loading project context but **not** the lead's conversation history. Coordination is
+  a **shared task list with file locking**; teammates self-claim, blocked tasks auto-unblock when
+  dependencies clear, and teammates message each other peer-to-peer. Optimal team size reported at
+  **3–5**. Demonstration of scale: 16 instances × 2 weeks × ~2,000 sessions produced a 100k-line
+  Rust C compiler that builds the Linux kernel on x86/ARM/RISC-V, for under $20k.
+- **Oh My OpenAgent (OmO / Sisyphus)** — OpenCode plugin, ~48k stars, 1.6M+ downloads. Three-layer
+  architecture: planning (Prometheus/Metis) → orchestration (Atlas) → execution (Sisyphus-Junior +
+  9 specialists). **Its multi-model routing is the closest published analogue to what you want**:
+  when the orchestrator delegates, it picks a *category* (`visual-engineering`, `ultrabrain`,
+  `deep`, `artistry`, `quick`, `unspecified-low`, `unspecified-high`, `writing`) and the category
+  maps to a model. Heavy reasoning → Opus; fast exploration → Gemini Flash; utility work → local
+  Ollama.
+- **The Ralph Loop** — a widely adopted stateless-but-iterative pattern: pick atomic task →
+  implement → validate → commit if passing → **reset context**. Our fly loop with
+  `rotate_session()` per bead is already this.
+
+### 2.6 Segment E — cloud async agents
+
+The segment that already solves *your third ask*, crudely: **queue work, walk away, review PRs when
+you return.** Jules (Google), Codex Web (OpenAI), Copilot coding agent, Claude Code Web, Devin.
+
+The practitioner consensus is a three-tier day: Tier 1 (in-process) for interactive work, Tier 2
+(local orchestrators) for parallel sprints, **Tier 3 (cloud async) to drain the backlog overnight**.
+"Queue five well-scoped tickets Friday afternoon, review five PRs Monday morning."
+
+**Their batching boundary is the pull request.** That is coarse: the human sees the *result*, never
+the *decisions taken along the way*, and cannot correct an early wrong assumption without
+re-running. This is exactly the gap the assumption ledger fills.
+
+### 2.7 Segment G — human-in-the-loop infrastructure
+
+The most directly relevant prior art for your third ask.
+
+**HumanLayer / CodeLayer** — began as a human-in-the-loop approval API (approval decorators,
+routing to teams or individuals, escalations, timeouts, learned auto-approvals, webhooks; delivery
+over Slack and email) and became a full coding-agent IDE. Notable specifics:
+
+- **QRSPI methodology** — six phases: **Q**uestions (clarifying inquiries before any code) →
+  **R**esearch (map dependencies and patterns) → **D**esign (draft doc open to real-time team
+  comment) → **S**tructure (phased verifiable milestones) → **P**lan (file paths + acceptance
+  criteria) → **I**mplement. The *Questions-first* phase is a direct competitor to our clarify step.
+- **Design reviews as collaborative checkpoints** — humans and agents comment inline; comments feed
+  directly into subsequent agent instructions rather than sitting in a doc.
+- **Architecture**: local daemons for parallel sessions + optional cloud daemons for long-running
+  work, synced through one API across web, desktop, and mobile. Tasks group sessions, artifacts, and
+  worktrees into shared workspaces for **asynchronous** team collaboration.
+- **BYOK billing** — Claude, Codex, and other subscriptions plug in directly; no per-token platform
+  margin. This is the model that is winning against credit-metered competitors.
+
+**Approval queues as runtime** — the emerging architectural pattern, worth adopting wholesale:
+
+- Approval items are **first-class runtime objects** carrying the proposed action + args, risk
+  classification and policy rationale, owner identity, allowed decisions (approve / edit / reject /
+  respond), **checkpoint identifier for graph resumption**, audit trace, timeout, and a post-hoc
+  receipt.
+- **Risk-tiered routing**: low-risk flows through immediately · **medium-risk batches for periodic
+  review** · high-risk interrupts a named owner · forbidden actions fail before reaching a human.
+- The motivating statistic: **~93% of permission prompts are clicked through** when systems ask for
+  blanket permission. Undifferentiated approval is theater.
+- **State persists outside model context**; resumption uses the *same thread identifier*, not a
+  fresh run.
+- Approval decisions are **production labels** — edits and rejections feed evaluation.
+
+Three published patterns for the pause: synchronous gate-keeping (max control, max latency),
+**asynchronous escalation** (agent continues other work while approval pends — requires rejection
+handling), and parallel feedback (execute while human reviews, halt on rejection — requires
+rollback). **Our design is asynchronous escalation with rollback, which is the strongest of the
+three and the only one that requires a `reconcile`.**
+
+### 2.8 Segment F — the plumbing, and one protocol note
+
+LangGraph handles micro-level agent reasoning; Temporal handles macro-level durable lifecycle;
+sophisticated teams run both. LangGraph 1.0 (Oct 2025) brought production checkpointing; the
+OpenAI Agents SDK × Temporal integration went GA March 2026. **Burr sits in the LangGraph tier and
+our use of it is well-placed** — but we have no Temporal-tier durability, which is the same
+observation as "we have no host daemon."
+
+**Protocol note — ACP is dead; A2A won.** The Agent Client Protocol (Zed, Aug 2025, JSON-RPC over
+stdio) wound down active development and contributed its technology into **A2A**, which reached v1.0
+in April 2026 under the Linux Foundation with 150+ organizations and native support in AWS, Azure,
+and GCP. The settled stack is **MCP for vertical tool integration, A2A for horizontal agent
+coordination**.
+
+This retroactively validates a decision we already made: `specs/042-acp-integration/` is still
+marked **Draft**, and we built **airframe** instead. That spec should be formally closed as
+superseded. If we later want cross-agent interop, the target is A2A, not ACP.
+
+### 2.9 Cross-field findings
+
+Consistent across independent sources:
+
+1. **"The bottleneck is no longer generation. It's verification."** Universal.
+2. **Isolation is table stakes** — worktrees (most) or containers (Sculptor).
+3. **"Your spec is the leverage."** Vague requirements *multiply* errors across parallel agents —
+   the cost of ambiguity scales with fan-out. This is the strongest possible argument for our
+   deterministic Spec Kit substrate.
+4. **WIP limits of 3–5 concurrent agents** for meaningful human oversight — from both Agent Teams
+   guidance and practitioner write-ups. Unbounded fan-out is a known anti-pattern.
+5. **Context multiplication**: "small harmless mistakes compound at a rate that's unsustainable"
+   without guardrails.
+6. **Human-curated `AGENTS.md` compounds; LLM-generated versions marginally *reduce* success (~3%)
+   while raising cost 20%+.** Never let agents edit it. We should enforce this.
+7. **Multi-model routing by task category is now standard practice**, not a differentiator.
+8. **BYOK/subscription beats credit-metering** on developer preference.
+9. **Quota handling is a solved pattern**: rotate to the next credential on quota/billing error,
+   apply a cooldown (24h cited), fall back to a configured model when exhausted, and use **per-task
+   credential leasing** so concurrent subagents don't collide.
+
+---
+
+## 3. Mapping the landscape onto your three-part thesis
+
+> *"Leverage Spec Kit under the covers, defer execution to multiple agents using different
+> models/subscriptions, and aggregate the human interaction into batches that meet the human's
+> schedule."*
+
+### 3.1 Spec Kit under the covers — **mostly built; one real gap**
+
+| Requirement | State |
+|---|---|
+| Spec Kit chain runs headlessly | ✅ `maverick spec` (spec 050), checkpointed, resumable, workspace-isolated |
+| Deterministic ingestion to a work graph | ✅ `refuel --speckit`, **zero model calls** (Guardrail 8) |
+| Phase barriers / dependency ordering | ✅ bd `blocks` edges wired at ingestion |
+| Delta re-runs as `tasks.md` grows | ✅ appends under existing epic, no duplicate epics |
+| **Delta edits to the spec itself** | ❌ **Gap** — Spec Kit's known brownfield weakness; OpenSpec's `ADDED`/`MODIFIED`/`REMOVED` is the field's answer |
+| Per-folder behavioral rules | ⚠️ Partial — constitution + `CLAUDE.md`, but not Kiro-style scoped steering files |
+| Event-driven hooks (on save/commit) | ⚠️ Partial — `hooks/` exists for safety; not a general automation surface |
+
+**Verdict: this leg of the thesis is essentially done and is a genuine differentiator.** Spec Kitty
+is the only competitor on the same substrate, and it does not have our determinism guarantee. The
+one thing worth stealing is OpenSpec's delta model for spec *modification*.
+
+### 3.2 Multi-agent execution across models and subscriptions — **the hard gap**
+
+| Requirement | State |
+|---|---|
+| Vendor-neutral runtime abstraction | ✅ **airframe** — 9 adapters, 8-method protocol, `Feature` flags, unified errors, `unwrap()`. Better-engineered than anything in the field. |
+| Route work to a model by task character | ✅ `actors.<wf>.<actor>.tiers.<complexity>` — **and ours is better grounded than OmO's**: complexity is assigned by the decomposer from the artifact, not guessed per-call |
+| Escalation ladder on failure | ✅ `squadron.tiers.escalation_ladder()`, with the correct guard that a rung must be a genuinely distinct binding |
+| **Concurrent execution of N beads** | ❌ **Gap** — fly is a serial drain loop |
+| **Isolation per concurrent agent** | ❌ **Blocked by Guardrail 0** — see §5.1 |
+| **Subscription/quota-aware routing** | ⚠️ Partial — quota *detection* exists (`exceptions/quota.py`); no credential pool, no leasing, no cooldown, no rotation |
+| Fleet visibility | ❌ Gap — no board, no monitor |
+| WIP limiting | ❌ N/A today (serial), but needed the moment we parallelize |
+
+**Verdict: airframe is the asset; the dispatcher is missing.** We have the routing *policy* layer
+and no *execution* layer to apply it across. Everything in §2.4 exists because these teams built the
+dispatcher first and the routing later; we did the reverse, which is the better order — but the bill
+comes due now.
+
+One honest flag: **multiplexing a single seat-based subscription across many concurrent agents may
+violate provider terms of service.** Per-provider concurrency limits should be a first-class config
+concept (`max_concurrent` per binding), not an emergent property of how many beads happen to be
+ready. Design it in as a compliance control, not just a rate limiter.
+
+### 3.3 Batched human interaction on the human's schedule — **our moat, half-built**
+
+This is where the analysis gets interesting. Compare what exists:
+
+| Approach | Who | Human interaction model | Weakness |
+|---|---|---|---|
+| Blocking clarification | Spec Kit `/clarify`, the reference platform's phased mode, HumanLayer's Questions phase | Modal, up-front, synchronous | Blocks the run; the human must be present *now* |
+| PR as the batch boundary | Jules, Codex Web, Copilot agent | Review the finished result later | Coarse — decisions taken en route are invisible and uncorrectable without a re-run |
+| Approval queue | HumanLayer API, approval-queue pattern | Risk-tiered: low flows, medium batches, high interrupts | Action-scoped, not intent-scoped; queue has no memory once decided |
+| Inline design comments | HumanLayer CodeLayer | Async comment threads that feed the next phase | Requires the human before implementation, not after |
+| **Assumption ledger** | **Maverick** | Agent adopts a documented assumption, **records it with severity, and keeps flying**; human answers later; `reconcile` folds the answer back into history retroactively | Not yet scheduled, not yet delivered out-of-terminal, not yet batched by time |
+
+**The ledger is categorically different from everything else in the field.** Every other approach
+either stops the agent or discards the decision. Ours converts a blocking question into a *durable,
+severity-graded, spec-owned artifact* that (a) doesn't stop the fleet, (b) gates landing so it can't
+be forgotten, and (c) — uniquely — can be answered *after the code was written* and folded back into
+jj history by `reconcile`.
+
+**That last property is what makes deferral safe rather than merely deferred, and it is why this
+thesis is achievable for us and not for them.** A competitor who batches questions has to either
+block or accept that late answers are unactionable. We can accept a late answer and rewrite history.
+
+What's genuinely missing to complete this leg:
+
+| Requirement | State |
+|---|---|
+| Non-blocking capture with severity | ✅ `assumptions/ledger.py`, low/medium/high |
+| Enforcement so nothing is forgotten | ✅ Strict land gate, any-severity, no bypass flag |
+| Retroactive correction | ✅ `maverick reconcile` + mid-flight trigger (spec 051/052) |
+| Batch resolution UI | ✅ `maverick-review` skill sweeps the queue via `AskUserQuestion` |
+| Bulk disposal | ✅ `review --spec <name> --waive` with severity filter |
+| Headless/scriptable | ✅ JSON verbs across review/reconcile/land (spec 053) |
+| **Risk-tiered routing of *when* to surface** | ❌ Severity drives *enforcement*, not *timing*. High should interrupt; medium should batch; low should accumulate silently. |
+| **Scheduling** — surface at times the human chose | ❌ **Gap.** No windows, no quiet hours, no "review at 9am." |
+| **Out-of-terminal delivery** | ❌ **Gap.** ntfy is an optional dep and unused for this. No Slack/email/push. |
+| **Timeouts + escalation** | ❌ Gap. An unanswered high-severity entry blocks forever with no nudge. |
+| **Learned auto-resolution** | ❌ Gap. HumanLayer learns auto-approvals from prior decisions; runway could do this from prior answers. |
+| Decisions as evaluation labels | ❌ Gap. Answers/waivers should feed runway as training signal. |
+
+---
+
+## 4. Where the whitespace is
+
+Plotting the field on two axes — *intent rigor* (how structured the spec substrate is) versus
+*human-latency tolerance* (how long the system can run productively without a human):
+
+- **High rigor, low latency tolerance**: Spec Kit, Kiro, Tessl, the reference platform's phased mode,
+  HumanLayer QRSPI. Excellent specs; the human must be present at each gate.
+- **Low rigor, high latency tolerance**: Jules, Codex Web, Copilot agent, Composio AO. Queue and
+  walk away; but "your spec is the leverage" and these have the thinnest specs, so the error
+  multiplication problem is worst here.
+- **High rigor, high latency tolerance**: **essentially empty.** Spec Kitty is the nearest approach
+  and still blocks on review lanes.
+
+**That empty quadrant is the thesis.** The reason it's empty is that high rigor normally *requires*
+synchronous human gates — unless you have a mechanism to defer a question without either blocking or
+losing it. The assumption ledger is that mechanism. It is the enabling primitive for the quadrant,
+and we built it for other reasons.
+
+Stated as a positioning claim:
+
+> **Maverick lets a fleet of heterogeneous agents work a rigorously specified backlog while the
+> human is asleep, records every judgment call it had to make instead of guessing silently, batches
+> those calls for the human's actual schedule, and rewrites history to match once they answer.**
+
+Nothing in the field currently claims that sentence.
+
+---
+
+## 5. The two architectural tensions
+
+### 5.1 Guardrail 0 versus parallel execution — the central conflict
+
+Every competitor in §2.4 gives each concurrent agent an isolated working copy. Guardrail 0 forbids
+exactly that: all long-running ops run in the user's checkout under `Path.cwd()`.
+
+The history matters. Guardrail 0 retired hidden workspaces because **`bd`'s gitignored
+`embeddeddolt/` doesn't travel with `jj workspace add`** — a bd constraint, not a worktree
+constraint. Spec 050 then proved the mechanism works fine when bd stays out of the workspace (the
+spec-chain never runs `bd` inside it).
+
+**Your thesis requires resolving this.** Options, in increasing order of ambition:
+
+1. **Agent-side isolation only.** Beads execute in worktrees; all bd/ledger/jj writes stay in the
+   orchestrating process in the user's checkout — exactly the spec-chain contract, generalized. The
+   agent never runs `bd`. This is the smallest change that unlocks parallelism and it follows a
+   pattern we have already shipped once.
+2. **Container isolation** (the Sculptor model). Stronger, and a better fit for untrusted parallel
+   work, but a much larger operational surface. Probably not now.
+3. **bd federation** — the pull-work-push architecture in
+   `.claude/scratchpads/architecture-pull-work-push.md`. The real answer, and the largest bet.
+
+**Recommendation: option 1.** It respects the actual constraint (bd), reuses a proven mechanism, and
+does not require federation. Guardrail 0 should be amended from "no workspaces" to "**no bd inside a
+workspace**" — which is what it always really meant.
+
+### 5.2 Serial-by-design versus the WIP-limit finding
+
+Worth noting in our favor: the field's own guidance converges on **3–5 concurrent agents** as the
+ceiling for meaningful oversight, and warns that context multiplication makes unbounded fan-out
+actively harmful. So the target is not "N agents for large N" — it is **3–5 well-isolated agents
+with hard quality gates**, which is a far more tractable engineering problem than it first appears.
+Combined with per-provider concurrency caps (§3.2), a bounded dispatcher is the right first build.
+
+---
+
+## 6. Revised path forward
+
+Reordered from the previous version to serve the three-part thesis directly.
+
+### Slice A — `maverick host` (daemon)
+
+Unchanged from prior analysis and now **more** important: a fleet needs a supervisor that outlives
+any one command. Per-repo process, JSON-RPC over `.maverick/host.sock`, `~/.maverick/hosts/` for
+discovery. Owns squadron lifetime (agents opened once, not per-invocation), run/task state, the
+`ProgressEvent` stream, provider health, **and the credential/quota pool from Slice C**. Existing
+commands become thin clients with one-shot fallback.
+
+This is also what makes fly survivable — kick it off, detach, reattach. Combined with remo, it
+closes the gap where cloud-async competitors are strongest *without* their weakness (their
+batch boundary is the PR; ours can be the ledger entry).
+
+### Slice B — the task container
+
+Promote `.maverick/runs/<run-id>/` into a resumable **task** spanning `spec → refuel → fly → land`:
+
+```
+.maverick/tasks/<task-id>/
+  task.json          # workspace folder(s), run location, spec ref, epic bead id, status
+  executions/        # per handoff: plan, verification, commits, cost, (provider, model) binding
+  events.jsonl       # full ProgressEvent stream
+  checkpoints/       # spec-chain checkpointing, generalized
+```
+
+Add the `(provider, model, credential)` binding to each execution record — that's what makes
+cross-subscription attribution and cost analysis possible later.
+
+### Slice C — the dispatcher **(the thesis's missing leg)**
+
+The largest new piece. Requires §5.1 resolved.
+
+1. **Amend Guardrail 0** to "no bd inside a workspace" and generalize spec-chain's workspace
+   mechanism into a reusable `workspace.run_isolated(...)`.
+2. **Concurrent bead execution** — replace fly's serial drain with a bounded worker pool. Default
+   WIP 3, hard cap configurable. Ready-set computed from bd's dependency graph as it is today.
+3. **Credential pool with leasing** — `agents.<role>.credentials[]` as a pool rather than a single
+   binding. Per-task lease, rotate on quota/billing error, cooldown on exhaustion, fall back to a
+   configured binding. **Per-binding `max_concurrent` as a ToS compliance control.**
+4. **Merge discipline** — each bead's worktree folds back via jj; conflicts route into the existing
+   round-budgeted conflict machinery from `reconcile`, which already solves this problem.
+5. Keep `tiers` as the routing policy — it is already better than the field's category maps.
+
+### Slice D — the batch scheduler **(the thesis's differentiating leg)**
+
+Turns the ledger from a queue into a *schedule-respecting* queue. Small relative to C, high value.
+
+1. **Severity → timing, not just enforcement.** Today severity drives ready-queue and land-gate
+   behavior. Add a delivery policy: `high` → interrupt (push immediately); `medium` → batch to the
+   next window; `low` → accumulate, surface only at review time or on `--waive` sweep.
+2. **Windows** — `assumptions.schedule` in `maverick.yaml`: review windows (`09:00`, `17:00`), quiet
+   hours, minimum batch size, maximum age before forced escalation.
+3. **Delivery channels** — ntfy is already an optional dependency and unused for this. A batch
+   notification carrying count-by-severity, owning specs, and the `maverick review` invocation is
+   most of the value. Slack/email later.
+4. **Timeouts and escalation** — an unanswered high-severity entry past its max age escalates
+   (re-notify, or auto-waive under an explicit policy with a recorded rationale). Never silent.
+5. **Learned auto-resolution** — feed answered entries into runway; when a new assumption closely
+   matches a previously answered one, propose the prior answer as the default in the review sweep.
+   This is HumanLayer's learned-auto-approval idea, and runway is the right home for it.
+6. **Decisions as labels** — persist answer/waive/edit outcomes as evaluation signal.
+
+### Slice E — verification with a real taxonomy
+
+Split fly's reviewer output into an explicit **plan-conformance** check against the bead's scope and
+acceptance criteria, emitting `critical | major | minor | outdated`, persisted as durable review
+artifacts under the task, consumed by the fix loop at a configurable severity threshold. Add the
+re-verify / fresh-verify distinction. **Keep this taxonomy separate from assumption severity** —
+"faithful to the plan" and "we guessed about intent" are different questions and conflating them
+muddies the land gate.
+
+### Slice F — console surfaces
+
+1. **`maverick monitor`** — Rich `Live` over the host's event stream. With Slice C this becomes the
+   fleet board that every Segment C competitor ships as a GUI: active beads, agent, bound model,
+   fix round, cost burn, assumption frontier.
+2. **Extend the skill family** — `maverick-review` proves the pattern. Add `maverick-plan` and
+   `maverick-verify`, each backed by JSON verbs, none touching jj/bd/files directly.
+
+The strategic point stands and is sharper after this survey: **every competitor in Segments B and C
+built a desktop application because their planning intelligence sits *outside* the coding agent.
+Ours sits inside it.** A packaged skill is not a lesser console UI — it is what their GUI is
+approximating.
+
+### Slice G — smaller, independently valuable
+
+- **OpenSpec-style delta layer** over `spec.md` — closes Spec Kit's known modification weakness.
+- **`maverick review-code [--diff|--epic|--paths]`** — standalone agentic review. (Naming needs
+  care; `review` is taken.)
+- **Prompt templates** — `.maverick/templates/*.md` with frontmatter applicability, Jinja2.
+- **Steering files** — Kiro-style per-directory rules, scoped narrower than the constitution.
+- **`AGENTS.md` protection** — the field's data says agent-authored context files *hurt*. A safety
+  hook forbidding agent writes to `AGENTS.md`/`CLAUDE.md` is cheap and evidence-backed.
+- **Model profile presets** — `balanced` / `frontier` over existing `tiers`, plus cost estimation.
+- **Close spec 042 (ACP)** as superseded — ACP folded into A2A; airframe was the right call.
+
+### Order
+
+```
+A (host) ──┬─→ C (dispatcher, needs §5.1)  ─→ F1 (fleet monitor)
+           └─→ B (task container) ─→ E (verification taxonomy)
+
+D (batch scheduler) ── independent, start now
+G (small items)     ── independent, start now
+```
+
+**D is the highest value-per-effort item and depends on nothing.** It converts an existing,
+differentiated capability into the thing you actually described wanting. C is the biggest build and
+the one that needs an architectural decision first (§5.1).
+
+---
+
+## 7. Honest assessment
+
+**On substance we are ahead of the field**, in ways that are hard to replicate: deterministic
+ingestion, dependency-graph work modeling, assumption provenance, retroactive history correction,
+jj-native curation, typed contracts throughout, and a runtime abstraction better engineered than
+anything published. `reconcile` solves a problem the category has not yet named.
+
+**On execution surface we are behind an entire segment.** Every Segment C competitor ships parallel
+isolated agents with a board; we ship a serial loop with a log. That gap is architectural
+(Guardrail 0), not incidental, and your thesis cannot be delivered without resolving it.
+
+**On the human-latency axis we have an unclaimed, defensible position.** The empty
+high-rigor/high-latency-tolerance quadrant exists because deferring a question normally means either
+blocking or losing it. We have the only published mechanism that does neither. We have not built the
+scheduling layer that would let us claim it, and it is a small build.
+
+**Where we can win outright**: headless autonomy (the reference platform pauses on sleep, we don't),
+determinism as a cost structure (they bill model calls where we parse), BYOK-by-construction via
+airframe (the model the market prefers), in-agent skill surface (they need a desktop app; we need a
+markdown file), and — the real one — **safe deferral of human judgment**.
+
+**Two risks worth stating plainly:**
+
+- **Subscription multiplexing has ToS exposure.** Per-binding concurrency caps must be a designed
+  compliance control, not an emergent side effect.
+- **Spec Kitty is on our substrate with our philosophy and already has parallelism.** It has no
+  ledger and no history curation, but it is the competitor most likely to arrive at the same
+  quadrant from the other direction. Worth tracking closely.
+
+## 8. Open questions
+
+- Does the host daemon own the Burr application, or supervise subprocesses that own their own?
+  (Affects crash isolation and the two-stage Ctrl-C contract — and matters much more once N beads
+  run concurrently.)
+- How do concurrent beads write to bd safely? Serialize all bd writes through the host daemon, or
+  does bd tolerate concurrent writers?
+- Does the mid-flight reconcile trigger still hold under parallelism? `_find_flying_run`'s
+  concurrency guard assumes one flying run parked at a safe empty-`@` boundary; with a worker pool
+  there is no such single boundary.
+- Should the batch scheduler live in the host daemon (requires residency) or run as a cron-style
+  external trigger (works today)? The latter is a viable Slice-D-without-Slice-A path.
+- Is an OpenSpec-style delta layer additive to Spec Kit, or does it force a substrate decision?
+- Multi-repo tasks: given the maverick / sample-maverick-project split, useful or a distraction?
+
+## Sources
+
+**Landscape and practitioner analysis**
+- [The Code Agent Orchestra — Addy Osmani](https://addyosmani.com/blog/code-agent-orchestra/)
+- [From Conductor to Orchestrator: Multi-Agent Coding in 2026](https://htdocs.dev/posts/from-conductor-to-orchestrator-a-practical-guide-to-multi-agent-coding-in-2026/)
+- [AI Agent Orchestration Tools for Coding (2026) — Tembo](https://www.tembo.io/blog/ai-agent-orchestration-tools)
+- [9 Open-Source Agent Orchestrators for AI Coding — Augment Code](https://www.augmentcode.com/tools/open-source-agent-orchestrators)
+- [AI Agent Orchestration in 2026 — amux](https://amux.io/guides/ai-agent-orchestration-2026/)
+
+**Spec-driven development**
+- [spec-compare: 6 SDD tools evaluated](https://github.com/cameronsjo/spec-compare)
+- [OpenSpec concepts](https://github.com/Fission-AI/OpenSpec/blob/main/docs/concepts.md) ·
+  [OpenSpec vs Spec Kit](https://codemyspec.com/blog/openspec-vs-spec-kit)
+- [Spec Kitty multi-agent orchestration](https://priivacy-ai.github.io/spec-kitty/explanation/multi-agent-orchestration.html) ·
+  [repo](https://github.com/Priivacy-ai/spec-kitty)
+- [AWS Kiro: specs as the unit of work](https://builder.aws.com/content/3DbBI7LQgNIcs6UUj7IPPvqFHOp/aws-kiro-the-agentic-ide-that-makes-specs-the-unit-of-work)
+
+**Parallel execution and isolation**
+- [Sculptor — Imbue](https://imbue.com/blog/sculptor-announce) ·
+  [coding agent sandboxes list](https://gist.github.com/wincent/2752d8d97727577050c043e4ff9e386e)
+- [Composio open-sources Agent Orchestrator](https://www.marktechpost.com/2026/02/23/composio-open-sources-agent-orchestrator-to-help-ai-developers-build-scalable-multi-agent-workflows-beyond-the-traditional-react-loops/)
+- [Git worktree isolation patterns — Zylos](https://zylos.ai/research/2026-02-22-git-worktree-parallel-ai-development/)
+
+**In-process multi-agent and model routing**
+- [Claude Code Agent Teams guide](https://www.morphllm.com/claude-code-agent-teams)
+- [Oh My OpenAgent overview](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/docs/guide/overview.md) ·
+  [OmO agents and model guide](https://www.glukhov.org/ai-devtools/opencode/oh-my-opencode-agents/)
+- [Agent-as-a-Router: agentic model routing for coding tasks (arXiv 2606.22902)](https://arxiv.org/abs/2606.22902)
+- [AI agent model routing strategies — Zylos](https://zylos.ai/research/2026-03-02-ai-agent-model-routing/)
+
+**Human-in-the-loop**
+- [HumanLayer](https://humanlayer.com)
+- [Approval queues are the runtime for agentic AI workflows — Focused Labs](https://focused.io/lab/approval-queues-are-the-runtime-for-agentic-ai-workflows)
+- [Async human approval for AI agents](https://github.com/AxmeAI/async-human-approval-for-ai-agents)
+- [The human review bottleneck](https://codex.danielvaughan.com/2026/05/24/human-review-bottleneck-code-review-strategies-agent-output/)
+
+**Cloud async agents**
+- [Google Jules async coding agent guide](https://www.digitalapplied.com/blog/google-jules-gemini-async-coding-agent-guide)
+- [Background coding agents compared](https://techsy.io/en/blog/background-coding-agents-compared)
+
+**Frameworks and protocols**
+- [LangGraph vs Temporal](https://www.langchain.com/resources/langgraph-vs-temporal)
+- [Durable agent execution in production 2026](https://agentmarketcap.ai/blog/2026/04/10/durable-agent-execution-production-temporal-modal-event-sourced)
+- [MCP, A2A, and where ACP went — Zuplo](https://zuplo.com/blog/agent-protocol-stack-mcp-a2a-acp-2026)
+- [Agent interoperability protocols 2026 — Zylos](https://zylos.ai/research/2026-03-26-agent-interoperability-protocols-mcp-a2a-acp-convergence/)
+
+**Internal**
+- [get2knowio/airframe](https://github.com/get2knowio/airframe) ·
+  [get2knowio/remo](https://github.com/get2knowio/remo)
+- This repository: `CLAUDE.md`, `FUTURE.md`, `.specify/memory/constitution.md`,
+  `specs/042`, `specs/048`–`053`, `src/maverick/`.

--- a/docs/specify-prompts-orchestration-roadmap.md
+++ b/docs/specify-prompts-orchestration-roadmap.md
@@ -1,0 +1,586 @@
+# Specify Prompts: Orchestration Roadmap
+
+A working sequence of `specify` prompts derived from
+`docs/competitive-analysis-orchestration-platforms.md` §6. Each prompt below is
+self-contained and ready to feed into the spec chain:
+
+```bash
+# Save the prompt block to a file, then:
+maverick spec <feature-name> --from-prd <file>
+maverick refuel <feature-name> --speckit
+maverick fly --epic <epic-id>
+```
+
+(or paste directly into `/speckit.specify` if driving Spec Kit by hand).
+
+Prompts are written per Spec Kit convention — intent, behavior, and constraints,
+with implementation left to the plan phase. Where a prompt references existing
+Maverick modules, that is context for the planner, not a design mandate.
+
+## Sequencing
+
+```
+Tier 0  (housekeeping, no spec):  close spec 042 as superseded
+
+Tier 1  (independent — start in any order):
+  1. assumption-batch-scheduler        ← highest value per effort
+  2. learned-assumption-resolution     (best after 1)
+  3. context-file-protection           (small)
+  4. isolated-bead-workspaces          ← unblocks the dispatcher
+  5. standalone-code-review            (small)
+  6. spec-delta-layer
+
+Tier 2  (the fleet backbone, in order):
+  7. maverick-host-daemon
+  8. task-container                    (after 7)
+  9. concurrent-fly-dispatcher         (after 4 and 7)
+ 10. credential-pool-leasing           (after 9; record-keeping ties to 8)
+
+Tier 3  (quality + surfaces):
+ 11. verification-taxonomy             (after 8)
+ 12. fleet-monitor                     (after 7; full value after 9)
+```
+
+Spec numbers (`NNN-`) are assigned by Spec Kit at specify time; the names below
+are suggestions. **Tier 0 is not a spec** — spec 042 (ACP integration) should
+simply be marked superseded in a small commit: ACP wound down into A2A, and
+airframe already occupies the layer 042 proposed.
+
+---
+
+## Tier 1 — independent
+
+### Prompt 1: `assumption-batch-scheduler` (Slice D core)
+
+```
+Add schedule-respecting, severity-tiered delivery of assumption-ledger entries
+to the human, so that questions raised by agents reach the human in batches
+that match the human's schedule instead of requiring them to poll `maverick
+brief`.
+
+Today, assumption severity drives enforcement (ready-queue deferral, blocks
+edges, the land gate) but not timing: nothing tells the human that entries
+exist until they run a command. This feature adds a delivery policy layered on
+severity:
+
+- high: interrupt — deliver a notification immediately when the entry is
+  recorded.
+- medium: batch — accumulate and deliver at the next configured review window.
+- low: accumulate silently — surfaced only during a review sweep or bulk
+  waive, never delivered proactively.
+
+Configuration lives in maverick.yaml under an assumptions schedule block:
+review windows as local times of day (e.g. 09:00 and 17:00), quiet hours
+during which nothing is delivered (with an explicit policy choice for whether
+high-severity interrupts override quiet hours — default: they do), a minimum
+batch size below which a window is skipped (entries roll to the next window),
+and a maximum entry age after which an undelivered or unanswered entry
+escalates regardless of batching rules.
+
+Delivery is via ntfy (already an optional dependency, currently unused for
+this). A batch notification carries: count by severity, the owning specs, the
+oldest entry's age, and the exact `maverick review` invocation to start the
+sweep. It does not carry entry contents — the notification is a summons, not
+the console.
+
+Timeouts and escalation: an unanswered high-severity entry past its maximum
+age re-notifies on a backoff schedule. An optional, explicitly configured
+policy may auto-waive aged low-severity entries with a recorded rationale on
+the ledger entry. Nothing ever expires silently.
+
+The scheduler must work without any resident daemon: it runs as an idempotent
+command (suitable for cron or a systemd timer) that evaluates the ledger
+against the schedule and delivers anything due. Re-running within the same
+window must not re-deliver the same batch. Delivery state (what was delivered,
+when) is persisted so that evaluation is deterministic and auditable. A future
+host daemon may later call the same evaluation in-process; nothing in this
+feature may assume residency.
+
+Out of scope: Slack/email channels, learned auto-resolution from prior
+answers, any change to enforcement semantics (the land gate and ready-queue
+behavior are untouched).
+
+Success looks like: a human with quiet hours 22:00–07:00 and windows at 09:00
+and 17:00 receives exactly one push at 09:00 summarizing everything that
+accumulated overnight, is interrupted only for high-severity entries, and can
+prove from persisted state why each notification fired.
+```
+
+### Prompt 2: `learned-assumption-resolution` (Slice D, items 5–6)
+
+```
+Feed resolved assumption-ledger entries into runway as reusable knowledge, so
+that when an agent adopts an assumption closely matching one the human has
+already answered, the prior answer is proposed as the default during review —
+and eventually the fleet stops asking questions the human has already
+answered.
+
+Two capabilities:
+
+1. Decisions as labels. Every terminal ledger outcome — answered (with the
+   answer text), waived (with the reason), and edited-then-answered — is
+   persisted as a structured decision record in runway, carrying the question,
+   the adopted answer, the human's resolution, severity, and the owning spec.
+   Records survive across specs and runs.
+
+2. Suggested answers at review time. When a new assumption is recorded, it is
+   matched against prior decision records. When a sufficiently close prior
+   decision exists, the entry carries a suggested resolution with provenance
+   (which prior entry, which spec, when). The suggestion surfaces in
+   `maverick review --list --json` as a field on the entry row, and the
+   maverick-review skill presents it as the default option in its
+   AskUserQuestion sweep. The land gate is unchanged: a suggestion never
+   auto-answers an entry.
+
+An explicit opt-in policy may allow auto-resolution for low-severity entries
+whose match confidence exceeds a configured threshold; auto-resolved entries
+are marked as such on the ledger with the source decision's provenance, and
+they appear in the land report distinctly from human-answered entries (a land
+that relied on any auto-resolution is at most conditionally-verified).
+
+Matching quality matters more than coverage: a wrong suggestion presented as a
+default is worse than no suggestion. The feature must define what "closely
+matching" means, how confidence is scored, and how false suggestions are
+suppressed after the human rejects them (a rejected suggestion for a given
+question shape must lower that pairing's future confidence).
+
+Out of scope: cross-repository knowledge sharing; any change to how
+assumptions are captured.
+```
+
+### Prompt 3: `context-file-protection` (Slice G)
+
+```
+Add a safety hook that prevents agents from modifying agent-context files —
+AGENTS.md, CLAUDE.md, and the Spec Kit constitution — anywhere in the
+repository, unless the human has explicitly allowed it.
+
+Field data shows LLM-generated context files measurably reduce task success
+and raise cost, while human-curated ones compound in value. Maverick's own
+constitution and CLAUDE.md are load-bearing; an implementer agent "helpfully"
+rewriting them mid-bead is silent corruption of the fleet's operating
+instructions.
+
+Behavior: any agent-initiated write (create, edit, delete, rename) targeting a
+protected path is blocked before it happens, the block is recorded as a
+structured event on the run, and the bead continues — a blocked context-file
+write is not a bead failure. The protected set defaults to AGENTS.md,
+CLAUDE.md, and .specify/memory/** at any depth, and is extensible via
+maverick.yaml (additional globs, or an explicit allowlist for repositories
+where agents are supposed to maintain such files). The hook applies to every
+agent role on every workflow, including inside isolated workspaces.
+
+The hook must fail closed for the protected set but must not degrade anything
+else: if the hook infrastructure itself errors, agent writes to unprotected
+paths proceed normally.
+
+Out of scope: protecting arbitrary user-designated files beyond the config
+mechanism; reviewing or reverting historical agent edits to context files.
+```
+
+### Prompt 4: `isolated-bead-workspaces` (Slice C step 1 — the Guardrail 0 amendment)
+
+```
+Generalize the spec-chain's hidden-workspace mechanism into a reusable
+isolated-execution primitive, and amend Guardrail 0 from "no workspaces" to
+"no bd inside a workspace" — its actual load-bearing constraint.
+
+History: Guardrail 0 retired hidden workspaces because bd's gitignored
+embeddeddolt/ store does not travel with `jj workspace add`, so bd cannot
+function inside one. That is a bd constraint, not a workspace constraint.
+Spec 050 (headless spec chain) then proved the workspace mechanism works when
+bd stays out: the agent mutates files in the workspace, while all bd, ledger,
+and jj-history writes happen in the orchestrating process against the user's
+checkout, and completed artifacts land atomically per step.
+
+This feature extracts that proven contract into a reusable primitive that any
+workflow can use to run an agent step in isolation:
+
+- The primitive provisions a workspace for a unit of work, executes the
+  agent's file mutations there, and folds the resulting delta back into the
+  user's checkout via jj on success — or discards it cleanly on failure, with
+  nothing half-written ever visible in the checkout.
+- The invariant is enforced structurally, not by convention: bd is never
+  invoked inside a workspace, and all bead, ledger, and commit-graph writes
+  occur in the orchestrating process. It should be difficult to violate this
+  accidentally.
+- Workspace lifecycle matches what spec-chain already does: created per unit
+  of work, torn down on completion, and abandoned workspaces are swept.
+
+As the first consumer and the proof of the fold-back mechanics, `maverick fly`
+gains an opt-in isolated mode: each bead executes in its own workspace,
+still strictly serially, with the fold-back producing the same bead commit
+(same subject prefix, same Bead trailer) the in-checkout path produces. A
+fold-back conflict fails the bead with a clear diagnostic; conflict
+*resolution* machinery is out of scope here and arrives with the concurrent
+dispatcher.
+
+The constitution amendment ships in the same feature: Guardrail 0's text is
+updated to state the single-repo model, the bd-stays-out invariant, and that
+isolated agent-side execution is permitted under this contract — replacing the
+current phrasing where spec-chain is a one-off exception.
+
+Success looks like: a fly run in isolated mode produces byte-identical history
+to a normal run for the same beads, the user's checkout never contains
+mid-bead intermediate state, and the constitution accurately describes the
+system.
+```
+
+### Prompt 5: `standalone-code-review` (Slice G)
+
+```
+Add a standalone agentic code-review command that reviews a diff, an epic's
+accumulated changes, or a set of paths on demand — outside the fly loop.
+
+Today the reviewer agent only runs inside `maverick fly` as part of the
+per-bead gate. Its judgment is useful on demand: before pushing a manual
+change, after landing an epic, or on a colleague's branch.
+
+Scope selection: review the working-copy diff against a base revision, review
+everything an epic's beads committed (located via bead commit trailers), or
+review explicit paths. The command reuses the existing reviewer agent and tier
+routing; it must not fork a second review implementation.
+
+Output: findings rendered to the terminal grouped by file with severity, and a
+persisted findings artifact under the run directory. A --json mode emits the
+findings through the shared JSON verb envelope so the command is scriptable
+and skill-callable. The command is read-only with respect to the repository:
+no commits, no bead writes, no fix loop — findings are for the human.
+
+Naming needs care: `maverick review` is taken by the assumption-review
+console. The spec should choose a name that will not collide or confuse
+(candidates: `maverick inspect`, `maverick critique`, `maverick review-code`).
+
+Out of scope: automated fixing of findings; CI integration; review of
+revisions not reachable from the current repository.
+```
+
+### Prompt 6: `spec-delta-layer` (Slice G — OpenSpec-style modification)
+
+```
+Add a delta layer for modifying existing specs, closing Spec Kit's known
+brownfield weakness: today, changing a shipped spec means editing spec.md in
+place, and `refuel --speckit`'s delta detection only handles tasks.md growth —
+there is no structured way to express "this requirement changed" and have it
+flow deterministically into new work.
+
+Model the field's answer (OpenSpec): a change proposal is a structured
+artifact describing deltas against an existing spec — requirements added,
+modified, or removed — with a lifecycle of propose, apply, and archive.
+
+- Propose: a delta document lives alongside the spec it modifies, expressing
+  each change as ADDED, MODIFIED (with before/after), or REMOVED, in a format
+  that is deterministically parseable (Guardrail 8: zero model calls to
+  ingest).
+- Apply: applying a delta rewrites spec.md and tasks.md to their new state,
+  and refuel ingests the consequences deterministically — new tasks become new
+  beads under the existing epic; removed requirements close their open,
+  unstarted beads; modified requirements with in-flight or completed beads
+  raise a flag for the human rather than silently mutating work.
+- Archive: an applied delta is preserved as provenance — the spec's history of
+  intentional change, distinct from git history.
+
+The spec must resolve whether this layer is purely additive on top of Spec Kit
+artifacts (preferred: our chain and ingestion continue to work on vanilla
+Spec Kit repos) or requires deviating from upstream Spec Kit conventions — and
+if the latter, what the compatibility story is.
+
+Out of scope: AI-authored delta proposals (a human or an upstream tool writes
+the delta; a later feature may generate them); retroactive reconstruction of
+deltas for past spec edits.
+```
+
+---
+
+## Tier 2 — the fleet backbone
+
+### Prompt 7: `maverick-host-daemon` (Slice A)
+
+```
+Add a per-repository host daemon that outlives any single CLI invocation, so
+that long-running work survives terminal disconnects and, later, a fleet of
+concurrent agents has a resident supervisor.
+
+Today every command is a foreground process: closing the terminal kills the
+run, agents are opened and torn down per invocation, and there is no single
+place that knows what is currently running. The daemon inverts this:
+
+- One daemon per repository, started on demand by the first command that
+  wants it, exposing a local RPC surface over a unix socket in the repo's
+  .maverick directory, with per-user discovery metadata so clients and tooling
+  can enumerate live hosts.
+- The daemon owns: squadron lifetime (agents opened once and reused across
+  invocations rather than per-command), run and task state, the ProgressEvent
+  stream (fanned out to any number of subscribed clients), and provider health.
+- Existing commands become thin clients: `maverick fly` submits work to the
+  daemon and streams events; detaching (Ctrl-C in the client, closing the
+  terminal, SSH drop) leaves the run flying; a new invocation reattaches to
+  the live event stream. The two-stage Ctrl-C contract is preserved with an
+  explicit mapping: detach is the default client action, graceful stop and
+  hard cancel are explicit signals to the daemon.
+- Every command must retain a one-shot fallback that works with no daemon
+  present — daemonless operation remains fully supported, and CI or scripting
+  contexts never need a resident process.
+
+Lifecycle: clean shutdown on idle after a configurable period, crash recovery
+on next start (a daemon that died mid-run must leave enough persisted state
+for the run to resume or be cleanly reported as interrupted), and stale
+socket/discovery cleanup. Exactly one daemon per repository is enforced.
+
+The spec must resolve one open architectural question: does the daemon own the
+Burr application in-process, or supervise subprocesses that own their own?
+This decides crash isolation (one bad action taking down the fleet supervisor)
+and matters more once beads run concurrently.
+
+Out of scope: concurrent bead execution (the dispatcher builds on this);
+remote/network access to the daemon (local socket only); any GUI.
+```
+
+### Prompt 8: `task-container` (Slice B)
+
+```
+Promote the per-run directory into a durable task container that spans a
+feature's whole lifecycle — spec, refuel, fly, land — so that everything
+Maverick did for a feature is one resumable, auditable unit.
+
+Today .maverick/runs/<run-id>/ is per-invocation: a feature that goes through
+spec, refuel, three fly sessions, and a land leaves its history scattered
+across unrelated run directories, and nothing ties them together or to the
+spec and epic they served.
+
+A task is created when work begins on a feature and accumulates until the
+feature lands:
+
+- Identity and status: which spec directory, which epic bead, which workspace
+  folder(s) if isolated execution was used, where the work ran, and a status
+  machine covering the lifecycle (specifying, refueled, flying, awaiting-
+  review, landing, landed, abandoned).
+- Execution records: one per agent handoff, carrying the plan/prompt context,
+  the verification outcome, resulting commits, cost, and — critically — the
+  resolved (provider, model, credential) binding that served it. That binding
+  is what makes cross-subscription attribution and per-feature cost analysis
+  possible once a credential pool exists.
+- The full ProgressEvent stream for the task, append-only.
+- Checkpoints: the spec-chain's checkpoint/resume mechanism generalized, so
+  any interrupted phase can resume from its last completed step.
+
+Existing commands adopt the container without breaking: run directories that
+exist today keep working, new work is recorded under tasks, and the land
+report and brief can aggregate by task. The host daemon, where present, is the
+writer of task state; daemonless invocations write it directly.
+
+Success looks like: after a feature lands, a single task directory answers —
+what was specified, what was assumed, who implemented each bead on which
+model and subscription, what it cost, what the reviewer said, and what
+landed.
+
+Out of scope: multi-repository tasks; any UI beyond existing commands reading
+task state.
+```
+
+### Prompt 9: `concurrent-fly-dispatcher` (Slice C — the thesis's missing leg)
+
+```
+Replace fly's serial drain loop with a bounded concurrent dispatcher: N beads
+in flight at once, each in its own isolated workspace, with all coordination
+serialized through the orchestrator.
+
+Prerequisites: isolated bead workspaces (the fold-back contract, already
+proven serially) and the host daemon (the resident supervisor).
+
+- Worker pool: default WIP limit of 3 concurrent beads, configurable with a
+  hard cap. The field's evidence is that 3–5 is the ceiling for meaningful
+  oversight; the default should reflect that, not maximize throughput.
+- Scheduling: the ready set continues to come from bd's dependency graph
+  exactly as today. The dispatcher claims a ready bead, leases it to a worker,
+  and never hands two workers overlapping file scopes when the beads declare
+  them (task-level [P] markers and file scope from Spec Kit ingestion are the
+  signal); beads with unknown scope are conservatively serialized.
+- Isolation: each bead executes in its own workspace via the isolated-
+  execution primitive. All bd writes, ledger writes, and jj history mutations
+  are serialized through the orchestrating process — bd is never assumed to
+  tolerate concurrent writers.
+- Merge discipline: a completed bead folds back into the checkout via jj. A
+  fold-back conflict routes into the existing round-budgeted conflict-
+  resolution machinery from reconcile (positioned child, agent resolution,
+  squash back, bounded rounds, escalate to a human bead on exhaustion) rather
+  than failing the bead outright.
+- Mid-flight reconcile must be re-contracted: its current guard assumes one
+  flying run parked at a safe empty-working-copy boundary between beads. Under
+  a pool there is no single boundary. The spec must define when reconcile may
+  run during a concurrent fly (e.g. a quiesce point where the dispatcher
+  drains in-flight beads before reconciling) or explicitly defer mid-flight
+  reconcile in concurrent mode to a follow-up, with the manual command still
+  available.
+- Failure isolation: one bead's failure (agent error, fold-back escalation,
+  budget exhaustion) never takes down the pool. The two-stage stop contract
+  generalizes: graceful stop finishes in-flight beads and claims no new ones;
+  hard cancel aborts workers and discards their workspaces cleanly.
+- Fix loops, tier routing, and escalation ladders apply per bead unchanged.
+
+Success looks like: an epic whose task graph permits parallelism completes in
+materially less wall-clock time than serial fly, with history that is
+bead-for-bead equivalent in structure to what serial fly would have produced,
+and with zero corrupted bd state across a large test matrix of concurrent
+runs.
+
+Out of scope: credential pooling across subscriptions (next feature — this
+feature runs the pool against each role's existing single binding, which
+naturally bounds per-provider concurrency); cross-repository dispatch.
+```
+
+### Prompt 10: `credential-pool-leasing` (Slice C — subscriptions)
+
+```
+Let a single agent role draw from a pool of credentials across providers and
+subscriptions, with per-task leasing, quota-aware rotation, and per-binding
+concurrency caps as a first-class terms-of-service compliance control.
+
+Today each role resolves to exactly one (provider, model) binding. With
+concurrent beads, that binding becomes both a throughput bottleneck and a
+compliance risk: multiplexing one seat-based subscription across many
+concurrent agents may violate provider terms.
+
+- Pool configuration: a role may declare a list of credential bindings instead
+  of a single one, each carrying provider, model, auth reference, and — 
+  required, not optional — max_concurrent. The cap is a designed compliance
+  control reflecting what the subscription's terms permit, not a rate limiter;
+  configuration that omits it does not validate.
+- Leasing: a worker leases one binding for the duration of a bead and releases
+  it on completion. Leases respect max_concurrent absolutely: no binding ever
+  serves more simultaneous work than its cap, even transiently.
+- Rotation and cooldown: on a quota or billing error (detection already exists
+  in the quota exception hierarchy), the lease's binding enters a cooldown
+  with backoff, the work retries on the next eligible binding in the pool, and
+  an exhausted pool falls back to an explicitly configured fallback binding or
+  parks the bead as blocked-on-capacity — never silent failure, never
+  hammering an exhausted subscription.
+- Attribution: every execution record in the task container carries the
+  binding that actually served it, so per-subscription usage and cost are
+  auditable after the fact.
+- Interaction with tiers: complexity tiers remain the routing policy (which
+  class of model should do this work); the pool is the capacity layer beneath
+  it (which concrete credential serves it now). Tier selection happens first,
+  then leasing within that tier's pool.
+
+Success looks like: a two-subscription setup with caps of 2 and 1 never
+exceeds either cap under a WIP-5 dispatcher, rotates within one retry on a
+simulated quota exhaustion, recovers the cooled binding after its window, and
+the task container attributes every bead to the subscription that ran it.
+
+Out of scope: automatic discovery of credentials; sharing pools across
+repositories; any attempt to evade provider rate limits — this feature exists
+to respect them.
+```
+
+---
+
+## Tier 3 — quality and surfaces
+
+### Prompt 11: `verification-taxonomy` (Slice E)
+
+```
+Give fly's review gate a real verification taxonomy: an explicit plan-
+conformance check against the bead's scope and acceptance criteria, findings
+graded on their own scale, persisted as durable artifacts, and consumed by the
+fix loop at a configurable threshold.
+
+Today the reviewer returns a pass/fail-ish judgment with prose findings.
+Missing: a defined severity scale for findings, an explicit check that the
+implementation matches the bead's declared scope (not just that the code is
+good), durable persistence of what the reviewer said, and a tunable answer to
+"which findings force a fix round?"
+
+- Findings taxonomy: critical, major, minor, outdated — where outdated marks a
+  finding invalidated by a later fix round rather than resolved. This scale is
+  deliberately distinct from assumption severity: "the code deviates from the
+  plan" and "the agent guessed about intent" are different questions, and
+  conflating them muddies the land gate. Nothing from this taxonomy enters
+  the assumption ledger.
+- Plan conformance: the reviewer explicitly verifies the diff against the
+  bead's scope, file expectations, and acceptance criteria from ingestion, and
+  reports out-of-scope changes as findings. Scope creep is a first-class
+  finding type, not a vibe.
+- Durable artifacts: each review round persists its full findings under the
+  bead's execution record in the task container, so review history survives
+  the session and is auditable per fix round.
+- Fix-loop threshold: which severities trigger a fix round is configuration
+  (default: critical and major fix; minor records without blocking). The
+  existing fix-round budget and tier-escalation behavior are unchanged.
+- Re-verify versus fresh-verify: after a fix round, the reviewer distinguishes
+  re-checking prior findings (marking them resolved or outdated) from
+  reviewing the fix as new code, and both are recorded.
+
+Out of scope: changing the reviewer agent's underlying model or prompts beyond
+what the structured output requires; standalone review (separate feature);
+any change to assumption-ledger semantics.
+```
+
+### Prompt 12: `fleet-monitor` (Slice F1)
+
+```
+Add `maverick monitor`: a live terminal fleet board over the host daemon's
+event stream, showing everything currently in flight in one place.
+
+This is the console answer to the GUI board every parallel-runner competitor
+ships. brief --watch already proves the render loop (Rich Live, in-place
+refresh); the monitor generalizes it from bead counts to the whole fleet.
+
+One screen shows, per in-flight bead: the bead id and title, current phase
+(implementing, gate, reviewing, fix round N), the agent role and its resolved
+model binding (and credential, once pooling exists), elapsed time, and cost so
+far. Around the board: the run/task identity, WIP versus limit, ready-queue
+depth, the assumption frontier (open entries by severity — the number that
+gates landing), and cumulative cost burn for the session.
+
+The monitor is a pure client of the daemon's event stream: read-only,
+attachable and detachable at any time, multiple monitors may watch one run,
+and it renders a truthful "nothing is flying" state (plus last-completed
+summary) when the fleet is idle. With a serial fly it degrades gracefully to a
+single-row board — useful on day one, before the dispatcher lands.
+
+Follow rendering conventions: no emoji, human-readable phase names, no
+implementation labels, structured warnings.
+
+Out of scope: any interaction beyond watching (answering entries stays in
+maverick review; stopping stays in the fly client); web or GUI surfaces;
+historical analytics (the task container holds the data for that later).
+```
+
+---
+
+## Smaller follow-ons (specify when wanted)
+
+Not sequenced — each is small, independent, and can slot in anywhere:
+
+- **`maverick-plan` / `maverick-verify` skills** (Slice F2) — extend the
+  packaged-skill family proven by `maverick-review`; each backed entirely by
+  JSON verbs, never touching jj/bd/files directly.
+- **Prompt templates** — `.maverick/templates/*.md` with frontmatter
+  applicability rules, rendered into agent prompts.
+- **Steering files** — Kiro-style per-directory behavioral rules, scoped
+  narrower than the constitution.
+- **Model profile presets** — named `balanced` / `frontier` presets over the
+  existing tiers config, plus pre-run cost estimation.
+
+## Relationship to the analysis
+
+| Prompt | Analysis slice | Depends on |
+|---|---|---|
+| 1 batch scheduler | D (1–4) | — |
+| 2 learned resolution | D (5–6) | 1 (soft) |
+| 3 context-file protection | G | — |
+| 4 isolated workspaces | C step 1 / §5.1 | — |
+| 5 standalone review | G | — |
+| 6 spec delta layer | G | — |
+| 7 host daemon | A | — |
+| 8 task container | B | 7 |
+| 9 dispatcher | C steps 2, 4, 5 | 4, 7 |
+| 10 credential pool | C step 3 | 9 (uses 8) |
+| 11 verification taxonomy | E | 8 |
+| 12 fleet monitor | F1 | 7 (full value: 9) |
+
+The three-part thesis maps as: **Spec Kit under the covers** — already built,
+sharpened by 6; **multiple agents / models / subscriptions** — 4 → 7 → 9 → 10;
+**batched human interaction on the human's schedule** — 1 → 2, delivered
+independently of everything else and first.


### PR DESCRIPTION
## Summary

Two documents-only additions:

- **`docs/competitive-analysis-orchestration-platforms.md`** — a broad competitive analysis of the agent-orchestration field across seven segments (spec-driven methodology, plan-first orchestration, local parallel-agent runners, in-process multi-agent, cloud async agents, durable-execution plumbing, HITL infrastructure), mapped onto the three-part thesis: Spec Kit under the covers, execution fanned out across multiple agents/models/subscriptions, and human interaction aggregated into schedule-respecting batches. Key findings: the high-rigor / high-latency-tolerance quadrant is empty and the assumption ledger + `reconcile` is the enabling primitive for it; isolation is table stakes (with a proposed Guardrail 0 amendment to "no bd inside a workspace"); Spec Kitty is the closest structural competitor; ACP folded into A2A, so spec 042 should close as superseded; subscription multiplexing needs per-binding concurrency caps as a designed ToS compliance control.

- **`docs/specify-prompts-orchestration-roadmap.md`** — twelve ready-to-paste `specify` prompts derived from the analysis's Slices A–G, sequenced by dependency: an independent tier (assumption batch scheduler, learned assumption resolution, context-file protection, isolated bead workspaces, standalone code review, spec delta layer), the fleet backbone (host daemon, task container, concurrent dispatcher, credential pool with leasing), and a quality/surfaces tier (verification taxonomy, fleet monitor).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U2VStxQbXt4U2bLRTPBDc
