### PR TITLE
feat(notify): assumption batch scheduler (054)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ test_bd.sh
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 /.maverick/runs
+# `maverick notify` delivery state + pid lockfile: per-machine, never
+# committed. jj-colocated checkouts auto-snapshot anything not ignored, so
+# leaving these tracked would make every cron fire dirty the working copy.
+/.maverick/notify

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/053-assumption-review-console"
+  "feature_directory": "specs/054-assumption-batch-scheduler"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -486,6 +486,7 @@ Mode is auto-detected from repository shape; `--speckit` forces it.
 | `maverick fly --epic <id>`                           | Implement beads (Burr drain loop)    |
 | `maverick land [--eject\|--finalize] [--status] [--json]` | Curate history and merge, or query the frontier |
 | `maverick reconcile [--dry-run] [--json]`            | Reapply changed human answers into jj history |
+| `maverick notify [--dry-run] [--json]`               | Evaluate and deliver due assumption-ledger notifications |
 | `maverick init`                                      | Initialize a Maverick project (installs the `maverick-review` skill) |
 | `maverick brief [--watch\|--human]`                  | Bead status + assumption counts      |
 | `maverick review <bead-id> [--answer\|--waive] [--json]` | Resolve a human-assigned bead     |
@@ -687,6 +688,83 @@ default `true`) — set `false` to disable and fall back to manual
 `maverick reconcile` runs. See
 `specs/052-conditional-landing/contracts/mid-flight-reconcile.md` and
 `src/maverick/workflows/fly_beads/mid_flight.py`.
+
+### notify (assumption batch scheduler)
+
+`maverick notify [--dry-run] [--json]` (054-assumption-batch-scheduler) is an
+idempotent, daemonless command that reads the assumption ledger, evaluates it
+against a configured delivery schedule, and pushes anything due via ntfy —
+designed to be wired into cron or a systemd timer, not run as a resident
+process (FR-001, FR-017). Severity drives the delivery policy (FR-002):
+`high` interrupts at the next evaluation after recording; `medium` batches
+into the next configured review window; `low` accumulates silently and is
+only counted (never delivered) in a batch summary, surfacing via a review
+sweep or bulk waive. A medium/high entry older than `max_entry_age_hours`
+escalates past the batching rules (FR-006); an unanswered high-severity
+interrupt then re-notifies on a backoff ladder (`renotify_backoff_hours`,
+default `4→8→16→24h`, repeating) rather than on every evaluation (FR-007).
+Legacy entries (no structured severity) are treated as medium — no new
+mapping code, `report_entries` already synthesizes it (research R9). An
+opt-in `auto_waive_low` policy (research R10) waives aged low-severity
+entries through the existing `assumptions.ledger.waive()` path, stamped
+`waived_by="maverick-scheduler"` with a recorded rationale — already
+distinguishable in `review --list`/land reporting via the existing waiver
+object, no ledger schema change.
+
+Configuration lives in two blocks (`contracts/config-schema.md`): the new
+`assumptions.schedule` block (`windows`, `quiet_hours`, `high_overrides_quiet`
+default `true`, `min_batch_size` default 1, `max_entry_age_hours` default 24,
+`renotify_backoff_hours`, `auto_waive_low`) plus the existing `notifications`
+block (`enabled`/`server`/`topic`) for the ntfy endpoint — reused rather than
+duplicated (research R3). No `assumptions.schedule` block means the command
+is strictly inert: exit 0, "not configured", zero deliveries (FR-021) — there
+is no built-in default schedule. A window whose pending batch is under
+`min_batch_size` rolls to the next window (FR-005); quiet hours suppress
+everything except high-severity interrupts unless `high_overrides_quiet` is
+set to make quiet hours absolute (FR-004); a window occurrence inside quiet
+hours shifts its due time to quiet-hours end rather than creating a second
+decision (research R8). Evaluation is a pure function of `(entries, schedule,
+state, now)` with `now` injected at the CLI boundary — the codebase's first
+clock seam (research R6).
+
+Delivery state persists at `.maverick/notify/state.json`
+(`schema_version: 1`, atomic writes) plus a pid-stamped advisory lockfile at
+`.maverick/notify/lock`, mirroring `workflows/reconcile/state.py`'s
+lock pattern byte-for-byte (research R4) — this is what makes re-running the
+same window a no-op (FR-010) and every delivery/skip reconstructible from
+ledger + config + state alone (FR-011). Records are retained while any
+covered entry stays open, plus 90 days past terminal state (FR-023).
+**Lock contention diverges from `reconcile` by design** (research R7):
+overlapping cron fires are expected operation here, not a fault, so a held
+lock is a benign `SUCCESS` exit with `result.skipped: "concurrent-evaluation"`
+and zero evaluation performed — not `reconcile`'s `locked` error kind. `bd`
+unavailability maps to `bd-unavailable`; an unusable `notifications` block
+(disabled or no `topic`) maps to `validation`, naming the exact missing key
+(FR-009). `--dry-run` evaluates and reports every decision with zero ntfy
+calls, zero bd writes, zero state writes.
+
+**JSON verbs**: `notify --json` (verb `notify.run`) and `notify --dry-run
+--json` (verb `notify.dry-run`) emit the shared envelope
+(`src/maverick/cli/json_output.py`) with every delivery and skip tagged by
+the rule that decided it (SC-004). Exhausted ntfy retries map to the new
+additive `ErrorKind.DELIVERY_FAILED` (`"delivery-failed"`, research R11),
+exit 1, with the batch left due — a failed delivery is never recorded as
+delivered (FR-012). See
+`specs/054-assumption-batch-scheduler/contracts/cli-notify-json.md` and
+`config-schema.md`; implementation in `src/maverick/cli/commands/notify.py`
+and `src/maverick/assumptions/schedule/`: `evaluate.py` (the pure entry
+point + orchestration) over four decision engines — `windows.py` (occurrence
+construction, DST-aware localization, quiet hours, window batching),
+`severity.py` (high-severity interrupts), `escalation.py` (max-age
+escalation, renotify backoff, auto-waive), all sharing the table-driven
+`decisions.py` — plus `tracking.py`, `models.py`, `state.py`, `deliver.py`,
+and `clock.py` (stdlib IANA local-zone resolution; the CLI's `now` must
+carry a real zone, not `datetime.now().astimezone()`'s fixed offset, or the
+DST handling is inert). Quiet hours suppress **deliveries**, not bookkeeping,
+and `high_overrides_quiet` governs high severity **only** — a medium
+escalation or a backlogged window batch is always held until quiet hours end
+(FR-004). Zero model calls, zero agents, zero Burr — deterministic library
+and CLI only.
 
 ### Assumption ledger
 

--- a/specs/054-assumption-batch-scheduler/checklists/requirements.md
+++ b/specs/054-assumption-batch-scheduler/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Assumption Batch Scheduler
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- ntfy is named in FR-009 and the delivery entities: the feature description
+  mandates ntfy as the delivery channel (an existing optional dependency), so
+  it is treated as a product constraint rather than an implementation leak.
+- The CLI command name is deliberately deferred to planning (see Assumptions);
+  the spec constrains its behavior (idempotent, cron-suitable, daemonless),
+  not its name.
+- All items pass; ready for `/speckit-clarify` or `/speckit-plan`.

--- a/specs/054-assumption-batch-scheduler/contracts/cli-notify-json.md
+++ b/specs/054-assumption-batch-scheduler/contracts/cli-notify-json.md
@@ -1,0 +1,122 @@
+# Contract: `maverick notify` CLI + JSON envelope
+
+## Command surface
+
+```
+maverick notify [--dry-run] [--json]
+```
+
+- `--dry-run` — evaluate and report every decision; zero ntfy calls, zero bd
+  writes, zero state writes.
+- `--json` — emit the shared `JsonEnvelope` (`src/maverick/cli/json_output.py`)
+  on stdout; all narration goes to `err_console`.
+
+Registered lazily in `main.py` `_LAZY_COMMANDS` as `"notify"`. Not added to
+`commands_needing_git_gh` (no VCS interaction) nor `commands_needing_config`
+gates; config is loaded in-command like `reconcile`.
+
+## Verbs
+
+| Invocation | `verb` |
+|---|---|
+| `maverick notify --json` | `notify.run` |
+| `maverick notify --dry-run --json` | `notify.dry-run` |
+
+`schema_version` is always `1`.
+
+## Success result shape (`ok: true`)
+
+```json
+{
+  "schema_version": 1,
+  "verb": "notify.run",
+  "ok": true,
+  "result": {
+    "configured": true,
+    "skipped": null,
+    "evaluated_at": "2026-08-05T09:00:12-04:00",
+    "deliveries": [
+      {
+        "kind": "window-batch",
+        "trigger": "2026-08-05/09:00",
+        "entry_ids": ["mav-abc", "mav-def"],
+        "summary": {
+          "counts": {"high": 0, "medium": 2, "low": 3},
+          "owner_specs": ["054-assumption-batch-scheduler"],
+          "oldest_age_hours": 11.5,
+          "review_invocation": "maverick review --list --status open"
+        },
+        "rule": "window 09:00 due"
+      }
+    ],
+    "skips": [
+      {"reason": "low-never-proactive", "entry_ids": ["mav-low1"], "occurrence": null,
+       "rule": "low severity accumulates silently"}
+    ],
+    "auto_waives": [],
+    "dry_run": false
+  },
+  "error": null
+}
+```
+
+Contract points:
+
+- `evaluated_at` is the injected local `now` (aware, machine-local offset) —
+  deliberately different from persisted state, where all timestamps are UTC
+  ISO-8601 (contracts/delivery-state-schema.md).
+- `configured: false` + `skipped: "not-configured"` + empty arrays when no
+  `assumptions.schedule` block exists — **exit 0, `ok: true`** (FR-021:
+  inert is an answer, not a failure).
+- `skipped: "concurrent-evaluation"` when the lockfile is held by a live pid —
+  **exit 0, `ok: true`**, no evaluation performed. This deliberately diverges
+  from `reconcile`'s `locked` error kind: overlapping cron fires are normal
+  operation for this command (research R7).
+- Every delivery and every skip carries `rule` — the human-readable citation of
+  the deciding rule (SC-004 auditability surfaces here and in persisted state).
+- `--dry-run` returns the identical shape with `dry_run: true`; `deliveries`
+  then means *would deliver*.
+- In dry-run, `auto_waives` lists would-waive entries; in real runs it lists
+  entries actually waived (with their recorded rationale text).
+
+## Error mapping (`ok: false`)
+
+| Condition | `error.kind` | Exit |
+|---|---|---|
+| Schedule configured but `notifications.enabled` false or `topic` unset | `validation` (message names the exact missing key) | 1 |
+| Malformed `maverick.yaml` / schedule values | `validation` | 1 |
+| bd missing / not initialized (`bd_ready_reason` non-None, or `verify_available()` False — translated explicitly, it does not raise) | `bd-unavailable` | 1 |
+| Ledger read failure (`AssumptionLedgerError`) | `validation` (existing `json_error_handler` mapping) | 1 |
+| ntfy delivery retries exhausted | `delivery-failed` (**new additive `ErrorKind`**) with `error.details.failed_deliveries` listing the undelivered decisions; partial successes are recorded in state before exit | 1 |
+| Unexpected exception | `internal` | 1 |
+
+`KeyboardInterrupt` follows house behavior: nothing emitted, exit 130.
+
+## Exit codes
+
+| Outcome | Exit |
+|---|---|
+| Evaluated (with or without deliveries), unconfigured no-op, or benign lock skip | 0 (`SUCCESS`) |
+| Any `ok: false` envelope | 1 (`FAILURE`) |
+| Interrupted | 130 |
+
+## Human-mode output (no `--json`)
+
+Follows Appendix C conventions — Rich console, no emoji, human-readable
+phrasing:
+
+- Unconfigured: single line
+  `Assumption delivery is not configured (no assumptions.schedule block in maverick.yaml).`
+- Deliveries: one completion line per delivery with timing-free summary, e.g.
+  `[green]✓[/] Delivered window batch (2 medium, 3 low; oldest 11.5h) for 09:00 window`
+- Skips are summarized only at verbose level; a quiet no-op run prints
+  `Nothing due.`
+- Delivery failure: `[red]✗[/] Delivery failed: <reason>` +
+  `[yellow]Warning:[/yellow]`-style guidance, exit 1.
+
+## Idempotence contract (FR-010/FR-013)
+
+Two consecutive invocations with unchanged ledger state and the same window
+occurrence produce: first → `deliveries` non-empty; second →
+`skips: [{"reason": "already-delivered", ...}]` and zero ntfy calls. Concurrent
+invocations: exactly one evaluates; the other reports the benign lock skip.

--- a/specs/054-assumption-batch-scheduler/contracts/config-schema.md
+++ b/specs/054-assumption-batch-scheduler/contracts/config-schema.md
@@ -1,0 +1,64 @@
+# Contract: configuration schema (`maverick.yaml`)
+
+Two blocks cooperate: the **new** `assumptions.schedule` block (delivery
+policy) and the **existing** `notifications` block (ntfy endpoint — reused
+unchanged, first consumer).
+
+## Full example
+
+```yaml
+notifications:
+  enabled: true
+  server: https://ntfy.sh        # default
+  topic: my-maverick-topic       # required for delivery
+
+assumptions:
+  schedule:
+    windows: ["09:00", "17:00"]  # required, >=1, HH:MM local time, unique
+    quiet_hours:                 # optional; absent => no quiet hours
+      start: "22:00"
+      end: "07:00"               # may be earlier than start (spans midnight)
+    high_overrides_quiet: true   # default true (FR-004)
+    min_batch_size: 1            # default 1, >=1 (FR-005)
+    max_entry_age_hours: 24      # default 24, >=1 (FR-006)
+    renotify_backoff_hours: [4, 8, 16, 24]  # default; non-decreasing, >0;
+                                            # last value repeats (FR-007)
+    auto_waive_low:              # optional; absent => never auto-waive (FR-015)
+      enabled: true              # default false — double opt-in with presence
+      after_hours: 168           # default 168 (7 days), >=1
+      rationale: "accepted-risk: low-severity assumptions expire after a week"
+```
+
+## Model placement
+
+- `MaverickConfig.assumptions: AssumptionsConfig` (new, `default_factory`).
+- `AssumptionsConfig.schedule: AssumptionScheduleConfig | None = None`.
+- Loading, env overrides (`MAVERICK_ASSUMPTIONS__SCHEDULE__...`), and
+  precedence follow the existing `load_config` / `YamlConfigSource` stack
+  untouched.
+
+## Validation semantics
+
+| Condition | Behavior | Where |
+|---|---|---|
+| `assumptions.schedule` absent | Command inert: exit 0, "not configured" (FR-021) | notify command |
+| `windows` empty / bad `HH:MM` / duplicates | `ConfigError`/`ValidationError` at load | Pydantic validators |
+| `quiet_hours.start == end` | rejected (ambiguous: zero- or full-day quiet) | Pydantic validator |
+| `renotify_backoff_hours` empty, non-positive, or decreasing | rejected | Pydantic validator |
+| `auto_waive_low.enabled: true` without `rationale` | rejected | Pydantic validator |
+| schedule present, `notifications.enabled: false` or `topic` unset | `validation` error naming the exact key to fix (FR-009) | notify command (the existing `NotificationConfig` validator only warns; other consumers keep that behavior) |
+
+## Interpretation rules
+
+- All times are **machine-local wall-clock** (`datetime.now().astimezone()`);
+  no per-config timezone override (spec Assumptions).
+- Each window time yields at most one occurrence per local calendar date;
+  occurrences are deadlines-to-deliver-after, not instants (FR-020, research
+  R6 covers DST fold/gap handling).
+- A window occurrence inside quiet hours shifts its due time to quiet-hours
+  end — same occurrence identity, so no double delivery (research R8).
+- `high_overrides_quiet` gates high-severity interrupts **and** high-severity
+  escalation re-notifications identically.
+- Defaults were fixed at plan time (clarify deferred them): `min_batch_size=1`,
+  `max_entry_age_hours=24`, backoff `4→8→16→24h` then repeating `24h`,
+  `auto_waive_low.after_hours=168`.

--- a/specs/054-assumption-batch-scheduler/contracts/delivery-state-schema.md
+++ b/specs/054-assumption-batch-scheduler/contracts/delivery-state-schema.md
@@ -1,0 +1,100 @@
+# Contract: persisted delivery state
+
+**Location**: `<cwd>/.maverick/notify/state.json` + `<cwd>/.maverick/notify/lock`
+(cwd resolved once at the CLI boundary — Guardrail 7). Cross-run feature state,
+deliberately *not* under `.maverick/runs/<run-id>/` (idempotence spans
+invocations). Per-machine, never committed, never shared between clones (spec
+Assumptions).
+
+## `state.json` schema (`schema_version: 1`)
+
+```json
+{
+  "schema_version": 1,
+  "updated_at": "2026-08-05T13:00:12Z",
+  "window_decisions": {
+    "2026-08-05/09:00": {
+      "outcome": "delivered",
+      "decided_at": "2026-08-05T13:00:12Z",
+      "entry_ids": ["mav-abc", "mav-def"],
+      "rule": "window 09:00 due"
+    },
+    "2026-08-04/17:00": {
+      "outcome": "skipped-min-batch",
+      "decided_at": "2026-08-04T21:00:03Z",
+      "entry_ids": ["mav-abc"],
+      "rule": "1 < min_batch_size 2; rolled to next window"
+    }
+  },
+  "entry_tracking": {
+    "mav-hi1": {
+      "first_seen": "2026-08-05T03:10:00Z",
+      "severity": "high",
+      "interrupt_delivered_at": "2026-08-05T03:10:05Z",
+      "escalation_delivered_at": null,
+      "renotify_count": 0,
+      "next_renotify_at": null,
+      "terminal": null
+    }
+  },
+  "deliveries": [
+    {
+      "kind": "interrupt",
+      "delivered_at": "2026-08-05T03:10:05Z",
+      "trigger": "high severity recorded; high_overrides_quiet=true",
+      "entry_ids": ["mav-hi1"],
+      "summary": {"counts": {"high": 1, "medium": 0, "low": 0},
+                   "owner_specs": ["054-assumption-batch-scheduler"],
+                   "oldest_age_hours": 0.1,
+                   "review_invocation": "maverick review --list --status open"}
+    }
+  ]
+}
+```
+
+Field semantics: see `data-model.md` §4. All persisted timestamps are UTC
+ISO-8601 (house convention); local-time reasoning happens only inside
+evaluation with the injected `now`.
+
+## Invariants
+
+1. **Occurrence idempotence (FR-010)**: a `window_decisions` key, once present,
+   is never re-decided. Keys are `"YYYY-MM-DD/HH:MM"` (local date + configured
+   window) — date-based identity makes DST fall-back double-delivery
+   structurally impossible.
+2. **Write-after-success (FR-012)**: `delivered_at` timestamps,
+   `window_decisions` entries with `outcome: "delivered"`, and `deliveries`
+   records are written only after the ntfy POST succeeded. A failed delivery
+   leaves state exactly as if the decision were never made — it re-arms on the
+   next run. Skip decisions (`skipped-min-batch`, `empty`) are recorded
+   immediately (no effect to fail).
+3. **Single writer (FR-013)**: all reads/writes happen under the pid lockfile.
+   Stale locks (dead pid, malformed file) are reclaimed; live locks cause a
+   benign skip (contract in `cli-notify-json.md`).
+4. **Atomicity**: every save is a whole-file `atomic_write_json`
+   (`maverick.utils.atomic`) via `asyncio.to_thread`; readers never observe a
+   torn file.
+5. **Nothing leaves silently (FR-016)**: an `entry_tracking` row may only be
+   pruned after `terminal` is set (`resolved-by-human` observed, or
+   `auto-waived` performed by the scheduler with its rationale in `detail`).
+6. **Retention (FR-023)**: prune runs at end of successful evaluation. An
+   `entry_tracking` row is prunable when `terminal.at` ≤ now − 90 days. A
+   `deliveries` record and a `window_decisions` key are prunable when **every**
+   entry id they reference is prunable by that rule. Records referencing any
+   open entry are never pruned. A record referencing **no** entry ids (an
+   empty-batch window decision) satisfies that rule vacuously but has no entry
+   to date it, so it is dated by its own `decided_at`/`delivered_at` against
+   the same 90-day horizon — the "why was nothing delivered at 09:00" audit
+   trail survives the full review horizon, and does not accumulate forever.
+7. **Unknown schema**: `schema_version` ≠ 1 → refuse to evaluate with a clear
+   error (never silently rewrite a newer schema); missing/corrupt file → treat
+   as empty state with a structured warning (delivery history is lost but
+   behavior stays safe: worst case is one re-delivery, never a missed entry).
+
+## Auditability (SC-004)
+
+For any notification (or skipped window), the tuple
+(ledger `created_at`/severity/status, `assumptions.schedule` config,
+`state.json` `rule` + timestamps) reconstructs the decision without reading
+any other source. `--dry-run --json` over the same inputs reproduces the
+decision set without mutating anything.

--- a/specs/054-assumption-batch-scheduler/contracts/ntfy-payload.md
+++ b/specs/054-assumption-batch-scheduler/contracts/ntfy-payload.md
@@ -1,0 +1,62 @@
+# Contract: ntfy notification payload
+
+**Single canonical wrapper** (Guardrail 5):
+`src/maverick/assumptions/schedule/deliver.py` is the only module that may
+construct ntfy requests.
+
+## Request
+
+```
+POST {notifications.server}/{notifications.topic}
+Title:    <title per kind, below>
+Priority: <priority per kind, below>
+Tags:     maverick,assumptions
+Body:     <plain-text summons, below>
+```
+
+- Client: `httpx.AsyncClient`, explicit 10-second timeout.
+- Retries: `tenacity.AsyncRetrying`, 3 attempts, exponential backoff, retrying
+  on `httpx.TransportError` and HTTP 5xx; 4xx fails immediately (config
+  problem, retrying cannot help).
+- Exhausted retries → `delivery-failed` error path; the decision is not
+  recorded as delivered (FR-012).
+
+## Content by kind
+
+| Kind | Title | Priority |
+|---|---|---|
+| `window-batch` | `Assumption review: N open entries` | `default` |
+| `interrupt` | `High-severity assumption recorded` | `urgent` |
+| `escalation` | `Assumption entries aging past limit` | `urgent` |
+| `renotify` | `High-severity assumption still unanswered` | `urgent` |
+
+Body template (all kinds; counts include low as informational context —
+clarification Q5):
+
+```
+{high} high, {medium} medium, {low} low open across {spec list}.
+Oldest: {oldest_age_hours}h.
+Run: {review_invocation}
+```
+
+`review_invocation` is the exact command to start the sweep
+(`maverick review --list --status open`, spec-scoped variant when all entries
+share one owning spec: `maverick review --list --spec {spec} --status open`).
+
+## Prohibitions (FR-008)
+
+The payload MUST NOT contain: entry question text, adopted answers,
+alternatives, waive reasons, bead descriptions, or any other entry content.
+The notification is a summons, not the console. (Bead **ids** are likewise
+omitted from the push body — they appear only in local persisted state — so
+nothing entry-specific transits ntfy beyond counts, spec names, and age.)
+
+Enforced structurally: `BatchSummary` (the only input `deliver.py` accepts)
+carries no content fields, so a leak would require a type-level change, not a
+formatting slip.
+
+## Test hooks
+
+Unit tests exercise the deliverer with `httpx.MockTransport` — asserting URL,
+headers, body template, retry-on-5xx, no-retry-on-4xx, and that failure
+surfaces as the typed delivery error consumed by the command layer.

--- a/specs/054-assumption-batch-scheduler/data-model.md
+++ b/specs/054-assumption-batch-scheduler/data-model.md
@@ -1,0 +1,213 @@
+# Data Model: Assumption Batch Scheduler
+
+Three model families: **config** (Pydantic, `maverick.config`), **evaluation**
+(frozen dataclasses, in-memory only, `assumptions/schedule/models.py`), and
+**persisted state** (frozen Pydantic, `assumptions/schedule/state.py`). Plus
+one additive change to existing ledger models.
+
+## 1. Existing-model extensions
+
+### `BeadDetails` (`src/maverick/beads/models.py`) — MODIFIED
+
+| Field | Type | Notes |
+|---|---|---|
+| `created_at` | `str \| None = None` | bd's UTC ISO-8601 creation timestamp (probe-verified `"2026-08-05T22:09:49Z"`); currently dropped by the extras-ignoring model |
+
+### `AssumptionRecord` / `AssumptionReportEntry` (`src/maverick/assumptions/models.py`) — MODIFIED
+
+- `AssumptionRecord.created_at: str | None` — copied from `BeadDetails` in
+  `ledger._record_from_details` / `_legacy_record_from_details`.
+- `AssumptionReportEntry` exposes it via its `record`; `entry_to_dict`
+  (`serialize.py`) adds `created_at` to the canonical row (additive — shared by
+  `review --list` and the land report by design; both surfaces gain the field
+  simultaneously).
+
+## 2. Configuration models (`src/maverick/config.py`)
+
+### `AssumptionsConfig`
+
+| Field | Type | Default | Constraint |
+|---|---|---|---|
+| `schedule` | `AssumptionScheduleConfig \| None` | `None` | `None` ⇒ scheduler inert (FR-021) |
+
+Wired as `MaverickConfig.assumptions` (`Field(default_factory=AssumptionsConfig)`).
+
+### `AssumptionScheduleConfig`
+
+| Field | Type | Default | Constraint / meaning |
+|---|---|---|---|
+| `windows` | `list[str]` | — (required) | ≥1 entry; each `HH:MM` 24-hour local time; validator parses to `time` and rejects duplicates |
+| `quiet_hours` | `QuietHoursConfig \| None` | `None` | absent ⇒ no quiet hours |
+| `high_overrides_quiet` | `bool` | `True` | FR-004 policy switch |
+| `min_batch_size` | `int` | `1` | `ge=1`; FR-005 |
+| `max_entry_age_hours` | `int` | `24` | `ge=1`; FR-006 escalation threshold |
+| `renotify_backoff_hours` | `list[float]` | `[4, 8, 16, 24]` | non-empty, each `> 0`, non-decreasing; last value repeats indefinitely (FR-007) |
+| `auto_waive_low` | `AutoWaivePolicyConfig \| None` | `None` | absent ⇒ never auto-waive (FR-015) |
+
+### `QuietHoursConfig`
+
+| Field | Type | Constraint |
+|---|---|---|
+| `start` | `str` | `HH:MM` local |
+| `end` | `str` | `HH:MM` local; may be < `start` (range spans midnight); `start == end` rejected |
+
+### `AutoWaivePolicyConfig`
+
+| Field | Type | Default | Constraint |
+|---|---|---|---|
+| `enabled` | `bool` | `False` | explicit opt-in |
+| `after_hours` | `int` | `168` (7 days) | `ge=1` |
+| `rationale` | `str` | — (required when `enabled`) | recorded on the ledger entry |
+
+**Endpoint config**: existing `NotificationConfig` (`notifications:` block —
+`enabled`, `server`, `topic`) is reused unchanged. Enforcement of
+"schedule present ⇒ notifications usable" happens in the notify command
+(actionable `validation` error), not in the config validator (which only
+warns, preserving existing behavior for other consumers).
+
+## 3. Evaluation models (frozen dataclasses, never persisted)
+
+### `WindowOccurrence`
+
+| Field | Type | Notes |
+|---|---|---|
+| `date` | `date` | local calendar date |
+| `window` | `str` | `"HH:MM"` as configured |
+| `due_at` | `datetime` | aware local; quiet-hours-shifted when applicable (R8); DST-fold-aware (R6) |
+
+Identity key: `(date, window)` — at most one decision per occurrence, ever.
+
+### `DeliveryDecision`
+
+| Field | Type | Notes |
+|---|---|---|
+| `kind` | `DecisionKind` | `WINDOW_BATCH \| INTERRUPT \| ESCALATION \| RENOTIFY` |
+| `entry_ids` | `tuple[str, ...]` | covered bead ids (open at evaluation time — FR-014 structural) |
+| `summary` | `BatchSummary` | counts by severity (incl. low), owning specs, oldest-entry age |
+| `occurrence` | `WindowOccurrence \| None` | set for `WINDOW_BATCH` only |
+| `rule` | `str` | human-readable rule citation for audit (e.g. `"window 09:00 due"`) |
+
+### `SkipDecision`
+
+| Field | Type | Notes |
+|---|---|---|
+| `reason` | `SkipReason` | `MIN_BATCH_SIZE \| QUIET_HOURS \| ALREADY_DELIVERED \| NOT_YET_DUE \| LOW_NEVER_PROACTIVE \| EMPTY_BATCH` |
+| `occurrence` | `WindowOccurrence \| None` | when window-scoped |
+| `entry_ids` | `tuple[str, ...]` | affected entries |
+| `rule` | `str` | audit citation |
+
+### `AutoWaiveDecision`
+
+| Field | Type |
+|---|---|
+| `entry_id` | `str` |
+| `reason_text` | `str` (full recorded rationale) |
+
+### `BatchSummary`
+
+| Field | Type | Notes |
+|---|---|---|
+| `counts` | `dict[Severity, int]` | includes `LOW` as informational (clarification Q5) |
+| `owner_specs` | `tuple[str, ...]` | sorted |
+| `oldest_age_hours` | `float` | from `created_at` basis (R1) |
+| `review_invocation` | `str` | e.g. `"maverick review --list --status open"` |
+
+### `EvaluationOutcome`
+
+| Field | Type |
+|---|---|
+| `deliveries` | `tuple[DeliveryDecision, ...]` |
+| `skips` | `tuple[SkipDecision, ...]` |
+| `auto_waives` | `tuple[AutoWaiveDecision, ...]` |
+| `state_after` | `DeliveryState` — the candidate state assuming every decision's effect succeeds; the effects layer removes each failed decision's mutations before saving (per-decision write-after-success, contracts/delivery-state-schema.md invariant 2) |
+
+## 4. Persisted state (`.maverick/notify/state.json`)
+
+Top-level `DeliveryState` (frozen Pydantic):
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | `int = 1` | |
+| `updated_at` | `str` | UTC ISO-8601 |
+| `window_decisions` | `dict[str, WindowDecisionRecord]` | key `"YYYY-MM-DD/HH:MM"` — the idempotence ledger for occurrences (FR-010) |
+| `entry_tracking` | `dict[str, EntryTrackingRecord]` | key = bead id |
+| `deliveries` | `list[DeliveryRecord]` | append-only audit trail (FR-011) |
+
+### `WindowDecisionRecord`
+
+| Field | Type | Notes |
+|---|---|---|
+| `outcome` | `str` | `"delivered" \| "skipped-min-batch" \| "empty"` |
+| `decided_at` | `str` | UTC ISO-8601 |
+| `entry_ids` | `list[str]` | |
+| `rule` | `str` | audit citation |
+
+### `EntryTrackingRecord`
+
+| Field | Type | Notes |
+|---|---|---|
+| `first_seen` | `str` | fallback age basis (R1) |
+| `severity` | `str` | as evaluated (legacy ⇒ `"medium"`) |
+| `interrupt_delivered_at` | `str \| None` | high-tier first delivery (FR-002) |
+| `escalation_delivered_at` | `str \| None` | max-age escalation delivery (FR-006) |
+| `renotify_count` | `int = 0` | index into backoff ladder (FR-007) |
+| `next_renotify_at` | `str \| None` | precomputed next backoff instant |
+| `terminal` | `TerminalOutcome \| None` | set when scheduler observes/creates terminal state (FR-016) |
+
+### `TerminalOutcome`
+
+| Field | Type | Notes |
+|---|---|---|
+| `kind` | `str` | `"resolved-by-human" \| "auto-waived"` |
+| `at` | `str` | UTC ISO-8601 — starts the FR-023 90-day retention clock |
+| `detail` | `str \| None` | auto-waive rationale |
+
+### `DeliveryRecord`
+
+| Field | Type | Notes |
+|---|---|---|
+| `kind` | `str` | `"window-batch" \| "interrupt" \| "escalation" \| "renotify"` |
+| `delivered_at` | `str` | UTC ISO-8601 (only written after ntfy success — FR-012) |
+| `trigger` | `str` | occurrence key or rule citation |
+| `entry_ids` | `list[str]` | |
+| `summary` | `dict` | serialized `BatchSummary` |
+
+### State transitions (per entry)
+
+```
+(untracked) ──first evaluation──► tracked{first_seen}
+tracked ──high tier, permissible──► interrupt_delivered_at set
+tracked ──age > max_entry_age (med/high)──► escalation_delivered_at set
+escalated(high) ──backoff elapses──► renotify_count += 1, next_renotify_at advanced
+escalated(medium) ──(no further deliveries)
+tracked ──human answers/waives (observed)──► terminal{resolved-by-human}
+tracked(low) ──auto-waive policy fires──► terminal{auto-waived} (+ bd waive)
+terminal + 90 days, all covered records terminal──► pruned (FR-023)
+```
+
+**Write discipline**: state is saved once per run via
+`atomic_write_json`, only after effects complete; a delivery that failed is
+excluded from `state_after` before saving (its occurrence stays undecided /
+its tracking timestamps stay unset), so failed deliveries remain due (FR-012).
+
+### Lockfile
+
+`<cwd>/.maverick/notify/lock` — pid-stamped advisory lock with stale-pid
+reclaim, byte-for-byte the pattern of `workflows/reconcile/state.py`.
+Contention ⇒ benign skip (R7).
+
+## 5. Validation rules traceability
+
+| Rule | Model enforcement |
+|---|---|
+| FR-003 config block | `AssumptionScheduleConfig` + validators |
+| FR-005 min batch | `evaluate()` + `SkipReason.MIN_BATCH_SIZE` |
+| FR-006/007 escalation | `EntryTrackingRecord` timestamps + backoff ladder |
+| FR-008 summons content | `BatchSummary` (no entry-content fields exist to leak) |
+| FR-010 idempotence | `window_decisions` occurrence keys; tracking timestamps |
+| FR-011 audit | `deliveries` append-only + `rule` citations everywhere |
+| FR-012 failure ≠ delivered | write-after-success discipline |
+| FR-013 concurrency | lockfile |
+| FR-015 auto-waive opt-in | `AutoWaivePolicyConfig.enabled=False` default |
+| FR-016 nothing silent | `TerminalOutcome` required to leave tracking |
+| FR-023 retention | prune predicate on `TerminalOutcome.at` + 90 days |

--- a/specs/054-assumption-batch-scheduler/plan.md
+++ b/specs/054-assumption-batch-scheduler/plan.md
@@ -1,0 +1,150 @@
+# Implementation Plan: Assumption Batch Scheduler
+
+**Branch**: `054-assumption-batch-scheduler` | **Date**: 2026-08-05 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/054-assumption-batch-scheduler/spec.md`
+
+## Summary
+
+Add `maverick notify` — an idempotent, daemonless CLI command (cron/systemd-timer
+friendly) that reads the assumption ledger via the existing `BeadClient`,
+evaluates it against a new `assumptions.schedule` config block with a **pure,
+clock-injected evaluation function**, and delivers severity-tiered ntfy push
+notifications: high = interrupt at next evaluation, medium = batched at review
+windows, low = never proactive. Delivery state persists under
+`.maverick/notify/` (atomic writes + pid lockfile, mirroring the reconcile
+state module) so re-runs never double-deliver and every fire/skip is auditable.
+Zero model calls, zero agents, zero Burr — this is a deterministic library +
+CLI feature (Principle XIII).
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (`from __future__ import annotations`)
+
+**Primary Dependencies**: Click + Rich (CLI), Pydantic v2 (config + state
+models), httpx (ntfy HTTP publish — already a declared dependency, first use),
+tenacity `AsyncRetrying` (delivery retries), structlog via
+`maverick.logging.get_logger`, `maverick.utils.atomic` (atomic state writes),
+`maverick.beads.client.BeadClient` (ledger reads, auto-waive writes)
+
+**Storage**: JSON file state at `<cwd>/.maverick/notify/state.json` (frozen
+Pydantic models, `schema_version: 1`, atomic writes) + pid-stamped advisory
+lockfile `<cwd>/.maverick/notify/lock`; the ledger itself remains bd beads
+
+**Testing**: pytest + pytest-asyncio (`asyncio_mode = "auto"`), CliRunner for
+CLI, `unittest.mock.patch` on `BeadClient.query/show` (house pattern — no bd
+subprocess in unit tests); evaluation tested as a pure function of
+`(entries, config, state, now)`
+
+**Target Platform**: Linux/macOS developer machines (local timezone semantics
+via `datetime.now().astimezone()`; DST handled by wall-clock window occurrences)
+
+**Project Type**: Single project — library modules under
+`src/maverick/assumptions/schedule/` + one CLI command
+
+**Performance Goals**: One evaluation completes in seconds at realistic ledger
+scale (tens of entries; `report_entries` costs 1 `bd query` + 2 subprocesses
+per candidate bead — acceptable at cron frequency, noted in research R12)
+
+**Constraints**: No resident process; idempotent under repeated and concurrent
+invocation; delivery failure must never be recorded as delivered; notifications
+carry summaries only, never entry contents; evaluation must be reconstructible
+from ledger + config + persisted state alone
+
+**Scale/Scope**: Single repository per invocation; ledgers of ~10–200 entries;
+2–4 review windows/day; state file bounded by FR-023 retention (90 days past
+terminal state)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Verdict | Notes |
+|---|---|---|
+| I. Async-First | PASS | All I/O paths async: `BeadClient`, httpx `AsyncClient`, state writes via `asyncio.to_thread(atomic_write_*)`. No `subprocess.run` anywhere in async paths. |
+| II. Separation of Concerns | PASS | No agents, no Burr — a deterministic command in the same class as `review --list`/`land --status`. Pure evaluation (decisions) is separated from effects (delivery, state writes, auto-waive). |
+| III. Dependency Injection | PASS | `evaluate()` receives entries, schedule config, prior state, and an injected `now: datetime` — the codebase's first clock seam, chosen over module-level `datetime.now()` precisely for this principle. CLI boundary resolves `cwd`, config, and clock once. |
+| IV. Fail Gracefully | PASS | ntfy failure → clear error, batch stays due, state untouched (FR-012). Ledger unreadable → abort with diagnostic, no state mutation. Lock contention → benign skip (research R7). |
+| V. Test-First | PASS | Pure evaluation function is designed for exhaustive unit testing (windows, quiet hours, DST, min-batch, escalation, backoff) without I/O. |
+| VI. Type Safety & Typed Contracts | PASS | Frozen dataclasses for decisions, frozen Pydantic models for config + persisted state; no `dict[str, Any]` blobs (Guardrail 3). |
+| VII. Simplicity | PASS | No new abstractions beyond one evaluation module, one state module, one deliverer, one command. |
+| VIII. Determinism over Inference (XIII) | PASS | Zero model calls. Every decision is a pure function of parseable inputs. |
+| IX. Hardening by Default | PASS | httpx explicit timeout (10s), tenacity retry with exponential backoff, specific exception handling mapped to envelope error kinds. |
+| X. Guardrail 0/7 (single-repo, explicit cwd) | PASS | State under `<cwd>/.maverick/notify/`; `cwd` resolved at CLI boundary and threaded explicitly; no `Path.cwd()` below the CLI. |
+| X. Guardrail 5 (one canonical wrapper) | PASS | ntfy is a new external system; `assumptions/schedule/deliver.py` becomes its single canonical wrapper. No other module may talk to ntfy. |
+| Appendix C (CLI output, JSON verbs) | PASS | Rich console only; `--json` emits the shared `JsonEnvelope` (verbs `notify.run` / `notify.dry-run`); narration to `err_console` in JSON mode. |
+
+**Post-Phase-1 re-check**: PASS — design artifacts introduce no violations; the
+one deliberate divergence (lock contention exits 0 for notify while reconcile
+exits non-zero) is a contract choice for cron ergonomics, documented in
+research R7 and the CLI contract, not a constitution violation.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/054-assumption-batch-scheduler/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── cli-notify-json.md        # Command surface + JSON envelope contract
+│   ├── config-schema.md          # assumptions.schedule + notifications config
+│   ├── delivery-state-schema.md  # Persisted state, retention, locking
+│   └── ntfy-payload.md           # Notification content contract
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/maverick/
+├── assumptions/
+│   ├── models.py                # MODIFIED: created_at on AssumptionRecord/AssumptionReportEntry
+│   ├── serialize.py             # MODIFIED: created_at + age surfaced in entry_to_dict
+│   └── schedule/                # NEW package — all scheduler logic
+│       ├── __init__.py          # public surface re-exports
+│       ├── models.py            # frozen dataclasses: WindowOccurrence, DeliveryDecision,
+│       │                        #   SkipReason, EvaluationOutcome, BatchSummary
+│       ├── evaluate.py          # pure evaluation: (entries, config, state, now) → outcome
+│       ├── state.py             # DeliveryState Pydantic models, load/save/prune,
+│       │                        #   pid lockfile (mirrors workflows/reconcile/state.py)
+│       └── deliver.py           # NtfyDeliverer: httpx + tenacity, the one ntfy wrapper
+├── beads/
+│   └── models.py                # MODIFIED: created_at: str | None on BeadDetails
+├── cli/
+│   ├── commands/
+│   │   └── notify.py            # NEW: maverick notify [--dry-run] [--json]
+│   └── json_output.py           # MODIFIED: ErrorKind.DELIVERY_FAILED (additive)
+├── config.py                    # MODIFIED: AssumptionScheduleConfig, QuietHoursConfig,
+│                                #   AutoWaivePolicyConfig, AssumptionsConfig; wired as
+│                                #   MaverickConfig.assumptions (NotificationConfig reused as-is)
+└── main.py                      # MODIFIED: "notify" entry in _LAZY_COMMANDS
+
+tests/
+├── unit/
+│   ├── assumptions/schedule/
+│   │   ├── test_evaluate_windows.py      # windows, min-batch, rolling, DST, midnight quiet hours
+│   │   ├── test_evaluate_severity.py     # interrupt/batch/silent tiers, legacy→medium
+│   │   ├── test_evaluate_escalation.py   # max-age escalation, high backoff, medium once
+│   │   ├── test_state.py                 # persistence, idempotence keys, retention pruning, lock
+│   │   └── test_deliver.py               # payload shape, retry, failure-not-recorded
+│   ├── cli/commands/test_notify_json.py  # envelope, verbs, error kinds, exit codes
+│   ├── cli/test_notify_command.py        # human-mode output, unconfigured no-op
+│   └── config/test_assumptions_schedule_config.py
+└── integration/test_notify_flow.py       # end-to-end with mocked BeadClient + ntfy transport
+```
+
+**Structure Decision**: Scheduler logic lives under
+`src/maverick/assumptions/schedule/` because all ledger logic already lives in
+`src/maverick/assumptions/` and the scheduler is a pure consumer of it; the CLI
+command is a thin module registered lazily in `main.py` per house convention.
+No workflow package is created — there is no state machine, no agents, and no
+squadron (Principle XIII: a model call on a path where parsing would do is a
+design smell; here even parsing is trivial).
+
+## Complexity Tracking
+
+No constitution violations — table intentionally empty.

--- a/specs/054-assumption-batch-scheduler/quickstart.md
+++ b/specs/054-assumption-batch-scheduler/quickstart.md
@@ -1,0 +1,114 @@
+# Quickstart: validating the assumption batch scheduler
+
+Runnable scenarios proving the feature end-to-end. Schemas and shapes live in
+[data-model.md](data-model.md) and [contracts/](contracts/) — this guide only
+runs them.
+
+## Prerequisites
+
+- `uv sync` completed; `bd` on PATH; repo initialized (`maverick init` /
+  `bd init` done — `.beads/` exists).
+- An ntfy topic you can watch: open `https://ntfy.sh/<your-topic>` in a
+  browser tab (or the ntfy app).
+
+## Setup
+
+Add to `maverick.yaml`:
+
+```yaml
+notifications:
+  enabled: true
+  topic: <your-topic>
+
+assumptions:
+  schedule:
+    windows: ["09:00", "17:00"]
+    quiet_hours: {start: "22:00", end: "07:00"}
+    min_batch_size: 1
+```
+
+Seed at least one open assumption entry (any spec's fly run records them; for
+a synthetic one, create a bead carrying the `assumption` label and the ledger
+state keys — see `tests/integration/test_notify_flow.py` for the exact shape).
+
+## Scenario 1 — unconfigured no-op (FR-021)
+
+With the `assumptions.schedule` block **removed**:
+
+```bash
+maverick notify --json
+```
+
+Expect: exit 0, `ok: true`, `result.configured: false`,
+`result.skipped: "not-configured"`, no state file created.
+
+## Scenario 2 — dry run shows every decision (SC-004)
+
+With config restored:
+
+```bash
+maverick notify --dry-run --json | python3 -m json.tool
+```
+
+Expect: exit 0; every open entry appears in `deliveries` (as *would deliver*),
+`skips` (with a `reason` + `rule`), or `auto_waives`; `.maverick/notify/`
+untouched; zero pushes received.
+
+## Scenario 3 — window batch delivery + idempotence (US1, US3)
+
+Run after a configured window time has passed (or set a `windows` value a
+minute in the future and wait):
+
+```bash
+maverick notify --json   # 1st: delivers
+maverick notify --json   # 2nd: skips
+```
+
+Expect: exactly **one** push on your topic — counts by severity, owning specs,
+oldest age, and a runnable `maverick review` line; no entry contents. Second
+run exits 0 with `skips: [{"reason": "already-delivered", ...}]` and no push.
+Verify the audit trail:
+
+```bash
+python3 -m json.tool .maverick/notify/state.json
+```
+
+Expect: a `window_decisions` key `"<today>/<window>"` with
+`outcome: "delivered"`, a matching `deliveries` record, and `rule` strings
+explaining each decision.
+
+## Scenario 4 — high-severity interrupt (US2)
+
+Record a high-severity entry (or edit a seeded bead's severity state key to
+`high`), then run `maverick notify` outside any window. Expect: an `urgent`
+push immediately, `entry_tracking.<id>.interrupt_delivered_at` set, and no
+second push on re-run. During quiet hours, expect delivery iff
+`high_overrides_quiet` is true.
+
+## Scenario 5 — delivery failure stays due (FR-012)
+
+Point `notifications.server` at an unreachable address, run `maverick notify
+--json` with a due batch. Expect: exit 1, `error.kind: "delivery-failed"`,
+state file unchanged for that decision. Restore the server, re-run: the same
+batch delivers.
+
+## Scenario 6 — concurrent runs (FR-013)
+
+```bash
+maverick notify --json & maverick notify --json; wait
+```
+
+Expect: one run evaluates; the other exits 0 with
+`result.skipped: "concurrent-evaluation"`; at most one push.
+
+## Automated validation
+
+```bash
+make test-fast    # unit: evaluation (windows/quiet/DST/escalation), state, deliverer, CLI envelope
+make test         # + integration: end-to-end notify flow with mocked bd + MockTransport ntfy
+make ci           # pre-push gate
+```
+
+Time-dependent behavior needs no waiting in tests: `evaluate()` takes `now`
+directly, and integration tests inject fixed local datetimes (including DST
+boundary dates) — see `tests/unit/assumptions/schedule/`.

--- a/specs/054-assumption-batch-scheduler/research.md
+++ b/specs/054-assumption-batch-scheduler/research.md
@@ -1,0 +1,254 @@
+# Research: Assumption Batch Scheduler
+
+All Technical Context unknowns resolved. Each decision below was verified
+against the codebase (file references) or by direct probe.
+
+## R1 — Entry age basis: bd `created_at`, verified by probe
+
+**Decision**: Compute entry age from bd's own `created_at` timestamp. Add
+`created_at: str | None = None` to `BeadDetails` (`src/maverick/beads/models.py`),
+thread it through `AssumptionRecord` / `AssumptionReportEntry`
+(`src/maverick/assumptions/models.py`) and `entry_to_dict`
+(`src/maverick/assumptions/serialize.py`).
+
+**Rationale**: A live probe (`bd create` + `bd show --json` in a throwaway
+repo) confirmed bd emits `"created_at": "2026-08-05T22:09:49Z"` (UTC ISO-8601)
+on both `list` and `show`. `BeadDetails` is a Pydantic model that currently
+ignores extras, so the field is being dropped today — adding it is a one-line,
+backward-compatible change. Using bd's timestamp makes age deterministic from
+the ledger itself (SC-004: reconstructible from ledger + config + state) and
+means age starts at recording time, not at first scheduler sighting.
+
+**Fallback**: An entry whose `created_at` is missing (malformed bead) falls
+back to the scheduler's persisted `first_seen` timestamp for that entry
+(recorded on first evaluation). It is never dropped from evaluation (FR-016).
+
+**Alternatives considered**: (a) Scheduler-side first-seen only — simpler, but
+age would start at first evaluation rather than recording, understating age for
+entries recorded while cron was down; kept only as fallback. (b) Parsing jj/git
+history for recording time — violates Guardrail 8's spirit (re-deriving what a
+structured artifact already carries).
+
+## R2 — Command surface: `maverick notify [--dry-run] [--json]`
+
+**Decision**: New top-level command `maverick notify`; JSON verbs `notify.run`
+and `notify.dry-run` (mirroring `reconcile.run` / `reconcile.dry-run`).
+Registered via `_LAZY_COMMANDS` in `src/maverick/main.py`; implemented in
+`src/maverick/cli/commands/notify.py` with `@async_command`.
+
+**Rationale**: The spec deferred naming to planning. `notify` states exactly
+what the command does (evaluate + deliver anything due) and collides with
+nothing (`review`, `brief`, `reconcile`, `land` taken). `--dry-run` evaluates
+and reports every decision with zero deliveries, zero state writes, and zero
+bd writes — same convention as `reconcile --dry-run`.
+
+**Alternatives considered**: `maverick schedule` (reads as *configuring* a
+schedule, not evaluating one); `maverick assumptions deliver` (no existing
+command-group precedent; every surface is a flat top-level command);
+`maverick brief --deliver` (overloads a read-only reporting command with
+side effects).
+
+## R3 — Config surface: new `assumptions.schedule` block + existing `notifications` block
+
+**Decision**: Add `AssumptionsConfig(BaseModel)` with field
+`schedule: AssumptionScheduleConfig | None = None`, wired as
+`MaverickConfig.assumptions` (`src/maverick/config.py`). The ntfy endpoint
+comes from the **existing** `NotificationConfig` (`notifications:` block:
+`enabled`, `server` (default `https://ntfy.sh`), `topic`) — already present at
+`config.py:59` and currently unused by any delivery code.
+
+Schedule fields (full schema in `contracts/config-schema.md`):
+`windows: list[str]` (HH:MM local, ≥1 required), `quiet_hours: {start, end} | None`,
+`high_overrides_quiet: bool = True`, `min_batch_size: int = 1 (ge=1)`,
+`max_entry_age_hours: int = 24 (ge=1)`,
+`renotify_backoff_hours: list[float] = [4, 8, 16, 24]` (last value repeats),
+`auto_waive_low: {enabled: bool = False, after_hours: int, rationale: str} | None`.
+
+**Rationale**: The spec mandates "an assumptions schedule block"; reusing
+`NotificationConfig` for the endpoint avoids a second ntfy config surface
+(Principle VII — no duplication). Numeric defaults were the one item clarify
+deferred to planning; values chosen: `min_batch_size=1` (no surprise skipping
+unless opted into), `max_entry_age_hours=24` (one full day before the batching
+rules are overridden), backoff `4→8→16→24h` (bounded, roughly-daily steady
+state — "spaced increasingly far apart" per FR-007).
+
+**Validation semantics (FR-009/FR-021)**: `schedule` absent → command is inert
+(exit 0, "not configured"). `schedule` present but `notifications.enabled` is
+false or `topic` unset → actionable `validation` error (the existing
+`NotificationConfig` validator only warns; the notify command enforces).
+Malformed schedule values (bad HH:MM, empty windows) → Pydantic
+`ValidationError` at config load, consistent with every other block.
+
+**Alternatives considered**: ntfy settings nested inside the schedule block —
+rejected as duplicate surface; a built-in default schedule — rejected by
+clarification Q1 (strictly opt-in).
+
+## R4 — Delivery state: `.maverick/notify/state.json` + pid lockfile, mirroring reconcile
+
+**Decision**: Persist all delivery state in one file,
+`<cwd>/.maverick/notify/state.json`: frozen Pydantic models with
+`schema_version: 1`, written via `asyncio.to_thread(atomic_write_json, ...)`
+(`src/maverick/utils/atomic.py`). Concurrency guard is a pid-stamped advisory
+lockfile `<cwd>/.maverick/notify/lock` with stale-lock reclaim, copied from the
+house pattern in `src/maverick/workflows/reconcile/state.py`
+(`acquire_lock`/`release_lock`/`_pid_is_alive`).
+
+**Rationale**: Delivery state is *cross-run* (idempotence spans invocations),
+so `.maverick/runs/<run-id>/` is the wrong home — a stable feature directory
+matches `.maverick/runway/`'s precedent. One file keeps load/evaluate/save
+atomic and trivially auditable; the reconcile state module is the proven
+implementation of exactly this shape (no `fcntl`/`filelock` exists anywhere in
+the codebase — the pid-file pattern is the house answer to FR-013).
+
+**Retention (FR-023)**: pruning runs at the end of each successful evaluation:
+delivery records and entry-tracking rows are removed only when every covered
+entry is terminal (answered/waived/closed) *and* 90 days have elapsed since the
+latest terminal transition the scheduler observed. Never prunes records
+covering open entries.
+
+**Alternatives considered**: JSONL append-only log (`runway/store.py` shape) —
+better for unbounded audit but splits idempotence state from audit records and
+needs compaction anyway once FR-023 pruning applies; SQLite — over-engineered
+for tens of records and a new storage dependency (Principle VII).
+
+## R5 — ntfy delivery: httpx + tenacity, one canonical wrapper
+
+**Decision**: `assumptions/schedule/deliver.py` owns all ntfy I/O:
+`httpx.AsyncClient` POST to `{server}/{topic}`, 10-second explicit timeout,
+`tenacity.AsyncRetrying` (3 attempts, `wait_exponential`, retrying on
+`httpx.TransportError` and 5xx). Payload contract in
+`contracts/ntfy-payload.md`: `Title`/`Priority`/`Tags` headers + plain-text
+summons body; priority `urgent` for high-severity interrupts and escalations,
+`default` for window batches.
+
+**Rationale**: `httpx` is already a declared dependency (currently unused —
+this is its first consumer; verified no HTTP client pattern exists in `src/` to
+conflict with). tenacity is constitutionally mandated for retries (Appendix B).
+Guardrail 5: this module is the single canonical ntfy wrapper; no other module
+may construct ntfy requests. Note: the old unimplemented spec 006 proposed
+aiohttp with degrade-to-success semantics — deliberately **not** followed here,
+because FR-012 requires failures to be loud and to leave the batch due.
+
+**Alternatives considered**: aiohttp (also a dep) — httpx has the cleaner
+async API and sync test transport (`httpx.MockTransport`) for unit tests;
+shelling out to `curl` — violates async-first and canonical-wrapper rules.
+
+## R6 — Pure evaluation with an injected clock (first clock seam in the codebase)
+
+**Decision**: `evaluate.py` exposes a pure function:
+`evaluate(entries, schedule, state, now) -> EvaluationOutcome` where `now` is a
+timezone-aware **local** datetime supplied by the CLI boundary
+(`datetime.now().astimezone()`). The outcome enumerates every decision —
+deliveries due (interrupt / window batch / escalation), skips
+(`min-batch-size`, `quiet-hours`, `already-delivered`, `not-yet-due`,
+`low-never-proactive`), and the state mutations to apply — each tagged with the
+rule that decided it (feeds SC-004 auditability and the `--json` result).
+Effects (ntfy, bd auto-waive, state save) happen in the command layer strictly
+after evaluation.
+
+**Rationale**: The codebase has no clock abstraction (verified: zero hits for
+injected clocks; tests patch `datetime.now` per module). Windows/quiet-hours/
+DST/backoff logic is untestable without a seam, and an explicit `now` parameter
+is the smallest one (Principle III), avoiding a freezegun-style test
+dependency.
+
+**Window occurrence semantics (FR-020)**: each configured window time yields at
+most one *occurrence* per local calendar date, keyed `(date, "HH:MM")`. An
+occurrence is **due** when `now` ≥ its wall-clock datetime (quiet-hours-shifted
+if applicable) and no decision for that key exists in state. Windows are
+deadlines-to-deliver-after, not instants: a machine asleep at 09:00 delivers at
+the next evaluation. DST spring-forward (nonexistent wall time) resolves to the
+first valid instant after the gap via fold-aware `zoneinfo` arithmetic;
+fall-back (repeated hour) cannot double-deliver because the occurrence key is
+date-based, not instant-based.
+
+**Alternatives considered**: a `Clock` protocol class — more surface than
+needed for one consumer; module-level `datetime.now()` with test patching —
+the exact untestable pattern this feature cannot afford.
+
+## R7 — Concurrency: lock contention is a benign skip (exit 0), unlike reconcile
+
+**Decision**: When `acquire_lock` fails against a live holder, `maverick
+notify` exits `SUCCESS` — human mode prints a single notice; JSON mode emits
+`ok: true` with `result.skipped: "concurrent-evaluation"` and no decisions.
+FR-013 is satisfied because the losing invocation performs no evaluation at
+all.
+
+**Rationale**: Overlapping cron fires are *expected operation* for this
+command, not a fault — a non-zero exit would page people from cron mail for
+normal behavior. This deliberately diverges from `reconcile --json`, which maps
+a held lock to error kind `locked` (there, a second invocation is a human
+mistake). The divergence is documented in `contracts/cli-notify-json.md`.
+
+**Alternatives considered**: reuse `locked` error semantics — wrong ergonomics
+for a cron-first command; lock-free last-writer-wins state — cannot guarantee
+FR-013's at-most-once delivery.
+
+## R8 — Quiet hours interaction: quiet wins, occurrences shift, policy gates high
+
+**Decision**: A window occurrence falling inside quiet hours shifts its due
+time to quiet-hours end (same occurrence key — still one decision, no double
+delivery). High-severity interrupts and escalation re-notifications are gated
+by `high_overrides_quiet`: `true` (default) delivers during quiet hours;
+`false` holds them until the first evaluation after quiet end. Quiet ranges may
+span midnight (`22:00–07:00`); containment is computed on local wall-clock
+time.
+
+**Rationale**: Directly implements clarified US1/US2 acceptance scenarios and
+the "window inside quiet hours" edge case with a single mechanism (due-time
+shifting) instead of special cases.
+
+## R9 — Severity tiers, legacy entries, and stale-batch exclusion
+
+**Decision**: Delivery tiers per FR-002: high → interrupt at next permissible
+evaluation; medium → window batches; low → never proactive but counted in
+batch summaries (clarification Q5). Legacy entries (bd-open
+`assumption-review`/`needs-human-review` beads without the `assumption` label)
+already surface from `report_entries` with synthesized `severity=MEDIUM`,
+`severity_defaulted=True`, `is_legacy=True` — FR-019 requires **no new
+mapping code**, only a test pinning the behavior. Resolution-between-
+accumulation-and-delivery (FR-014) is structural: the batch is computed from
+open entries re-read at evaluation time, so resolved entries can never appear;
+an occurrence whose batch is empty records a decision with zero deliveries.
+
+## R10 — Auto-waive rides the existing ledger mutation path
+
+**Decision**: Opt-in auto-waive (FR-015) calls the existing
+`assumptions.ledger.waive(client, bead_id=..., reason=..., waived_by="maverick-scheduler")`
+with reason
+`"auto-waived by schedule policy after {after_hours}h: {configured rationale}"`.
+No ledger schema change: `waived_by` is free-form, flows through
+`entry_to_dict`'s `waiver` object into `review --list` and the land report, so
+auto-waived entries are already distinguishable (the land gate's
+conditionally-verified classification applies unchanged). Auto-waive executes
+in the effects phase, after evaluation, and is recorded in delivery state as a
+terminal outcome (FR-016); `--dry-run` reports would-waive decisions without
+touching bd.
+
+**Alternatives considered**: a dedicated `assumption_auto_waived` state key —
+more ledger surface for information `waived_by` already carries.
+
+## R11 — JSON envelope: one additive error kind, `delivery-failed`
+
+**Decision**: Add `ErrorKind.DELIVERY_FAILED = "delivery-failed"` to
+`src/maverick/cli/json_output.py` (registry is additive-only by contract) for
+exhausted ntfy delivery retries. Mapping: unconfigured schedule → `ok: true`
+no-op (FR-021, *not* an error); schedule present but notifications
+disabled/topic missing → `validation`; bd unavailable → `bd-unavailable`
+(translated explicitly — `BeadClient.verify_available()` returns `False`, it
+does not raise); ledger read failure → `validation` via existing
+`AssumptionLedgerError` mapping; delivery exhausted → `delivery-failed`, exit
+`FAILURE`, batch remains due.
+
+## R12 — Evaluation cost at cron frequency: acceptable, with a cheap guard
+
+**Decision**: Accept `report_entries()`'s cost profile (1 `bd query` + 2
+subprocesses per candidate bead) at recommended cron frequencies (1–5 min).
+Add one cheap guard: when the schedule yields no due-or-potentially-due work
+(inside quiet hours with `high_overrides_quiet=false` and no undecided past
+occurrence), the command exits before touching bd at all.
+
+**Rationale**: Realistic ledgers are tens of beads; ~2N subprocesses every few
+minutes is noise. Caching ledger reads in delivery state would create a second
+source of truth and violate the reconstructibility story (SC-004) for marginal
+savings. Re-evaluate only if field usage shows multi-hundred-entry ledgers.

--- a/specs/054-assumption-batch-scheduler/spec.md
+++ b/specs/054-assumption-batch-scheduler/spec.md
@@ -1,0 +1,164 @@
+# Feature Specification: Assumption Batch Scheduler
+
+**Feature Branch**: `054-assumption-batch-scheduler`
+
+**Created**: 2026-08-05
+
+**Status**: Draft
+
+**Input**: User description: "Add schedule-respecting, severity-tiered delivery of assumption-ledger entries to the human, so that questions raised by agents reach the human in batches that match the human's schedule instead of requiring them to poll `maverick brief`."
+
+## Clarifications
+
+### Session 2026-08-05
+
+- Q: What should the scheduler command do when no assumptions schedule block is configured? → A: It is inert — exit success with a clear "not configured" report, deliver nothing; there is no built-in default schedule, delivery is strictly opt-in.
+- Q: Which severities does maximum-entry-age escalation actually deliver? → A: Medium and high escalate to delivery; only high re-notifies on a backoff schedule afterwards; low is never delivered proactively — its only aging path is the opt-in auto-waive policy.
+- Q: Should the evaluation command offer a machine-readable output mode? → A: Yes — a `--json` mode emitting the shared JSON verb envelope, carrying the full evaluation outcome (what was delivered, what was skipped, and the rule that decided each).
+- Q: How long must persisted delivery records be retained? → A: While any covered entry remains open, plus 90 days after all covered entries reach a terminal state; only then may they be pruned.
+- Q: Do batch notification counts-by-severity include low-severity entries? → A: Yes, as informational context — but low entries never trigger or block a delivery.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Batched morning summons (Priority: P1)
+
+A human running autonomous overnight work has configured review windows at 09:00 and 17:00 with quiet hours from 22:00 to 07:00. Agents record several medium- and low-severity assumption-ledger entries overnight. At 09:00 the human receives exactly one push notification summarizing everything that accumulated: counts by severity, the owning specs, the age of the oldest entry, and the exact `maverick review` invocation to start the sweep. The human opens their terminal, runs the printed command, and works the queue.
+
+**Why this priority**: This is the core value of the feature — the human stops polling `maverick brief` and instead gets summoned on their own schedule. Without it, nothing else in this feature matters.
+
+**Independent Test**: Seed a ledger with medium-severity entries recorded at various times overnight, run the scheduler evaluation at a simulated 09:00 with the configuration above, and verify exactly one notification is delivered carrying the correct counts, owning specs, oldest-entry age, and review invocation — and that entry contents (question/answer text) are absent.
+
+**Acceptance Scenarios**:
+
+1. **Given** quiet hours 22:00–07:00 and windows at 09:00 and 17:00, with three medium-severity entries recorded overnight, **When** the scheduler evaluates at 09:00, **Then** exactly one batch notification is delivered summarizing all three entries.
+2. **Given** the same configuration, **When** the scheduler evaluates at 03:00 (inside quiet hours) with medium-severity entries pending, **Then** nothing is delivered and the entries remain accumulated for the 09:00 window.
+3. **Given** a batch notification, **When** its content is inspected, **Then** it carries count by severity, the owning specs, the oldest entry's age, and the exact `maverick review` invocation — and never the entry's question or answer text.
+4. **Given** a window whose pending batch is smaller than the configured minimum batch size, **When** the scheduler evaluates at that window, **Then** the window is skipped and the entries roll to the next window.
+5. **Given** low-severity entries only, **When** any window arrives, **Then** no notification is delivered — low-severity entries accumulate silently and surface only during a review sweep or bulk waive.
+
+---
+
+### User Story 2 - High-severity interrupt (Priority: P2)
+
+An agent records a high-severity assumption that is blocking downstream work. The human is notified at the next scheduler evaluation regardless of review windows, because high severity means "interrupt", not "batch". If the entry is recorded during quiet hours, the default policy still delivers it (high overrides quiet hours), but a human who has explicitly configured quiet hours as absolute is not disturbed until quiet hours end.
+
+**Why this priority**: High-severity entries gate downstream work via blocks edges; hours of latency on them stalls the fleet. But the interrupt path is meaningless without the delivery machinery from Story 1.
+
+**Independent Test**: Record a high-severity entry, run the scheduler evaluation outside any window, and verify an interrupt notification is delivered immediately; repeat inside quiet hours under both override policies and verify delivery matches the configured policy.
+
+**Acceptance Scenarios**:
+
+1. **Given** a high-severity entry recorded at 14:23 with windows at 09:00 and 17:00, **When** the scheduler next evaluates, **Then** an interrupt notification for that entry is delivered without waiting for the 17:00 window.
+2. **Given** a high-severity entry recorded at 23:30 and the default quiet-hours policy, **When** the scheduler evaluates during quiet hours, **Then** the interrupt is delivered (high overrides quiet hours by default).
+3. **Given** the same entry and an explicit configuration that quiet hours are absolute, **When** the scheduler evaluates during quiet hours, **Then** nothing is delivered, and the interrupt is delivered at the first evaluation after quiet hours end.
+4. **Given** a delivered high-severity interrupt that remains unanswered past the configured maximum entry age, **When** subsequent evaluations run, **Then** the entry re-notifies on a backoff schedule rather than on every evaluation.
+
+---
+
+### User Story 3 - Idempotent evaluation from cron (Priority: P3)
+
+The human wires the scheduler command into cron (or a systemd timer) to run every few minutes. Each run evaluates the ledger against the schedule and delivers anything due. Re-running within the same window never re-delivers the same batch; every delivery is recorded in persisted state so the human can prove, after the fact, why each notification fired — or why one did not.
+
+**Why this priority**: Without idempotence and persisted delivery state, a cron-driven scheduler would spam duplicates and the feature's behavior would be unauditable. This story makes Stories 1 and 2 safe to automate.
+
+**Independent Test**: Run the scheduler command twice in succession within the same window against the same ledger state and verify the second run delivers nothing; inspect persisted delivery state and verify it records what was delivered, when, and which entries each delivery covered.
+
+**Acceptance Scenarios**:
+
+1. **Given** a batch delivered at the 09:00 window, **When** the scheduler runs again at 09:05 with no new entries, **Then** nothing is re-delivered.
+2. **Given** a batch delivered at the 09:00 window, **When** a new medium-severity entry is recorded at 09:10, **Then** that entry waits for the 17:00 window rather than triggering an immediate second batch.
+3. **Given** any sequence of evaluations, **When** the persisted delivery state is inspected, **Then** it records each delivery (what, when, which entries) such that the outcome of every evaluation is reproducible from the ledger state, the configuration, and the delivery state.
+4. **Given** a delivery attempt that fails (notification service unreachable), **When** the scheduler next evaluates, **Then** the batch is re-attempted — a failed delivery is never recorded as delivered.
+5. **Given** two scheduler processes started concurrently (overlapping cron fires), **When** both evaluate the same due batch, **Then** the batch is delivered exactly once.
+
+---
+
+### User Story 4 - Age-based escalation and explicit expiry (Priority: P4)
+
+Entries do not linger forever. An undelivered or unanswered medium- or high-severity entry past the configured maximum age escalates regardless of batching rules: it is delivered (or re-delivered) even if its window's minimum batch size was never met. Separately, a human who has explicitly opted in may configure aged low-severity entries to be auto-waived, with the rationale recorded on the ledger entry. Nothing ever expires silently.
+
+**Why this priority**: This is the safety net around the batching rules — it prevents the minimum-batch-size and low-severity-silence rules from starving entries indefinitely. It refines Stories 1–3 rather than standing alone.
+
+**Independent Test**: Configure a maximum entry age, seed entries that would otherwise never meet the minimum batch size, advance past the age threshold, and verify they are delivered anyway; enable the auto-waive policy for low severity and verify aged low entries are waived with a recorded rationale and appear in ledger reporting as waived.
+
+**Acceptance Scenarios**:
+
+1. **Given** a single medium-severity entry below the minimum batch size that keeps rolling forward, **When** its age exceeds the configured maximum entry age, **Then** it is delivered at the next permissible evaluation despite the minimum-batch-size rule.
+2. **Given** the auto-waive policy is not configured, **When** low-severity entries age past any threshold, **Then** they are never waived automatically — they remain open and continue to block `maverick land` per existing enforcement semantics.
+3. **Given** the auto-waive policy is explicitly enabled for low severity, **When** a low-severity entry ages past the configured threshold, **Then** it is waived with a recorded rationale on the ledger entry, and the waiver is visible through existing review/land reporting surfaces.
+4. **Given** any entry that reaches a terminal state via this feature (auto-waived), **When** the ledger is inspected, **Then** the entry shows who/what resolved it and why — nothing expires without a persisted record.
+
+---
+
+### Edge Cases
+
+- Quiet hours spanning midnight (22:00–07:00) must suppress deliveries correctly on both sides of the day boundary.
+- A review window that falls inside quiet hours: quiet hours win — the window's batch rolls to the first evaluation after quiet hours end (except high-severity interrupts under the default override policy).
+- An entry answered or waived between accumulation and the delivery window must not be counted in the delivered batch; a batch whose entries have all been resolved before the window delivers nothing.
+- Daylight-saving transitions: local-time windows fire once per local day; a skipped or repeated wall-clock hour must not cause a double delivery or a silently missed window.
+- The scheduler run may be arbitrarily delayed relative to a window (cron granularity, machine asleep): a window whose time has passed but whose batch was never delivered is still due at the next evaluation — windows are deadlines to deliver after, not instants to hit exactly.
+- Notification service misconfigured or unreachable: the evaluation still runs, the failure is reported clearly, and no delivery is recorded; the batch remains due.
+- Ledger unreadable at evaluation time: the run fails with a clear diagnostic; it must not record deliveries or mutate state based on a partial read.
+- Entries in the legacy severity bucket (no structured severity) must map to a defined delivery tier rather than being dropped from delivery evaluation.
+- Machine timezone differs from the human's expectation: windows and quiet hours are interpreted in the machine's local timezone, and delivery state records enough timing context to make that auditable.
+- No assumptions schedule block configured: the command is inert and says so — it must not error, must not invent a default schedule, and must deliver nothing.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide an idempotent evaluation command that reads the assumption ledger, evaluates it against the configured schedule, delivers anything due, and exits — with no resident process required. The command MUST be safe to run at any frequency from cron or a systemd timer.
+- **FR-002**: The system MUST implement a severity-tiered delivery policy: high-severity entries are delivered as interrupts at the next evaluation after recording; medium-severity entries accumulate and are delivered as a batch at the next configured review window; low-severity entries accumulate silently and are never delivered proactively.
+- **FR-003**: Delivery scheduling MUST be configurable in the project configuration file under an assumptions schedule block, covering: review windows as local times of day, quiet hours, the quiet-hours override policy for high severity, a minimum batch size, and a maximum entry age.
+- **FR-004**: During quiet hours, the system MUST deliver nothing except high-severity interrupts when the override policy permits them. The override policy MUST default to allowing high-severity interrupts through quiet hours, and MUST be explicitly configurable to make quiet hours absolute.
+- **FR-005**: A review window whose pending batch is smaller than the configured minimum batch size MUST be skipped, with the pending entries rolling to the next window.
+- **FR-006**: An undelivered or unanswered medium- or high-severity entry older than the configured maximum entry age MUST escalate: it becomes due for delivery (or re-delivery) regardless of minimum-batch-size and window rules, subject only to the quiet-hours policy. Low-severity entries never escalate to delivery; their only aging path is the opt-in auto-waive policy (FR-015).
+- **FR-007**: An unanswered high-severity entry past its maximum age MUST re-notify on a backoff schedule — successive re-notifications spaced increasingly far apart — rather than on every evaluation. An escalated medium-severity entry is delivered once per escalation and does not re-notify.
+- **FR-008**: Batch notifications MUST carry: entry count by severity (including low, as informational context — low entries never trigger or block a delivery), the owning specs, the oldest entry's age, and the exact `maverick review` invocation to start the sweep. Notifications MUST NOT carry entry contents (question, adopted answer, alternatives) — the notification is a summons, not the console.
+- **FR-009**: Delivery MUST use the ntfy push-notification service. Absent or invalid ntfy configuration MUST produce a clear, actionable error from the evaluation command, not a silent no-op.
+- **FR-010**: Re-running the evaluation within the same window against unchanged ledger state MUST NOT re-deliver a batch already delivered. Idempotence MUST hold across process restarts (state is persisted, not in-memory).
+- **FR-011**: The system MUST persist delivery state — what was delivered, when, to which window or trigger, and covering which entries — such that the outcome of any evaluation is deterministic and auditable from the ledger state, the configuration, and the persisted delivery state.
+- **FR-012**: A failed delivery attempt MUST NOT be recorded as delivered; the batch or interrupt remains due at the next evaluation. Delivery failures MUST be reported clearly to the invoker.
+- **FR-013**: Concurrent evaluation runs (e.g. overlapping cron fires) MUST NOT double-deliver: at most one of the concurrent runs delivers any given due batch or interrupt.
+- **FR-014**: Entries resolved (answered or waived) between accumulation and delivery MUST be excluded from the delivered batch. A batch left empty by resolution delivers nothing.
+- **FR-015**: The system MAY auto-waive aged low-severity entries only under an explicitly configured opt-in policy. Auto-waived entries MUST carry a recorded rationale on the ledger entry and MUST be distinguishable from human-waived entries in ledger reporting. Absent the opt-in, no entry is ever auto-resolved.
+- **FR-016**: No entry may ever leave delivery evaluation silently: an entry leaves the scheduler's tracking only via a persisted terminal outcome — resolved by a human, or auto-waived with rationale. Deliveries themselves never end tracking; they are recorded as audit records under FR-011 while the entry remains tracked until resolved.
+- **FR-017**: The evaluation logic MUST be invocable without assuming a resident process, and MUST be structured so a future host daemon can invoke the same evaluation in-process. Nothing in the feature may depend on residency, background threads, or long-lived scheduling state in memory.
+- **FR-018**: This feature MUST NOT change enforcement semantics: the land gate, ready-queue deferral, and blocks-edge behavior for assumption entries are untouched. Delivery is a notification layer only.
+- **FR-019**: Entries carrying only legacy severity metadata MUST be assigned a defined delivery tier (treated as medium) so they participate in batching rather than being invisible to delivery.
+- **FR-020**: Windows and quiet hours MUST be interpreted in the machine's local timezone, and behavior across daylight-saving transitions MUST avoid both double delivery and silently missed windows. A window whose time has passed without delivery remains due at the next permissible evaluation.
+- **FR-021**: When no assumptions schedule block is configured, the evaluation command MUST be inert: it exits successfully, reports clearly that delivery is not configured, and delivers nothing. There is no built-in default schedule — delivery is strictly opt-in.
+- **FR-022**: The evaluation command MUST offer a machine-readable output mode (`--json`) emitting the shared JSON verb envelope used by the other assumption-lifecycle verbs, carrying the full evaluation outcome: what was delivered, what was skipped, and the rule that decided each.
+- **FR-023**: Delivery records MUST be retained for as long as any entry they cover remains open, and for at least 90 days after every covered entry reaches a terminal state; only then may they be pruned. Pruning MUST never remove a record needed to prove why an open entry's notification fired or was skipped.
+
+### Key Entities
+
+- **Schedule configuration**: The human's delivery policy — review windows (local times of day), quiet hours (a local-time range, possibly spanning midnight), quiet-hours override policy for high severity, minimum batch size, maximum entry age, re-notification backoff parameters, and the optional low-severity auto-waive policy. Lives in the project configuration file.
+- **Assumption-ledger entry** (existing): The unit being delivered. Relevant attributes: severity (high/medium/low or legacy), status (open/answered/waived), recording time, owning spec. This feature reads entries and — only under the opt-in auto-waive policy — resolves them; it does not otherwise mutate them.
+- **Delivery record**: The persisted, append-style account of one delivery: what kind (window batch, high-severity interrupt, escalation re-notification), when it was delivered, which window or trigger caused it, and which entries it covered. The source of truth for idempotence and audit. Retained while any covered entry is open, plus 90 days after all covered entries reach a terminal state; prunable only after that.
+- **Batch**: The evaluated set of due, still-open entries grouped for one notification, summarized as counts by severity, owning specs, and oldest-entry age.
+- **Notification**: The outbound message delivered via the push service — a summons carrying the batch summary and the exact review invocation, never entry contents.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A human with quiet hours 22:00–07:00 and windows at 09:00 and 17:00 receives exactly one notification at the 09:00 window summarizing everything that accumulated overnight — verified across a simulated multi-day run with entries recorded at arbitrary hours.
+- **SC-002**: High-severity entries reach the human at the first evaluation after recording (subject only to the configured quiet-hours policy), while medium-severity entries never generate a notification outside a review window and low-severity entries never generate a notification at all.
+- **SC-003**: Running the evaluation command any number of times within one window produces at most one delivery of a given batch — zero duplicate notifications across a test matrix of repeated and concurrent invocations.
+- **SC-004**: For every notification delivered (and every window skipped), the human can reconstruct from persisted state alone why it fired or was skipped — which entries, which rule (window, interrupt, escalation, minimum-batch-size skip), and when.
+- **SC-005**: No entry is ever dropped from tracking without a persisted outcome: across a simulated run including resolutions, escalations, and (opted-in) auto-waivers, 100% of recorded entries are accounted for as delivered, human-resolved, or auto-waived-with-rationale.
+- **SC-006**: The human polls nothing: in a workflow driven entirely by scheduler notifications, the human runs `maverick brief` zero times and still learns of every open entry within one review window of its recording (or immediately, for high severity).
+
+## Assumptions
+
+- "Immediate" delivery for high-severity interrupts means at the next scheduler evaluation, since there is no resident process; the effective interrupt latency is bounded by the cron/timer frequency the human chooses. This is inherent to the daemonless design and acceptable.
+- The scheduler evaluates one repository's ledger per invocation, consistent with Maverick's single-repo workflow model; multi-repository aggregation is out of scope.
+- ntfy connection details (server URL, topic) are part of the new configuration surface; the feature assumes the human has a working ntfy subscription on their devices. Validating ntfy reachability is done per delivery attempt, not ahead of time.
+- Delivery state is persisted under the repository's existing Maverick state area alongside runs and plans, and is not intended to be committed or shared between machines. Two machines running schedulers against clones of the same repository are out of scope.
+- Local times in configuration are interpreted in the machine's local timezone; no per-config timezone override is provided in this feature.
+- The default for the low-severity auto-waive policy is off; the default quiet-hours override policy is that high severity interrupts through quiet hours — both as stated in the feature description.
+- Legacy-severity entries (open escalation beads without structured severity) are treated as medium for delivery, mirroring how the land gate already treats them.
+- Answered-but-unreconciled entries are not the scheduler's concern: delivery targets open entries awaiting a human decision. Reconciliation prompting remains with existing `maverick land`/`maverick reconcile` surfaces.
+- The exact CLI command name and its placement in the existing command tree are deferred to planning; the feature requires only that it be a single idempotent command suitable for cron.
+- Out of scope, per the feature description: Slack/email/other channels, learned auto-resolution from prior answers, and any change to enforcement semantics.

--- a/specs/054-assumption-batch-scheduler/tasks.md
+++ b/specs/054-assumption-batch-scheduler/tasks.md
@@ -1,0 +1,244 @@
+# Tasks: Assumption Batch Scheduler
+
+**Input**: Design documents from `/specs/054-assumption-batch-scheduler/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included — the constitution mandates test-first (Principle V,
+red-green-refactor). Every test task must be written and observed failing
+before its implementation task.
+
+**Organization**: Tasks are grouped by user story to enable independent
+implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1–US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Single project: `src/maverick/`, `tests/` at repository root (per plan.md).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Package skeleton so all subsequent tasks have homes
+
+- [X] T001 Create package skeleton: `src/maverick/assumptions/schedule/__init__.py` (empty public-surface module), empty `models.py`, `evaluate.py`, `state.py`, `deliver.py` in the same directory, plus `tests/unit/assumptions/schedule/__init__.py`; confirm `make lint` and `make typecheck` stay green
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: `created_at` plumbing, config models, domain dataclasses, and persisted-state module — every user story reads these
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T002 [P] Write failing tests for `created_at` propagation: extend `tests/unit/assumptions/test_models.py` (AssumptionRecord carries `created_at`), `tests/unit/assumptions/test_serialize.py` (`entry_to_dict` row includes `created_at`), and `tests/unit/assumptions/test_ledger_query.py` (`report_entries` copies `created_at` from `BeadDetails`, including the legacy-entry path)
+- [X] T003 Add `created_at: str | None = None` to `BeadDetails` in `src/maverick/beads/models.py` (bd emits UTC ISO-8601 per research R1 probe)
+- [X] T004 Thread `created_at` through the ledger: add field to `AssumptionRecord` in `src/maverick/assumptions/models.py`, populate it in `_record_from_details` and `_legacy_record_from_details` in `src/maverick/assumptions/ledger.py`, and emit it from `entry_to_dict` in `src/maverick/assumptions/serialize.py`; T002 tests go green
+- [X] T005 [P] Write failing config tests in `tests/unit/config/test_assumptions_schedule_config.py`: defaults per contracts/config-schema.md, HH:MM validation, duplicate/empty windows rejected, `quiet_hours.start == end` rejected, non-decreasing backoff enforced, `auto_waive_low.enabled` without `rationale` rejected, env-override via `MAVERICK_ASSUMPTIONS__SCHEDULE__...`
+- [X] T006 Implement config models in `src/maverick/config.py`: `QuietHoursConfig`, `AutoWaivePolicyConfig`, `AssumptionScheduleConfig`, `AssumptionsConfig`; wire `MaverickConfig.assumptions` with `default_factory`; export via `__all__`; T005 tests go green
+- [X] T007 Implement evaluation domain models in `src/maverick/assumptions/schedule/models.py`: frozen dataclasses `WindowOccurrence`, `BatchSummary`, `DeliveryDecision`, `SkipDecision`, `AutoWaiveDecision`, `EvaluationOutcome`, enums `DecisionKind`, `SkipReason` (shapes per data-model.md §3)
+- [X] T008 [P] Write failing state tests in `tests/unit/assumptions/schedule/test_state.py`: round-trip load/save of `DeliveryState` (schema per contracts/delivery-state-schema.md), atomic write via `maverick.utils.atomic`, missing file → empty state, `schema_version != 1` → refusal error, corrupt file → empty state + structured warning, pid lockfile acquire/release/stale-reclaim, FR-023 prune predicate (terminal + 90 days, never prunes records referencing open entries)
+- [X] T009 Implement `src/maverick/assumptions/schedule/state.py`: frozen Pydantic models `DeliveryState`, `WindowDecisionRecord`, `EntryTrackingRecord`, `TerminalOutcome`, `DeliveryRecord`; `async load_state(cwd)` / `async save_state(state, cwd)` using `asyncio.to_thread(atomic_write_json, ...)` under `<cwd>/.maverick/notify/state.json`; `async acquire_lock(cwd) -> bool` / `async release_lock(cwd)` mirroring `src/maverick/workflows/reconcile/state.py`'s pid pattern; `prune(state, now) -> DeliveryState`; T008 tests go green
+
+**Checkpoint**: Foundation ready — user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Batched morning summons (Priority: P1) 🎯 MVP
+
+**Goal**: Medium-severity entries accumulate and deliver as exactly one ntfy
+batch per review window, respecting quiet hours and minimum batch size; low
+stays silent but counted; the summons carries counts/specs/age/invocation and
+never entry contents.
+
+**Independent Test**: quickstart.md Scenarios 1–3 — seed medium entries, run
+`maverick notify --json` at a simulated 09:00 with quiet hours 22:00–07:00,
+verify one delivery with correct summary; re-run delivers nothing; unconfigured
+repo is an exit-0 no-op.
+
+### Tests for User Story 1 (write first, observe failing)
+
+- [X] T010 [P] [US1] Write failing window-evaluation tests in `tests/unit/assumptions/schedule/test_evaluate_windows.py`: occurrence due/not-yet-due, delayed-cron delivery after window time, `already-delivered` skip on decided occurrence, min-batch-size skip rolls entries forward, midnight-spanning quiet hours suppress and shift occurrences to quiet-end (research R8), DST spring-forward gap and fall-back non-double-delivery (research R6), empty-batch occurrence records `empty` decision (FR-014) — all via direct `evaluate(entries, schedule, state, now)` calls with injected aware local datetimes
+- [X] T011 [P] [US1] Write failing severity-tier tests in `tests/unit/assumptions/schedule/test_evaluate_severity.py`: medium batches at windows only, low never triggers delivery but appears in `BatchSummary.counts` (clarification Q5) and yields `low-never-proactive` skip entries, legacy entries (`is_legacy=True`, synthesized medium) batch like medium (FR-019), resolved-before-window entries excluded structurally
+- [X] T012 [P] [US1] Write failing deliverer tests in `tests/unit/assumptions/schedule/test_deliver.py` using `httpx.MockTransport`: POST to `{server}/{topic}`, Title/Priority/Tags headers and body template per contracts/ntfy-payload.md, `window-batch` → priority `default`, retry on 5xx/transport error (3 attempts, tenacity), no retry on 4xx, exhausted retries raise the typed delivery error, body contains no entry-content fields
+- [X] T013 [P] [US1] Write failing CLI tests in `tests/unit/cli/test_notify_command.py` (human mode: unconfigured single-line no-op exit 0, "Nothing due.", delivery completion line, `✗` + warning on failure) and `tests/unit/cli/commands/test_notify_json.py` (envelope per contracts/cli-notify-json.md: verbs `notify.run`/`notify.dry-run`, `configured: false` no-op `ok: true`, schedule-present-but-notifications-unusable → `validation` naming the missing key, bd unavailable → `bd-unavailable`, delivery exhausted → `delivery-failed` exit 1, dry-run zero side effects) — mock `BeadClient` per house pattern, invoke via `cli_runner`
+
+### Implementation for User Story 1
+
+- [X] T014 [US1] Implement window-batch evaluation in `src/maverick/assumptions/schedule/evaluate.py`: pure `evaluate(entries, schedule, state, now) -> EvaluationOutcome` covering occurrence computation (fold-aware `zoneinfo` arithmetic), quiet-hours shifting, min-batch-size, batching by severity tier, skips with `rule` citations, age from `created_at` with `first_seen` fallback (research R1); T010 + T011 go green
+- [X] T015 [US1] Implement `src/maverick/assumptions/schedule/deliver.py`: `NtfyDeliverer` with `httpx.AsyncClient` (10s timeout), `tenacity.AsyncRetrying`, payload construction from `BatchSummary` only; typed `DeliveryFailedError`; T012 goes green
+- [X] T016 [US1] Add `ErrorKind.DELIVERY_FAILED = "delivery-failed"` to `src/maverick/cli/json_output.py` and extend `tests/unit/cli/test_json_output.py` for the new kind (additive registry contract)
+- [X] T017 [US1] Implement `src/maverick/cli/commands/notify.py`: `@async_command` with `--dry-run`/`--json`; resolve `cwd` once; load config; FR-021 inert path; notifications-usable enforcement; bd preflight (`bd_ready_reason` + `verify_available()` translated to `bd-unavailable`); read entries via `report_entries`; call `evaluate` with `datetime.now().astimezone()`; deliver due decisions; persist state write-after-success per decision (FR-012); emit envelope or Rich output per contracts/cli-notify-json.md; T013 goes green
+- [X] T018 [US1] Register the command: add `"notify"` entry to `_LAZY_COMMANDS` in `src/maverick/main.py` pointing at `maverick.cli.commands.notify:notify` with help text; verify `maverick notify --help` renders
+
+**Checkpoint**: MVP — quickstart Scenarios 1–3 pass end-to-end; `make test-fast` green
+
+---
+
+## Phase 4: User Story 2 - High-severity interrupt (Priority: P2)
+
+**Goal**: High-severity entries deliver as `urgent` interrupts at the next
+permissible evaluation, gated by `high_overrides_quiet`, exactly once per
+entry.
+
+**Independent Test**: quickstart.md Scenario 4 — record a high entry, run
+outside any window, receive one urgent push; repeat inside quiet hours under
+both policy values; re-run never re-delivers.
+
+> **Scope note**: spec US2 acceptance scenario 4 (backoff re-notification of
+> aged high entries) is deliberately implemented in Phase 6 (T025/T027) with
+> the rest of the escalation machinery — this phase's checkpoint covers US2
+> scenarios 1–3 only.
+
+### Tests for User Story 2 (write first, observe failing)
+
+- [X] T019 [P] [US2] Write failing interrupt tests in `tests/unit/assumptions/schedule/test_evaluate_severity.py` (extend): high entry → `INTERRUPT` decision outside windows, `interrupt_delivered_at` set in `state_after` and suppresses re-delivery, quiet hours + `high_overrides_quiet=true` → delivers, `=false` → `quiet-hours` skip then due at first post-quiet evaluation, multiple simultaneous high entries coalesce into one interrupt delivery with combined summary
+
+### Implementation for User Story 2
+
+- [X] T020 [US2] Implement interrupt tier in `src/maverick/assumptions/schedule/evaluate.py`: high-severity decision path with `high_overrides_quiet` gating and `EntryTrackingRecord.interrupt_delivered_at` idempotence; T019 goes green
+- [X] T021 [US2] Wire interrupt delivery through `src/maverick/cli/commands/notify.py` and `deliver.py` (`interrupt` kind → priority `urgent`, title per contracts/ntfy-payload.md); extend `tests/unit/cli/commands/test_notify_json.py` with an interrupt-delivery envelope case
+
+**Checkpoint**: US1 and US2 both pass independently; a mixed ledger produces one batch + one interrupt with no cross-talk
+
+---
+
+## Phase 5: User Story 3 - Idempotent evaluation from cron (Priority: P3)
+
+**Goal**: Arbitrary re-runs and overlapping invocations never double-deliver;
+failed deliveries stay due; persisted state fully explains every fire/skip.
+
+**Independent Test**: quickstart.md Scenarios 5–6 — double invocation delivers
+once; concurrent invocations produce one evaluation + one benign skip;
+unreachable ntfy leaves the batch due and re-delivers after recovery.
+
+### Tests for User Story 3 (write first, observe failing)
+
+- [X] T022 [P] [US3] Write failing idempotence/failure tests: extend `tests/unit/assumptions/schedule/test_state.py` (delivery failure excluded from `state_after` → occurrence stays undecided, partial success persists only succeeded decisions) and `tests/unit/cli/commands/test_notify_json.py` (second run same window → `already-delivered` skip + zero transport calls; held lock with live pid → `ok: true`, `result.skipped: "concurrent-evaluation"`, exit 0 per research R7; stale lock reclaimed and evaluation proceeds; ledger read failure (`AssumptionLedgerError`) → `validation` envelope with zero state-file mutation, per the spec's ledger-unreadable edge case)
+- [X] T023 [P] [US3] Write failing end-to-end integration test in `tests/integration/test_notify_flow.py`: simulated multi-day run (mocked `BeadClient.query/show`, `httpx.MockTransport`, injected `now` sequence) — overnight accumulation delivers exactly one 09:00 batch (SC-001), repeated invocations idempotent (SC-003), every fire/skip reconstructible from `state.json` alone (SC-004), every entry accounted for (SC-005)
+
+### Implementation for User Story 3
+
+- [X] T024 [US3] Harden the effects layer in `src/maverick/cli/commands/notify.py`: per-decision write-after-success (failed delivery → decision excluded from saved state, envelope `error.details.failed_deliveries`, exit 1; partial successes recorded), lock acquire/release around the whole evaluate-deliver-save sequence with benign-skip result on contention; T022 + T023 go green
+
+**Checkpoint**: Command is cron-safe; all three stories pass independently
+
+---
+
+## Phase 6: User Story 4 - Age-based escalation and explicit expiry (Priority: P4)
+
+**Goal**: Aged medium/high entries escalate past batching rules; high
+re-notifies on the backoff ladder; opted-in aged low entries auto-waive with
+recorded rationale; nothing leaves tracking without a persisted outcome.
+
+**Independent Test**: quickstart-style simulation — a lone medium entry below
+min-batch-size delivers once its age exceeds `max_entry_age_hours`; an
+unanswered high entry re-notifies at 4/8/16/24h spacing; with auto-waive
+enabled, an aged low entry is waived with the configured rationale visible in
+`maverick review --list`.
+
+### Tests for User Story 4 (write first, observe failing)
+
+- [X] T025 [P] [US4] Write failing escalation tests in `tests/unit/assumptions/schedule/test_evaluate_escalation.py`: medium past `max_entry_age_hours` → `ESCALATION` decision bypassing min-batch-size (US4 scenario 1), medium escalates exactly once (FR-007), high past max age → `RENOTIFY` decisions at backoff-ladder spacing with `renotify_count`/`next_renotify_at` advancing and last rung repeating, low never escalates to delivery (clarification Q2), escalation respects `high_overrides_quiet` gating during quiet hours
+- [X] T026 [P] [US4] Write failing auto-waive tests: extend `tests/unit/assumptions/schedule/test_evaluate_escalation.py` (policy absent/disabled → never an `AutoWaiveDecision`; enabled + aged low → decision with full rationale text) and `tests/unit/cli/commands/test_notify_json.py` (real run calls `ledger.waive` with `waived_by="maverick-scheduler"`, records `terminal: {kind: "auto-waived"}` in state; `--dry-run` reports would-waive with zero bd calls)
+
+### Implementation for User Story 4
+
+- [X] T027 [US4] Implement escalation + backoff in `src/maverick/assumptions/schedule/evaluate.py`: max-age escalation for medium/high, backoff-ladder re-notification for high (`renotify_backoff_hours`, last value repeating), quiet-hours gating; T025 goes green
+- [X] T028 [US4] Implement auto-waive effects in `src/maverick/cli/commands/notify.py`: execute `AutoWaiveDecision`s via `assumptions.ledger.waive(client, bead_id=..., reason="auto-waived by schedule policy after {h}h: {rationale}", waived_by="maverick-scheduler")` (research R10), record `TerminalOutcome` in state, skip entirely in dry-run; extend `deliver.py` with `escalation`/`renotify` payload kinds (priority `urgent`); T026 goes green
+
+**Checkpoint**: All four stories independently functional; full FR coverage
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T029 [P] Update `CLAUDE.md`: add `notify` to the shared-commands table and a `### notify` subsection (severity tiers, config blocks, state location, JSON verbs, benign-lock divergence from reconcile), mirroring the existing per-command sections
+- [X] T030 [P] Pin serializer contract against regressions: confirm `entry_to_dict`'s new `created_at` field flows into `review --list --json` and the land report without regression (`tests/unit/cli/commands/test_review_listing.py`, `tests/unit/assumptions/test_land_report.py` — extend, don't fork)
+- [X] T031 Run quickstart.md Scenarios 1–6 against a live ntfy topic in a scratch repo; fix any drift between contracts and behavior
+- [X] T032 Run `make format-fix && make ci` (the pre-push gate — `make lint` alone misses `ruff format --check`) and resolve anything red
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies
+- **Foundational (Phase 2)**: depends on T001 — BLOCKS all user stories
+- **US1 (Phase 3)**: depends on Phase 2 — delivers the MVP
+- **US2 (Phase 4)**: depends on Phase 2; shares `evaluate.py`/`notify.py` with US1, so runs after US1 in a serial fly (file-scope overlap, not logical dependency)
+- **US3 (Phase 5)**: depends on US1 (exercises its delivery path); T024 touches `notify.py`
+- **US4 (Phase 6)**: depends on US1 (escalation reuses batch delivery machinery); touches `evaluate.py`/`notify.py`/`deliver.py`
+- **Polish (Phase 7)**: depends on US1–US4
+
+### Within Each User Story
+
+- Test tasks first; observe them fail; then implementation (red-green-refactor)
+- `models.py` → `evaluate.py`/`state.py`/`deliver.py` → `notify.py` → registration
+
+### Parallel Opportunities
+
+- Phase 2: T002 ∥ T005 ∥ T008 (three disjoint test files); after T004+T006: T007 ∥ T009
+- Phase 3: T010 ∥ T011 ∥ T012 ∥ T013 (four disjoint test files), then T014 ∥ T015 (disjoint modules), then T016 → T017 → T018
+- Phases 4–6 are internally small; their test tasks ([P]) parallelize against nothing else in-phase because implementations share `evaluate.py`/`notify.py`
+- Phase 7: T029 ∥ T030
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all US1 test authoring together (four disjoint files):
+Task: "T010 window-evaluation tests in tests/unit/assumptions/schedule/test_evaluate_windows.py"
+Task: "T011 severity-tier tests in tests/unit/assumptions/schedule/test_evaluate_severity.py"
+Task: "T012 deliverer tests in tests/unit/assumptions/schedule/test_deliver.py"
+Task: "T013 CLI tests in tests/unit/cli/test_notify_command.py + tests/unit/cli/commands/test_notify_json.py"
+
+# Then implementation in two parallel tracks:
+Task: "T014 evaluate.py window batching"
+Task: "T015 deliver.py NtfyDeliverer"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Phase 1 → Phase 2 (foundation blocks everything)
+2. Phase 3 (US1) → **STOP and VALIDATE**: quickstart Scenarios 1–3 with a real
+   ntfy topic
+3. This alone retires the feature's core promise: no more polling for
+   medium-severity questions
+
+### Incremental Delivery
+
+1. Setup + Foundational → foundation ready
+2. US1 → batched windows work (MVP — deployable to cron immediately)
+3. US2 → high-severity interrupts
+4. US3 → cron-hardening (idempotence + concurrency + failure semantics proven
+   end-to-end)
+5. US4 → escalation, backoff, auto-waive
+6. Polish → docs, contract pinning, `make ci`
+
+Each story lands green and independently testable; `bead(<id>)` commits per
+task or logical group.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks
+- Every test task must fail before its implementation task starts (Principle V)
+- No new external dependencies: httpx, tenacity, Pydantic, atomicwrites are all
+  already declared (research R5)
+- `evaluate()` stays pure — any temptation to read disk/network inside it is a
+  design violation (plan.md Constitution Check, Principle III)
+- Zero model calls anywhere in this feature (Principle XIII)

--- a/src/maverick/assumptions/ledger.py
+++ b/src/maverick/assumptions/ledger.py
@@ -267,6 +267,7 @@ def _record_from_details(details: object) -> AssumptionRecord:
         source_bead=state.get(KEY_SOURCE_BEAD, ""),
         change_ids=change_ids,
         is_legacy=False,
+        created_at=getattr(details, "created_at", None),
     )
 
 
@@ -290,6 +291,7 @@ def _legacy_record_from_details(details: object) -> AssumptionRecord:
         source_bead=state.get(KEY_SOURCE_BEAD, ""),
         change_ids=(),
         is_legacy=True,
+        created_at=getattr(details, "created_at", None),
     )
 
 

--- a/src/maverick/assumptions/models.py
+++ b/src/maverick/assumptions/models.py
@@ -151,6 +151,10 @@ class AssumptionRecord:
         source_bead: The bead this entry was discovered from.
         change_ids: jj change IDs stamping this entry; empty = unstamped.
         is_legacy: True for pre-feature escalation beads without ledger state.
+        created_at: bd's UTC ISO-8601 creation timestamp, copied verbatim
+            from ``BeadDetails.created_at`` (spec 054 research R1). ``None``
+            when bd omitted it; the scheduler falls back to its own
+            persisted ``first_seen`` timestamp in that case.
     """
 
     bead_id: str
@@ -164,6 +168,7 @@ class AssumptionRecord:
     source_bead: str
     change_ids: tuple[str, ...]
     is_legacy: bool
+    created_at: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/maverick/assumptions/schedule/__init__.py
+++ b/src/maverick/assumptions/schedule/__init__.py
@@ -1,0 +1,30 @@
+"""Assumption batch scheduler — evaluation, delivery, and persisted state.
+
+Public API re-exported here; see ``specs/054-assumption-batch-scheduler/``
+for the full contract. Evaluation models are pure in-memory dataclasses
+(never persisted); the persisted counterpart lives in ``state.py``.
+"""
+
+from __future__ import annotations
+
+from maverick.assumptions.schedule.models import (
+    AutoWaiveDecision,
+    BatchSummary,
+    DecisionKind,
+    DeliveryDecision,
+    EvaluationOutcome,
+    SkipDecision,
+    SkipReason,
+    WindowOccurrence,
+)
+
+__all__ = [
+    "AutoWaiveDecision",
+    "BatchSummary",
+    "DecisionKind",
+    "DeliveryDecision",
+    "EvaluationOutcome",
+    "SkipDecision",
+    "SkipReason",
+    "WindowOccurrence",
+]

--- a/src/maverick/assumptions/schedule/clock.py
+++ b/src/maverick/assumptions/schedule/clock.py
@@ -1,0 +1,200 @@
+"""The evaluation clock for the assumption batch scheduler (``maverick notify``).
+
+``assumptions.schedule`` windows and quiet hours are *machine-local wall
+clock* (contracts/config-schema.md), and
+:func:`maverick.assumptions.schedule.evaluate.evaluate` reuses the ``tzinfo``
+of the ``now`` it is handed to build every window occurrence it considers —
+including occurrences on dates other than today (yesterday's catch-up, a
+rolled-forward window). That only produces correct wall-clock times if the
+``tzinfo`` is a real IANA zone: ``datetime.now().astimezone()`` returns a
+*fixed-offset* :class:`datetime.timezone` frozen at today's offset, so an
+occurrence on the far side of a DST transition comes out shifted by the DST
+delta (in ``America/New_York``, evaluating at 10:00 EDT on 2026-03-08 would
+build 2026-03-07's occurrence with UTC-4 when that date was UTC-5).
+
+This module resolves the machine's real IANA zone with the standard library
+only — no ``tzlocal`` dependency — in the order:
+
+1. the ``TZ`` environment variable, when it names a zone :class:`ZoneInfo`
+   accepts (POSIX offset spellings such as ``EST5EDT`` or ``<+07>-7`` do not
+   and fall through);
+2. the ``/etc/localtime`` symlink target, mapped back to a zone key by taking
+   the path tail after its ``zoneinfo`` component;
+3. the contents of ``/etc/timezone`` (Debian family).
+
+When none resolve — a distro that ships ``/etc/localtime`` as a plain copy
+with no ``/etc/timezone``, a container with no tz database — resolution
+*degrades* to the historical fixed-offset behaviour rather than raising, and
+logs that once per process. A fixed offset is still a correct instant; only
+cross-DST wall-clock arithmetic loses fidelity, which is strictly better than
+refusing to notify at all.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, tzinfo
+from pathlib import Path
+from typing import Final
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from maverick.logging import get_logger
+
+__all__ = ["local_timezone", "now_local", "resolve_local_zone"]
+
+logger = get_logger(__name__)
+
+#: The symlink every systemd-era distro points at the active zone's tzfile.
+#: Module-level so tests can redirect it without touching the real ``/etc``.
+_LOCALTIME_PATH: Final = Path("/etc/localtime")
+
+#: Debian-family plain-text zone key (e.g. ``America/New_York\n``).
+_TIMEZONE_FILE_PATH: Final = Path("/etc/timezone")
+
+#: The path component that separates the tz-database root from the zone key.
+_ZONEINFO_DIR_NAME: Final = "zoneinfo"
+
+#: Whether this process has already reported a failed zone resolution. The
+#: degradation is a property of the machine, not of the call, so repeating it
+#: on every :func:`local_timezone` call would be pure noise.
+_degradation_logged = False
+
+
+def _zone_or_none(key: str) -> ZoneInfo | None:
+    """Return :class:`ZoneInfo` for *key*, or ``None`` if it names no zone.
+
+    Args:
+        key: A candidate IANA zone key (e.g. ``"America/New_York"``).
+
+    Returns:
+        The constructed zone, or ``None`` when *key* is empty, malformed, or
+        absent from the tz database.
+    """
+    if not key:
+        return None
+    try:
+        return ZoneInfo(key)
+    except (ZoneInfoNotFoundError, ValueError, OSError):
+        return None
+
+
+def _zone_from_env() -> ZoneInfo | None:
+    """Resolve the zone named by ``TZ``, if it names one.
+
+    A leading ``":"`` is legal POSIX (``TZ=:America/New_York``) and is
+    stripped before lookup. POSIX offset specs (``EST5EDT``, ``<+07>-7``)
+    that are not also zone keys resolve to ``None``.
+    """
+    raw = os.environ.get("TZ")
+    if raw is None:
+        return None
+    return _zone_or_none(raw.strip().lstrip(":"))
+
+
+def _zone_key_from_path(path: Path) -> str | None:
+    """Map a tzfile path back to its zone key.
+
+    Args:
+        path: An absolute path such as
+            ``/usr/share/zoneinfo/America/New_York``.
+
+    Returns:
+        The path tail after the last ``zoneinfo`` component
+        (``"America/New_York"``), or ``None`` when the path has no such
+        component — the case when ``/etc/localtime`` is a plain copy of a
+        tzfile rather than a symlink into the database.
+    """
+    parts = path.parts
+    for index in range(len(parts) - 1, -1, -1):
+        if parts[index] == _ZONEINFO_DIR_NAME:
+            tail = parts[index + 1 :]
+            return "/".join(tail) if tail else None
+    return None
+
+
+def _zone_from_localtime_symlink() -> ZoneInfo | None:
+    """Resolve the zone ``/etc/localtime`` points at, if it is a symlink."""
+    path = _LOCALTIME_PATH
+    try:
+        if not path.is_symlink():
+            return None
+        target = path.resolve()
+    except OSError:
+        return None
+    key = _zone_key_from_path(target)
+    return _zone_or_none(key) if key is not None else None
+
+
+def _zone_from_timezone_file() -> ZoneInfo | None:
+    """Resolve the zone named by ``/etc/timezone`` (Debian family)."""
+    try:
+        contents = _TIMEZONE_FILE_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in contents.splitlines():
+        candidate = line.strip()
+        if candidate and not candidate.startswith("#"):
+            return _zone_or_none(candidate)
+    return None
+
+
+def resolve_local_zone() -> ZoneInfo | None:
+    """Resolve the machine's local IANA timezone.
+
+    Returns:
+        The machine's zone as a :class:`zoneinfo.ZoneInfo`, or ``None`` when
+        no source (``TZ``, ``/etc/localtime``, ``/etc/timezone``) names a zone
+        the tz database knows. Never raises.
+    """
+    for source in (_zone_from_env, _zone_from_localtime_symlink, _zone_from_timezone_file):
+        zone = source()
+        if zone is not None:
+            return zone
+    return None
+
+
+def local_timezone() -> tzinfo:
+    """Return the timezone to bind the evaluation clock to.
+
+    Returns:
+        The machine's IANA zone when resolvable — DST-aware, so wall-clock
+        arithmetic on any date is correct — otherwise the fixed-offset
+        :class:`datetime.timezone` of the current moment, which is the
+        historical behaviour and is logged once per process as a degradation.
+    """
+    global _degradation_logged
+
+    zone = resolve_local_zone()
+    if zone is not None:
+        return zone
+
+    fallback = datetime.now().astimezone().tzinfo
+    assert fallback is not None  # astimezone() always yields an aware datetime
+    if not _degradation_logged:
+        _degradation_logged = True
+        logger.warning(
+            "local_timezone_unresolved",
+            fallback_offset=str(fallback),
+            detail=(
+                "could not resolve an IANA local timezone from TZ, "
+                "/etc/localtime, or /etc/timezone; falling back to a "
+                "fixed UTC offset (wall-clock times across a DST "
+                "transition may be off by the DST delta)"
+            ),
+        )
+    return fallback
+
+
+def now_local() -> datetime:
+    """Return the current time as an aware datetime in the machine's local zone.
+
+    This is the injected clock seam (research R6) every ``maverick notify``
+    evaluation is driven from: the CLI boundary calls it once and passes the
+    result to :func:`~maverick.assumptions.schedule.evaluate.evaluate`, which
+    reuses its ``tzinfo`` for every window occurrence it builds.
+
+    Returns:
+        ``datetime.now()`` bound to :func:`local_timezone`'s result — always
+        aware, never naive.
+    """
+    return datetime.now(tz=local_timezone())

--- a/src/maverick/assumptions/schedule/decisions.py
+++ b/src/maverick/assumptions/schedule/decisions.py
@@ -1,0 +1,197 @@
+"""Decision plumbing shared by every scheduler decision kind.
+
+Three things live here, all of them the mechanics of *emitting* a decision
+rather than the policy of *making* one:
+
+* :class:`DecisionSink` — the accumulator every decision-producing helper
+  appends to, pairing each delivery with its speculative audit record so
+  the two can never drift apart.
+* :func:`build_delivery_record` — that speculative audit record.
+* :class:`EntryDecisionSpec` / :func:`process_entry_decisions` — the one
+  entry-scoped decision engine behind high-severity interrupts, max-age
+  escalations, and backoff re-notifications. Those three differ only in
+  policy (which entries are due, whether quiet hours hold them, what gets
+  stamped on delivery), so each supplies a spec instead of transcribing the
+  control flow again. Adding a fourth kind is a fourth spec, not a fourth
+  copy — the divergence that once left ``ESCALATION``/``RENOTIFY`` out of
+  ``state.finalize_state``'s revert table (FR-012) started as exactly that
+  kind of transcription.
+
+Window batches are deliberately *not* routed through
+:func:`process_entry_decisions`: they are occurrence-scoped, carry a
+:class:`~maverick.assumptions.schedule.models.WindowOccurrence`, and persist
+a :class:`~maverick.assumptions.schedule.state.WindowDecisionRecord` — see
+:func:`~maverick.assumptions.schedule.windows.process_due_occurrence`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+
+from maverick.assumptions.models import AssumptionReportEntry
+from maverick.assumptions.schedule.models import (
+    BatchSummary,
+    DecisionKind,
+    DeliveryDecision,
+    SkipDecision,
+    SkipReason,
+    format_utc,
+)
+from maverick.assumptions.schedule.state import DeliveryRecord, EntryTrackingRecord
+
+_DeliveryKindLiteral = Literal["window-batch", "interrupt", "escalation", "renotify"]
+
+
+def _delivery_kind_literal(kind: DecisionKind) -> _DeliveryKindLiteral:
+    """Map :class:`DecisionKind` to :class:`DeliveryRecord`'s kind literal.
+
+    A explicit match (rather than reusing the matching ``StrEnum`` values
+    directly) keeps this mypy-strict: ``DeliveryRecord.kind`` is a
+    ``Literal[...]``, and each branch below narrows to exactly one member.
+    """
+    match kind:
+        case DecisionKind.WINDOW_BATCH:
+            return "window-batch"
+        case DecisionKind.INTERRUPT:
+            return "interrupt"
+        case DecisionKind.ESCALATION:
+            return "escalation"
+        case DecisionKind.RENOTIFY:
+            return "renotify"
+
+
+def build_delivery_record(decision: DeliveryDecision, now: datetime) -> DeliveryRecord:
+    """Speculative audit-trail entry for one :class:`DeliveryDecision`.
+
+    Assumes the eventual ntfy push succeeds — per data-model.md §3, the
+    effects layer (``notify.py``, T017/T024) strips this record back out
+    of the state it actually persists for any decision whose delivery
+    attempt fails (write-after-success, FR-012).
+    """
+    trigger = decision.occurrence.key if decision.occurrence is not None else decision.rule
+    return DeliveryRecord(
+        kind=_delivery_kind_literal(decision.kind),
+        delivered_at=format_utc(now),
+        trigger=trigger,
+        entry_ids=list(decision.entry_ids),
+        summary=decision.summary.to_dict(),
+    )
+
+
+@dataclass(frozen=True)
+class DecisionSink:
+    """Accumulator for one ``evaluate()`` call's decisions.
+
+    Frozen so the three lists can't be swapped out, but the lists
+    themselves are appended to in place — a small, deliberate exception to
+    this package's otherwise functional style, scoped to gathering results
+    across the several decision engines one evaluation runs. Appending a
+    delivery and its :class:`DeliveryRecord` is a single operation
+    (:meth:`deliver`) precisely so no caller can record one without the
+    other.
+    """
+
+    deliveries: list[DeliveryDecision] = field(default_factory=list)
+    skips: list[SkipDecision] = field(default_factory=list)
+    delivery_records: list[DeliveryRecord] = field(default_factory=list)
+
+    def deliver(self, decision: DeliveryDecision, now: datetime) -> None:
+        """Record *decision* plus the audit record its push will confirm."""
+        self.deliveries.append(decision)
+        self.delivery_records.append(build_delivery_record(decision, now))
+
+    def skip(self, decision: SkipDecision) -> None:
+        """Record a decision that produced no delivery."""
+        self.skips.append(decision)
+
+
+@dataclass(frozen=True)
+class EntryDecisionSpec:
+    """One entry-scoped decision kind, expressed as data (research R9).
+
+    Attributes:
+        kind: The :class:`DecisionKind` a due batch delivers under.
+        due_rule: Human-readable rule text on the delivery decision.
+        held_rule: Human-readable rule text on the quiet-hours skip.
+        is_due: Per-entry eligibility, evaluated before quiet hours —
+            covers idempotence bookkeeping (already delivered?), age
+            thresholds, and backoff timing. Returning ``False`` drops the
+            entry from this evaluation entirely, producing neither a
+            delivery nor a skip.
+        held_by_quiet_hours: Whether quiet hours hold *this kind* right
+            now. Severity-scoped, and the reason this is a per-spec value
+            rather than one shared check: ``high_overrides_quiet`` governs
+            high-severity traffic only, while medium escalation is held
+            unconditionally (FR-004, contracts/config-schema.md). Computed
+            once per call — it is a function of ``now`` and the schedule,
+            never of an individual entry.
+        stamp: Idempotence bookkeeping applied to each *delivered* entry's
+            tracking row — held entries are deliberately left unstamped so
+            they stay due at the first evaluation after quiet hours end.
+    """
+
+    kind: DecisionKind
+    due_rule: str
+    held_rule: str
+    is_due: Callable[[AssumptionReportEntry], bool]
+    held_by_quiet_hours: bool
+    stamp: Callable[[str, EntryTrackingRecord], EntryTrackingRecord]
+
+
+def process_entry_decisions(
+    spec: EntryDecisionSpec,
+    *,
+    entries: Sequence[AssumptionReportEntry],
+    tracking: dict[str, EntryTrackingRecord],
+    summary: BatchSummary,
+    now: datetime,
+    sink: DecisionSink,
+) -> None:
+    """Resolve *entries* under *spec* into at most one delivery and one skip.
+
+    Every due entry coalesces into a *single* delivery carrying the
+    content-free, whole-ledger *summary* every decision kind uses (research
+    R9) — one push, not one per entry — and every held entry into a single
+    :attr:`SkipReason.QUIET_HOURS` skip. An entry that is not due produces
+    neither.
+
+    Mutates *tracking* and *sink* in place; see :class:`DecisionSink`.
+    """
+    due_ids: list[str] = []
+    held_ids: list[str] = []
+
+    for entry in entries:
+        if not spec.is_due(entry):
+            continue
+        bead_id = entry.record.bead_id
+        if spec.held_by_quiet_hours:
+            held_ids.append(bead_id)
+        else:
+            due_ids.append(bead_id)
+
+    if due_ids:
+        sink.deliver(
+            DeliveryDecision(
+                kind=spec.kind,
+                entry_ids=tuple(due_ids),
+                summary=summary,
+                occurrence=None,
+                rule=spec.due_rule,
+            ),
+            now,
+        )
+        for bead_id in due_ids:
+            tracking[bead_id] = spec.stamp(bead_id, tracking[bead_id])
+
+    if held_ids:
+        sink.skip(
+            SkipDecision(
+                reason=SkipReason.QUIET_HOURS,
+                occurrence=None,
+                entry_ids=tuple(held_ids),
+                rule=spec.held_rule,
+            )
+        )

--- a/src/maverick/assumptions/schedule/deliver.py
+++ b/src/maverick/assumptions/schedule/deliver.py
@@ -1,0 +1,321 @@
+"""ntfy delivery for the assumption batch scheduler (``maverick notify``).
+
+**Single canonical wrapper** (Guardrail 5): this module is the only one
+that may construct ntfy requests — see
+``specs/054-assumption-batch-scheduler/contracts/ntfy-payload.md``.
+
+:class:`NtfyDeliverer` POSTs to ``{server}/{topic}`` via ``httpx.AsyncClient``
+with an explicit 10-second timeout, retrying transient failures
+(``httpx.TransportError`` and HTTP 5xx) with ``tenacity.AsyncRetrying`` (3
+attempts, exponential backoff). HTTP 4xx responses are a configuration
+problem retrying cannot fix, so they fail immediately. Exhausted retries and
+non-retryable rejections both raise :class:`DeliveryFailedError` — per
+FR-012, the triggering decision must never be recorded as delivered, so the
+batch stays due for the next evaluation.
+
+Payloads are built from :class:`~maverick.assumptions.schedule.models.BatchSummary`
+only (never entry contents — FR-008): counts by severity, owning specs,
+oldest-entry age, and a suggested review invocation. :func:`build_payload`
+takes the delivery ``kind`` explicitly so the escalation/renotify kinds
+wired in by later phases (T021, T028) are pure additions to the priority/
+title tables below, not a restructuring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+from tenacity import (
+    AsyncRetrying,
+    RetryError,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+from tenacity.wait import WaitBaseT
+
+from maverick.assumptions.models import Severity
+from maverick.assumptions.schedule.models import BatchSummary, DecisionKind, format_age_hours
+from maverick.exceptions.base import MaverickError
+from maverick.logging import get_logger
+
+__all__ = [
+    "DeliveryFailedError",
+    "NtfyDeliverer",
+    "NtfyPayload",
+    "build_payload",
+]
+
+logger = get_logger(__name__)
+
+#: Explicit request timeout (contracts/ntfy-payload.md, research.md R5).
+_REQUEST_TIMEOUT_SECONDS = 10.0
+
+#: Retry budget: 3 attempts total (1 initial + 2 retries), exponential
+#: backoff (contracts/ntfy-payload.md, research.md R5).
+_MAX_ATTEMPTS = 3
+_DEFAULT_WAIT: WaitBaseT = wait_exponential(multiplier=1, min=1, max=8)
+
+#: HTTP status thresholds: >=500 retries, >=400 (and <500) fails immediately.
+_RETRYABLE_STATUS_FLOOR = 500
+_CLIENT_ERROR_STATUS_FLOOR = 400
+
+_TAGS = "maverick,assumptions"
+
+#: Stand-in for the spec list when no open entry carries an owning spec —
+#: without it the body reads "... low open across ." (an empty join).
+_NO_SPEC_PLACEHOLDER = "no owning spec"
+
+#: Title per DecisionKind (contracts/ntfy-payload.md). window-batch's
+#: ``{count}`` placeholder is filled from the summary's total open-entry
+#: count; the other kinds carry no placeholder and pass through unchanged.
+_TITLES: dict[DecisionKind, str] = {
+    DecisionKind.WINDOW_BATCH: "Assumption review: {count} open entries",
+    DecisionKind.INTERRUPT: "High-severity assumption recorded",
+    DecisionKind.ESCALATION: "Assumption entries aging past limit",
+    DecisionKind.RENOTIFY: "High-severity assumption still unanswered",
+}
+
+#: Priority per DecisionKind (contracts/ntfy-payload.md): every kind but
+#: window-batch is urgent.
+_URGENT_KINDS = frozenset({DecisionKind.INTERRUPT, DecisionKind.ESCALATION, DecisionKind.RENOTIFY})
+
+
+class DeliveryFailedError(MaverickError):
+    """Raised when an ntfy delivery cannot be completed (FR-012).
+
+    Covers both exhausted retries (5xx / transport errors across
+    ``_MAX_ATTEMPTS`` attempts) and an immediate 4xx rejection. In either
+    case the triggering decision must not be recorded as delivered — the
+    caller (the ``notify`` command layer) leaves the batch due.
+
+    Attributes:
+        kind: The delivery kind that failed to send.
+        status_code: The last HTTP status code observed, or ``None`` when
+            every attempt failed at the transport layer without a response.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        kind: DecisionKind,
+        status_code: int | None = None,
+    ) -> None:
+        """Initialize the DeliveryFailedError.
+
+        Args:
+            message: Human-readable error message.
+            kind: The delivery kind that failed to send.
+            status_code: The last HTTP status code observed, if any.
+        """
+        self.kind = kind
+        self.status_code = status_code
+        super().__init__(message)
+
+
+class _RetryableStatusError(Exception):
+    """Internal signal: an ntfy response was 5xx and tenacity should retry.
+
+    Never escapes :class:`NtfyDeliverer` — it is either swallowed by a
+    successful subsequent attempt or translated into
+    :class:`DeliveryFailedError` once retries are exhausted.
+    """
+
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+        super().__init__(f"ntfy responded {status_code}")
+
+
+@dataclass(frozen=True, slots=True)
+class NtfyPayload:
+    """The literal ntfy request shape for one delivery.
+
+    Attributes:
+        title: The ``Title`` header value.
+        priority: The ``Priority`` header value (``"default"`` or
+            ``"urgent"``).
+        tags: The ``Tags`` header value.
+        body: The plain-text request body.
+    """
+
+    title: str
+    priority: str
+    tags: str
+    body: str
+
+
+def build_payload(kind: DecisionKind, summary: BatchSummary) -> NtfyPayload:
+    """Build the content-free ntfy payload for one delivery decision.
+
+    The payload is derived exclusively from *summary* — counts, owning
+    specs, oldest-entry age, and a review invocation. There are no
+    entry-content fields on :class:`BatchSummary` to leak (FR-008); a
+    prohibited field would require a type-level change here, not a
+    formatting slip.
+
+    Args:
+        kind: Which delivery category this payload represents. Selects
+            the title template and priority per
+            contracts/ntfy-payload.md's table.
+        summary: Content-free aggregate of the covered entries.
+
+    Returns:
+        The ``Title``/``Priority``/``Tags``/body values to send.
+    """
+    total = sum(summary.counts.values())
+    title = _TITLES[kind].format(count=total)
+    priority = "urgent" if kind in _URGENT_KINDS else "default"
+    specs = ", ".join(summary.owner_specs) if summary.owner_specs else _NO_SPEC_PLACEHOLDER
+    body = (
+        f"{summary.counts.get(Severity.HIGH, 0)} high, "
+        f"{summary.counts.get(Severity.MEDIUM, 0)} medium, "
+        f"{summary.counts.get(Severity.LOW, 0)} low open across "
+        f"{specs}.\n"
+        f"Oldest: {format_age_hours(summary.oldest_age_hours)}h.\n"
+        f"Run: {summary.review_invocation}"
+    )
+    return NtfyPayload(title=title, priority=priority, tags=_TAGS, body=body)
+
+
+class NtfyDeliverer:
+    """Delivers assumption-scheduler notifications to an ntfy topic.
+
+    The only module permitted to construct ntfy requests (Guardrail 5).
+    Owns one ``httpx.AsyncClient`` for its lifetime; callers should use it
+    as an async context manager or call :meth:`aclose` explicitly.
+    """
+
+    def __init__(
+        self,
+        server: str,
+        topic: str,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+        timeout: float = _REQUEST_TIMEOUT_SECONDS,
+        wait: WaitBaseT | None = None,
+    ) -> None:
+        """Initialize the NtfyDeliverer.
+
+        Args:
+            server: ntfy server base URL (``notifications.server``), e.g.
+                ``"https://ntfy.sh"``.
+            topic: ntfy topic name (``notifications.topic``).
+            transport: Optional ``httpx`` transport override — used in
+                tests to inject ``httpx.MockTransport``. ``None`` uses
+                httpx's default transport.
+            timeout: Explicit request timeout in seconds, applied to
+                connect/read/write/pool phases uniformly.
+            wait: Optional tenacity wait strategy override — used in tests
+                to avoid real sleeps. Defaults to exponential backoff
+                (multiplier=1s, min=1s, max=8s).
+        """
+        self._server = server.rstrip("/")
+        self._topic = topic
+        self._client = httpx.AsyncClient(timeout=timeout, transport=transport)
+        self._wait: WaitBaseT = wait if wait is not None else _DEFAULT_WAIT
+
+    async def __aenter__(self) -> NtfyDeliverer:
+        """Enter the async context, returning self."""
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        """Exit the async context, closing the underlying HTTP client."""
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the underlying ``httpx.AsyncClient``."""
+        await self._client.aclose()
+
+    async def deliver(self, kind: DecisionKind, summary: BatchSummary) -> None:
+        """Deliver one notification to the configured ntfy topic.
+
+        Args:
+            kind: Which delivery category to send — selects title/priority
+                per contracts/ntfy-payload.md.
+            summary: Content-free aggregate of the covered entries; the
+                sole input to payload construction (FR-008).
+
+        Raises:
+            DeliveryFailedError: The request was rejected with a 4xx
+                status (no retry), or retries were exhausted against 5xx
+                responses / transport errors.
+        """
+        payload = build_payload(kind, summary)
+        response = await self._post_with_retry(kind, payload)
+
+        if response.status_code >= _CLIENT_ERROR_STATUS_FLOOR:
+            logger.warning(
+                "ntfy_delivery_rejected",
+                kind=str(kind),
+                status_code=response.status_code,
+            )
+            raise DeliveryFailedError(
+                f"ntfy rejected delivery with status {response.status_code}",
+                kind=kind,
+                status_code=response.status_code,
+            )
+
+    async def _post_with_retry(self, kind: DecisionKind, payload: NtfyPayload) -> httpx.Response:
+        """POST *payload*, retrying transient failures per the retry policy.
+
+        A 5xx response or ``httpx.TransportError`` triggers a retry (up to
+        ``_MAX_ATTEMPTS`` total attempts, exponential backoff). A 2xx or
+        4xx response returns immediately — 4xx is a configuration problem
+        retrying cannot fix and is left for :meth:`deliver` to translate
+        into :class:`DeliveryFailedError`.
+
+        Args:
+            kind: The delivery kind being sent, for error attribution.
+            payload: The already-built ntfy payload.
+
+        Returns:
+            The final ``httpx.Response`` (2xx or 4xx).
+
+        Raises:
+            DeliveryFailedError: Retries exhausted against 5xx responses
+                or transport errors.
+        """
+        url = f"{self._server}/{self._topic}"
+        headers = {
+            "Title": payload.title,
+            "Priority": payload.priority,
+            "Tags": payload.tags,
+        }
+
+        try:
+            async for attempt in AsyncRetrying(
+                stop=stop_after_attempt(_MAX_ATTEMPTS),
+                wait=self._wait,
+                retry=retry_if_exception_type((httpx.TransportError, _RetryableStatusError)),
+            ):
+                with attempt:
+                    response = await self._client.post(
+                        url,
+                        content=payload.body.encode("utf-8"),
+                        headers=headers,
+                    )
+                    if response.status_code >= _RETRYABLE_STATUS_FLOOR:
+                        raise _RetryableStatusError(response.status_code)
+                    return response
+        except RetryError as exc:
+            cause = exc.last_attempt.exception()
+            status_code = cause.status_code if isinstance(cause, _RetryableStatusError) else None
+            logger.warning(
+                "ntfy_delivery_exhausted",
+                kind=str(kind),
+                status_code=status_code,
+                attempts=_MAX_ATTEMPTS,
+            )
+            detail = f" (last status {status_code})" if status_code is not None else ""
+            raise DeliveryFailedError(
+                f"ntfy delivery failed after {_MAX_ATTEMPTS} attempts{detail}",
+                kind=kind,
+                status_code=status_code,
+            ) from exc
+
+        # Unreachable: AsyncRetrying either returns via a successful attempt
+        # above or raises RetryError, which is handled. Satisfies the type
+        # checker (mirrors the house pattern in runners/github.py).
+        raise AssertionError("unreachable: AsyncRetrying attempt loop exited without returning")

--- a/src/maverick/assumptions/schedule/escalation.py
+++ b/src/maverick/assumptions/schedule/escalation.py
@@ -1,0 +1,255 @@
+"""Age-driven safety nets: escalation, backoff re-notification, auto-waive.
+
+Three policies for entries the normal paths have left sitting (US4):
+
+* :func:`process_medium_escalations` — a medium entry past
+  ``max_entry_age_hours`` bypasses windows and ``min_batch_size`` entirely,
+  exactly once (FR-006/FR-007).
+* :func:`process_high_renotify` — an already-interrupted high entry still
+  open past that age keeps re-notifying on the configured backoff ladder,
+  indefinitely (FR-007).
+* :func:`process_auto_waives` — aged low entries, which have no delivery
+  path at all, under an opt-in waive policy (FR-015, research R10).
+
+The first two differ from each other, and from
+:func:`~maverick.assumptions.schedule.severity.process_high_interrupts`,
+only in policy; all three share
+:func:`~maverick.assumptions.schedule.decisions.process_entry_decisions`.
+Note the quiet-hours asymmetry between them: escalation is medium-severity
+and is therefore held **unconditionally**, while re-notification is
+high-severity and obeys ``high_overrides_quiet`` (FR-004).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timedelta
+
+from maverick.assumptions.models import AssumptionReportEntry
+from maverick.assumptions.schedule.decisions import (
+    DecisionSink,
+    EntryDecisionSpec,
+    process_entry_decisions,
+)
+from maverick.assumptions.schedule.models import (
+    AutoWaiveDecision,
+    BatchSummary,
+    DecisionKind,
+    format_utc,
+    parse_utc,
+)
+from maverick.assumptions.schedule.state import EntryTrackingRecord
+from maverick.assumptions.schedule.tracking import entry_age_hours
+from maverick.assumptions.schedule.windows import (
+    high_severity_held_by_quiet_hours,
+    in_quiet_hours_now,
+)
+from maverick.config import AssumptionScheduleConfig
+
+
+def process_medium_escalations(
+    *,
+    medium_entries: Sequence[AssumptionReportEntry],
+    already_batched_ids: frozenset[str],
+    tracking: dict[str, EntryTrackingRecord],
+    schedule: AssumptionScheduleConfig,
+    summary: BatchSummary,
+    now: datetime,
+    sink: DecisionSink,
+) -> None:
+    """Decide max-age escalation for medium entries (US4, FR-006/FR-007).
+
+    An open medium entry (including legacy entries, already synthesized as
+    medium — FR-019) whose age exceeds ``schedule.max_entry_age_hours``
+    escalates regardless of ``min_batch_size`` and window rules, bypassing
+    both entirely (FR-006) — this is the safety net that stops a
+    perpetually-below-threshold batch from starving. Idempotence is
+    per-entry via :attr:`EntryTrackingRecord.escalation_delivered_at`: an
+    entry escalates *exactly once* (FR-007) and never re-notifies
+    afterward, unlike the high-severity backoff ladder in
+    :func:`process_high_renotify`. An entry already covered by this same
+    evaluation's window-batch delivery (*already_batched_ids*) is skipped
+    here — it was just delivered on time.
+
+    Quiet-hours gating is **unconditional** here (FR-004, research R8), and
+    this is where it differs from
+    :func:`~maverick.assumptions.schedule.severity.process_high_interrupts`:
+    these are medium-severity entries, and ``high_overrides_quiet`` gates
+    high severity only (contracts/config-schema.md), so an escalation
+    reached inside quiet hours is always held — nothing is stamped, leaving
+    the entry eligible until the first evaluation after quiet hours end.
+
+    Mutates *tracking* and *sink* in place — the same deliberate, scoped
+    exception to this package's functional style used throughout its
+    decision-producing helpers.
+    """
+    delivered_at = format_utc(now)
+
+    def is_due(entry: AssumptionReportEntry) -> bool:
+        bead_id = entry.record.bead_id
+        if bead_id in already_batched_ids:
+            return False  # delivered on time via this evaluation's window batch
+
+        record = tracking.get(bead_id)
+        if record is not None and record.escalation_delivered_at is not None:
+            return False  # escalates exactly once (FR-007)
+
+        return entry_age_hours(entry, tracking, now) >= schedule.max_entry_age_hours
+
+    def stamp(bead_id: str, record: EntryTrackingRecord) -> EntryTrackingRecord:
+        return record.model_copy(update={"escalation_delivered_at": delivered_at})
+
+    process_entry_decisions(
+        EntryDecisionSpec(
+            kind=DecisionKind.ESCALATION,
+            due_rule=f"max entry age ({schedule.max_entry_age_hours}h) exceeded; escalated",
+            held_rule=(
+                "escalation held: quiet hours suppress medium-severity delivery "
+                "(high_overrides_quiet governs high severity only)"
+            ),
+            is_due=is_due,
+            # Medium severity: quiet hours are absolute regardless of
+            # `high_overrides_quiet`, which governs high severity only.
+            held_by_quiet_hours=in_quiet_hours_now(now, schedule.quiet_hours),
+            stamp=stamp,
+        ),
+        entries=medium_entries,
+        tracking=tracking,
+        summary=summary,
+        now=now,
+        sink=sink,
+    )
+
+
+def process_high_renotify(
+    *,
+    high_entries: Sequence[AssumptionReportEntry],
+    prior_tracking: dict[str, EntryTrackingRecord],
+    tracking: dict[str, EntryTrackingRecord],
+    schedule: AssumptionScheduleConfig,
+    summary: BatchSummary,
+    now: datetime,
+    sink: DecisionSink,
+) -> None:
+    """Decide backoff-ladder re-notification for high entries (US4, FR-007).
+
+    A high entry that was already interrupted *as of a prior evaluation*
+    (``prior_tracking[bead_id].interrupt_delivered_at`` set — never this
+    call's own fresh interrupt, see the ``prior_tracking`` snapshot taken
+    in :func:`~maverick.assumptions.schedule.evaluate.evaluate`) and remains
+    open past ``max_entry_age_hours`` re-notifies rather than staying
+    silent, spaced by ``schedule.renotify_backoff_hours`` — the last rung
+    repeats indefinitely once the ladder is exhausted. Unlike medium
+    escalation, this never stops firing while the entry stays open and
+    unanswered.
+
+    Rung selection: the *Nth* re-notification (0-indexed by the entry's
+    ``renotify_count`` going in) schedules its successor
+    ``schedule.renotify_backoff_hours[min(N, len(ladder) - 1)]`` hours
+    later — so a ladder of ``[4, 8]`` re-notifies after 4h, then 8h, then
+    8h again, forever.
+
+    Quiet-hours gating mirrors
+    :func:`~maverick.assumptions.schedule.severity.process_high_interrupts`
+    exactly (both read
+    :func:`~maverick.assumptions.schedule.windows.high_severity_held_by_quiet_hours`
+    — ``high_overrides_quiet`` gates the two identically): a held
+    re-notification leaves ``next_renotify_at`` untouched, so it is still
+    due at the first evaluation after quiet hours end.
+
+    Mutates *tracking* and *sink* in place — the same deliberate, scoped
+    exception to this package's functional style used throughout its
+    decision-producing helpers.
+    """
+    ladder = schedule.renotify_backoff_hours
+
+    def is_due(entry: AssumptionReportEntry) -> bool:
+        prior = prior_tracking.get(entry.record.bead_id)
+        if prior is None or prior.interrupt_delivered_at is None:
+            return False  # not interrupted as of a prior evaluation yet
+
+        if entry_age_hours(entry, tracking, now) < schedule.max_entry_age_hours:
+            return False
+
+        # Not yet due for the next backoff rung.
+        next_renotify_at = parse_utc(prior.next_renotify_at)
+        return next_renotify_at is None or now >= next_renotify_at
+
+    def stamp(bead_id: str, record: EntryTrackingRecord) -> EntryTrackingRecord:
+        prior = prior_tracking[bead_id]
+        index = min(prior.renotify_count, len(ladder) - 1)
+        next_renotify_at = now + timedelta(hours=ladder[index])
+        return record.model_copy(
+            update={
+                "renotify_count": prior.renotify_count + 1,
+                "next_renotify_at": format_utc(next_renotify_at),
+            }
+        )
+
+    process_entry_decisions(
+        EntryDecisionSpec(
+            kind=DecisionKind.RENOTIFY,
+            due_rule=(
+                "unanswered high-severity entry past max age; re-notifying on backoff ladder"
+            ),
+            held_rule=(
+                "re-notification held: quiet hours are absolute (high_overrides_quiet=false)"
+            ),
+            is_due=is_due,
+            held_by_quiet_hours=high_severity_held_by_quiet_hours(now, schedule),
+            stamp=stamp,
+        ),
+        entries=high_entries,
+        tracking=tracking,
+        summary=summary,
+        now=now,
+        sink=sink,
+    )
+
+
+def process_auto_waives(
+    *,
+    low_entries: Sequence[AssumptionReportEntry],
+    tracking: dict[str, EntryTrackingRecord],
+    schedule: AssumptionScheduleConfig,
+    now: datetime,
+) -> tuple[AutoWaiveDecision, ...]:
+    """Decide auto-waive candidates for aged low entries (US4, FR-015).
+
+    Absent an explicit, doubly opt-in policy (``schedule.auto_waive_low``
+    unset, or set but ``enabled=False``), this never produces a decision —
+    low-severity entries otherwise age with no delivery path at all
+    (clarification Q2). When enabled, every open low entry whose age meets
+    or exceeds ``auto_waive_low.after_hours`` yields one
+    :class:`AutoWaiveDecision` carrying the full recorded rationale
+    (research R10's format), ready for the effects layer (``notify.py``,
+    T028) to execute via ``assumptions.ledger.waive`` and never touched
+    here — this function performs no bd I/O (Principle III: pure
+    evaluation). No idempotence bookkeeping is needed: a successfully
+    auto-waived entry is closed in bd and therefore absent from the next
+    evaluation's *open* entries entirely.
+
+    Args:
+        low_entries: Open low-severity entries at evaluation time.
+        tracking: Per-entry scheduler state (age fallback basis only).
+        schedule: The delivery policy, carrying the optional
+            ``auto_waive_low`` policy.
+        now: The evaluation clock.
+
+    Returns:
+        One decision per entry due for auto-waive; empty when the policy
+        is absent, disabled, or no entry has aged past its threshold.
+    """
+    policy = schedule.auto_waive_low
+    if policy is None or not policy.enabled:
+        return ()
+
+    decisions: list[AutoWaiveDecision] = []
+    for entry in low_entries:
+        if entry_age_hours(entry, tracking, now) < policy.after_hours:
+            continue
+        reason_text = (
+            f"auto-waived by schedule policy after {policy.after_hours}h: {policy.rationale}"
+        )
+        decisions.append(AutoWaiveDecision(entry_id=entry.record.bead_id, reason_text=reason_text))
+    return tuple(decisions)

--- a/src/maverick/assumptions/schedule/evaluate.py
+++ b/src/maverick/assumptions/schedule/evaluate.py
@@ -1,0 +1,349 @@
+"""Pure window/severity evaluation for the assumption batch scheduler.
+
+:func:`evaluate` is the scheduler's decision engine: given the currently
+open ledger entries, the configured delivery policy, prior persisted state,
+and an injected clock, it decides — without touching disk or network —
+which review-window occurrences are due, how each due occurrence's batch
+resolves (delivered, rolled forward, empty, or held by quiet hours), and
+how severity tiers route (medium batches at windows, low counted but
+silent, legacy entries already synthesized to medium by ``report_entries``
+and requiring no extra mapping — research R9).
+
+Quiet hours are a *severity-scoped* policy, not a global mute: the
+``high_overrides_quiet`` flag governs high-severity traffic only —
+interrupts and backoff re-notifications — while every medium/legacy
+decision (window batches and max-age escalations alike) is held
+unconditionally until quiet hours end (FR-004, FR-006,
+contracts/config-schema.md).
+
+This module MUST stay pure (plan.md Constitution Check, Principle III):
+``entries``/``schedule``/``state``/``now`` are its only inputs, and its only
+output is a fresh :class:`~maverick.assumptions.schedule.models.EvaluationOutcome`.
+All effects — ntfy delivery, bd auto-waive, and persisting state to disk —
+belong to the ``notify`` CLI command layer, strictly after evaluation
+(research R6).
+
+Scope (tasks.md T027, US4): beyond window-batch delivery (medium/low tiers)
+and high-severity interrupts (:attr:`DecisionKind.INTERRUPT`), evaluation
+also decides max-age escalation for medium entries
+(:attr:`DecisionKind.ESCALATION`, FR-006/FR-007) and backoff-ladder
+re-notification for high entries (:attr:`DecisionKind.RENOTIFY`,
+FR-007), plus opt-in auto-waive candidates for aged low entries
+(FR-015).
+
+:func:`evaluate` itself is the orchestrator; each decision engine it drives
+lives in a sibling module, all of them equally pure:
+
+* :mod:`~maverick.assumptions.schedule.windows` — occurrence construction,
+  quiet-hours and DST arithmetic, and the window-batch engine.
+* :mod:`~maverick.assumptions.schedule.severity` — high-severity interrupts.
+* :mod:`~maverick.assumptions.schedule.escalation` — max-age escalation,
+  backoff re-notification, and auto-waive candidates.
+* :mod:`~maverick.assumptions.schedule.tracking` — per-entry bookkeeping
+  and entry age.
+* :mod:`~maverick.assumptions.schedule.decisions` — the shared decision
+  plumbing the entry-scoped engines are all expressed against.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timedelta
+from typing import Final
+
+from maverick.assumptions.models import STATUS_OPEN, AssumptionReportEntry, Severity
+from maverick.assumptions.schedule.decisions import DecisionSink
+from maverick.assumptions.schedule.escalation import (
+    process_auto_waives,
+    process_high_renotify,
+    process_medium_escalations,
+)
+from maverick.assumptions.schedule.models import (
+    BatchSummary,
+    DecisionKind,
+    EvaluationOutcome,
+    SkipDecision,
+    SkipReason,
+    format_utc,
+    occurrence_key,
+    parse_utc,
+)
+from maverick.assumptions.schedule.severity import process_high_interrupts
+from maverick.assumptions.schedule.state import DeliveryState, EntryTrackingRecord
+from maverick.assumptions.schedule.tracking import (
+    ensure_tracking,
+    entry_age_hours,
+    observe_terminal_entries,
+)
+from maverick.assumptions.schedule.windows import (
+    build_occurrence,
+    previously_held_by_quiet_hours,
+    process_due_occurrence,
+)
+from maverick.config import AssumptionScheduleConfig
+
+__all__ = ["evaluate"]
+
+#: Suggested review invocation carried on a :class:`BatchSummary` whose
+#: open entries span more than one owning spec (data-model.md §3). When they
+#: all share one spec, :func:`_build_summary` narrows it to the spec-scoped
+#: variant (contracts/ntfy-payload.md).
+_REVIEW_INVOCATION: Final = "maverick review --list --status open"
+
+
+def evaluate(
+    entries: Sequence[AssumptionReportEntry],
+    schedule: AssumptionScheduleConfig,
+    state: DeliveryState,
+    now: datetime,
+) -> EvaluationOutcome:
+    """Evaluate the ledger against the schedule and prior state.
+
+    Pure function of its four arguments (research R6) — no disk or network
+    reads. Every configured window is checked against today's occurrence
+    (always reported: delivered, rolled forward, empty, held by quiet hours,
+    not yet due, or already decided) and, when still undecided, yesterday's
+    occurrence too, but only when quiet hours shifted its due time onto
+    today (the midnight-spanning-quiet-hours case, research R8, and a
+    same-day delayed evaluation, FR-020) or a prior evaluation held it
+    inside quiet hours
+    (:func:`~maverick.assumptions.schedule.windows.previously_held_by_quiet_hours`).
+    Resolved
+    entries (answered/waived) are structurally excluded before any batching
+    occurs (FR-014).
+
+    Args:
+        entries: Ledger entries as read by ``report_entries()`` at
+            evaluation time. Entries whose ``record.status`` is not
+            ``"open"`` are excluded from batching (FR-014) — they may
+            still appear in *entries* (e.g. resolved between accumulation
+            and delivery); this function is responsible for filtering
+            them out, not the caller.
+        schedule: The delivery policy (`assumptions.schedule` config).
+        state: Prior persisted delivery state — read-only; a fresh
+            candidate state is returned via
+            :attr:`EvaluationOutcome.state_after`, never mutated in place.
+        now: An aware local datetime
+            (:func:`maverick.assumptions.schedule.clock.now_local` at the
+            CLI boundary, or an injected aware datetime in tests). Its
+            ``tzinfo`` is reused to construct every window occurrence this
+            call considers, so DST fold/gap handling is correct for
+            whichever timezone the caller passes — pass a ``ZoneInfo``-backed
+            ``now`` (what ``now_local()`` resolves) rather than the
+            fixed-offset ``timezone`` from ``datetime.now().astimezone()``,
+            which would apply today's offset to occurrences on the far side
+            of a transition.
+
+    Returns:
+        The full set of decisions plus the candidate state assuming every
+        delivery decision's ntfy push succeeds — the effects layer removes
+        each failed decision's mutations before persisting
+        (contracts/delivery-state-schema.md invariant 2).
+
+    Raises:
+        ValueError: ``now`` is naive (no ``tzinfo``) — window/quiet-hours
+            arithmetic requires an aware clock.
+    """
+    tz = now.tzinfo
+    if tz is None:
+        raise ValueError("evaluate() requires an aware `now` (tzinfo is None)")
+
+    open_entries = tuple(entry for entry in entries if entry.record.status == STATUS_OPEN)
+    tracking = ensure_tracking(open_entries, state.entry_tracking, now)
+    # FR-016: an entry never leaves tracking silently. A human answering or
+    # waiving an entry simply drops it out of `open_entries`, so this is the
+    # only place that observation can be recorded — and without it no
+    # tracking row ever becomes prunable (FR-023) and `state.json` grows
+    # without bound.
+    tracking = observe_terminal_entries(entries, tracking, now)
+    # Snapshot *before* `process_high_interrupts` mutates `tracking` in
+    # place: `process_high_renotify` (US4) must see whether an entry was
+    # *already* interrupted as of a prior evaluation, not one this very
+    # call just performed — a freshly-interrupted entry is never
+    # renotify-eligible in the same evaluation that interrupted it.
+    prior_tracking = dict(tracking)
+    summary = _build_summary(open_entries, tracking, now)
+
+    medium_entries = [entry for entry in open_entries if entry.record.severity is Severity.MEDIUM]
+    low_entries = [entry for entry in open_entries if entry.record.severity is Severity.LOW]
+    high_entries = [entry for entry in open_entries if entry.record.severity is Severity.HIGH]
+    medium_ids = tuple(entry.record.bead_id for entry in medium_entries)
+    low_ids = tuple(entry.record.bead_id for entry in low_entries)
+
+    window_decisions = dict(state.window_decisions)
+    sink = DecisionSink()
+
+    # High-severity interrupts (US2, FR-002/FR-004) are entry-scoped, not
+    # occurrence-scoped — decided once, up front, independent of the window
+    # loop below. `tracking` is mutated in place to stamp each delivered
+    # entry's `interrupt_delivered_at` (idempotence, T020).
+    process_high_interrupts(
+        high_entries=high_entries,
+        tracking=tracking,
+        schedule=schedule,
+        summary=summary,
+        now=now,
+        sink=sink,
+    )
+
+    today = now.date()
+    yesterday = today - timedelta(days=1)
+    last_evaluated_at = parse_utc(state.updated_at)
+
+    for window_str in schedule.windows:
+        # Catch-up: yesterday's occurrence matters in exactly two cases —
+        # quiet hours shifted its due time forward onto *today* (research
+        # R8; e.g. a 23:00 window inside 22:00-07:00 quiet hours becomes due
+        # the next morning, one day after its own occurrence date), or this
+        # scheduler itself held it inside quiet hours and left it undecided
+        # (:func:`_previously_held_by_quiet_hours`, FR-004/FR-020). A plain,
+        # unshifted stale occurrence nobody ever evaluated (cron down for
+        # days) is deliberately left alone here — it's the max-entry-age
+        # escalation path's job (T027), not this one's, otherwise every
+        # fresh evaluation of a brand-new schedule would double-fire.
+        key_yesterday = occurrence_key(yesterday, window_str)
+        if key_yesterday not in window_decisions:
+            occ_yesterday = build_occurrence(yesterday, window_str, schedule.quiet_hours, tz)
+            if occ_yesterday.due_at.date() == today or previously_held_by_quiet_hours(
+                occ=occ_yesterday,
+                last_evaluated_at=last_evaluated_at,
+                quiet=schedule.quiet_hours,
+                now=now,
+                tz=tz,
+            ):
+                process_due_occurrence(
+                    occ=occ_yesterday,
+                    key=key_yesterday,
+                    window_str=window_str,
+                    now=now,
+                    medium_ids=medium_ids,
+                    low_ids=low_ids,
+                    min_batch_size=schedule.min_batch_size,
+                    quiet=schedule.quiet_hours,
+                    summary=summary,
+                    window_decisions=window_decisions,
+                    sink=sink,
+                )
+
+        key_today = occurrence_key(today, window_str)
+        occ_today = build_occurrence(today, window_str, schedule.quiet_hours, tz)
+        existing_today = window_decisions.get(key_today)
+        if existing_today is not None:
+            sink.skip(
+                SkipDecision(
+                    reason=SkipReason.ALREADY_DELIVERED,
+                    occurrence=occ_today,
+                    entry_ids=tuple(existing_today.entry_ids),
+                    rule=existing_today.rule,
+                )
+            )
+        else:
+            process_due_occurrence(
+                occ=occ_today,
+                key=key_today,
+                window_str=window_str,
+                now=now,
+                medium_ids=medium_ids,
+                low_ids=low_ids,
+                min_batch_size=schedule.min_batch_size,
+                quiet=schedule.quiet_hours,
+                summary=summary,
+                window_decisions=window_decisions,
+                sink=sink,
+            )
+
+    # Max-age escalation (US4, FR-006/FR-007): a medium entry already
+    # covered by a *this-evaluation* window-batch delivery is excluded —
+    # it was just delivered on time, so it isn't the starved entry the
+    # safety net exists for.
+    already_batched_ids = frozenset(
+        bead_id
+        for decision in sink.deliveries
+        if decision.kind is DecisionKind.WINDOW_BATCH
+        for bead_id in decision.entry_ids
+    )
+    process_medium_escalations(
+        medium_entries=medium_entries,
+        already_batched_ids=already_batched_ids,
+        tracking=tracking,
+        schedule=schedule,
+        summary=summary,
+        now=now,
+        sink=sink,
+    )
+
+    # Backoff-ladder re-notification (US4, FR-007): high entries interrupted
+    # as of a *prior* evaluation, still open past max_entry_age_hours.
+    process_high_renotify(
+        high_entries=high_entries,
+        prior_tracking=prior_tracking,
+        tracking=tracking,
+        schedule=schedule,
+        summary=summary,
+        now=now,
+        sink=sink,
+    )
+
+    auto_waives = process_auto_waives(
+        low_entries=low_entries, tracking=tracking, schedule=schedule, now=now
+    )
+
+    state_after = state.model_copy(
+        update={
+            "updated_at": format_utc(now),
+            "window_decisions": window_decisions,
+            "entry_tracking": tracking,
+            "deliveries": [*state.deliveries, *sink.delivery_records],
+        }
+    )
+
+    return EvaluationOutcome(
+        deliveries=tuple(sink.deliveries),
+        skips=tuple(sink.skips),
+        auto_waives=auto_waives,
+        state_after=state_after,
+    )
+
+
+def _build_summary(
+    open_entries: Sequence[AssumptionReportEntry],
+    tracking: dict[str, EntryTrackingRecord],
+    now: datetime,
+) -> BatchSummary:
+    """Content-free aggregate over every currently open entry (FR-008).
+
+    Deliberately global rather than scoped to one decision's covered
+    entries: the notification is a "wake up, here's everything pending"
+    summons, so counts (including ``LOW`` — clarification Q5), owning
+    specs, and the oldest-entry age all reflect the full open set. Which
+    bead ids a given decision actually covers is tracked separately on
+    :attr:`DeliveryDecision.entry_ids`.
+    """
+    counts: dict[Severity, int] = dict.fromkeys(Severity, 0)
+    for entry in open_entries:
+        counts[entry.record.severity] += 1
+    owner_specs = tuple(sorted({entry.record.owner_spec for entry in open_entries}))
+    oldest_age_hours = (
+        max(entry_age_hours(entry, tracking, now) for entry in open_entries)
+        if open_entries
+        else 0.0
+    )
+    return BatchSummary(
+        counts=counts,
+        owner_specs=owner_specs,
+        oldest_age_hours=oldest_age_hours,
+        review_invocation=_review_invocation(owner_specs),
+    )
+
+
+def _review_invocation(owner_specs: tuple[str, ...]) -> str:
+    """The exact sweep command to put in the push (contracts/ntfy-payload.md).
+
+    Narrowed to ``--spec <name>`` when every open entry shares one owning
+    spec — the common single-feature case, where the unscoped variant would
+    make the recipient re-filter by hand. An empty/unknown spec name is not
+    a usable filter, so it falls back to the unscoped form.
+    """
+    if len(owner_specs) == 1 and owner_specs[0]:
+        return f"maverick review --list --spec {owner_specs[0]} --status open"
+    return _REVIEW_INVOCATION

--- a/src/maverick/assumptions/schedule/models.py
+++ b/src/maverick/assumptions/schedule/models.py
@@ -1,0 +1,313 @@
+"""Evaluation-domain models for the assumption batch scheduler.
+
+Pure, in-memory frozen dataclasses produced by
+:func:`maverick.assumptions.schedule.evaluate.evaluate` and consumed by
+:mod:`maverick.assumptions.schedule.deliver` and the ``notify`` CLI command.
+These are never persisted directly — the persisted counterpart lives in
+:mod:`maverick.assumptions.schedule.state`. See
+``specs/054-assumption-batch-scheduler/data-model.md`` §3.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from enum import StrEnum
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+from maverick.assumptions.models import Severity
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from maverick.assumptions.schedule.state import DeliveryState
+
+__all__ = [
+    "AutoWaiveDecision",
+    "BatchSummary",
+    "DecisionKind",
+    "DeliveryDecision",
+    "EvaluationOutcome",
+    "SkipDecision",
+    "SkipReason",
+    "WindowOccurrence",
+    "format_age_hours",
+    "format_utc",
+    "occurrence_key",
+    "parse_utc",
+]
+
+
+def format_utc(moment: datetime) -> str:
+    """UTC ISO-8601 ``"YYYY-MM-DDTHH:MM:SSZ"`` (the house convention).
+
+    The single formatter for every timestamp this feature persists or
+    stamps — ``evaluate``, ``state``, and the ``notify`` command all route
+    through it so the three can never drift apart on precision or suffix.
+
+    Args:
+        moment: Any aware datetime; converted to UTC before formatting.
+
+    Returns:
+        The UTC instant as an ISO-8601 string with a ``Z`` suffix.
+    """
+    return moment.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def parse_utc(value: str | None) -> datetime | None:
+    """Parse a UTC ISO-8601 timestamp (``...Z`` or explicit offset), tolerantly.
+
+    Timestamps reaching the scheduler come from outside its own writes —
+    ``created_at`` is copied verbatim from bd, and ``state.json`` is a
+    plain file a human can edit — so a malformed value must degrade to
+    "unknown" rather than crashing an unattended cron invocation. Callers
+    fall back to their own basis (tracked ``first_seen``, or ``now``) on
+    ``None``.
+
+    Args:
+        value: The candidate timestamp, or ``None``.
+
+    Returns:
+        An aware UTC-normalized ``datetime``, or ``None`` when *value* is
+        missing, empty, or unparseable.
+    """
+    if not value:
+        return None
+    normalized = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def occurrence_key(occ_date: date, window: str) -> str:
+    """``"YYYY-MM-DD/HH:MM"`` — the window-occurrence idempotence key (FR-010).
+
+    Args:
+        occ_date: The occurrence's local calendar date.
+        window: The configured ``"HH:MM"`` window string.
+
+    Returns:
+        The key used in ``DeliveryState.window_decisions`` and as a
+        delivery record's ``trigger``.
+    """
+    return f"{occ_date.isoformat()}/{window}"
+
+
+def format_age_hours(hours: float) -> str:
+    """Render an age in hours for human/push display (one decimal place).
+
+    ``oldest_age_hours`` is raw float arithmetic, so the unrounded value
+    reads as ``11.499999999999998h`` in an ntfy push. Every display site
+    formats through here.
+
+    Args:
+        hours: The age in hours.
+
+    Returns:
+        The age rounded to one decimal place, without a unit suffix.
+    """
+    return f"{hours:.1f}"
+
+
+class DecisionKind(StrEnum):
+    """Categories of :class:`DeliveryDecision` (data-model.md §3).
+
+    Attributes:
+        WINDOW_BATCH: A batched medium/legacy delivery at a review window.
+        INTERRUPT: An immediate high-severity delivery outside windows.
+        ESCALATION: A medium/high entry delivered after exceeding
+            ``max_entry_age_hours``, bypassing min-batch-size.
+        RENOTIFY: A repeat high-severity delivery per the backoff ladder.
+    """
+
+    WINDOW_BATCH = "window-batch"
+    INTERRUPT = "interrupt"
+    ESCALATION = "escalation"
+    RENOTIFY = "renotify"
+
+
+class SkipReason(StrEnum):
+    """Why a candidate occurrence or entry produced no delivery.
+
+    Attributes:
+        MIN_BATCH_SIZE: Batch below the configured minimum; entries roll
+            forward to the next occurrence.
+        QUIET_HOURS: Suppressed by quiet hours (subject to
+            ``high_overrides_quiet`` for high-severity entries).
+        ALREADY_DELIVERED: The occurrence already has a recorded decision
+            (idempotence, FR-010).
+        NOT_YET_DUE: The occurrence's ``due_at`` has not yet elapsed.
+        LOW_NEVER_PROACTIVE: Low-severity entries never trigger a delivery
+            on their own (clarification Q5); still counted in
+            :class:`BatchSummary`.
+        EMPTY_BATCH: The occurrence became due with zero covered entries
+            (FR-014).
+    """
+
+    MIN_BATCH_SIZE = "min-batch-size"
+    QUIET_HOURS = "quiet-hours"
+    ALREADY_DELIVERED = "already-delivered"
+    NOT_YET_DUE = "not-yet-due"
+    LOW_NEVER_PROACTIVE = "low-never-proactive"
+    EMPTY_BATCH = "empty-batch"
+
+
+@dataclass(frozen=True, slots=True)
+class WindowOccurrence:
+    """One scheduled review-window instance on one calendar date.
+
+    Identity key: ``(date, window)`` — at most one decision is ever recorded
+    against a given occurrence, enforced via ``state.window_decisions``
+    (idempotence, FR-010).
+
+    Attributes:
+        date: Local calendar date the window falls on.
+        window: Configured ``"HH:MM"`` window string, as written in
+            ``AssumptionScheduleConfig.windows``.
+        due_at: Aware local datetime the occurrence becomes due; shifted
+            past quiet hours when applicable (research R8) and fold-aware
+            across DST transitions (research R6).
+    """
+
+    date: date
+    window: str
+    due_at: datetime
+
+    @property
+    def key(self) -> str:
+        """This occurrence's ``"YYYY-MM-DD/HH:MM"`` idempotence key (FR-010)."""
+        return occurrence_key(self.date, self.window)
+
+
+@dataclass(frozen=True, slots=True)
+class BatchSummary:
+    """Aggregate, content-free view of the entries covered by one decision.
+
+    Never carries question/answer text or any other entry content
+    (FR-008) — only counts and metadata safe to push to a phone.
+
+    One instance is built per evaluation and attached to *every*
+    :class:`DeliveryDecision` in the run as well as to every persisted
+    delivery record, so :attr:`counts` must not be writable through the
+    summary: ``frozen=True`` protects the field binding, not the mapping's
+    contents, and a single consumer mutating it would silently rewrite
+    every other decision's counts and the persisted audit trail.
+    :meth:`__post_init__` therefore snapshots whatever mapping the caller
+    passes into a read-only :class:`types.MappingProxyType` — construction
+    stays ergonomic (pass a plain ``dict``), reads are unchanged, and
+    writes raise.
+
+    Attributes:
+        counts: Read-only open-entry counts keyed by severity; includes
+            ``LOW`` as an informational-only count even though low never
+            triggers delivery on its own (clarification Q5).
+        owner_specs: Sorted tuple of owning spec identifiers covered by
+            this batch.
+        oldest_age_hours: Age in hours of the oldest covered entry, from
+            ``created_at`` with a ``first_seen`` fallback (research R1).
+        review_invocation: Suggested CLI invocation to review the batch,
+            e.g. ``"maverick review --list --status open"``.
+    """
+
+    counts: Mapping[Severity, int]
+    owner_specs: tuple[str, ...]
+    oldest_age_hours: float
+    review_invocation: str
+
+    def __post_init__(self) -> None:
+        """Detach and freeze :attr:`counts` (see the class docstring)."""
+        object.__setattr__(self, "counts", MappingProxyType(dict(self.counts)))
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable projection, shared by persisted state and ``--json``.
+
+        One projection so the audit trail written into ``state.json`` and
+        the envelope ``maverick notify --json`` emits can never drift.
+
+        Returns:
+            The summary as plain JSON-safe types.
+        """
+        return {
+            "counts": {severity.value: count for severity, count in self.counts.items()},
+            "owner_specs": list(self.owner_specs),
+            "oldest_age_hours": self.oldest_age_hours,
+            "review_invocation": self.review_invocation,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class DeliveryDecision:
+    """A decision to deliver one notification (batch, interrupt, or aged).
+
+    Attributes:
+        kind: Which delivery category this decision represents.
+        entry_ids: Bead IDs covered by this delivery — open at evaluation
+            time (FR-014 structural exclusion of resolved entries).
+        summary: Content-free aggregate of the covered entries.
+        occurrence: The window occurrence this decision fulfils; set only
+            for :attr:`DecisionKind.WINDOW_BATCH`, ``None`` otherwise.
+        rule: Human-readable rule citation for the audit trail (e.g.
+            ``"window 09:00 due"``).
+    """
+
+    kind: DecisionKind
+    entry_ids: tuple[str, ...]
+    summary: BatchSummary
+    occurrence: WindowOccurrence | None
+    rule: str
+
+
+@dataclass(frozen=True, slots=True)
+class SkipDecision:
+    """A decision that no delivery occurs, with its cited rule.
+
+    Attributes:
+        reason: Why no delivery occurred.
+        occurrence: The window occurrence this skip applies to, when
+            window-scoped; ``None`` for entry-scoped skips.
+        entry_ids: Bead IDs affected by this skip.
+        rule: Human-readable rule citation for the audit trail.
+    """
+
+    reason: SkipReason
+    occurrence: WindowOccurrence | None
+    entry_ids: tuple[str, ...]
+    rule: str
+
+
+@dataclass(frozen=True, slots=True)
+class AutoWaiveDecision:
+    """A decision to auto-waive one aged low-severity entry (FR-015).
+
+    Attributes:
+        entry_id: The bead ID to waive.
+        reason_text: The full rationale recorded on the ledger entry.
+    """
+
+    entry_id: str
+    reason_text: str
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationOutcome:
+    """The complete result of one ``evaluate()`` call.
+
+    Attributes:
+        deliveries: Decisions that produce a notification.
+        skips: Decisions that produce no notification, with their rule.
+        auto_waives: Entries to auto-waive as a side effect of this
+            evaluation.
+        state_after: The candidate persisted state assuming every
+            decision's effect succeeds; the effects layer removes each
+            failed decision's mutations before saving (per-decision
+            write-after-success — contracts/delivery-state-schema.md
+            invariant 2).
+    """
+
+    deliveries: tuple[DeliveryDecision, ...]
+    skips: tuple[SkipDecision, ...]
+    auto_waives: tuple[AutoWaiveDecision, ...]
+    state_after: DeliveryState

--- a/src/maverick/assumptions/schedule/severity.py
+++ b/src/maverick/assumptions/schedule/severity.py
@@ -1,0 +1,84 @@
+"""High-severity interrupt policy (US2, FR-002, FR-004).
+
+The one decision kind that fires the moment an entry is recorded, with no
+window to wait for. Everything about *how* the decision is emitted lives in
+:mod:`~maverick.assumptions.schedule.decisions`; this module contributes
+only the policy — who is due, and whether quiet hours may hold them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+
+from maverick.assumptions.models import AssumptionReportEntry
+from maverick.assumptions.schedule.decisions import (
+    DecisionSink,
+    EntryDecisionSpec,
+    process_entry_decisions,
+)
+from maverick.assumptions.schedule.models import BatchSummary, DecisionKind, format_utc
+from maverick.assumptions.schedule.state import EntryTrackingRecord
+from maverick.assumptions.schedule.windows import high_severity_held_by_quiet_hours
+from maverick.config import AssumptionScheduleConfig
+
+
+def process_high_interrupts(
+    *,
+    high_entries: Sequence[AssumptionReportEntry],
+    tracking: dict[str, EntryTrackingRecord],
+    schedule: AssumptionScheduleConfig,
+    summary: BatchSummary,
+    now: datetime,
+    sink: DecisionSink,
+) -> None:
+    """Decide interrupt delivery for *high_entries* (US2, FR-002, FR-004).
+
+    Idempotence here is per-entry via
+    :attr:`EntryTrackingRecord.interrupt_delivered_at`, not per-occurrence
+    like window batches: an entry that already carries a timestamp there
+    never produces a second :attr:`DecisionKind.INTERRUPT` decision.
+
+    Quiet-hours gating (research R8,
+    :func:`~maverick.assumptions.schedule.windows.high_severity_held_by_quiet_hours`):
+    when ``schedule.quiet_hours`` is set and ``schedule.high_overrides_quiet``
+    is ``False``, an entry whose interrupt would otherwise fire during quiet
+    hours is held — recorded as a :attr:`SkipReason.QUIET_HOURS` skip, *not*
+    stamped as delivered — so it becomes due again at the first evaluation
+    after quiet hours end. Any other combination (no quiet hours configured,
+    or ``high_overrides_quiet=True``) delivers immediately. This is one of
+    the two decision kinds ``high_overrides_quiet`` governs; the other is
+    :func:`~maverick.assumptions.schedule.escalation.process_high_renotify`.
+
+    Mutates *tracking* and *sink* in place — the same deliberate, scoped
+    exception to this package's functional style as every other
+    decision-producing helper.
+    """
+    delivered_at = format_utc(now)
+
+    def is_due(entry: AssumptionReportEntry) -> bool:
+        record = tracking.get(entry.record.bead_id)
+        # already delivered — idempotent, never re-fires here
+        return record is None or record.interrupt_delivered_at is None
+
+    def stamp(bead_id: str, record: EntryTrackingRecord) -> EntryTrackingRecord:
+        return record.model_copy(update={"interrupt_delivered_at": delivered_at})
+
+    process_entry_decisions(
+        EntryDecisionSpec(
+            kind=DecisionKind.INTERRUPT,
+            due_rule="high-severity interrupt due",
+            held_rule=(
+                "high-severity interrupt held: quiet hours are absolute "
+                "(high_overrides_quiet=false)"
+            ),
+            is_due=is_due,
+            held_by_quiet_hours=high_severity_held_by_quiet_hours(now, schedule),
+            stamp=stamp,
+        ),
+        entries=high_entries,
+        tracking=tracking,
+        summary=summary,
+        now=now,
+        sink=sink,
+    )

--- a/src/maverick/assumptions/schedule/state.py
+++ b/src/maverick/assumptions/schedule/state.py
@@ -1,0 +1,535 @@
+"""Persisted delivery state for the assumption batch scheduler (`maverick notify`).
+
+State is persisted to ``<cwd>/.maverick/notify/state.json`` (schema_version 1)
+via whole-file atomic writes (``maverick.utils.atomic.atomic_write_json``).
+Unlike per-run state under ``.maverick/runs/<run-id>/``, this file is
+cross-run: idempotence (FR-010), delivery history (FR-011), and escalation
+backoff (FR-006/FR-007) all span invocations, so it lives in a stable
+feature directory instead. Concurrency is guarded by a pid-stamped advisory
+lockfile at ``<cwd>/.maverick/notify/lock``, mirroring
+``maverick.workflows.reconcile.state``'s ``acquire_lock``/``release_lock``/
+``_pid_is_alive`` pattern byte-for-byte (research.md R4).
+
+See specs/054-assumption-batch-scheduler/data-model.md §4 and
+specs/054-assumption-batch-scheduler/contracts/delivery-state-schema.md for
+the full schema and invariants.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import Iterable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from maverick.assumptions.schedule.models import DecisionKind, format_utc, parse_utc
+from maverick.exceptions.base import MaverickError
+from maverick.logging import get_logger
+from maverick.utils.atomic import atomic_write_json
+
+if TYPE_CHECKING:
+    from maverick.assumptions.schedule.models import DeliveryDecision, EvaluationOutcome
+
+__all__ = [
+    "DeliveryRecord",
+    "DeliveryState",
+    "DeliveryStateSchemaError",
+    "EntryTrackingRecord",
+    "TerminalOutcome",
+    "WindowDecisionRecord",
+    "acquire_lock",
+    "finalize_state",
+    "load_state",
+    "prune",
+    "release_lock",
+    "save_state",
+]
+
+logger = get_logger(__name__)
+
+_NOTIFY_SUBDIR = Path(".maverick") / "notify"
+_STATE_FILENAME = "state.json"
+_LOCK_FILENAME = "lock"
+
+#: Only schema_version 1 is understood. Any other value is refused rather
+#: than silently rewritten (contracts/delivery-state-schema.md invariant 7).
+_SUPPORTED_SCHEMA_VERSION = 1
+
+#: FR-023 retention window: a terminal entry's tracking row (and the
+#: deliveries/window_decisions records that reference only terminal
+#: entries) become prunable 90 days after the terminal transition.
+_RETENTION = timedelta(days=90)
+
+
+class DeliveryStateSchemaError(MaverickError):
+    """Raised when persisted notify state carries an unsupported schema_version.
+
+    Per contracts/delivery-state-schema.md invariant 7: an unrecognized
+    ``schema_version`` must never be silently rewritten — evaluation refuses
+    with a clear error instead of guessing at the shape of a newer schema.
+    """
+
+
+class WindowDecisionRecord(BaseModel):
+    """One decided window occurrence, keyed ``"YYYY-MM-DD/HH:MM"`` in
+    :attr:`DeliveryState.window_decisions` — the idempotence ledger for
+    occurrences (FR-010)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    outcome: Literal["delivered", "skipped-min-batch", "empty"] = Field(
+        description="What happened to this occurrence"
+    )
+    decided_at: str = Field(description="UTC ISO-8601 timestamp of the decision")
+    entry_ids: list[str] = Field(
+        default_factory=list, description="Bead ids covered by this decision"
+    )
+    rule: str = Field(description="Human-readable rule citation for audit (SC-004)")
+
+
+class TerminalOutcome(BaseModel):
+    """Terminal state for a tracked entry (FR-016: nothing leaves silently).
+
+    Starts the FR-023 90-day retention clock via :attr:`at`.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["resolved-by-human", "auto-waived"] = Field(
+        description="How the entry left tracking"
+    )
+    at: str = Field(description="UTC ISO-8601 timestamp; starts the retention clock")
+    detail: str | None = Field(default=None, description="Auto-waive rationale, if applicable")
+
+
+class EntryTrackingRecord(BaseModel):
+    """Per-entry scheduler state, keyed by bead id in
+    :attr:`DeliveryState.entry_tracking`."""
+
+    model_config = ConfigDict(frozen=True)
+
+    first_seen: str = Field(description="Fallback age basis when created_at is missing (R1)")
+    severity: str = Field(description="Severity as evaluated (legacy entries => 'medium')")
+    interrupt_delivered_at: str | None = Field(
+        default=None, description="High-tier first delivery timestamp (FR-002)"
+    )
+    escalation_delivered_at: str | None = Field(
+        default=None, description="Max-age escalation delivery timestamp (FR-006)"
+    )
+    renotify_count: int = Field(default=0, description="Index into the backoff ladder (FR-007)")
+    next_renotify_at: str | None = Field(
+        default=None, description="Precomputed next backoff instant"
+    )
+    terminal: TerminalOutcome | None = Field(
+        default=None, description="Set once the scheduler observes/creates terminal state"
+    )
+
+
+class DeliveryRecord(BaseModel):
+    """One append-only audit trail entry in :attr:`DeliveryState.deliveries`
+    (FR-011). Only written after the underlying ntfy POST succeeded
+    (FR-012)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["window-batch", "interrupt", "escalation", "renotify"] = Field(
+        description="Delivery kind"
+    )
+    delivered_at: str = Field(description="UTC ISO-8601; only set after ntfy success")
+    trigger: str = Field(description="Occurrence key or rule citation")
+    entry_ids: list[str] = Field(default_factory=list, description="Bead ids covered")
+    summary: dict[str, Any] = Field(description="Serialized BatchSummary")
+
+
+class DeliveryState(BaseModel):
+    """Top-level persisted state, round-tripped to
+    ``<cwd>/.maverick/notify/state.json`` (contracts/delivery-state-schema.md)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    schema_version: int = Field(default=1, description="Guards future migrations")
+    updated_at: str = Field(description="UTC ISO-8601 timestamp of last update")
+    window_decisions: dict[str, WindowDecisionRecord] = Field(
+        default_factory=dict, description="Occurrence idempotence ledger (FR-010)"
+    )
+    entry_tracking: dict[str, EntryTrackingRecord] = Field(
+        default_factory=dict, description="Per-entry scheduler state, keyed by bead id"
+    )
+    deliveries: list[DeliveryRecord] = Field(
+        default_factory=list, description="Append-only audit trail (FR-011)"
+    )
+
+
+def _utc_now_iso() -> str:
+    """Current UTC instant as ``"YYYY-MM-DDTHH:MM:SSZ"`` (house convention)."""
+    return format_utc(datetime.now(UTC))
+
+
+def _empty_state() -> DeliveryState:
+    return DeliveryState(updated_at=_utc_now_iso())
+
+
+def _state_path(cwd: Path) -> Path:
+    return cwd / _NOTIFY_SUBDIR / _STATE_FILENAME
+
+
+def _lock_path(cwd: Path) -> Path:
+    return cwd / _NOTIFY_SUBDIR / _LOCK_FILENAME
+
+
+async def load_state(cwd: Path) -> DeliveryState:
+    """Load persisted delivery state from ``<cwd>/.maverick/notify/state.json``.
+
+    A missing file returns a fresh empty state (first run). A corrupt or
+    unparseable file also degrades to an empty state, logged as a structured
+    warning: delivery history is lost but behavior stays safe (worst case is
+    one re-delivery, never a missed entry — contracts/delivery-state-schema.md
+    invariant 7). A file carrying an unsupported ``schema_version`` is a hard
+    refusal — see :class:`DeliveryStateSchemaError`.
+
+    Args:
+        cwd: Repository root, resolved once at the CLI boundary.
+
+    Returns:
+        The persisted state, or an empty :class:`DeliveryState` if none
+        exists or the file is unreadable.
+
+    Raises:
+        DeliveryStateSchemaError: ``schema_version`` is present and not 1.
+    """
+    path = _state_path(cwd)
+    if not await asyncio.to_thread(path.is_file):
+        return _empty_state()
+
+    try:
+        text = await asyncio.to_thread(path.read_text, encoding="utf-8")
+        raw = json.loads(text)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("notify_state_corrupt", path=str(path), error=str(exc))
+        return _empty_state()
+
+    schema_version = raw.get("schema_version") if isinstance(raw, dict) else None
+    if schema_version is not None and schema_version != _SUPPORTED_SCHEMA_VERSION:
+        raise DeliveryStateSchemaError(
+            f"Unsupported notify state schema_version {schema_version!r} at "
+            f"{path} (expected {_SUPPORTED_SCHEMA_VERSION}); refusing to "
+            "evaluate rather than silently rewrite a newer schema."
+        )
+
+    try:
+        return DeliveryState.model_validate(raw)
+    except ValidationError as exc:
+        logger.warning("notify_state_corrupt", path=str(path), error=str(exc))
+        return _empty_state()
+
+
+async def save_state(state: DeliveryState, cwd: Path) -> None:
+    """Atomically persist *state* to ``<cwd>/.maverick/notify/state.json``.
+
+    Args:
+        state: The delivery state to persist. Callers own setting
+            ``updated_at`` before calling (write-after-success discipline —
+            contracts/delivery-state-schema.md invariant 2 — means this is
+            called once per run, after effects complete).
+        cwd: Repository root, resolved once at the CLI boundary.
+    """
+    path = _state_path(cwd)
+    content = state.model_dump(mode="json")
+    await asyncio.to_thread(atomic_write_json, path, content)
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Whether *pid* refers to a live process.
+
+    ``ProcessLookupError`` means the pid is dead (reclaim the lock).
+    ``PermissionError`` means it's alive but owned by another user (treat
+    as live — we can't reclaim what we can't verify is dead).
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+async def acquire_lock(cwd: Path) -> bool:
+    """Acquire the notify lockfile at ``<cwd>/.maverick/notify/lock``.
+
+    Mirrors ``maverick.workflows.reconcile.state.acquire_lock`` byte-for-byte
+    (research.md R4): a malformed or unreadable existing lockfile, or one
+    naming a dead pid, is treated as stale and reclaimed. Contention against
+    a live holder is a benign skip for `maverick notify` (research.md R7),
+    not an error — the caller decides what that means for exit status.
+
+    Args:
+        cwd: Repository root, resolved once at the CLI boundary.
+
+    Returns:
+        ``True`` if the lock was acquired (current pid now stamped into the
+        lockfile), ``False`` if a live process already holds it.
+    """
+    lock_path = _lock_path(cwd)
+
+    def _try_acquire() -> bool:
+        if lock_path.is_file():
+            try:
+                existing_pid = int(lock_path.read_text(encoding="utf-8").strip())
+            except (OSError, ValueError) as exc:
+                logger.debug(
+                    "notify_lock_malformed_reclaimed", path=str(lock_path), error=str(exc)
+                )
+            else:
+                if _pid_is_alive(existing_pid):
+                    return False
+                logger.debug("notify_lock_stale_reclaimed", stale_pid=existing_pid)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(str(os.getpid()), encoding="utf-8")
+        return True
+
+    return await asyncio.to_thread(_try_acquire)
+
+
+async def release_lock(cwd: Path) -> None:
+    """Release the notify lockfile. Best-effort: no error if missing.
+
+    Args:
+        cwd: Repository root, resolved once at the CLI boundary.
+    """
+    lock_path = _lock_path(cwd)
+
+    def _release() -> None:
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    await asyncio.to_thread(_release)
+
+
+def prune(state: DeliveryState, now: datetime) -> DeliveryState:
+    """Apply the FR-023 retention rule to *state*.
+
+    An ``entry_tracking`` row is prunable once its :attr:`TerminalOutcome.at`
+    is at least 90 days before *now*. A ``deliveries`` record or a
+    ``window_decisions`` key is prunable when every entry id it references
+    is itself prunable; a record referencing any still-open entry is never
+    pruned (contracts/delivery-state-schema.md invariants 5 and 6).
+
+    A record referencing *zero* entries — an ``"empty"`` window decision,
+    the audit trail for "why was nothing delivered at 09:00" — satisfies
+    that rule vacuously but has no entry to date it, so it falls back to
+    its own decision timestamp (``decided_at`` / ``delivered_at``) against
+    the same 90-day horizon. Keeping such records forever would make every
+    quiet window occurrence immortal state (three windows a day against a
+    quiet ledger is ~1,100 permanent keys a year, rewritten in full on
+    every cron fire); pruning them immediately would destroy the audit
+    trail inside the review horizon.
+
+    An entry id that isn't present in ``entry_tracking`` at all is
+    conservatively treated as not prunable — unknown status errs toward
+    "open". An unparseable timestamp is likewise treated as not prunable.
+
+    Args:
+        state: The state to prune.
+        now: Aware datetime to measure retention against (UTC recommended;
+            any aware datetime works since terminal timestamps are UTC).
+
+    Returns:
+        A new :class:`DeliveryState` with prunable records removed;
+        *state* itself is never mutated.
+    """
+
+    def _retained_elapsed(timestamp: str) -> bool:
+        moment = parse_utc(timestamp)
+        return moment is not None and (now - moment) >= _RETENTION
+
+    def _entry_prunable(entry_id: str) -> bool:
+        record = state.entry_tracking.get(entry_id)
+        if record is None or record.terminal is None:
+            return False
+        return _retained_elapsed(record.terminal.at)
+
+    def _record_prunable(entry_ids: list[str], own_timestamp: str) -> bool:
+        if not entry_ids:
+            return _retained_elapsed(own_timestamp)
+        return all(_entry_prunable(eid) for eid in entry_ids)
+
+    pruned_entry_tracking = {
+        entry_id: record
+        for entry_id, record in state.entry_tracking.items()
+        if not _entry_prunable(entry_id)
+    }
+    pruned_window_decisions = {
+        key: record
+        for key, record in state.window_decisions.items()
+        if not _record_prunable(record.entry_ids, record.decided_at)
+    }
+    pruned_deliveries = [
+        record
+        for record in state.deliveries
+        if not _record_prunable(record.entry_ids, record.delivered_at)
+    ]
+
+    return state.model_copy(
+        update={
+            "entry_tracking": pruned_entry_tracking,
+            "window_decisions": pruned_window_decisions,
+            "deliveries": pruned_deliveries,
+        }
+    )
+
+
+#: The :class:`EntryTrackingRecord` fields each per-entry decision kind
+#: stamps speculatively, and which therefore must be reverted when that
+#: decision's ntfy push fails (FR-012).
+#: :attr:`DecisionKind.WINDOW_BATCH` owns no per-entry field — its
+#: idempotence lives entirely in ``window_decisions`` — so it is absent.
+_ENTRY_TRACKING_FIELDS_BY_KIND: dict[DecisionKind, tuple[str, ...]] = {
+    DecisionKind.INTERRUPT: ("interrupt_delivered_at",),
+    DecisionKind.ESCALATION: ("escalation_delivered_at",),
+    DecisionKind.RENOTIFY: ("renotify_count", "next_renotify_at"),
+}
+
+
+def _revert_entry_tracking_mutation(
+    entry_tracking: dict[str, EntryTrackingRecord],
+    prior_tracking: dict[str, EntryTrackingRecord],
+    decision: DeliveryDecision,
+) -> dict[str, EntryTrackingRecord]:
+    """Undo one failed decision's speculative ``entry_tracking`` mutation (FR-012).
+
+    Per-entry decision kinds stamp a "delivered" marker on each covered
+    entry's :class:`EntryTrackingRecord` speculatively, before the effects
+    layer (``maverick notify``) knows whether the ntfy push actually
+    succeeded (mirrors how
+    :func:`~maverick.assumptions.schedule.evaluate.evaluate` speculatively
+    records window decisions). A failed push must leave the marker exactly
+    as it was before this evaluation, so the entry is due again next time;
+    this is the per-entry counterpart to the window_decisions-keyed
+    reversion in :func:`finalize_state`.
+
+    Every per-entry kind is covered via
+    :data:`_ENTRY_TRACKING_FIELDS_BY_KIND`, not just INTERRUPT: an
+    unreverted ESCALATION would leave ``escalation_delivered_at`` stamped
+    on an entry whose push never landed, and escalation fires *exactly
+    once* — so that entry would never escalate again. An unreverted
+    RENOTIFY would likewise advance the backoff ladder without delivering.
+    :attr:`DecisionKind.WINDOW_BATCH` owns no per-entry field and is a
+    no-op here.
+
+    Args:
+        entry_tracking: The candidate ``entry_tracking`` mapping to revert
+            (typically ``outcome.state_after.entry_tracking``) — this
+            function returns a new dict rather than mutating in place.
+        prior_tracking: ``prior_state.entry_tracking``, the pre-evaluation
+            baseline to revert back to.
+        decision: The delivery decision whose ntfy push failed.
+
+    Returns:
+        A new mapping with *decision*'s per-entry markers reverted for each
+        of its ``entry_ids``.
+    """
+    fields = _ENTRY_TRACKING_FIELDS_BY_KIND.get(decision.kind)
+    if fields is None:
+        return entry_tracking
+
+    reverted = dict(entry_tracking)
+    for bead_id in decision.entry_ids:
+        current = reverted.get(bead_id)
+        if current is None:
+            continue
+        prior = prior_tracking.get(bead_id)
+        update = {
+            name: (
+                getattr(prior, name)
+                if prior is not None
+                else EntryTrackingRecord.model_fields[name].get_default()
+            )
+            for name in fields
+        }
+        reverted[bead_id] = current.model_copy(update=update)
+    return reverted
+
+
+def finalize_state(
+    *,
+    outcome: EvaluationOutcome,
+    prior_state: DeliveryState,
+    failed_indices: Iterable[int],
+    now: datetime,
+) -> DeliveryState:
+    """Strip failed decisions' mutations out of ``outcome.state_after`` (FR-012).
+
+    :func:`~maverick.assumptions.schedule.evaluate.evaluate` builds
+    ``outcome.state_after`` assuming every delivery decision's ntfy push
+    succeeds (its own docstring says as much) — this is the pure,
+    effects-adjacent counterpart that reverts exactly the window-decision
+    keys, per-entry tracking markers, and audit-trail records belonging to
+    decisions whose delivery actually failed, so the underlying
+    occurrence/entry stays undecided (and therefore due again) on the next
+    evaluation. A decision that succeeds is recorded individually — a
+    partial-success run (some due decisions deliver, others fail) persists
+    exactly the successes. Also applies FR-023 retention pruning to
+    whatever survives.
+
+    This function performs no I/O — the ``notify`` CLI command is
+    responsible for calling :func:`save_state` with its result.
+
+    Args:
+        outcome: The :class:`~maverick.assumptions.schedule.models.EvaluationOutcome`
+            returned by ``evaluate()``.
+        prior_state: The state ``evaluate()`` was called with — the
+            pre-evaluation baseline every failed decision reverts to.
+        failed_indices: Positions into ``outcome.deliveries`` whose ntfy
+            push failed. Empty means every decision succeeded.
+        now: The same aware local ``now`` passed to ``evaluate()``, used
+            for FR-023 retention pruning.
+
+    Returns:
+        A new :class:`DeliveryState` ready to persist via
+        :func:`save_state`.
+    """
+    state_after = outcome.state_after
+    failed = set(failed_indices)
+    if not failed:
+        return prune(state_after, now.astimezone(UTC))
+
+    revert_keys: set[str] = set()
+    entry_tracking = dict(state_after.entry_tracking)
+    for i in failed:
+        decision = outcome.deliveries[i]
+        if decision.occurrence is not None:
+            revert_keys.add(decision.occurrence.key)
+        entry_tracking = _revert_entry_tracking_mutation(
+            entry_tracking, prior_state.entry_tracking, decision
+        )
+    window_decisions = {
+        key: record
+        for key, record in state_after.window_decisions.items()
+        if key not in revert_keys
+    }
+
+    # `state_after.deliveries` is `[*prior_state.deliveries, *delivery_records]`
+    # (evaluate.py), and `delivery_records` is built 1:1, in order, with
+    # `outcome.deliveries` — so the tail past `prior_state.deliveries` lines
+    # up index-for-index with `outcome.deliveries`.
+    original_count = len(prior_state.deliveries)
+    new_records = state_after.deliveries[original_count:]
+    kept_records = [record for i, record in enumerate(new_records) if i not in failed]
+    final_deliveries = [*prior_state.deliveries, *kept_records]
+
+    final_state = state_after.model_copy(
+        update={
+            "window_decisions": window_decisions,
+            "entry_tracking": entry_tracking,
+            "deliveries": final_deliveries,
+        }
+    )
+    return prune(final_state, now.astimezone(UTC))

--- a/src/maverick/assumptions/schedule/tracking.py
+++ b/src/maverick/assumptions/schedule/tracking.py
@@ -1,0 +1,133 @@
+"""Per-entry scheduler bookkeeping: tracking rows and entry age.
+
+:attr:`~maverick.assumptions.schedule.state.DeliveryState.entry_tracking` is
+the scheduler's own view of each ledger entry — when it first saw the entry,
+what it has already delivered about it, and whether the entry has reached a
+terminal state. This module owns that mapping's lifecycle (bootstrap,
+terminal observation) and the age computation every threshold in the policy
+is measured against.
+
+Both functions here return a *new* mapping rather than mutating the one they
+are given: they run before any decision engine, on state that is still
+purely derived from the ledger.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+from maverick.assumptions.models import STATUS_OPEN, AssumptionReportEntry
+from maverick.assumptions.schedule.models import format_utc, parse_utc
+from maverick.assumptions.schedule.state import EntryTrackingRecord, TerminalOutcome
+
+
+def ensure_tracking(
+    open_entries: Sequence[AssumptionReportEntry],
+    tracking: dict[str, EntryTrackingRecord],
+    now: datetime,
+) -> dict[str, EntryTrackingRecord]:
+    """Bootstrap/refresh :attr:`DeliveryState.entry_tracking` for *open_entries*.
+
+    ``first_seen`` is set once, on an entry's first evaluation, and never
+    overwritten thereafter — it is only ever the *fallback* age basis, used
+    when ``created_at`` is missing (research R1). Every other field is
+    preserved from the prior tracking row (later phases populate them);
+    ``severity`` is refreshed to the currently observed value each call.
+    """
+    updated = dict(tracking)
+    for entry in open_entries:
+        bead_id = entry.record.bead_id
+        existing = updated.get(bead_id)
+        # `created_at` is bd's string, copied verbatim — only adopt it as the
+        # persisted fallback basis when it actually parses, else this row's
+        # own fallback would be as unusable as the value it replaces.
+        created_at = entry.record.created_at if parse_utc(entry.record.created_at) else None
+        first_seen = (
+            existing.first_seen if existing is not None else (created_at or format_utc(now))
+        )
+        updated[bead_id] = EntryTrackingRecord(
+            first_seen=first_seen,
+            severity=entry.record.severity.value,
+            interrupt_delivered_at=existing.interrupt_delivered_at if existing else None,
+            escalation_delivered_at=existing.escalation_delivered_at if existing else None,
+            renotify_count=existing.renotify_count if existing else 0,
+            next_renotify_at=existing.next_renotify_at if existing else None,
+            terminal=existing.terminal if existing else None,
+        )
+    return updated
+
+
+def observe_terminal_entries(
+    entries: Sequence[AssumptionReportEntry],
+    tracking: dict[str, EntryTrackingRecord],
+    now: datetime,
+) -> dict[str, EntryTrackingRecord]:
+    """Stamp ``terminal`` on tracked entries a human answered or waived (FR-016).
+
+    "No entry leaves delivery evaluation silently" has two halves. The
+    scheduler's own auto-waives are stamped by the ``notify`` command
+    (which knows the waive actually landed in bd); the other half — a
+    human resolving an entry via ``maverick review`` — is only ever
+    *observed*, because resolution simply makes the entry stop appearing
+    in the open set. Without this observation a resolved entry's tracking
+    row keeps ``terminal=None`` forever, which also means
+    :func:`~maverick.assumptions.schedule.state.prune` can never retire it
+    or the delivery/window records referencing it (FR-023).
+
+    Only rows this scheduler already tracks are stamped: an entry that was
+    resolved before it was ever seen was never in tracking, and inventing
+    a row for it would resurrect exactly the growth this prevents.
+
+    Args:
+        entries: *All* ledger entries from ``report_entries()``, not just
+            the open ones — the resolved entries are the whole point.
+        tracking: The candidate tracking mapping; never mutated in place.
+        now: The evaluation clock; starts the FR-023 retention window.
+
+    Returns:
+        A new mapping with a ``resolved-by-human`` terminal outcome on each
+        newly-observed resolved entry.
+    """
+    updated = dict(tracking)
+    observed_at = format_utc(now)
+    for entry in entries:
+        if entry.record.status == STATUS_OPEN:
+            continue
+        record = updated.get(entry.record.bead_id)
+        if record is None or record.terminal is not None:
+            continue
+        updated[entry.record.bead_id] = record.model_copy(
+            update={"terminal": TerminalOutcome(kind="resolved-by-human", at=observed_at)}
+        )
+    return updated
+
+
+def entry_age_hours(
+    entry: AssumptionReportEntry, tracking: dict[str, EntryTrackingRecord], now: datetime
+) -> float:
+    """Age in hours from ``created_at``, falling back to tracked ``first_seen``."""
+    basis = _age_basis(entry, tracking, now)
+    delta_hours = (now.astimezone(UTC) - basis).total_seconds() / 3600.0
+    return max(delta_hours, 0.0)
+
+
+def _age_basis(
+    entry: AssumptionReportEntry, tracking: dict[str, EntryTrackingRecord], now: datetime
+) -> datetime:
+    """Age basis: bd's ``created_at``, then tracked ``first_seen``, then *now*.
+
+    Both candidates are external strings (``created_at`` is copied verbatim
+    from bd; ``first_seen`` round-trips through a hand-editable state file),
+    so each is parsed tolerantly — an unparseable value falls through to the
+    next basis rather than crashing an unattended cron run.
+    """
+    created = parse_utc(entry.record.created_at)
+    if created is not None:
+        return created
+    tracked = tracking.get(entry.record.bead_id)
+    if tracked is not None:
+        first_seen = parse_utc(tracked.first_seen)
+        if first_seen is not None:
+            return first_seen
+    return now.astimezone(UTC)

--- a/src/maverick/assumptions/schedule/windows.py
+++ b/src/maverick/assumptions/schedule/windows.py
@@ -1,0 +1,334 @@
+"""Window occurrences, quiet-hours arithmetic, and the batching engine.
+
+Everything time-shaped in the scheduler lives here: parsing the validated
+``"HH:MM"`` config strings, attaching a timezone to a wall time across DST
+edges (:func:`_localize`, research R6), deciding whether a moment falls
+inside quiet hours, building the occurrence a configured window has on a
+given date (:func:`build_occurrence`, research R8), and resolving a due
+occurrence into a delivered / rolled-forward / empty / held decision
+(:func:`process_due_occurrence`).
+
+Quiet hours split into a severity-blind question and a severity-scoped one:
+:func:`in_quiet_hours_now` answers "is this a quiet moment?", while
+:func:`high_severity_held_by_quiet_hours` answers "may *this* decision fire
+anyway?" — the ``high_overrides_quiet`` flag governs high-severity traffic
+only (FR-004, contracts/config-schema.md).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time, timedelta, tzinfo
+
+from maverick.assumptions.schedule.decisions import DecisionSink
+from maverick.assumptions.schedule.models import (
+    BatchSummary,
+    DecisionKind,
+    DeliveryDecision,
+    SkipDecision,
+    SkipReason,
+    WindowOccurrence,
+    format_utc,
+)
+from maverick.assumptions.schedule.state import WindowDecisionRecord
+from maverick.config import AssumptionScheduleConfig, QuietHoursConfig
+
+
+def _parse_hh_mm(value: str) -> time:
+    """Parse an already-validated ``"HH:MM"`` config string.
+
+    *value* comes from :class:`AssumptionScheduleConfig`/
+    :class:`QuietHoursConfig`, both validated at config-load time
+    (contracts/config-schema.md) — no error handling needed here.
+    """
+    hour_str, _, minute_str = value.partition(":")
+    return time(hour=int(hour_str), minute=int(minute_str))
+
+
+def _localize(naive: datetime, tz: tzinfo) -> datetime:
+    """Attach *tz* to a naive local datetime and resolve DST edge cases.
+
+    Round-tripping through UTC (research R6, PEP 495) is a no-op for an
+    unambiguous wall time, but for a spring-forward *gap* (a nonexistent
+    local time) it resolves the ``fold=0`` pre-transition interpretation
+    forward into the real post-transition instant it actually denotes,
+    rather than leaving an imaginary local time in play. Ambiguous
+    fall-back times keep their ``fold=0`` (first-occurrence) instant,
+    which is a real, valid instant either way.
+    """
+    aware = naive.replace(tzinfo=tz)
+    return aware.astimezone(UTC).astimezone(tz)
+
+
+def _in_quiet_hours(moment: time, quiet: QuietHoursConfig) -> bool:
+    """Whether wall-clock *moment* falls inside *quiet* (may span midnight)."""
+    start = _parse_hh_mm(quiet.start)
+    end = _parse_hh_mm(quiet.end)
+    if start < end:
+        return start <= moment < end
+    # Spans midnight (config rejects start == end): quiet from `start` to
+    # 24:00, and again from 00:00 to `end`.
+    return moment >= start or moment < end
+
+
+def in_quiet_hours_now(now: datetime, quiet: QuietHoursConfig | None) -> bool:
+    """Whether quiet hours are configured and *now* falls inside them.
+
+    The severity-blind half of the policy: "is this a quiet moment?".
+    Whether a given decision may nonetheless be delivered is
+    severity-specific — see :func:`high_severity_held_by_quiet_hours`.
+    """
+    return quiet is not None and _in_quiet_hours(now.time(), quiet)
+
+
+def high_severity_held_by_quiet_hours(now: datetime, schedule: AssumptionScheduleConfig) -> bool:
+    """Whether a *high-severity* decision is held by quiet hours (FR-004).
+
+    ``high_overrides_quiet`` gates high-severity interrupts and
+    high-severity backoff re-notifications identically, and *only* those
+    (contracts/config-schema.md). Under the default ``True`` a high entry
+    punches through quiet hours; under ``False`` quiet hours are absolute
+    and it is held until they end.
+
+    Medium-severity traffic — window batches and max-age escalations — is
+    deliberately **not** routed through here: it is held by quiet hours
+    unconditionally (:func:`in_quiet_hours_now`), whichever way the
+    override is configured. Reading ``high_overrides_quiet`` on a medium
+    decision is what let an aged medium entry fire an urgent 03:00 push
+    under the default config.
+    """
+    return not schedule.high_overrides_quiet and in_quiet_hours_now(now, schedule.quiet_hours)
+
+
+def _quiet_hours_shifted_due(
+    occ_date: date, window_time: time, quiet: QuietHoursConfig, tz: tzinfo
+) -> datetime:
+    """Due time shifted to quiet-hours end, same occurrence identity (R8)."""
+    start = _parse_hh_mm(quiet.start)
+    end = _parse_hh_mm(quiet.end)
+    end_date = occ_date
+    if start > end and window_time >= start:
+        # Evening portion of a midnight-spanning range: quiet end lands
+        # the next calendar day (e.g. window 23:00, quiet 22:00-07:00).
+        end_date = occ_date + timedelta(days=1)
+    return _localize(datetime.combine(end_date, end), tz)
+
+
+def build_occurrence(
+    occ_date: date, window_str: str, quiet: QuietHoursConfig | None, tz: tzinfo
+) -> WindowOccurrence:
+    """Construct the occurrence for *window_str* on *occ_date*.
+
+    ``date``/``window`` are the occurrence's identity (never shifted);
+    ``due_at`` shifts to quiet-hours end when the configured window time
+    falls inside quiet hours (research R8) and is fold-aware across DST
+    transitions (research R6).
+    """
+    window_time = _parse_hh_mm(window_str)
+    if quiet is not None and _in_quiet_hours(window_time, quiet):
+        due_at = _quiet_hours_shifted_due(occ_date, window_time, quiet, tz)
+    else:
+        due_at = _localize(datetime.combine(occ_date, window_time), tz)
+    return WindowOccurrence(date=occ_date, window=window_str, due_at=due_at)
+
+
+def previously_held_by_quiet_hours(
+    *,
+    occ: WindowOccurrence,
+    last_evaluated_at: datetime | None,
+    quiet: QuietHoursConfig | None,
+    now: datetime,
+    tz: tzinfo,
+) -> bool:
+    """Whether *occ* is an undecided occurrence this scheduler itself held.
+
+    An occurrence that became due is always settled by
+    :func:`process_due_occurrence` — with one exception: a would-be
+    delivery reached inside quiet hours is held with no window decision
+    recorded, so it stays due (FR-020). Finding it again the next calendar
+    day needs a fingerprint, since its ``due_at`` no longer falls on
+    ``now``'s date: **the previous evaluation ran at or after this
+    occurrence became due, at or before now, and inside quiet hours** —
+    i.e. that evaluation is the one that held it. (A delivery whose ntfy
+    push failed is reverted to undecided by ``state.finalize_state`` the
+    same way, and legitimately retries here.)
+
+    Deliberately *not* satisfied by a plainly stale occurrence nobody ever
+    evaluated: ``last_evaluated_at`` then predates ``occ.due_at`` (cron down
+    for days) or falls outside quiet hours (a brand-new schedule's first
+    run, whose empty state is stamped with the current instant), and the
+    caller leaves the occurrence alone rather than double-firing it
+    alongside today's. The one case that does slip through is a first-ever
+    run started *inside* quiet hours, which cannot be distinguished from a
+    genuine hold without persisting more state; the cost is one extra
+    summary push on that first morning.
+
+    Args:
+        occ: Yesterday's candidate occurrence, known to be undecided.
+        last_evaluated_at: ``DeliveryState.updated_at`` parsed to UTC — the
+            previous evaluation's clock, or ``None`` if unparseable.
+        quiet: The configured quiet hours, if any.
+        now: This evaluation's clock.
+        tz: ``now``'s timezone, used to read the previous evaluation's
+            *local* wall time (quiet hours are a local-time policy).
+
+    Returns:
+        ``True`` when the occurrence should be reconsidered now.
+    """
+    if quiet is None or last_evaluated_at is None:
+        return False
+    if not (occ.due_at <= last_evaluated_at <= now):
+        return False
+    return _in_quiet_hours(last_evaluated_at.astimezone(tz).time(), quiet)
+
+
+def process_due_occurrence(
+    *,
+    occ: WindowOccurrence,
+    key: str,
+    window_str: str,
+    now: datetime,
+    medium_ids: tuple[str, ...],
+    low_ids: tuple[str, ...],
+    min_batch_size: int,
+    quiet: QuietHoursConfig | None,
+    summary: BatchSummary,
+    window_decisions: dict[str, WindowDecisionRecord],
+    sink: DecisionSink,
+) -> None:
+    """Decide one not-yet-decided occurrence, appending its outcome.
+
+    Quiet-hours gating (FR-004): a window batch is a medium/legacy delivery,
+    so it is held whenever *now* falls inside quiet hours — including a
+    window whose own configured time sits outside them, reached by a
+    backlogged evaluation (machine asleep, cron catching up). Shifting
+    ``due_at`` at occurrence-build time (:func:`build_occurrence`, research
+    R8) only covers the case where the *configured* window time is itself
+    inside quiet hours; this is the second gate that case does not reach.
+    ``high_overrides_quiet`` never applies here — it governs high-severity
+    traffic only (contracts/config-schema.md).
+
+    Quiet hours suppress *deliveries*, not bookkeeping: an occurrence that
+    resolves to a skip anyway (empty, low-only, below min-batch-size)
+    settles normally, because settling it delivers nothing. Only a would-be
+    delivery is held, and it is held by recording *no* window decision at
+    all, so the occurrence stays due and delivers at the first permissible
+    evaluation (FR-020) — see :func:`previously_held_by_quiet_hours` for
+    how the next day's evaluation finds it again.
+
+    Mutates *window_decisions* and *sink* in place — a small, deliberate
+    exception to this package's otherwise functional style, scoped to
+    accumulating one ``evaluate()`` call's results across the
+    (today, catch-up-yesterday) x windows loop.
+    """
+    if now < occ.due_at:
+        sink.skip(
+            SkipDecision(
+                reason=SkipReason.NOT_YET_DUE,
+                occurrence=occ,
+                entry_ids=(),
+                rule=f"window {window_str} not yet due (due {occ.due_at.isoformat()})",
+            )
+        )
+        return
+
+    decision, record = _decide_batch(
+        occ=occ,
+        window_str=window_str,
+        medium_ids=medium_ids,
+        low_ids=low_ids,
+        min_batch_size=min_batch_size,
+        summary=summary,
+        now=now,
+    )
+    if isinstance(decision, DeliveryDecision) and in_quiet_hours_now(now, quiet):
+        sink.skip(
+            SkipDecision(
+                reason=SkipReason.QUIET_HOURS,
+                occurrence=occ,
+                entry_ids=decision.entry_ids,
+                rule=(
+                    f"window {window_str} batch held: quiet hours suppress "
+                    "medium-severity delivery; rolls to the first evaluation "
+                    "after quiet hours end"
+                ),
+            )
+        )
+        return
+
+    window_decisions[key] = record
+    if isinstance(decision, DeliveryDecision):
+        sink.deliver(decision, now)
+    else:
+        sink.skip(decision)
+
+
+def _decide_batch(
+    *,
+    occ: WindowOccurrence,
+    window_str: str,
+    medium_ids: tuple[str, ...],
+    low_ids: tuple[str, ...],
+    min_batch_size: int,
+    summary: BatchSummary,
+    now: datetime,
+) -> tuple[DeliveryDecision | SkipDecision, WindowDecisionRecord]:
+    """Resolve one due occurrence into a decision plus its persisted record.
+
+    Order of precedence: no medium entries at all (empty, or low-only) →
+    min-batch-size roll-forward → deliver. Legacy entries need no special
+    case here — ``report_entries`` already synthesizes their severity as
+    ``MEDIUM`` (FR-019, research R9), so they arrive in *medium_ids* like
+    any other medium entry.
+    """
+    decided_at = format_utc(now)
+
+    if not medium_ids:
+        if low_ids:
+            rule = (
+                f"window {window_str} due; only low-severity entries pending, "
+                "never delivered proactively"
+            )
+            return (
+                SkipDecision(
+                    reason=SkipReason.LOW_NEVER_PROACTIVE,
+                    occurrence=occ,
+                    entry_ids=low_ids,
+                    rule=rule,
+                ),
+                WindowDecisionRecord(
+                    outcome="empty", decided_at=decided_at, entry_ids=list(low_ids), rule=rule
+                ),
+            )
+        rule = f"window {window_str} due; batch empty (no open entries pending)"
+        return (
+            SkipDecision(reason=SkipReason.EMPTY_BATCH, occurrence=occ, entry_ids=(), rule=rule),
+            WindowDecisionRecord(outcome="empty", decided_at=decided_at, entry_ids=[], rule=rule),
+        )
+
+    if len(medium_ids) < min_batch_size:
+        rule = f"{len(medium_ids)} < min_batch_size {min_batch_size}; rolled to next window"
+        return (
+            SkipDecision(
+                reason=SkipReason.MIN_BATCH_SIZE, occurrence=occ, entry_ids=medium_ids, rule=rule
+            ),
+            WindowDecisionRecord(
+                outcome="skipped-min-batch",
+                decided_at=decided_at,
+                entry_ids=list(medium_ids),
+                rule=rule,
+            ),
+        )
+
+    rule = f"window {window_str} due"
+    return (
+        DeliveryDecision(
+            kind=DecisionKind.WINDOW_BATCH,
+            entry_ids=medium_ids,
+            summary=summary,
+            occurrence=occ,
+            rule=rule,
+        ),
+        WindowDecisionRecord(
+            outcome="delivered", decided_at=decided_at, entry_ids=list(medium_ids), rule=rule
+        ),
+    )

--- a/src/maverick/assumptions/serialize.py
+++ b/src/maverick/assumptions/serialize.py
@@ -63,6 +63,7 @@ def entry_to_dict(entry: AssumptionReportEntry) -> dict[str, object]:
         "severity_defaulted": record.severity_defaulted,
         "is_legacy": record.is_legacy,
         "source_bead": record.source_bead,
+        "created_at": record.created_at,
         "affected_change_ids": list(entry.affected_change_ids),
         "waiver": waiver,
         "reconcile": {

--- a/src/maverick/beads/models.py
+++ b/src/maverick/beads/models.py
@@ -198,6 +198,9 @@ class BeadDetails(BaseModel):
         parent_id: Parent bead ID if any.
         labels: Labels attached to the bead.
         state: Arbitrary key-value state metadata.
+        created_at: bd's UTC ISO-8601 creation timestamp (e.g.
+            ``"2026-08-05T22:09:49Z"``), probe-verified in research R1 of
+            spec 054. ``None`` when bd omits it (malformed/legacy bead).
     """
 
     id: str = Field(min_length=1, description="Bead ID")
@@ -209,6 +212,9 @@ class BeadDetails(BaseModel):
     parent_id: str | None = Field(default=None, description="Parent bead ID")
     labels: list[str] = Field(default_factory=list, description="Labels")
     state: dict[str, str] = Field(default_factory=dict, description="State metadata")
+    created_at: str | None = Field(
+        default=None, description="bd's UTC ISO-8601 creation timestamp"
+    )
 
     model_config = ConfigDict(frozen=True)
 

--- a/src/maverick/cli/commands/notify.py
+++ b/src/maverick/cli/commands/notify.py
@@ -1,0 +1,600 @@
+"""``maverick notify`` — evaluate and deliver due assumption-ledger notifications.
+
+See ``specs/054-assumption-batch-scheduler/contracts/cli-notify-json.md`` for
+the full contract (verbs, envelope shape, error mapping, exit codes) and
+``specs/054-assumption-batch-scheduler/quickstart.md`` for the acceptance
+scenarios this command implements (Scenarios 1-3, the MVP checkpoint).
+
+This module is the effects layer sitting downstream of three pure/typed
+building blocks that already exist and are never mutated by this file:
+
+* :func:`maverick.assumptions.schedule.evaluate.evaluate` — pure decision
+  engine (no disk/network reads); this module is the only caller responsible
+  for turning its decisions into ntfy pushes and persisted state.
+* :class:`maverick.assumptions.schedule.deliver.NtfyDeliverer` — the sole
+  ntfy wrapper (Guardrail 5).
+* :mod:`maverick.assumptions.schedule.state` — persisted delivery state
+  (``<cwd>/.maverick/notify/state.json``) plus the pid-stamped lockfile.
+* :func:`maverick.assumptions.schedule.clock.now_local` — the injected clock
+  seam (research R6). This module is where "now" enters the evaluation, bound
+  to the machine's real IANA zone so window/quiet-hours wall-clock arithmetic
+  stays correct across DST transitions.
+
+Write-after-success (FR-012): :func:`evaluate` returns a candidate
+``state_after`` that *assumes* every delivery decision succeeds (see that
+module's docstring).
+:func:`~maverick.assumptions.schedule.state.finalize_state` strips the
+mutations belonging to any decision whose ntfy push actually failed before
+the state is persisted, so a failed batch stays due for the next
+evaluation — a partial-success run (some due decisions deliver, others
+fail) persists exactly the successes, individually.
+
+Concurrency (research R7): unlike ``reconcile``, a held lock is a *benign*
+skip for this command — cron overlap is expected operation, not a fault —
+so contention exits ``SUCCESS`` with ``result.skipped: "concurrent-evaluation"``
+rather than the ``locked`` error kind.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Final
+
+import click
+
+from maverick.assumptions.errors import AssumptionLedgerError
+from maverick.assumptions.ledger import report_entries
+from maverick.assumptions.ledger import waive as ledger_waive
+from maverick.assumptions.models import Severity
+from maverick.assumptions.schedule.clock import now_local
+from maverick.assumptions.schedule.deliver import DeliveryFailedError, NtfyDeliverer
+from maverick.assumptions.schedule.evaluate import evaluate
+from maverick.assumptions.schedule.models import (
+    AutoWaiveDecision,
+    BatchSummary,
+    DecisionKind,
+    DeliveryDecision,
+    SkipDecision,
+    WindowOccurrence,
+    format_age_hours,
+    format_utc,
+)
+from maverick.assumptions.schedule.state import (
+    DeliveryState,
+    TerminalOutcome,
+    acquire_lock,
+    finalize_state,
+    load_state,
+    release_lock,
+    save_state,
+)
+from maverick.beads.client import BeadClient
+from maverick.cli.common import BD_MISSING, BD_NOT_INITIALIZED, bd_ready_reason, cli_error_handler
+from maverick.cli.console import console, err_console
+from maverick.cli.context import ExitCode, async_command
+from maverick.cli.json_output import ErrorKind, JsonEnvelope, emit_json, json_error_handler
+from maverick.config import (
+    AssumptionScheduleConfig,
+    MaverickConfig,
+    NotificationConfig,
+    load_config,
+)
+from maverick.exceptions import BeadError
+from maverick.logging import get_logger
+
+__all__ = ["notify"]
+
+logger = get_logger(__name__)
+
+#: ``waived_by`` value stamped on every scheduler-initiated auto-waive
+#: (research R10) — distinguishes it from a human waiver in ledger
+#: reporting (FR-015).
+_AUTO_WAIVE_ACTOR: Final = "maverick-scheduler"
+
+#: Machine reason (``maverick.cli.common.bd_ready_reason``) -> the message
+#: the ``bd-unavailable`` envelope/console line carries. Mirrors
+#: ``maverick.cli.commands.reconcile._BD_REASON_MESSAGES``.
+_BD_REASON_MESSAGES = {
+    BD_MISSING: "The bd CLI is required but not found on PATH.",
+    BD_NOT_INITIALIZED: (
+        "this project hasn't been initialized for Maverick yet — run `maverick init`."
+    ),
+}
+
+#: Human-mode label per :class:`DecisionKind` (contract's completion-line example).
+_KIND_HUMAN: dict[DecisionKind, str] = {
+    DecisionKind.WINDOW_BATCH: "window batch",
+    DecisionKind.INTERRUPT: "interrupt",
+    DecisionKind.ESCALATION: "escalation",
+    DecisionKind.RENOTIFY: "renotification",
+}
+
+
+@dataclass(slots=True)
+class _DeliveryOutcome:
+    """One ntfy delivery attempt that failed, with its position in
+    ``EvaluationOutcome.deliveries`` (used to locate the matching
+    ``state_after`` mutations to strip — see
+    :func:`~maverick.assumptions.schedule.state.finalize_state`)."""
+
+    decision: DeliveryDecision
+    index: int
+    error: str
+
+
+@dataclass(slots=True)
+class _NotifyRun:
+    """The outcome of one evaluate-deliver-save pass, or a benign lock skip."""
+
+    configured: bool
+    skipped: str | None
+    evaluated_at: datetime | None
+    delivered: list[DeliveryDecision]
+    failed: list[_DeliveryOutcome]
+    skips: list[SkipDecision]
+    auto_waives: list[AutoWaiveDecision]
+    dry_run: bool
+
+
+def _notifications_usability_error(notif: NotificationConfig) -> str | None:
+    """FR-009: an ``assumptions.schedule`` block requires a usable ntfy endpoint.
+
+    ``NotificationConfig``'s own validator only *warns* when enabled-but-
+    topicless (it doesn't know a schedule block is asking it to actually
+    deliver something) — this is the enforcement point. Returns a message
+    naming the exact missing/misconfigured key, or ``None`` when usable.
+    """
+    if not notif.enabled:
+        return (
+            "assumptions.schedule is configured but notifications.enabled is "
+            "false in maverick.yaml — set `notifications.enabled: true` to use "
+            "`maverick notify`."
+        )
+    if not notif.topic:
+        return (
+            "assumptions.schedule is configured but notifications.topic is not "
+            "set in maverick.yaml — set `notifications.topic` to use `maverick "
+            "notify`."
+        )
+    return None
+
+
+async def _bd_preflight_error(cwd: Path, client: BeadClient) -> str | None:
+    """Return a bd-unavailable message, or ``None`` when bd is ready.
+
+    Combines the two existing bd-readiness checks — :func:`bd_ready_reason`
+    (bd on PATH + ``.beads/`` initialized) and
+    :meth:`BeadClient.verify_available` (``bd --version`` actually
+    succeeds) — so either failure mode maps to the same ``bd-unavailable``
+    error kind (contracts/cli-notify-json.md).
+    """
+    reason = bd_ready_reason(cwd)
+    if reason is not None:
+        return _BD_REASON_MESSAGES.get(reason, f"bd is not ready ({reason}).")
+    if not await client.verify_available():
+        return "The `bd` CLI is on PATH but is not responding (`bd --version` failed)."
+    return None
+
+
+async def _evaluate_and_effect(
+    *,
+    cwd: Path,
+    client: BeadClient,
+    schedule: AssumptionScheduleConfig,
+    notif: NotificationConfig,
+    dry_run: bool,
+) -> _NotifyRun:
+    """Evaluate the schedule against the ledger and apply effects.
+
+    ``--dry-run`` never acquires the lock, never delivers, and never
+    persists state (contract: "zero ntfy calls, zero bd writes, zero state
+    writes"). A real run acquires the lockfile around the whole
+    evaluate-deliver-save sequence (research R7); contention is a benign
+    skip, not a failure.
+
+    Raises:
+        AssumptionLedgerError: The ledger sweep (``report_entries``) failed.
+    """
+    if not dry_run:
+        acquired = await acquire_lock(cwd)
+        if not acquired:
+            return _NotifyRun(
+                configured=True,
+                skipped="concurrent-evaluation",
+                evaluated_at=None,
+                delivered=[],
+                failed=[],
+                skips=[],
+                auto_waives=[],
+                dry_run=dry_run,
+            )
+
+    try:
+        entries = await report_entries(client)
+        state = await load_state(cwd)
+        now = now_local()
+        outcome = evaluate(entries, schedule, state, now)
+
+        delivered: list[DeliveryDecision] = []
+        failed: list[_DeliveryOutcome] = []
+
+        if dry_run:
+            delivered = list(outcome.deliveries)
+        elif outcome.deliveries:
+            topic = notif.topic
+            if topic is None:
+                # Unreachable in practice: callers validate notifications
+                # usability (`_notifications_usability_error`) before ever
+                # reaching this point. Guards mypy's narrowing and fails
+                # loudly instead of silently, if that invariant ever slips.
+                raise AssertionError(
+                    "notify: notifications.topic must be validated before delivery"
+                )
+            async with NtfyDeliverer(server=notif.server, topic=topic) as deliverer:
+                for index, decision in enumerate(outcome.deliveries):
+                    try:
+                        await deliverer.deliver(decision.kind, decision.summary)
+                        delivered.append(decision)
+                    except DeliveryFailedError as exc:
+                        failed.append(
+                            _DeliveryOutcome(decision=decision, index=index, error=str(exc))
+                        )
+
+        auto_waived: list[AutoWaiveDecision] = []
+        if dry_run:
+            auto_waived = list(outcome.auto_waives)
+        elif outcome.auto_waives:
+            auto_waived = await _execute_auto_waives(client=client, decisions=outcome.auto_waives)
+
+        if not dry_run:
+            final_state = finalize_state(
+                outcome=outcome,
+                prior_state=state,
+                failed_indices={f.index for f in failed},
+                now=now,
+            )
+            final_state = _apply_auto_waive_terminal(final_state, auto_waived, now)
+            await save_state(final_state, cwd)
+
+        return _NotifyRun(
+            configured=True,
+            skipped=None,
+            evaluated_at=now,
+            delivered=delivered,
+            failed=failed,
+            skips=list(outcome.skips),
+            auto_waives=auto_waived,
+            dry_run=dry_run,
+        )
+    finally:
+        if not dry_run:
+            await release_lock(cwd)
+
+
+async def _execute_auto_waives(
+    *, client: BeadClient, decisions: Sequence[AutoWaiveDecision]
+) -> list[AutoWaiveDecision]:
+    """Execute auto-waive decisions via the ledger (research R10, FR-015).
+
+    Never called in ``--dry-run`` mode (the contract's "zero bd calls").
+    Each waive is attempted independently — Principle III ("one agent
+    failing must not crash the workflow") applies equally to this
+    effects loop: a bd failure waiving one entry must not prevent the
+    rest of the run's due decisions (deliveries, other auto-waives) from
+    completing, and must not fabricate a persisted terminal outcome for
+    an entry that was never actually waived.
+
+    Args:
+        client: The bead client to waive through.
+        decisions: Auto-waive candidates from
+            :func:`~maverick.assumptions.schedule.evaluate.evaluate`.
+
+    Returns:
+        Only the decisions whose ``ledger.waive`` call actually
+        succeeded, in the same order — the caller stamps a
+        :class:`~maverick.assumptions.schedule.state.TerminalOutcome`
+        for exactly these.
+    """
+    succeeded: list[AutoWaiveDecision] = []
+    for decision in decisions:
+        try:
+            await ledger_waive(
+                client,
+                bead_id=decision.entry_id,
+                reason=decision.reason_text,
+                waived_by=_AUTO_WAIVE_ACTOR,
+            )
+        except AssumptionLedgerError as exc:
+            logger.warning("notify_auto_waive_failed", bead_id=decision.entry_id, error=str(exc))
+            continue
+        succeeded.append(decision)
+    return succeeded
+
+
+def _apply_auto_waive_terminal(
+    state: DeliveryState, waived: Sequence[AutoWaiveDecision], now: datetime
+) -> DeliveryState:
+    """Stamp a :class:`TerminalOutcome` for each successfully auto-waived entry.
+
+    FR-016 ("nothing leaves tracking without a persisted outcome") applies
+    to the auto-waive path exactly as it does to human resolution — this
+    is where the scheduler records who/what/why for FR-023's 90-day
+    retention clock (``TerminalOutcome.at``) and audit (``detail`` carries
+    the full rationale).
+
+    Args:
+        state: The state ``finalize_state`` already produced for this
+            run's delivery decisions.
+        waived: The auto-waive decisions that actually succeeded
+            (:func:`_execute_auto_waives`'s return value).
+        now: The same evaluation clock passed to ``evaluate()``.
+
+    Returns:
+        *state* unchanged if *waived* is empty, otherwise a new
+        :class:`DeliveryState` with each waived entry's tracking row
+        carrying its terminal outcome.
+    """
+    if not waived:
+        return state
+    at = format_utc(now)
+    tracking = dict(state.entry_tracking)
+    for decision in waived:
+        record = tracking.get(decision.entry_id)
+        if record is None:
+            continue
+        tracking[decision.entry_id] = record.model_copy(
+            update={
+                "terminal": TerminalOutcome(kind="auto-waived", at=at, detail=decision.reason_text)
+            }
+        )
+    return state.model_copy(update={"entry_tracking": tracking})
+
+
+# --- JSON projection -------------------------------------------------------
+
+
+def _delivery_trigger(decision: DeliveryDecision) -> str:
+    if decision.occurrence is not None:
+        return decision.occurrence.key
+    return decision.rule
+
+
+def _delivery_to_dict(decision: DeliveryDecision) -> dict[str, Any]:
+    return {
+        "kind": decision.kind.value,
+        "trigger": _delivery_trigger(decision),
+        "entry_ids": list(decision.entry_ids),
+        "summary": decision.summary.to_dict(),
+        "rule": decision.rule,
+    }
+
+
+def _occurrence_to_dict(occurrence: WindowOccurrence | None) -> dict[str, Any] | None:
+    if occurrence is None:
+        return None
+    return {
+        "date": occurrence.date.isoformat(),
+        "window": occurrence.window,
+        "due_at": occurrence.due_at.isoformat(),
+    }
+
+
+def _skip_to_dict(skip: SkipDecision) -> dict[str, Any]:
+    return {
+        "reason": skip.reason.value,
+        "entry_ids": list(skip.entry_ids),
+        "occurrence": _occurrence_to_dict(skip.occurrence),
+        "rule": skip.rule,
+    }
+
+
+def _auto_waive_to_dict(decision: AutoWaiveDecision) -> dict[str, Any]:
+    return {"entry_id": decision.entry_id, "reason": decision.reason_text}
+
+
+def _failed_delivery_to_dict(outcome: _DeliveryOutcome) -> dict[str, Any]:
+    payload = _delivery_to_dict(outcome.decision)
+    payload["error"] = outcome.error
+    return payload
+
+
+def _no_op_result(*, dry_run: bool) -> dict[str, Any]:
+    """FR-021: the inert, no-``assumptions.schedule`` result shape."""
+    return {
+        "configured": False,
+        "skipped": "not-configured",
+        "evaluated_at": None,
+        "deliveries": [],
+        "skips": [],
+        "auto_waives": [],
+        "dry_run": dry_run,
+    }
+
+
+def _run_to_dict(run: _NotifyRun) -> dict[str, Any]:
+    return {
+        "configured": run.configured,
+        "skipped": run.skipped,
+        "evaluated_at": (
+            run.evaluated_at.isoformat(timespec="seconds")
+            if run.evaluated_at is not None
+            else None
+        ),
+        "deliveries": [_delivery_to_dict(d) for d in run.delivered],
+        "skips": [_skip_to_dict(s) for s in run.skips],
+        "auto_waives": [_auto_waive_to_dict(w) for w in run.auto_waives],
+        "dry_run": run.dry_run,
+    }
+
+
+async def _run_notify_json(*, dry_run: bool, cwd: Path, config: MaverickConfig) -> None:
+    """Drive notify end-to-end in ``--json`` mode: one envelope on stdout."""
+    verb = "notify.dry-run" if dry_run else "notify.run"
+
+    schedule = config.assumptions.schedule
+    if schedule is None:
+        emit_json(JsonEnvelope.success(verb, _no_op_result(dry_run=dry_run)))
+        raise SystemExit(ExitCode.SUCCESS)
+
+    notif = config.notifications
+    usability_error = _notifications_usability_error(notif)
+    if usability_error is not None:
+        emit_json(JsonEnvelope.failure(verb, ErrorKind.VALIDATION, usability_error))
+        raise SystemExit(ExitCode.FAILURE)
+
+    run: _NotifyRun | None = None
+    with json_error_handler(verb):
+        client = BeadClient(cwd=cwd)
+        bd_error = await _bd_preflight_error(cwd, client)
+        if bd_error is not None:
+            raise BeadError(bd_error)
+
+        run = await _evaluate_and_effect(
+            cwd=cwd, client=client, schedule=schedule, notif=notif, dry_run=dry_run
+        )
+
+    assert run is not None  # json_error_handler() already exited on any exception above
+
+    if run.failed:
+        details: dict[str, object] = {
+            "failed_deliveries": [_failed_delivery_to_dict(f) for f in run.failed]
+        }
+        message = f"{len(run.failed)} delivery(ies) failed; the affected batch(es) remain due."
+        emit_json(JsonEnvelope.failure(verb, ErrorKind.DELIVERY_FAILED, message, details))
+        raise SystemExit(ExitCode.FAILURE)
+
+    emit_json(JsonEnvelope.success(verb, _run_to_dict(run)))
+    raise SystemExit(ExitCode.SUCCESS)
+
+
+# --- Human-mode rendering ---------------------------------------------------
+
+
+def _counts_phrase(summary: BatchSummary) -> str:
+    high = summary.counts.get(Severity.HIGH, 0)
+    medium = summary.counts.get(Severity.MEDIUM, 0)
+    low = summary.counts.get(Severity.LOW, 0)
+    parts = [f"{high} high"] if high else []
+    parts.append(f"{medium} medium")
+    parts.append(f"{low} low")
+    return f"{', '.join(parts)}; oldest {format_age_hours(summary.oldest_age_hours)}h"
+
+
+def _occurrence_phrase(decision: DeliveryDecision) -> str:
+    if decision.occurrence is not None:
+        return f"{decision.occurrence.window} window"
+    return decision.rule
+
+
+def _render_human_result(run: _NotifyRun, *, dry_run: bool) -> None:
+    """Render one evaluation's outcome per the contract's "Human-mode output"
+    section, then exit with the matching code."""
+    if run.skipped == "concurrent-evaluation":
+        console.print("Another `maverick notify` evaluation is already in progress — skipped.")
+        raise SystemExit(ExitCode.SUCCESS)
+
+    verb_word = "Would deliver" if dry_run else "Delivered"
+    for decision in run.delivered:
+        console.print(
+            f"[green]✓[/] {verb_word} {_KIND_HUMAN[decision.kind]} "
+            f"({_counts_phrase(decision.summary)}) for {_occurrence_phrase(decision)}"
+        )
+
+    waive_verb = "Would auto-waive" if dry_run else "Auto-waived"
+    for waived in run.auto_waives:
+        console.print(f"[green]✓[/] {waive_verb} {waived.entry_id} ({waived.reason_text})")
+
+    if run.failed:
+        for failure in run.failed:
+            console.print(f"[red]✗[/] Delivery failed: {failure.error}")
+        console.print(
+            "[yellow]Warning:[/yellow] the batch remains due — it will be "
+            "retried on the next evaluation."
+        )
+        raise SystemExit(ExitCode.FAILURE)
+
+    if not run.delivered and not run.auto_waives:
+        console.print("Nothing due.")
+
+    raise SystemExit(ExitCode.SUCCESS)
+
+
+async def _run_notify_human(*, dry_run: bool, cwd: Path, config: MaverickConfig) -> None:
+    """Drive notify end-to-end in human (Rich console) mode."""
+    schedule = config.assumptions.schedule
+    if schedule is None:
+        console.print(
+            "Assumption delivery is not configured (no assumptions.schedule "
+            "block in maverick.yaml)."
+        )
+        raise SystemExit(ExitCode.SUCCESS)
+
+    notif = config.notifications
+    usability_error = _notifications_usability_error(notif)
+    if usability_error is not None:
+        err_console.print(f"[red]Error:[/red] {usability_error}")
+        raise SystemExit(ExitCode.FAILURE)
+
+    run: _NotifyRun | None = None
+    with cli_error_handler():
+        client = BeadClient(cwd=cwd)
+        bd_error = await _bd_preflight_error(cwd, client)
+        if bd_error is not None:
+            err_console.print(f"[red]Error:[/red] {bd_error}")
+            raise SystemExit(ExitCode.FAILURE)
+
+        run = await _evaluate_and_effect(
+            cwd=cwd, client=client, schedule=schedule, notif=notif, dry_run=dry_run
+        )
+
+    assert run is not None  # cli_error_handler() already exited on any exception above
+    _render_human_result(run, dry_run=dry_run)
+
+
+@click.command("notify")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Evaluate and report every decision; zero ntfy calls, zero bd writes, zero state writes.",
+)
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    default=False,
+    help="Emit a single machine-readable JSON envelope to stdout instead of Rich console output.",
+)
+@click.pass_context
+@async_command
+async def notify(ctx: click.Context, dry_run: bool, json_output: bool) -> None:
+    """Evaluate the assumption-ledger delivery schedule and deliver anything due.
+
+    Batches medium-severity assumption-ledger entries into ntfy pushes at
+    configured review windows (respecting quiet hours and the minimum
+    batch size), counts low-severity entries without ever pushing for them
+    on their own, and is safe to run repeatedly from cron: a window
+    occurrence delivers at most once, and overlapping invocations produce
+    one evaluation plus a benign skip rather than a duplicate push. Inert
+    (exit 0, no-op) when no ``assumptions.schedule`` block is configured
+    (FR-021). See specs/054-assumption-batch-scheduler/contracts/cli-notify-json.md.
+
+    Examples:
+
+        maverick notify
+
+        maverick notify --dry-run --json
+    """
+    cwd = Path.cwd().resolve()
+    config = (ctx.obj or {}).get("config") if ctx.obj else None
+    if config is None:
+        config = load_config()
+
+    if json_output:
+        await _run_notify_json(dry_run=dry_run, cwd=cwd, config=config)
+        return
+
+    await _run_notify_human(dry_run=dry_run, cwd=cwd, config=config)

--- a/src/maverick/cli/json_output.py
+++ b/src/maverick/cli/json_output.py
@@ -72,6 +72,7 @@ class ErrorKind(StrEnum):
     CURATION_FAILED = "curation-failed"
     VCS = "vcs"
     INTERNAL = "internal"
+    DELIVERY_FAILED = "delivery-failed"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/maverick/config.py
+++ b/src/maverick/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextvars
+import re
 from pathlib import Path
 from typing import Any, Literal, Self
 
@@ -21,12 +22,16 @@ __all__ = [
     "ActorConfig",
     "AgentBindingConfig",
     "AgentsConfig",
+    "AssumptionScheduleConfig",
+    "AssumptionsConfig",
+    "AutoWaivePolicyConfig",
     "CustomToolConfig",
     "GitHubConfig",
     "MaverickConfig",
     "NotificationConfig",
     "ParallelConfig",
     "PreflightValidationConfig",
+    "QuietHoursConfig",
     "ReconcileConfig",
     "RunwayConfig",
     "RunwayConsolidationConfig",
@@ -46,6 +51,28 @@ logger = get_logger(__name__)
 _project_config_path_var: contextvars.ContextVar[Path | None] = contextvars.ContextVar(
     "_project_config_path", default=None
 )
+
+# HH:MM 24-hour local wall-clock time, e.g. "09:00" or "23:59".
+_HH_MM_PATTERN = re.compile(r"^([01]\d|2[0-3]):([0-5]\d)$")
+
+
+def _validate_hh_mm(value: str, *, field_name: str) -> str:
+    """Validate a ``HH:MM`` 24-hour local-time string.
+
+    Args:
+        value: The candidate time string.
+        field_name: Name to report in the raised error.
+
+    Returns:
+        The validated string, unchanged.
+
+    Raises:
+        ValueError: If ``value`` is not a well-formed ``HH:MM`` string
+            (``00``-``23`` hours, ``00``-``59`` minutes).
+    """
+    if not _HH_MM_PATTERN.match(value):
+        raise ValueError(f"{field_name} must be a 24-hour 'HH:MM' time string (got {value!r})")
+    return value
 
 
 class GitHubConfig(BaseModel):
@@ -421,6 +448,139 @@ class ReconcileConfig(BaseModel):
     )
 
 
+class QuietHoursConfig(BaseModel):
+    """A local wall-clock quiet-hours range for the assumption scheduler.
+
+    ``start``/``end`` are ``HH:MM`` 24-hour local time. ``end`` may be
+    earlier than ``start`` (the range spans midnight, e.g. ``22:00``-
+    ``07:00``); ``start == end`` is rejected as ambiguous (would mean
+    either zero quiet hours or a full day of them).
+
+    Attributes:
+        start: Quiet-hours start, ``HH:MM``.
+        end: Quiet-hours end, ``HH:MM``.
+    """
+
+    start: str
+    end: str
+
+    @field_validator("start", "end")
+    @classmethod
+    def check_hh_mm(cls, v: str, info: Any) -> str:
+        return _validate_hh_mm(v, field_name=str(info.field_name))
+
+    @model_validator(mode="after")
+    def check_start_ne_end(self) -> Self:
+        if self.start == self.end:
+            raise ValueError(
+                f"quiet_hours.start must differ from quiet_hours.end (both were {self.start!r})"
+            )
+        return self
+
+
+class AutoWaivePolicyConfig(BaseModel):
+    """Opt-in policy to auto-waive aged low-severity assumption entries.
+
+    Absent from :class:`AssumptionScheduleConfig` (``auto_waive_low: None``),
+    the scheduler never auto-waives (FR-015). When present, ``enabled``
+    is itself a second explicit opt-in — double opt-in by design.
+
+    Attributes:
+        enabled: Whether auto-waive is active.
+        after_hours: Age threshold in hours before an aged low-severity
+            entry is auto-waived. Default ``168`` (7 days).
+        rationale: Human-readable rationale recorded on the ledger entry.
+            Required (non-empty) when ``enabled`` is ``True``.
+    """
+
+    enabled: bool = False
+    after_hours: int = Field(default=168, ge=1)
+    rationale: str | None = None
+
+    @model_validator(mode="after")
+    def check_rationale_when_enabled(self) -> Self:
+        if self.enabled and not self.rationale:
+            raise ValueError(
+                "auto_waive_low.rationale is required when auto_waive_low.enabled is true"
+            )
+        return self
+
+
+class AssumptionScheduleConfig(BaseModel):
+    """Delivery-policy schedule for the assumption-ledger batch scheduler.
+
+    Drives ``maverick notify`` (spec 054): when medium-severity entries
+    batch into review windows, when high-severity entries interrupt, and
+    the escalation/backoff/auto-waive rules for entries that age out of
+    their normal tier. The ntfy endpoint itself (server/topic) is *not*
+    duplicated here — it comes from the existing :class:`NotificationConfig`
+    (``notifications:`` block).
+
+    Attributes:
+        windows: Review-window times, ``HH:MM`` 24-hour local time.
+            Required, at least one, no duplicates.
+        quiet_hours: Optional quiet-hours range. Absent means no quiet
+            hours are observed.
+        high_overrides_quiet: Whether high-severity interrupts and
+            escalation re-notifications are delivered during quiet hours
+            (FR-004). Default ``True``.
+        min_batch_size: Minimum entries required before a window batch
+            delivers; smaller batches roll forward to the next window
+            (FR-005). Default ``1`` (deliver whatever is due).
+        max_entry_age_hours: Age in hours past which a medium/high entry
+            escalates past normal batching rules (FR-006). Default ``24``.
+        renotify_backoff_hours: Backoff ladder, in hours, for high-severity
+            re-notification spacing (FR-007). Must be non-empty, each value
+            ``> 0``, and non-decreasing; the last value repeats indefinitely.
+            Default ``[4, 8, 16, 24]``.
+        auto_waive_low: Optional opt-in policy to auto-waive aged
+            low-severity entries (FR-015). Absent means never auto-waive.
+    """
+
+    windows: list[str] = Field(..., min_length=1)
+    quiet_hours: QuietHoursConfig | None = None
+    high_overrides_quiet: bool = True
+    min_batch_size: int = Field(default=1, ge=1)
+    max_entry_age_hours: int = Field(default=24, ge=1)
+    renotify_backoff_hours: list[float] = Field(default_factory=lambda: [4.0, 8.0, 16.0, 24.0])
+    auto_waive_low: AutoWaivePolicyConfig | None = None
+
+    @field_validator("windows")
+    @classmethod
+    def check_windows(cls, v: list[str]) -> list[str]:
+        for window in v:
+            _validate_hh_mm(window, field_name="windows")
+        if len(set(v)) != len(v):
+            raise ValueError(f"windows must not contain duplicates (got {v})")
+        return v
+
+    @field_validator("renotify_backoff_hours")
+    @classmethod
+    def check_renotify_backoff_hours(cls, v: list[float]) -> list[float]:
+        if not v:
+            raise ValueError("renotify_backoff_hours must be non-empty")
+        for value in v:
+            if value <= 0:
+                raise ValueError(f"renotify_backoff_hours values must all be > 0 (got {v})")
+        for previous, current in zip(v, v[1:], strict=False):
+            if current < previous:
+                raise ValueError(f"renotify_backoff_hours must be non-decreasing (got {v})")
+        return v
+
+
+class AssumptionsConfig(BaseModel):
+    """Root config block for assumption-ledger behavior.
+
+    Attributes:
+        schedule: Optional batch-scheduler delivery policy for
+            ``maverick notify``. Absent (``None``, the default) means the
+            scheduler is inert — ``maverick notify`` exits 0 as a no-op
+            (FR-021).
+    """
+
+    schedule: AssumptionScheduleConfig | None = None
+
+
 class AgentBindingConfig(BaseModel, frozen=True):
     """One ``(provider, model_id)`` binding for a single agent role.
 
@@ -681,6 +841,13 @@ class MaverickConfig(BaseSettings):
 
     github: GitHubConfig = Field(default_factory=GitHubConfig)
     notifications: NotificationConfig = Field(default_factory=NotificationConfig)
+    assumptions: AssumptionsConfig = Field(
+        default_factory=AssumptionsConfig,
+        description=(
+            "Assumption-ledger behavior, including the optional "
+            "'schedule' batch-delivery policy for `maverick notify`."
+        ),
+    )
     validation: ValidationConfig = Field(default_factory=ValidationConfig)
     preflight: PreflightValidationConfig = Field(default_factory=PreflightValidationConfig)
     parallel: ParallelConfig = Field(default_factory=ParallelConfig)

--- a/src/maverick/main.py
+++ b/src/maverick/main.py
@@ -61,6 +61,10 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
         "maverick.cli.commands.land:land",
         "Curate commit history and apply to local repo.",
     ),
+    "notify": (
+        "maverick.cli.commands.notify:notify",
+        "Evaluate the assumption-ledger delivery schedule and deliver anything due.",
+    ),
     "plan": (
         "maverick.cli.commands.flight_plan:flight_plan",
         "Create and validate flight plan files.",

--- a/tests/integration/test_notify_flow.py
+++ b/tests/integration/test_notify_flow.py
@@ -1,0 +1,359 @@
+"""Integration test: end-to-end ``maverick notify`` flow (tasks.md T023, US3).
+
+Simulates a multi-day cron-driven run of the assumption batch scheduler by
+composing the real production modules the same way
+``src/maverick/cli/commands/notify.py::_evaluate_and_effect`` does —
+:func:`~maverick.assumptions.ledger.report_entries` (against a mocked
+``BeadClient.query``/``.show``, never a real ``bd``),
+:func:`~maverick.assumptions.schedule.evaluate.evaluate` (pure, injected
+``now``), :class:`~maverick.assumptions.schedule.deliver.NtfyDeliverer`
+(real HTTP-shaped requests captured via ``httpx.MockTransport``, never a
+real network call), and :mod:`~maverick.assumptions.schedule.state`'s
+``load_state``/``finalize_state``/``save_state`` — driven tick by tick with
+an injected sequence of ``now`` values instead of the wall clock, per
+research R6 ("no freezegun, no ``datetime.now`` mocking"). The CLI dispatch
+layer itself (lock acquisition, JSON envelope shape, error mapping) is
+already covered by ``tests/unit/cli/commands/test_notify_json.py`` — this
+file proves the module composition end-to-end instead.
+
+Covers:
+
+* **SC-001**: entries recorded at arbitrary hours overnight accumulate
+  silently through quiet hours and deliver as exactly one 09:00 batch.
+* **SC-003**: repeated invocations — within the same window, and later the
+  same day with nothing new — never re-deliver.
+* **SC-004**: every fire is reconstructible from ``state.json`` alone
+  (rule citations + covered entry ids match what actually happened).
+* **SC-005**: every entry in a mixed run (open medium, open high,
+  answered, waived, low-severity) ends up accounted for — delivered,
+  human-resolved, or knowingly silent-and-low — never silently dropped.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import httpx
+import pytest
+from tenacity import wait_fixed
+
+from maverick.assumptions.ledger import report_entries
+from maverick.assumptions.models import STATUS_ANSWERED, STATUS_OPEN, STATUS_WAIVED
+from maverick.assumptions.schedule.deliver import DeliveryFailedError, NtfyDeliverer
+from maverick.assumptions.schedule.evaluate import evaluate
+from maverick.assumptions.schedule.models import EvaluationOutcome
+from maverick.assumptions.schedule.state import (
+    DeliveryState,
+    finalize_state,
+    load_state,
+    save_state,
+)
+from maverick.beads.client import BeadClient
+from maverick.beads.models import BeadDetails, BeadSummary
+from maverick.config import AssumptionScheduleConfig, NotificationConfig, QuietHoursConfig
+
+NY = ZoneInfo("America/New_York")
+
+_DESCRIPTION = (
+    "## Question\n\nQ?\n\n"
+    "## Adopted Answer\n\nA.\n\n"
+    "## Alternatives Considered\n\n(none)\n\n"
+    "## Context\n\nSource bead: mav-source — Source\n"
+)
+
+
+def _bead(
+    bead_id: str,
+    *,
+    severity: str = "medium",
+    status: str = STATUS_OPEN,
+    owner_spec: str = "054-assumption-batch-scheduler",
+    created_at: str,
+    answer_text: str | None = None,
+    waived_by: str | None = None,
+    waive_reason: str | None = None,
+) -> BeadDetails:
+    """A minimal, valid ``assumption``-labeled bead — real enough for
+    ``report_entries()``/``evaluate()`` to process; inert on everything
+    they don't look at (question/answer text)."""
+    state: dict[str, str] = {
+        "assumption_severity": severity,
+        "assumption_status": status,
+        "assumption_owner_spec": owner_spec,
+        "source_bead": "mav-source",
+    }
+    if answer_text is not None:
+        state["assumption_answer"] = answer_text
+    if waived_by is not None:
+        state["assumption_waived_by"] = waived_by
+        state["assumption_waive_reason"] = waive_reason or "n/a"
+        state["assumption_waived_at"] = created_at
+    return BeadDetails(
+        id=bead_id,
+        title=f"Assumption: {bead_id}",
+        description=_DESCRIPTION,
+        bead_type="task",
+        status="open" if status == STATUS_OPEN else "closed",
+        labels=["assumption"],
+        state=state,
+        created_at=created_at,
+    )
+
+
+def _wire_ledger(monkeypatch: pytest.MonkeyPatch, beads: dict[str, BeadDetails]) -> None:
+    """Point a real ``BeadClient`` at an in-memory, mutable bd-shaped
+    ledger — ``.query``/``.show`` read *beads* live, so mutating the dict
+    between ticks (answer/waive) is visible on the next sweep, exactly as
+    a real ``bd`` database would be. Never shells out to a real ``bd``."""
+
+    async def _query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+        return [
+            BeadSummary(id=details.id, title=details.title, status=details.status)
+            for details in beads.values()
+        ]
+
+    async def _show(self: BeadClient, bead_id: str) -> BeadDetails:
+        return beads[bead_id]
+
+    async def _verify_available(self: BeadClient) -> bool:
+        return True
+
+    monkeypatch.setattr(BeadClient, "query", _query)
+    monkeypatch.setattr(BeadClient, "show", _show)
+    monkeypatch.setattr(BeadClient, "verify_available", _verify_available)
+
+
+async def _run_tick(
+    *,
+    cwd: Path,
+    client: BeadClient,
+    schedule: AssumptionScheduleConfig,
+    notif: NotificationConfig,
+    now: datetime,
+    transport: httpx.MockTransport,
+) -> tuple[EvaluationOutcome, DeliveryState]:
+    """One ``maverick notify`` evaluation.
+
+    Replicates ``notify.py``'s real-mode ``_evaluate_and_effect`` body —
+    the same ``report_entries`` -> ``evaluate`` -> deliver ->
+    ``finalize_state`` -> ``save_state`` composition — sans the CLI/lock
+    plumbing around it (lock acquisition and the JSON envelope are proven
+    directly against the CLI in ``tests/unit/cli/commands/test_notify_json.py``).
+    Driven with an injected *now* instead of the wall clock (research R6).
+    """
+    entries = await report_entries(client)
+    state = await load_state(cwd)
+    outcome = evaluate(entries, schedule, state, now)
+
+    failed_indices: set[int] = set()
+    if outcome.deliveries:
+        assert notif.topic is not None
+        async with NtfyDeliverer(
+            server=notif.server,
+            topic=notif.topic,
+            transport=transport,
+            wait=wait_fixed(0),
+        ) as deliverer:
+            for index, decision in enumerate(outcome.deliveries):
+                try:
+                    await deliverer.deliver(decision.kind, decision.summary)
+                except DeliveryFailedError:
+                    failed_indices.add(index)
+
+    final_state = finalize_state(
+        outcome=outcome, prior_state=state, failed_indices=failed_indices, now=now
+    )
+    await save_state(final_state, cwd)
+    return outcome, final_state
+
+
+def _mock_transport(sent: list[httpx.Request]) -> httpx.MockTransport:
+    def _handler(request: httpx.Request) -> httpx.Response:
+        sent.append(request)
+        return httpx.Response(200)
+
+    return httpx.MockTransport(_handler)
+
+
+@pytest.mark.asyncio
+async def test_overnight_accumulation_delivers_exactly_one_batch_and_stays_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SC-001 + SC-003: entries recorded at arbitrary overnight hours
+    accumulate silently through quiet hours and deliver as exactly one
+    09:00 batch; re-running afterwards — within the same window, and
+    later the same day with nothing new — never re-delivers.
+
+    A single configured window (rather than the human-facing 09:00/17:00
+    pair) keeps this scenario isolated to the 09:00 occurrence under test:
+    a 17:00 window would already be past-due by the "overnight" ticks
+    below (FR-020's delayed-cron behavior, pinned separately in
+    ``tests/unit/assumptions/schedule/test_evaluate_windows.py``'s
+    ``TestDelayedCron``) and would contaminate the "nothing fires
+    overnight" assertion with an unrelated occurrence.
+    """
+    schedule = AssumptionScheduleConfig(
+        windows=["09:00"],
+        quiet_hours=QuietHoursConfig(start="22:00", end="07:00"),
+        min_batch_size=1,
+    )
+    notif = NotificationConfig(enabled=True, server="https://ntfy.test", topic="scheduler-test")
+
+    beads: dict[str, BeadDetails] = {}
+    _wire_ledger(monkeypatch, beads)
+    client = BeadClient(cwd=tmp_path)
+
+    sent: list[httpx.Request] = []
+    transport = _mock_transport(sent)
+
+    async def _tick(now: datetime) -> EvaluationOutcome:
+        outcome, _ = await _run_tick(
+            cwd=tmp_path,
+            client=client,
+            schedule=schedule,
+            notif=notif,
+            now=now,
+            transport=transport,
+        )
+        return outcome
+
+    # Seed continuity: settle *yesterday's* 09:00 occurrence (empty — no
+    # entries recorded yet) before quiet hours begin, exactly as a
+    # daily-running cron already would have. Without this, the very first
+    # evaluation below (at 23:30) would itself be evaluating an
+    # already-past-due-but-never-decided 09:00 occurrence and would
+    # deliver immediately (FR-020) — this seed isolates the scenario to
+    # the *next* day's 09:00 occurrence, the one actually under test.
+    await _tick(datetime(2026, 8, 5, 9, 5, tzinfo=NY))
+    assert sent == []
+
+    # Entries recorded at arbitrary hours overnight, inside quiet hours:
+    # each evaluation accumulates silently, nothing fires.
+    beads["mav-1"] = _bead("mav-1", created_at="2026-08-05T23:10:00Z")
+    await _tick(datetime(2026, 8, 5, 23, 30, tzinfo=NY))
+    assert sent == []
+
+    beads["mav-2"] = _bead("mav-2", created_at="2026-08-06T02:45:00Z")
+    await _tick(datetime(2026, 8, 6, 3, 0, tzinfo=NY))
+    assert sent == []
+
+    beads["mav-3"] = _bead("mav-3", created_at="2026-08-06T06:50:00Z")
+    await _tick(datetime(2026, 8, 6, 6, 55, tzinfo=NY))
+    assert sent == []
+
+    # 09:00: exactly one batch, covering every accumulated entry.
+    delivered = await _tick(datetime(2026, 8, 6, 9, 0, tzinfo=NY))
+    assert len(sent) == 1
+    assert len(delivered.deliveries) == 1
+    batch = delivered.deliveries[0]
+    assert set(batch.entry_ids) == {"mav-1", "mav-2", "mav-3"}
+
+    # 09:05, same window: idempotent re-run (SC-003) — zero new pushes.
+    rerun = await _tick(datetime(2026, 8, 6, 9, 5, tzinfo=NY))
+    assert rerun.deliveries == ()
+    assert any(skip.reason.value == "already-delivered" for skip in rerun.skips)
+    assert len(sent) == 1
+
+    # Later the same day, nothing new accumulated: nothing due — the
+    # single 09:00 occurrence for today is already decided. Picked well
+    # under mav-1's 24h max_entry_age_hours (created 2026-08-05T23:10:00Z)
+    # so this tick stays isolated to window-batch idempotence and doesn't
+    # cross into US4's max-age escalation (T027) — that interaction is
+    # covered separately in test_evaluate_escalation.py.
+    later = await _tick(datetime(2026, 8, 6, 15, 0, tzinfo=NY))
+    assert later.deliveries == ()
+    assert len(sent) == 1
+
+    # SC-004: the delivery is fully reconstructible from state.json alone.
+    state_path = tmp_path / ".maverick" / "notify" / "state.json"
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+    key = "2026-08-06/09:00"
+    window_decision = persisted["window_decisions"][key]
+    assert window_decision["outcome"] == "delivered"
+    assert set(window_decision["entry_ids"]) == {"mav-1", "mav-2", "mav-3"}
+    assert window_decision["rule"]  # non-empty rule citation
+
+    assert len(persisted["deliveries"]) == 1
+    delivery_record = persisted["deliveries"][0]
+    assert delivery_record["kind"] == "window-batch"
+    assert delivery_record["trigger"] == key
+    assert set(delivery_record["entry_ids"]) == {"mav-1", "mav-2", "mav-3"}
+    assert delivery_record["delivered_at"]
+
+
+@pytest.mark.asyncio
+async def test_every_entry_is_accounted_for_across_a_mixed_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SC-005: across a run mixing an open medium entry, an open high
+    entry, an already-answered entry, an already-waived entry, and a
+    low-severity entry, every single entry ends the evaluation either
+    delivered, human-resolved, or knowingly silent-and-low — none is
+    silently dropped from evaluation (FR-016)."""
+    schedule = AssumptionScheduleConfig(windows=["09:00"], min_batch_size=1)
+    notif = NotificationConfig(enabled=True, server="https://ntfy.test", topic="scheduler-test")
+
+    beads: dict[str, BeadDetails] = {
+        "mav-med": _bead("mav-med", severity="medium", created_at="2026-08-06T05:00:00Z"),
+        "mav-hi": _bead("mav-hi", severity="high", created_at="2026-08-06T05:00:00Z"),
+        "mav-answered": _bead(
+            "mav-answered",
+            severity="medium",
+            status=STATUS_ANSWERED,
+            created_at="2026-08-06T05:00:00Z",
+            answer_text="Yes.",
+        ),
+        "mav-waived": _bead(
+            "mav-waived",
+            severity="medium",
+            status=STATUS_WAIVED,
+            created_at="2026-08-06T05:00:00Z",
+            waived_by="alice",
+            waive_reason="not needed",
+        ),
+        "mav-low": _bead("mav-low", severity="low", created_at="2026-08-06T05:00:00Z"),
+    }
+    _wire_ledger(monkeypatch, beads)
+    client = BeadClient(cwd=tmp_path)
+    sent: list[httpx.Request] = []
+    transport = _mock_transport(sent)
+
+    outcome, final_state = await _run_tick(
+        cwd=tmp_path,
+        client=client,
+        schedule=schedule,
+        notif=notif,
+        now=datetime(2026, 8, 6, 14, 0, tzinfo=NY),
+        transport=transport,
+    )
+
+    covered_by_delivery: set[str] = set()
+    for decision in outcome.deliveries:
+        covered_by_delivery.update(decision.entry_ids)
+
+    entries = await report_entries(client)
+    for entry in entries:
+        bead_id = entry.record.bead_id
+        if bead_id in covered_by_delivery:
+            continue
+        if entry.bucket in ("resolved", "waived"):
+            continue  # human-resolved — accounted for
+        if entry.record.severity.value == "low":
+            continue  # knowingly silent by design (clarification Q5) — not a drop
+        pytest.fail(f"entry {bead_id} was neither delivered, resolved, nor low-severity")
+
+    # Concretely: the open medium and high entries were both delivered
+    # (as a window batch and an interrupt respectively, no cross-talk)...
+    assert "mav-med" in covered_by_delivery
+    assert "mav-hi" in covered_by_delivery
+    # ...the already-resolved entries never entered a batch at all
+    # (FR-014, structural exclusion)...
+    assert "mav-answered" not in covered_by_delivery
+    assert "mav-waived" not in covered_by_delivery
+    # ...and the low entry is tracked (so its age is auditable) but never
+    # delivered on its own — silently accumulating by design, not dropped.
+    assert "mav-low" in final_state.entry_tracking
+    assert "mav-low" not in covered_by_delivery

--- a/tests/unit/assumptions/schedule/test_clock.py
+++ b/tests/unit/assumptions/schedule/test_clock.py
@@ -1,0 +1,284 @@
+"""Tests for ``maverick.assumptions.schedule.clock`` — IANA local-zone resolution.
+
+These cover the DST-correctness contract behind research R6: the evaluation
+clock injected at the CLI boundary must carry a *real* zone (whose UTC offset
+varies across a DST transition), not the fixed-offset ``timezone`` that
+``datetime.now().astimezone()`` produces.
+
+Every source (``TZ``, ``/etc/localtime``, ``/etc/timezone``) is stubbed, so no
+assertion depends on the timezone the CI machine happens to be configured for.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import pytest
+
+from maverick.assumptions.schedule import clock
+
+#: A zone with a well-known DST transition (2026-03-08 02:00 local).
+_DST_ZONE = "America/New_York"
+
+
+def _tzdata_available() -> bool:
+    """Whether the tz database can be queried at all on this machine."""
+    try:
+        ZoneInfo(_DST_ZONE)
+    except (ZoneInfoNotFoundError, ValueError, OSError):
+        return False
+    return True
+
+
+#: Tests that need a real zone to exist; everything else (fall-through,
+#: fixed-offset degradation) runs regardless of the machine's tz database.
+requires_tzdata = pytest.mark.skipif(
+    not _tzdata_available(), reason="tz database unavailable on this machine"
+)
+
+
+def _zoneinfo_root() -> Path:
+    """Return the system zoneinfo directory, skipping if unavailable."""
+    root = Path("/usr/share/zoneinfo")
+    if not (root / _DST_ZONE).exists():
+        pytest.skip("system zoneinfo directory not available")
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sources(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point every resolution source at nothing, so each test opts in explicitly."""
+    monkeypatch.delenv("TZ", raising=False)
+    monkeypatch.setattr(clock, "_LOCALTIME_PATH", tmp_path / "missing-localtime")
+    monkeypatch.setattr(clock, "_TIMEZONE_FILE_PATH", tmp_path / "missing-timezone")
+
+
+@requires_tzdata
+class TestTzEnvironmentVariable:
+    def test_resolves_zone_named_by_tz(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TZ", _DST_ZONE)
+
+        tz = clock.local_timezone()
+
+        assert isinstance(tz, ZoneInfo)
+        assert tz.key == _DST_ZONE
+
+    def test_strips_posix_leading_colon(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TZ", f":{_DST_ZONE}")
+
+        tz = clock.local_timezone()
+
+        assert isinstance(tz, ZoneInfo)
+        assert tz.key == _DST_ZONE
+
+    def test_unknown_tz_value_falls_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TZ", "Not/AZone")
+
+        tz = clock.local_timezone()
+
+        assert not isinstance(tz, ZoneInfo)
+
+    def test_posix_offset_string_falls_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # "EST5EDT" is a legal POSIX TZ spelling that also happens to be a
+        # zoneinfo key on most systems; "<+07>-7" is not a key anywhere.
+        monkeypatch.setenv("TZ", "<+07>-7")
+
+        tz = clock.local_timezone()
+
+        assert not isinstance(tz, ZoneInfo)
+
+    def test_empty_tz_falls_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TZ", "")
+
+        tz = clock.local_timezone()
+
+        assert not isinstance(tz, ZoneInfo)
+
+
+@requires_tzdata
+class TestLocaltimeSymlink:
+    def test_resolves_zone_from_symlink_target(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        target = _zoneinfo_root() / _DST_ZONE
+        link = tmp_path / "localtime"
+        link.symlink_to(target)
+        monkeypatch.setattr(clock, "_LOCALTIME_PATH", link)
+
+        tz = clock.local_timezone()
+
+        assert isinstance(tz, ZoneInfo)
+        assert tz.key == _DST_ZONE
+
+    def test_resolves_relative_symlink_target(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Mirrors distros that ship /etc/localtime -> ../usr/share/zoneinfo/...
+        zone_dir = tmp_path / "usr" / "share" / "zoneinfo" / "America"
+        zone_dir.mkdir(parents=True)
+        (zone_dir / "New_York").write_bytes(b"TZif")
+        etc = tmp_path / "etc"
+        etc.mkdir()
+        link = etc / "localtime"
+        link.symlink_to(Path("..") / "usr" / "share" / "zoneinfo" / "America" / "New_York")
+        monkeypatch.setattr(clock, "_LOCALTIME_PATH", link)
+
+        tz = clock.local_timezone()
+
+        assert isinstance(tz, ZoneInfo)
+        assert tz.key == _DST_ZONE
+
+    def test_tz_env_wins_over_symlink(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        link = tmp_path / "localtime"
+        link.symlink_to(_zoneinfo_root() / "Europe" / "Berlin")
+        monkeypatch.setattr(clock, "_LOCALTIME_PATH", link)
+        monkeypatch.setenv("TZ", _DST_ZONE)
+
+        tz = clock.local_timezone()
+
+        assert isinstance(tz, ZoneInfo)
+        assert tz.key == _DST_ZONE
+
+    def test_plain_file_without_zoneinfo_component_falls_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        copied = tmp_path / "localtime"
+        copied.write_bytes(b"TZif2")
+        monkeypatch.setattr(clock, "_LOCALTIME_PATH", copied)
+
+        tz = clock.local_timezone()
+
+        assert not isinstance(tz, ZoneInfo)
+
+
+@requires_tzdata
+class TestTimezoneFile:
+    def test_resolves_zone_from_etc_timezone(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        tz_file = tmp_path / "timezone"
+        tz_file.write_text(f"{_DST_ZONE}\n")
+        monkeypatch.setattr(clock, "_TIMEZONE_FILE_PATH", tz_file)
+
+        tz = clock.local_timezone()
+
+        assert isinstance(tz, ZoneInfo)
+        assert tz.key == _DST_ZONE
+
+    def test_garbage_contents_fall_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        tz_file = tmp_path / "timezone"
+        tz_file.write_text("# nothing useful here\n")
+        monkeypatch.setattr(clock, "_TIMEZONE_FILE_PATH", tz_file)
+
+        tz = clock.local_timezone()
+
+        assert not isinstance(tz, ZoneInfo)
+
+    def test_symlink_wins_over_timezone_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        link = tmp_path / "localtime"
+        link.symlink_to(_zoneinfo_root() / _DST_ZONE)
+        monkeypatch.setattr(clock, "_LOCALTIME_PATH", link)
+        tz_file = tmp_path / "timezone"
+        tz_file.write_text("Europe/Berlin\n")
+        monkeypatch.setattr(clock, "_TIMEZONE_FILE_PATH", tz_file)
+
+        tz = clock.local_timezone()
+
+        assert isinstance(tz, ZoneInfo)
+        assert tz.key == _DST_ZONE
+
+
+class TestFallback:
+    def test_unresolvable_degrades_to_fixed_offset(self) -> None:
+        tz = clock.local_timezone()
+
+        assert not isinstance(tz, ZoneInfo)
+        assert isinstance(tz, timezone)
+
+    def test_unresolvable_now_local_is_aware(self) -> None:
+        now = clock.now_local()
+
+        assert now.tzinfo is not None
+        assert now.utcoffset() is not None
+
+    def test_degradation_is_logged_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        events: list[tuple[str, dict[str, object]]] = []
+
+        class _Recorder:
+            def warning(self, event: str, **kwargs: object) -> None:
+                events.append((event, kwargs))
+
+        monkeypatch.setattr(clock, "_degradation_logged", False)
+        monkeypatch.setattr(clock, "logger", _Recorder())
+
+        clock.local_timezone()
+        clock.local_timezone()
+
+        assert len(events) == 1
+        assert events[0][0] == "local_timezone_unresolved"
+
+    @requires_tzdata
+    def test_resolved_zone_logs_no_degradation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        events: list[str] = []
+
+        class _Recorder:
+            def warning(self, event: str, **kwargs: object) -> None:
+                events.append(event)
+
+        monkeypatch.setattr(clock, "_degradation_logged", False)
+        monkeypatch.setattr(clock, "logger", _Recorder())
+        monkeypatch.setenv("TZ", _DST_ZONE)
+
+        clock.local_timezone()
+
+        assert events == []
+
+
+class TestDstAwareness:
+    """The regression this module exists for: a resolvable zone must yield a
+    *different* UTC offset on either side of a DST transition."""
+
+    @requires_tzdata
+    def test_offset_differs_across_dst_boundary(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TZ", _DST_ZONE)
+
+        tz = clock.local_timezone()
+
+        before = datetime(2026, 3, 7, 10, 0, tzinfo=tz)  # EST (UTC-5)
+        after = datetime(2026, 3, 9, 10, 0, tzinfo=tz)  # EDT (UTC-4)
+        assert before.utcoffset() != after.utcoffset()
+
+    def test_fixed_offset_fallback_cannot_vary(self) -> None:
+        tz = clock.local_timezone()
+
+        before = datetime(2026, 3, 7, 10, 0, tzinfo=tz)
+        after = datetime(2026, 3, 9, 10, 0, tzinfo=tz)
+        assert before.utcoffset() == after.utcoffset()
+
+
+@requires_tzdata
+class TestNowLocal:
+    def test_carries_resolved_zone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TZ", _DST_ZONE)
+
+        now = clock.now_local()
+
+        assert isinstance(now.tzinfo, ZoneInfo)
+        assert now.tzinfo.key == _DST_ZONE
+
+    def test_matches_wall_clock_instant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TZ", _DST_ZONE)
+
+        before = datetime.now(tz=ZoneInfo(_DST_ZONE))
+        now = clock.now_local()
+        after = datetime.now(tz=ZoneInfo(_DST_ZONE))
+
+        assert before <= now <= after

--- a/tests/unit/assumptions/schedule/test_deliver.py
+++ b/tests/unit/assumptions/schedule/test_deliver.py
@@ -1,0 +1,278 @@
+"""Tests for the ntfy deliverer (contracts/ntfy-payload.md, tasks.md T012).
+
+Covers request shape (URL, headers, body template), the window-batch
+priority mapping, the retry-on-5xx/transport-error and no-retry-on-4xx
+policies, the typed error raised once retries are exhausted, and the
+content-free-payload guarantee (FR-008).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from tenacity import wait_none
+
+from maverick.assumptions.models import Severity
+from maverick.assumptions.schedule.deliver import (
+    DeliveryFailedError,
+    NtfyDeliverer,
+    build_payload,
+)
+from maverick.assumptions.schedule.models import BatchSummary, DecisionKind
+
+_SERVER = "https://ntfy.example.com"
+_TOPIC = "maverick-assumptions"
+
+
+def _make_summary(
+    *,
+    high: int = 1,
+    medium: int = 2,
+    low: int = 3,
+    owner_specs: tuple[str, ...] = ("054-assumption-batch-scheduler",),
+    oldest_age_hours: float = 26.5,
+    review_invocation: str = "maverick review --list --status open",
+) -> BatchSummary:
+    return BatchSummary(
+        counts={Severity.HIGH: high, Severity.MEDIUM: medium, Severity.LOW: low},
+        owner_specs=owner_specs,
+        oldest_age_hours=oldest_age_hours,
+        review_invocation=review_invocation,
+    )
+
+
+def _deliverer(handler: httpx.MockTransport, *, wait: object = None) -> NtfyDeliverer:
+    return NtfyDeliverer(
+        _SERVER,
+        _TOPIC,
+        transport=handler,
+        wait=wait_none() if wait is None else wait,
+    )
+
+
+class _CountingHandler:
+    """A MockTransport handler that records every request and can be
+    scripted to return a fixed sequence of responses/exceptions."""
+
+    def __init__(self, responses: list[httpx.Response | Exception]) -> None:
+        self._responses = list(responses)
+        self.requests: list[httpx.Request] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        outcome = self._responses[len(self.requests) - 1]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    @property
+    def call_count(self) -> int:
+        return len(self.requests)
+
+
+# --- build_payload -----------------------------------------------------------
+
+
+class TestBuildPayload:
+    def test_window_batch_title_and_priority(self) -> None:
+        summary = _make_summary(high=1, medium=2, low=3)
+
+        payload = build_payload(DecisionKind.WINDOW_BATCH, summary)
+
+        assert payload.title == "Assumption review: 6 open entries"
+        assert payload.priority == "default"
+        assert payload.tags == "maverick,assumptions"
+
+    def test_interrupt_escalation_renotify_are_urgent(self) -> None:
+        summary = _make_summary()
+
+        for kind, expected_title in (
+            (DecisionKind.INTERRUPT, "High-severity assumption recorded"),
+            (DecisionKind.ESCALATION, "Assumption entries aging past limit"),
+            (DecisionKind.RENOTIFY, "High-severity assumption still unanswered"),
+        ):
+            payload = build_payload(kind, summary)
+            assert payload.priority == "urgent"
+            assert payload.title == expected_title
+
+    def test_body_matches_template(self) -> None:
+        summary = _make_summary(
+            high=1,
+            medium=2,
+            low=3,
+            owner_specs=("054-assumption-batch-scheduler", "049-assumption-ledger"),
+            oldest_age_hours=26.5,
+            review_invocation="maverick review --list --status open",
+        )
+
+        payload = build_payload(DecisionKind.WINDOW_BATCH, summary)
+
+        assert payload.body == (
+            "1 high, 2 medium, 3 low open across "
+            "054-assumption-batch-scheduler, 049-assumption-ledger.\n"
+            "Oldest: 26.5h.\n"
+            "Run: maverick review --list --status open"
+        )
+
+    def test_body_contains_no_entry_content_fields(self) -> None:
+        """FR-008: the payload must never carry entry-specific content —
+        BatchSummary structurally has none to leak, but pin it anyway."""
+        summary = _make_summary(
+            review_invocation="maverick review --list --spec 054 --status open"
+        )
+
+        payload = build_payload(DecisionKind.WINDOW_BATCH, summary)
+        full_text = f"{payload.title}\n{payload.body}"
+
+        for forbidden in ("bd-", "question", "answer", "waive", "rationale", "alternative"):
+            assert forbidden not in full_text.lower()
+
+
+# --- NtfyDeliverer: request shape ---------------------------------------------
+
+
+class TestNtfyDelivererRequestShape:
+    @pytest.mark.asyncio
+    async def test_posts_to_server_slash_topic(self) -> None:
+        handler = _CountingHandler([httpx.Response(200)])
+        deliverer = _deliverer(httpx.MockTransport(handler))
+
+        await deliverer.deliver(DecisionKind.WINDOW_BATCH, _make_summary())
+        await deliverer.aclose()
+
+        assert handler.call_count == 1
+        request = handler.requests[0]
+        assert request.method == "POST"
+        assert str(request.url) == f"{_SERVER}/{_TOPIC}"
+
+    @pytest.mark.asyncio
+    async def test_headers_and_body_sent_on_wire(self) -> None:
+        handler = _CountingHandler([httpx.Response(200)])
+        deliverer = _deliverer(httpx.MockTransport(handler))
+        summary = _make_summary(high=0, medium=1, low=0)
+
+        await deliverer.deliver(DecisionKind.WINDOW_BATCH, summary)
+        await deliverer.aclose()
+
+        request = handler.requests[0]
+        assert request.headers["Title"] == "Assumption review: 1 open entries"
+        assert request.headers["Priority"] == "default"
+        assert request.headers["Tags"] == "maverick,assumptions"
+        assert (
+            request.content.decode("utf-8")
+            == build_payload(DecisionKind.WINDOW_BATCH, summary).body
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_trailing_slash_normalized(self) -> None:
+        handler = _CountingHandler([httpx.Response(200)])
+        deliverer = NtfyDeliverer(
+            f"{_SERVER}/",
+            _TOPIC,
+            transport=httpx.MockTransport(handler),
+            wait=wait_none(),
+        )
+
+        await deliverer.deliver(DecisionKind.WINDOW_BATCH, _make_summary())
+        await deliverer.aclose()
+
+        assert str(handler.requests[0].url) == f"{_SERVER}/{_TOPIC}"
+
+
+# --- NtfyDeliverer: retry policy -----------------------------------------------
+
+
+class TestNtfyDelivererRetryPolicy:
+    @pytest.mark.asyncio
+    async def test_retries_on_5xx_then_succeeds(self) -> None:
+        handler = _CountingHandler([httpx.Response(503), httpx.Response(502), httpx.Response(200)])
+        deliverer = _deliverer(httpx.MockTransport(handler))
+
+        await deliverer.deliver(DecisionKind.WINDOW_BATCH, _make_summary())
+        await deliverer.aclose()
+
+        assert handler.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retries_on_transport_error_then_succeeds(self) -> None:
+        handler = _CountingHandler(
+            [
+                httpx.ConnectError("connection refused"),
+                httpx.ReadTimeout("timed out"),
+                httpx.Response(200),
+            ]
+        )
+        deliverer = _deliverer(httpx.MockTransport(handler))
+
+        await deliverer.deliver(DecisionKind.WINDOW_BATCH, _make_summary())
+        await deliverer.aclose()
+
+        assert handler.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_exhausted_5xx_retries_raise_typed_error(self) -> None:
+        handler = _CountingHandler([httpx.Response(500), httpx.Response(500), httpx.Response(500)])
+        deliverer = _deliverer(httpx.MockTransport(handler))
+
+        with pytest.raises(DeliveryFailedError) as exc_info:
+            await deliverer.deliver(DecisionKind.WINDOW_BATCH, _make_summary())
+        await deliverer.aclose()
+
+        assert handler.call_count == 3
+        assert exc_info.value.kind == DecisionKind.WINDOW_BATCH
+        assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_exhausted_transport_error_retries_raise_typed_error(self) -> None:
+        handler = _CountingHandler(
+            [
+                httpx.ConnectError("connection refused"),
+                httpx.ConnectError("connection refused"),
+                httpx.ConnectError("connection refused"),
+            ]
+        )
+        deliverer = _deliverer(httpx.MockTransport(handler))
+
+        with pytest.raises(DeliveryFailedError) as exc_info:
+            await deliverer.deliver(DecisionKind.WINDOW_BATCH, _make_summary())
+        await deliverer.aclose()
+
+        assert handler.call_count == 3
+        assert exc_info.value.status_code is None
+
+    @pytest.mark.asyncio
+    async def test_4xx_fails_immediately_without_retry(self) -> None:
+        handler = _CountingHandler([httpx.Response(400)])
+        deliverer = _deliverer(httpx.MockTransport(handler))
+
+        with pytest.raises(DeliveryFailedError) as exc_info:
+            await deliverer.deliver(DecisionKind.WINDOW_BATCH, _make_summary())
+        await deliverer.aclose()
+
+        assert handler.call_count == 1
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_404_fails_immediately_without_retry(self) -> None:
+        handler = _CountingHandler([httpx.Response(404)])
+        deliverer = _deliverer(httpx.MockTransport(handler))
+
+        with pytest.raises(DeliveryFailedError):
+            await deliverer.deliver(DecisionKind.WINDOW_BATCH, _make_summary())
+        await deliverer.aclose()
+
+        assert handler.call_count == 1
+
+
+# --- Async context manager -----------------------------------------------------
+
+
+class TestNtfyDelivererContextManager:
+    @pytest.mark.asyncio
+    async def test_async_context_manager_closes_client(self) -> None:
+        handler = _CountingHandler([httpx.Response(200)])
+
+        async with _deliverer(httpx.MockTransport(handler)) as deliverer:
+            await deliverer.deliver(DecisionKind.WINDOW_BATCH, _make_summary())
+
+        assert handler.call_count == 1

--- a/tests/unit/assumptions/schedule/test_evaluate_escalation.py
+++ b/tests/unit/assumptions/schedule/test_evaluate_escalation.py
@@ -1,0 +1,531 @@
+"""Escalation, backoff, and auto-waive evaluation tests (tasks.md T025, T026).
+
+Covers US4 (age-based escalation and explicit expiry): max-age escalation
+for medium entries bypassing min-batch-size (FR-006, spec.md US4 scenario
+1), exactly-once escalation (FR-007), backoff-ladder re-notification for
+high entries with the last rung repeating (FR-007), low entries never
+escalating to delivery (clarification Q2), quiet-hours gating shared with
+interrupts (FR-004/FR-006), and opt-in auto-waive candidates for aged low
+entries (FR-015).
+
+Direct ``evaluate(entries, schedule, state, now)`` calls with injected
+aware local datetimes only — no freezegun, no ``datetime.now`` mocking
+(plan.md Constitution Check, Principle III).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from maverick.assumptions.models import (
+    STATUS_OPEN,
+    AssumptionRecord,
+    AssumptionReportEntry,
+    Severity,
+)
+from maverick.assumptions.schedule.evaluate import evaluate
+from maverick.assumptions.schedule.models import DecisionKind, SkipReason
+from maverick.assumptions.schedule.state import DeliveryState, EntryTrackingRecord
+from maverick.config import AssumptionScheduleConfig, AutoWaivePolicyConfig, QuietHoursConfig
+
+NY = ZoneInfo("America/New_York")
+
+
+def _iso(dt: datetime) -> str:
+    """UTC ISO-8601 ``...Z`` timestamp, matching bd's own ``created_at`` shape."""
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _config(
+    *,
+    windows: list[str] | None = None,
+    min_batch_size: int = 1,
+    max_entry_age_hours: int = 24,
+    renotify_backoff_hours: list[float] | None = None,
+    quiet_hours: QuietHoursConfig | None = None,
+    high_overrides_quiet: bool = True,
+    auto_waive_low: AutoWaivePolicyConfig | None = None,
+) -> AssumptionScheduleConfig:
+    return AssumptionScheduleConfig(
+        windows=windows if windows is not None else ["09:00"],
+        min_batch_size=min_batch_size,
+        max_entry_age_hours=max_entry_age_hours,
+        renotify_backoff_hours=(
+            renotify_backoff_hours
+            if renotify_backoff_hours is not None
+            else [4.0, 8.0, 16.0, 24.0]
+        ),
+        quiet_hours=quiet_hours,
+        high_overrides_quiet=high_overrides_quiet,
+        auto_waive_low=auto_waive_low,
+    )
+
+
+def _state(**overrides: object) -> DeliveryState:
+    defaults: dict[str, object] = {"updated_at": "2026-08-01T00:00:00Z"}
+    defaults.update(overrides)
+    return DeliveryState(**defaults)  # type: ignore[arg-type]
+
+
+def _entry(
+    bead_id: str,
+    *,
+    severity: Severity = Severity.MEDIUM,
+    status: str = STATUS_OPEN,
+    owner_spec: str = "054-assumption-batch-scheduler",
+    created_at: str | None = None,
+) -> AssumptionReportEntry:
+    return AssumptionReportEntry(
+        record=AssumptionRecord(
+            bead_id=bead_id,
+            question="Q?",
+            adopted_answer="A.",
+            alternatives=(),
+            severity=severity,
+            severity_defaulted=False,
+            status=status,
+            owner_spec=owner_spec,
+            source_bead="mav-source",
+            change_ids=(),
+            is_legacy=False,
+            created_at=created_at,
+        ),
+        final_answer=None,
+        waived_by=None,
+        waived_at=None,
+        waive_reason=None,
+        reconcile_status=None,
+        reconciled_answer=None,
+        reconcile_change_id=None,
+        reconcile_reason=None,
+        pending_reconcile=False,
+    )
+
+
+_FAR_PAST = datetime(2026, 8, 1, 0, 0, tzinfo=NY)
+
+
+class TestMediumMaxAgeEscalation:
+    """FR-006/FR-007, US4 acceptance scenario 1."""
+
+    def test_aged_medium_below_min_batch_escalates_bypassing_min_batch_size(self) -> None:
+        schedule = _config(windows=["09:00"], min_batch_size=5, max_entry_age_hours=24)
+        entries = (_entry("mav-1", severity=Severity.MEDIUM, created_at=_iso(_FAR_PAST)),)
+        now = datetime(2026, 8, 6, 9, 5, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), now)
+
+        # The window itself still rolls the entry forward (min_batch_size
+        # not met)...
+        min_batch_skips = [s for s in outcome.skips if s.reason == SkipReason.MIN_BATCH_SIZE]
+        assert len(min_batch_skips) == 1
+        assert min_batch_skips[0].entry_ids == ("mav-1",)
+
+        # ...but escalation delivers it anyway, bypassing that rule.
+        escalations = [d for d in outcome.deliveries if d.kind == DecisionKind.ESCALATION]
+        assert len(escalations) == 1
+        assert escalations[0].entry_ids == ("mav-1",)
+        assert escalations[0].occurrence is None
+
+        tracked = outcome.state_after.entry_tracking["mav-1"]
+        assert tracked.escalation_delivered_at is not None
+
+    def test_medium_escalates_exactly_once(self) -> None:
+        """FR-007: an escalated medium entry does not re-notify."""
+        schedule = _config(windows=["09:00"], min_batch_size=5, max_entry_age_hours=24)
+        entries = (_entry("mav-1", severity=Severity.MEDIUM, created_at=_iso(_FAR_PAST)),)
+        first_now = datetime(2026, 8, 6, 9, 5, tzinfo=NY)
+
+        first = evaluate(entries, schedule, _state(), first_now)
+        assert any(d.kind == DecisionKind.ESCALATION for d in first.deliveries)
+
+        second = evaluate(entries, schedule, first.state_after, first_now + timedelta(days=10))
+
+        assert not any(d.kind == DecisionKind.ESCALATION for d in second.deliveries)
+
+    def test_entry_delivered_via_window_batch_this_run_is_not_also_escalated(self) -> None:
+        """An entry delivered on time via its window batch is excluded from
+        escalation in the *same* evaluation — escalation is the safety net
+        for entries the batching rules would otherwise starve, not a
+        second delivery for one that just went out normally."""
+        schedule = _config(windows=["09:00"], min_batch_size=1, max_entry_age_hours=24)
+        entries = (_entry("mav-1", severity=Severity.MEDIUM, created_at=_iso(_FAR_PAST)),)
+        now = datetime(2026, 8, 6, 9, 5, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), now)
+
+        assert len(outcome.deliveries) == 1
+        assert outcome.deliveries[0].kind == DecisionKind.WINDOW_BATCH
+        assert not any(d.kind == DecisionKind.ESCALATION for d in outcome.deliveries)
+
+
+class TestHighBackoffRenotify:
+    """FR-007: an unanswered high entry past max age re-notifies on the
+    configured backoff ladder, the last rung repeating indefinitely."""
+
+    def _prior_state_with_interrupted_high(self, bead_id: str) -> DeliveryState:
+        return _state(
+            entry_tracking={
+                bead_id: EntryTrackingRecord(
+                    first_seen=_iso(_FAR_PAST),
+                    severity="high",
+                    interrupt_delivered_at=_iso(_FAR_PAST),
+                )
+            }
+        )
+
+    def test_renotify_fires_at_ladder_spacing_and_repeats_last_rung(self) -> None:
+        schedule = _config(
+            windows=["09:00"], max_entry_age_hours=1, renotify_backoff_hours=[4.0, 8.0]
+        )
+        entries = (_entry("mav-hi", severity=Severity.HIGH, created_at=_iso(_FAR_PAST)),)
+        state = self._prior_state_with_interrupted_high("mav-hi")
+        t0 = datetime(2026, 8, 6, 9, 0, tzinfo=NY)
+
+        # First renotify: due immediately (next_renotify_at was unset).
+        first = evaluate(entries, schedule, state, t0)
+        renotifies = [d for d in first.deliveries if d.kind == DecisionKind.RENOTIFY]
+        assert len(renotifies) == 1
+        assert renotifies[0].entry_ids == ("mav-hi",)
+        tracked1 = first.state_after.entry_tracking["mav-hi"]
+        assert tracked1.renotify_count == 1
+        assert tracked1.next_renotify_at is not None
+        assert _parse(tracked1.next_renotify_at) == (t0 + timedelta(hours=4)).astimezone(UTC)
+
+        # Too early for the next rung: nothing fires.
+        second = evaluate(entries, schedule, first.state_after, t0 + timedelta(hours=2))
+        assert not any(d.kind == DecisionKind.RENOTIFY for d in second.deliveries)
+        assert second.state_after.entry_tracking["mav-hi"].renotify_count == 1
+
+        # Second renotify: due at/after the first rung (4h); spacing to the
+        # next one uses the second rung (8h).
+        t1 = t0 + timedelta(hours=4, minutes=1)
+        third = evaluate(entries, schedule, first.state_after, t1)
+        renotifies3 = [d for d in third.deliveries if d.kind == DecisionKind.RENOTIFY]
+        assert len(renotifies3) == 1
+        tracked3 = third.state_after.entry_tracking["mav-hi"]
+        assert tracked3.renotify_count == 2
+        assert tracked3.next_renotify_at is not None
+        assert _parse(tracked3.next_renotify_at) == (t1 + timedelta(hours=8)).astimezone(UTC)
+
+        # Third renotify: the ladder is exhausted (2 rungs); the last rung
+        # (8h) repeats indefinitely.
+        t2 = _parse(tracked3.next_renotify_at).astimezone(NY) + timedelta(minutes=1)
+        fourth = evaluate(entries, schedule, third.state_after, t2)
+        renotifies4 = [d for d in fourth.deliveries if d.kind == DecisionKind.RENOTIFY]
+        assert len(renotifies4) == 1
+        tracked4 = fourth.state_after.entry_tracking["mav-hi"]
+        assert tracked4.renotify_count == 3
+        assert tracked4.next_renotify_at is not None
+        assert _parse(tracked4.next_renotify_at) == (t2 + timedelta(hours=8)).astimezone(UTC)
+
+    def test_high_not_yet_interrupted_is_not_renotify_eligible(self) -> None:
+        """A high entry with no prior interrupt delivery never renotifies —
+        it's still on the ordinary interrupt path (T020), not this one."""
+        schedule = _config(windows=["09:00"], max_entry_age_hours=1)
+        entries = (_entry("mav-hi", severity=Severity.HIGH, created_at=_iso(_FAR_PAST)),)
+        now = datetime(2026, 8, 6, 9, 0, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), now)
+
+        assert not any(d.kind == DecisionKind.RENOTIFY for d in outcome.deliveries)
+        assert any(d.kind == DecisionKind.INTERRUPT for d in outcome.deliveries)
+
+    def test_renotify_freshly_interrupted_this_evaluation_does_not_also_fire(self) -> None:
+        """An entry interrupted for the first time *in this very call* must
+        not simultaneously renotify — ``prior_tracking`` is the pre-call
+        snapshot, so a fresh interrupt is never renotify-eligible until a
+        later evaluation."""
+        schedule = _config(windows=["09:00"], max_entry_age_hours=1)
+        entries = (_entry("mav-hi", severity=Severity.HIGH, created_at=_iso(_FAR_PAST)),)
+        now = datetime(2026, 8, 6, 9, 0, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), now)
+
+        interrupts = [d for d in outcome.deliveries if d.kind == DecisionKind.INTERRUPT]
+        renotifies = [d for d in outcome.deliveries if d.kind == DecisionKind.RENOTIFY]
+        assert len(interrupts) == 1
+        assert renotifies == []
+
+
+class TestLowNeverEscalatesToDelivery:
+    """Clarification Q2: low never escalates to delivery — its only aging
+    path is the opt-in auto-waive policy."""
+
+    def test_aged_low_entry_never_produces_a_delivery(self) -> None:
+        schedule = _config(windows=["09:00"], max_entry_age_hours=1)
+        entries = (_entry("mav-lo", severity=Severity.LOW, created_at=_iso(_FAR_PAST)),)
+        now = datetime(2026, 8, 6, 9, 0, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), now)
+
+        assert outcome.deliveries == ()
+        low_skips = [s for s in outcome.skips if s.reason == SkipReason.LOW_NEVER_PROACTIVE]
+        assert len(low_skips) == 1
+        assert low_skips[0].entry_ids == ("mav-lo",)
+
+
+class TestMediumEscalationQuietHoursGating:
+    """Quiet hours gate escalation by *severity*, not by
+    ``high_overrides_quiet`` (FR-004, FR-006, contracts/config-schema.md:
+    the flag gates high-severity interrupts and high-severity
+    re-notifications, and only those). A medium entry's escalation is
+    therefore always held until quiet hours end, whichever way the override
+    is configured — an aged medium entry must never fire an urgent push at
+    03:00.
+    """
+
+    def _schedule(self, *, high_overrides_quiet: bool) -> AssumptionScheduleConfig:
+        return _config(
+            windows=["09:00"],
+            min_batch_size=5,
+            max_entry_age_hours=1,
+            quiet_hours=QuietHoursConfig(start="22:00", end="07:00"),
+            high_overrides_quiet=high_overrides_quiet,
+        )
+
+    def test_absolute_quiet_hours_hold_escalation_then_deliver_after_quiet_ends(self) -> None:
+        schedule = self._schedule(high_overrides_quiet=False)
+        entries = (_entry("mav-1", severity=Severity.MEDIUM, created_at=_iso(_FAR_PAST)),)
+        during_quiet = datetime(2026, 8, 6, 23, 30, tzinfo=NY)
+
+        held = evaluate(entries, schedule, _state(), during_quiet)
+
+        assert not any(d.kind == DecisionKind.ESCALATION for d in held.deliveries)
+        # Entry-scoped (`occurrence is None`) — the window-scoped quiet-hours
+        # hold is a separate skip with its own occurrence attached.
+        quiet_skips = [
+            s for s in held.skips if s.reason == SkipReason.QUIET_HOURS and s.occurrence is None
+        ]
+        assert len(quiet_skips) == 1
+        assert quiet_skips[0].entry_ids == ("mav-1",)
+        assert held.state_after.entry_tracking["mav-1"].escalation_delivered_at is None
+
+        after_quiet = datetime(2026, 8, 7, 7, 30, tzinfo=NY)
+        delivered = evaluate(entries, schedule, held.state_after, after_quiet)
+
+        escalations = [d for d in delivered.deliveries if d.kind == DecisionKind.ESCALATION]
+        assert len(escalations) == 1
+        assert escalations[0].entry_ids == ("mav-1",)
+
+    def test_default_override_still_holds_medium_escalation_during_quiet_hours(self) -> None:
+        """``high_overrides_quiet=True`` (the default) must not push a
+        *medium* escalation through quiet hours — it governs high severity
+        only. This is the 03:00 urgent-push regression."""
+        schedule = self._schedule(high_overrides_quiet=True)
+        entries = (_entry("mav-1", severity=Severity.MEDIUM, created_at=_iso(_FAR_PAST)),)
+        during_quiet = datetime(2026, 8, 6, 23, 30, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), during_quiet)
+
+        assert not any(d.kind == DecisionKind.ESCALATION for d in outcome.deliveries)
+        quiet_skips = [
+            s for s in outcome.skips if s.reason == SkipReason.QUIET_HOURS and s.occurrence is None
+        ]
+        assert len(quiet_skips) == 1
+        assert quiet_skips[0].entry_ids == ("mav-1",)
+        assert "quiet hours" in quiet_skips[0].rule
+        # Nothing stamped: the entry is still escalation-eligible.
+        assert outcome.state_after.entry_tracking["mav-1"].escalation_delivered_at is None
+
+    def test_held_medium_escalation_delivers_exactly_once_after_quiet_hours_end(self) -> None:
+        """FR-020: the held escalation becomes due at the first permissible
+        evaluation — and, per FR-007, fires there exactly once."""
+        schedule = self._schedule(high_overrides_quiet=True)
+        entries = (_entry("mav-1", severity=Severity.MEDIUM, created_at=_iso(_FAR_PAST)),)
+
+        held = evaluate(entries, schedule, _state(), datetime(2026, 8, 6, 23, 30, tzinfo=NY))
+        assert not any(d.kind == DecisionKind.ESCALATION for d in held.deliveries)
+
+        # 07:30 — the first evaluation quiet hours (22:00-07:00) permit.
+        delivered = evaluate(
+            entries, schedule, held.state_after, datetime(2026, 8, 7, 7, 30, tzinfo=NY)
+        )
+        escalations = [d for d in delivered.deliveries if d.kind == DecisionKind.ESCALATION]
+        assert len(escalations) == 1
+        assert escalations[0].entry_ids == ("mav-1",)
+        assert delivered.state_after.entry_tracking["mav-1"].escalation_delivered_at is not None
+
+        rerun = evaluate(
+            entries, schedule, delivered.state_after, datetime(2026, 8, 7, 8, 0, tzinfo=NY)
+        )
+        assert not any(d.kind == DecisionKind.ESCALATION for d in rerun.deliveries)
+
+
+class TestHighSeverityQuietHoursOverride:
+    """``high_overrides_quiet`` gates high-severity interrupts and
+    high-severity re-notifications identically, and *only* those
+    (contracts/config-schema.md). Default ``True`` => both punch through
+    quiet hours; ``False`` => quiet hours are absolute and both are held
+    until they end."""
+
+    def _schedule(self, *, high_overrides_quiet: bool) -> AssumptionScheduleConfig:
+        return _config(
+            windows=["09:00"],
+            min_batch_size=5,
+            max_entry_age_hours=1,
+            renotify_backoff_hours=[4.0],
+            quiet_hours=QuietHoursConfig(start="22:00", end="07:00"),
+            high_overrides_quiet=high_overrides_quiet,
+        )
+
+    def _interrupted_state(self, bead_id: str) -> DeliveryState:
+        return _state(
+            entry_tracking={
+                bead_id: EntryTrackingRecord(
+                    first_seen=_iso(_FAR_PAST),
+                    severity="high",
+                    interrupt_delivered_at=_iso(_FAR_PAST),
+                )
+            }
+        )
+
+    def test_default_override_delivers_high_interrupt_through_quiet_hours(self) -> None:
+        schedule = self._schedule(high_overrides_quiet=True)
+        entries = (_entry("mav-hi", severity=Severity.HIGH, created_at=_iso(_FAR_PAST)),)
+
+        outcome = evaluate(entries, schedule, _state(), datetime(2026, 8, 6, 23, 30, tzinfo=NY))
+
+        interrupts = [d for d in outcome.deliveries if d.kind == DecisionKind.INTERRUPT]
+        assert len(interrupts) == 1
+        assert interrupts[0].entry_ids == ("mav-hi",)
+        assert outcome.state_after.entry_tracking["mav-hi"].interrupt_delivered_at is not None
+
+    def test_absolute_quiet_hours_hold_high_interrupt_until_quiet_ends(self) -> None:
+        schedule = self._schedule(high_overrides_quiet=False)
+        entries = (_entry("mav-hi", severity=Severity.HIGH, created_at=_iso(_FAR_PAST)),)
+
+        held = evaluate(entries, schedule, _state(), datetime(2026, 8, 6, 23, 30, tzinfo=NY))
+
+        assert not any(d.kind == DecisionKind.INTERRUPT for d in held.deliveries)
+        quiet_skips = [
+            s for s in held.skips if s.reason == SkipReason.QUIET_HOURS and s.occurrence is None
+        ]
+        assert len(quiet_skips) == 1
+        assert quiet_skips[0].entry_ids == ("mav-hi",)
+        assert held.state_after.entry_tracking["mav-hi"].interrupt_delivered_at is None
+
+        delivered = evaluate(
+            entries, schedule, held.state_after, datetime(2026, 8, 7, 7, 30, tzinfo=NY)
+        )
+        interrupts = [d for d in delivered.deliveries if d.kind == DecisionKind.INTERRUPT]
+        assert len(interrupts) == 1
+        assert interrupts[0].entry_ids == ("mav-hi",)
+
+    def test_default_override_delivers_high_renotify_through_quiet_hours(self) -> None:
+        schedule = self._schedule(high_overrides_quiet=True)
+        entries = (_entry("mav-hi", severity=Severity.HIGH, created_at=_iso(_FAR_PAST)),)
+
+        outcome = evaluate(
+            entries,
+            schedule,
+            self._interrupted_state("mav-hi"),
+            datetime(2026, 8, 6, 23, 30, tzinfo=NY),
+        )
+
+        renotifies = [d for d in outcome.deliveries if d.kind == DecisionKind.RENOTIFY]
+        assert len(renotifies) == 1
+        assert renotifies[0].entry_ids == ("mav-hi",)
+        assert outcome.state_after.entry_tracking["mav-hi"].renotify_count == 1
+
+    def test_absolute_quiet_hours_hold_high_renotify_until_quiet_ends(self) -> None:
+        schedule = self._schedule(high_overrides_quiet=False)
+        entries = (_entry("mav-hi", severity=Severity.HIGH, created_at=_iso(_FAR_PAST)),)
+
+        held = evaluate(
+            entries,
+            schedule,
+            self._interrupted_state("mav-hi"),
+            datetime(2026, 8, 6, 23, 30, tzinfo=NY),
+        )
+
+        assert not any(d.kind == DecisionKind.RENOTIFY for d in held.deliveries)
+        quiet_skips = [
+            s for s in held.skips if s.reason == SkipReason.QUIET_HOURS and s.occurrence is None
+        ]
+        assert len(quiet_skips) == 1
+        assert quiet_skips[0].entry_ids == ("mav-hi",)
+        tracked = held.state_after.entry_tracking["mav-hi"]
+        assert tracked.renotify_count == 0
+        assert tracked.next_renotify_at is None
+
+        delivered = evaluate(
+            entries, schedule, held.state_after, datetime(2026, 8, 7, 7, 30, tzinfo=NY)
+        )
+        renotifies = [d for d in delivered.deliveries if d.kind == DecisionKind.RENOTIFY]
+        assert len(renotifies) == 1
+        assert delivered.state_after.entry_tracking["mav-hi"].renotify_count == 1
+
+
+# --- T026: auto-waive -------------------------------------------------------
+
+
+_AGED_LOW_CREATED_AT = _iso(_FAR_PAST)
+
+
+class TestAutoWaivePolicy:
+    """FR-015: opt-in auto-waive of aged low-severity entries."""
+
+    def test_policy_absent_never_yields_auto_waive_decision(self) -> None:
+        schedule = _config(windows=["09:00"], auto_waive_low=None)
+        entries = (_entry("mav-lo", severity=Severity.LOW, created_at=_AGED_LOW_CREATED_AT),)
+
+        outcome = evaluate(entries, schedule, _state(), datetime(2026, 8, 6, 9, 0, tzinfo=NY))
+
+        assert outcome.auto_waives == ()
+
+    def test_policy_disabled_never_yields_auto_waive_decision(self) -> None:
+        policy = AutoWaivePolicyConfig(enabled=False)
+        schedule = _config(windows=["09:00"], auto_waive_low=policy)
+        entries = (_entry("mav-lo", severity=Severity.LOW, created_at=_AGED_LOW_CREATED_AT),)
+
+        outcome = evaluate(entries, schedule, _state(), datetime(2026, 8, 6, 9, 0, tzinfo=NY))
+
+        assert outcome.auto_waives == ()
+
+    def test_enabled_aged_low_yields_decision_with_full_rationale_text(self) -> None:
+        policy = AutoWaivePolicyConfig(
+            enabled=True, after_hours=48, rationale="stale low-severity noise, accepted risk"
+        )
+        schedule = _config(windows=["09:00"], auto_waive_low=policy)
+        entries = (_entry("mav-lo", severity=Severity.LOW, created_at=_AGED_LOW_CREATED_AT),)
+
+        outcome = evaluate(entries, schedule, _state(), datetime(2026, 8, 6, 9, 0, tzinfo=NY))
+
+        assert len(outcome.auto_waives) == 1
+        decision = outcome.auto_waives[0]
+        assert decision.entry_id == "mav-lo"
+        assert "48h" in decision.reason_text
+        assert "stale low-severity noise, accepted risk" in decision.reason_text
+
+    def test_enabled_not_yet_aged_past_threshold_yields_no_decision(self) -> None:
+        policy = AutoWaivePolicyConfig(
+            enabled=True, after_hours=100_000, rationale="not aged enough"
+        )
+        schedule = _config(windows=["09:00"], auto_waive_low=policy)
+        entries = (_entry("mav-lo", severity=Severity.LOW, created_at=_AGED_LOW_CREATED_AT),)
+
+        outcome = evaluate(entries, schedule, _state(), datetime(2026, 8, 6, 9, 0, tzinfo=NY))
+
+        assert outcome.auto_waives == ()
+
+    def test_medium_and_high_entries_are_never_auto_waive_candidates(self) -> None:
+        """Auto-waive is a low-only path — medium/high age via
+        escalation/renotify instead, never auto-waive."""
+        policy = AutoWaivePolicyConfig(
+            enabled=True, after_hours=1, rationale="should never apply to non-low"
+        )
+        schedule = _config(windows=["09:00"], max_entry_age_hours=100_000, auto_waive_low=policy)
+        entries = (
+            _entry("mav-med", severity=Severity.MEDIUM, created_at=_AGED_LOW_CREATED_AT),
+            _entry("mav-hi", severity=Severity.HIGH, created_at=_AGED_LOW_CREATED_AT),
+        )
+
+        outcome = evaluate(entries, schedule, _state(), datetime(2026, 8, 6, 9, 0, tzinfo=NY))
+
+        assert outcome.auto_waives == ()

--- a/tests/unit/assumptions/schedule/test_evaluate_severity.py
+++ b/tests/unit/assumptions/schedule/test_evaluate_severity.py
@@ -1,0 +1,378 @@
+"""Severity-tier evaluation tests (tasks.md T011).
+
+Covers: medium batches only at windows, low counted-but-silent
+(clarification Q5), legacy entries batching like medium (FR-019, research
+R9), and structural exclusion of entries resolved before their window
+(FR-014).
+
+Direct ``evaluate(entries, schedule, state, now)`` calls with injected
+aware local datetimes only — no freezegun, no ``datetime.now`` mocking.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from maverick.assumptions.models import (
+    STATUS_ANSWERED,
+    STATUS_OPEN,
+    STATUS_WAIVED,
+    AssumptionRecord,
+    AssumptionReportEntry,
+    Severity,
+)
+from maverick.assumptions.schedule.evaluate import evaluate
+from maverick.assumptions.schedule.models import DecisionKind, SkipReason
+from maverick.assumptions.schedule.state import DeliveryState
+from maverick.config import AssumptionScheduleConfig, QuietHoursConfig
+
+NY = ZoneInfo("America/New_York")
+
+
+def _config(
+    *, windows: list[str] | None = None, min_batch_size: int = 1
+) -> AssumptionScheduleConfig:
+    return AssumptionScheduleConfig(
+        windows=windows if windows is not None else ["09:00"],
+        min_batch_size=min_batch_size,
+    )
+
+
+def _state() -> DeliveryState:
+    return DeliveryState(updated_at="2026-08-01T00:00:00Z")
+
+
+def _entry(
+    bead_id: str,
+    *,
+    severity: Severity = Severity.MEDIUM,
+    status: str = STATUS_OPEN,
+    owner_spec: str = "054-assumption-batch-scheduler",
+    created_at: str | None = None,
+    is_legacy: bool = False,
+) -> AssumptionReportEntry:
+    return AssumptionReportEntry(
+        record=AssumptionRecord(
+            bead_id=bead_id,
+            question="Q?",
+            adopted_answer="A.",
+            alternatives=(),
+            severity=severity,
+            severity_defaulted=False,
+            status=status,
+            owner_spec=owner_spec,
+            source_bead="mav-source",
+            change_ids=(),
+            is_legacy=is_legacy,
+            created_at=created_at,
+        ),
+        final_answer="Yes." if status == STATUS_ANSWERED else None,
+        waived_by="alice" if status == STATUS_WAIVED else None,
+        waived_at="2026-07-24T14:00:00Z" if status == STATUS_WAIVED else None,
+        waive_reason="n/a" if status == STATUS_WAIVED else None,
+        reconcile_status=None,
+        reconciled_answer=None,
+        reconcile_change_id=None,
+        reconcile_reason=None,
+        pending_reconcile=False,
+    )
+
+
+_NOON = datetime(2026, 8, 6, 9, 0, tzinfo=NY)
+
+
+class TestMediumBatchesOnly:
+    def test_medium_entries_deliver_at_window(self) -> None:
+        schedule = _config()
+        entries = (_entry("mav-1", severity=Severity.MEDIUM),)
+
+        outcome = evaluate(entries, schedule, _state(), _NOON)
+
+        assert len(outcome.deliveries) == 1
+        delivery = outcome.deliveries[0]
+        assert delivery.kind == DecisionKind.WINDOW_BATCH
+        assert delivery.entry_ids == ("mav-1",)
+
+    def test_high_entries_do_not_drive_window_batching(self) -> None:
+        """A high-severity entry never itself triggers or blocks a window
+        *batch* decision — the window occurrence still records empty (no
+        medium entries pending it). It is delivered separately, as an
+        interrupt (T020, ``TestHighSeverityInterrupt`` below) — not folded
+        into window-batch accounting."""
+        schedule = _config()
+        entries = (_entry("mav-hi", severity=Severity.HIGH),)
+
+        outcome = evaluate(entries, schedule, _state(), _NOON)
+
+        assert not any(d.kind == DecisionKind.WINDOW_BATCH for d in outcome.deliveries)
+        window_skips = [s for s in outcome.skips if s.reason == SkipReason.EMPTY_BATCH]
+        assert len(window_skips) == 1
+        assert window_skips[0].entry_ids == ()
+
+
+class TestLowNeverProactive:
+    def test_low_only_yields_low_never_proactive_skip(self) -> None:
+        schedule = _config()
+        entries = (
+            _entry("mav-lo1", severity=Severity.LOW),
+            _entry("mav-lo2", severity=Severity.LOW),
+        )
+
+        outcome = evaluate(entries, schedule, _state(), _NOON)
+
+        assert outcome.deliveries == ()
+        skip = outcome.skips[0]
+        assert skip.reason == SkipReason.LOW_NEVER_PROACTIVE
+        assert set(skip.entry_ids) == {"mav-lo1", "mav-lo2"}
+
+    def test_low_entries_never_deliver_even_across_many_windows(self) -> None:
+        schedule = _config(windows=["09:00", "17:00"])
+        entries = (_entry("mav-lo1", severity=Severity.LOW),)
+
+        first = evaluate(entries, schedule, _state(), datetime(2026, 8, 6, 9, 0, tzinfo=NY))
+        second = evaluate(
+            entries, schedule, first.state_after, datetime(2026, 8, 6, 17, 0, tzinfo=NY)
+        )
+
+        assert first.deliveries == ()
+        assert second.deliveries == ()
+
+    def test_low_counted_in_batch_summary_when_medium_batch_delivers(self) -> None:
+        """A mixed ledger (medium + low + high) yields a window batch *and*
+        a separate high-severity interrupt (T020) — the batch's summary
+        still counts every severity (clarification Q5), but the batch's
+        covered ``entry_ids`` never include the high entry (no cross-talk;
+        see also ``TestMixedLedgerNoCrossTalk`` below)."""
+        schedule = _config()
+        entries = (
+            _entry("mav-med", severity=Severity.MEDIUM),
+            _entry("mav-lo1", severity=Severity.LOW),
+            _entry("mav-lo2", severity=Severity.LOW),
+            _entry("mav-hi", severity=Severity.HIGH),
+        )
+
+        outcome = evaluate(entries, schedule, _state(), _NOON)
+
+        by_kind = {d.kind: d for d in outcome.deliveries}
+        assert set(by_kind) == {DecisionKind.WINDOW_BATCH, DecisionKind.INTERRUPT}
+
+        batch = by_kind[DecisionKind.WINDOW_BATCH]
+        summary = batch.summary
+        assert summary.counts[Severity.MEDIUM] == 1
+        assert summary.counts[Severity.LOW] == 2
+        assert summary.counts[Severity.HIGH] == 1
+        # Low entries are informational only — never part of what's covered.
+        assert batch.entry_ids == ("mav-med",)
+
+        interrupt = by_kind[DecisionKind.INTERRUPT]
+        assert interrupt.entry_ids == ("mav-hi",)
+
+
+class TestLegacyEntriesBatchLikeMedium:
+    def test_legacy_entry_participates_in_min_batch_and_delivery(self) -> None:
+        """report_entries() already synthesizes legacy severity as MEDIUM
+        (FR-019, research R9) — evaluate() needs no special-casing, only
+        this pinned behavior."""
+        schedule = _config(min_batch_size=2)
+        legacy = _entry("mav-legacy", severity=Severity.MEDIUM, is_legacy=True)
+        medium = _entry("mav-2", severity=Severity.MEDIUM)
+
+        outcome = evaluate((legacy, medium), schedule, _state(), _NOON)
+
+        assert len(outcome.deliveries) == 1
+        assert set(outcome.deliveries[0].entry_ids) == {"mav-legacy", "mav-2"}
+
+    def test_lone_legacy_entry_below_min_batch_rolls_forward(self) -> None:
+        schedule = _config(min_batch_size=2)
+        legacy = _entry("mav-legacy", severity=Severity.MEDIUM, is_legacy=True)
+
+        outcome = evaluate((legacy,), schedule, _state(), _NOON)
+
+        assert outcome.deliveries == ()
+        skip = outcome.skips[0]
+        assert skip.reason == SkipReason.MIN_BATCH_SIZE
+        assert skip.entry_ids == ("mav-legacy",)
+
+
+class TestResolvedBeforeWindowExcludedStructurally:
+    def test_answered_entry_excluded_from_batch(self) -> None:
+        schedule = _config()
+        answered = _entry("mav-answered", severity=Severity.MEDIUM, status=STATUS_ANSWERED)
+
+        outcome = evaluate((answered,), schedule, _state(), _NOON)
+
+        assert outcome.deliveries == ()
+        skip = outcome.skips[0]
+        assert skip.reason == SkipReason.EMPTY_BATCH
+        assert skip.entry_ids == ()
+
+    def test_waived_entry_excluded_from_batch(self) -> None:
+        schedule = _config()
+        waived = _entry("mav-waived", severity=Severity.MEDIUM, status=STATUS_WAIVED)
+
+        outcome = evaluate((waived,), schedule, _state(), _NOON)
+
+        assert outcome.deliveries == ()
+        assert outcome.skips[0].reason == SkipReason.EMPTY_BATCH
+
+    def test_batch_resolved_between_accumulation_and_delivery_is_empty(self) -> None:
+        """FR-014: entries resolved between accumulation and the delivery
+        window must be excluded — a batch whose entries are all resolved by
+        the time the window fires delivers nothing."""
+        schedule = _config(min_batch_size=1)
+        # By the time the window is (re-)evaluated, the entry was answered.
+        resolved_by_window_time = (
+            _entry("mav-1", severity=Severity.MEDIUM, status=STATUS_ANSWERED),
+        )
+
+        outcome = evaluate(resolved_by_window_time, schedule, _state(), _NOON)
+
+        assert outcome.deliveries == ()
+        assert outcome.skips[0].reason == SkipReason.EMPTY_BATCH
+
+    def test_mixed_open_and_resolved_only_open_counted(self) -> None:
+        schedule = _config(min_batch_size=1)
+        entries = (
+            _entry("mav-open", severity=Severity.MEDIUM, status=STATUS_OPEN),
+            _entry("mav-answered", severity=Severity.MEDIUM, status=STATUS_ANSWERED),
+            _entry("mav-waived", severity=Severity.MEDIUM, status=STATUS_WAIVED),
+        )
+
+        outcome = evaluate(entries, schedule, _state(), _NOON)
+
+        assert len(outcome.deliveries) == 1
+        assert outcome.deliveries[0].entry_ids == ("mav-open",)
+        assert outcome.deliveries[0].summary.counts[Severity.MEDIUM] == 1
+
+
+class TestHighSeverityInterrupt:
+    """T019/US2: high-severity entries deliver as interrupts at the next
+    permissible evaluation, independent of review windows (FR-002, FR-004,
+    spec.md US2 acceptance scenarios 1-3)."""
+
+    def test_high_entry_delivers_interrupt_outside_windows(self) -> None:
+        """US2 scenario 1: a high entry delivers at the next evaluation —
+        it does not wait for the 17:00 window."""
+        schedule = _config(windows=["09:00", "17:00"])
+        entries = (_entry("mav-hi", severity=Severity.HIGH),)
+        mid_afternoon = datetime(2026, 8, 6, 14, 23, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), mid_afternoon)
+
+        interrupts = [d for d in outcome.deliveries if d.kind == DecisionKind.INTERRUPT]
+        assert len(interrupts) == 1
+        assert interrupts[0].entry_ids == ("mav-hi",)
+        assert interrupts[0].occurrence is None
+
+    def test_interrupt_delivered_at_set_and_suppresses_redelivery(self) -> None:
+        schedule = _config()
+        entries = (_entry("mav-hi", severity=Severity.HIGH),)
+
+        first = evaluate(entries, schedule, _state(), _NOON)
+
+        assert any(d.kind == DecisionKind.INTERRUPT for d in first.deliveries)
+        tracked = first.state_after.entry_tracking["mav-hi"]
+        assert tracked.interrupt_delivered_at is not None
+
+        one_hour_later = _NOON + timedelta(hours=1)
+        second = evaluate(entries, schedule, first.state_after, one_hour_later)
+
+        assert not any(d.kind == DecisionKind.INTERRUPT for d in second.deliveries)
+        assert not any(s.reason == SkipReason.QUIET_HOURS for s in second.skips)
+
+    def test_quiet_hours_high_overrides_quiet_true_delivers(self) -> None:
+        """US2 scenario 2: default policy delivers through quiet hours."""
+        schedule = AssumptionScheduleConfig(
+            windows=["09:00"],
+            quiet_hours=QuietHoursConfig(start="22:00", end="07:00"),
+            high_overrides_quiet=True,
+        )
+        entries = (_entry("mav-hi", severity=Severity.HIGH),)
+        during_quiet = datetime(2026, 8, 6, 23, 30, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), during_quiet)
+
+        interrupts = [d for d in outcome.deliveries if d.kind == DecisionKind.INTERRUPT]
+        assert len(interrupts) == 1
+        assert interrupts[0].entry_ids == ("mav-hi",)
+
+    def test_quiet_hours_absolute_holds_then_delivers_after_quiet_ends(self) -> None:
+        """US2 scenario 3: an explicit absolute-quiet-hours policy holds the
+        interrupt, then delivers it at the first post-quiet evaluation."""
+        schedule = AssumptionScheduleConfig(
+            windows=["09:00"],
+            quiet_hours=QuietHoursConfig(start="22:00", end="07:00"),
+            high_overrides_quiet=False,
+        )
+        entries = (_entry("mav-hi", severity=Severity.HIGH),)
+        during_quiet = datetime(2026, 8, 6, 23, 30, tzinfo=NY)
+
+        held = evaluate(entries, schedule, _state(), during_quiet)
+
+        assert not any(d.kind == DecisionKind.INTERRUPT for d in held.deliveries)
+        quiet_skips = [s for s in held.skips if s.reason == SkipReason.QUIET_HOURS]
+        assert len(quiet_skips) == 1
+        assert quiet_skips[0].entry_ids == ("mav-hi",)
+        # Not marked delivered — still due at the next evaluation.
+        assert held.state_after.entry_tracking["mav-hi"].interrupt_delivered_at is None
+
+        after_quiet = datetime(2026, 8, 7, 7, 30, tzinfo=NY)
+        delivered = evaluate(entries, schedule, held.state_after, after_quiet)
+
+        interrupts = [d for d in delivered.deliveries if d.kind == DecisionKind.INTERRUPT]
+        assert len(interrupts) == 1
+        assert interrupts[0].entry_ids == ("mav-hi",)
+
+    def test_multiple_simultaneous_high_entries_coalesce_into_one_interrupt(self) -> None:
+        schedule = _config()
+        entries = (
+            _entry("mav-hi1", severity=Severity.HIGH),
+            _entry("mav-hi2", severity=Severity.HIGH),
+        )
+
+        outcome = evaluate(entries, schedule, _state(), _NOON)
+
+        interrupts = [d for d in outcome.deliveries if d.kind == DecisionKind.INTERRUPT]
+        assert len(interrupts) == 1
+        assert set(interrupts[0].entry_ids) == {"mav-hi1", "mav-hi2"}
+        # Combined summary: both high entries reflected in the shared count.
+        assert interrupts[0].summary.counts[Severity.HIGH] == 2
+
+        both_tracked = outcome.state_after.entry_tracking
+        assert both_tracked["mav-hi1"].interrupt_delivered_at is not None
+        assert both_tracked["mav-hi2"].interrupt_delivered_at is not None
+
+
+class TestMixedLedgerNoCrossTalk:
+    """Checkpoint (tasks.md Phase 4): a mixed ledger produces one batch
+    delivery plus one interrupt delivery, with no cross-talk between the
+    two mechanisms' idempotence state."""
+
+    def test_one_medium_and_one_high_produce_batch_and_interrupt(self) -> None:
+        schedule = _config()
+        entries = (
+            _entry("mav-med", severity=Severity.MEDIUM),
+            _entry("mav-hi", severity=Severity.HIGH),
+        )
+
+        outcome = evaluate(entries, schedule, _state(), _NOON)
+
+        assert len(outcome.deliveries) == 2
+        by_kind = {d.kind: d for d in outcome.deliveries}
+        batch = by_kind[DecisionKind.WINDOW_BATCH]
+        interrupt = by_kind[DecisionKind.INTERRUPT]
+
+        assert batch.entry_ids == ("mav-med",)
+        assert interrupt.entry_ids == ("mav-hi",)
+
+        # No cross-talk: the window's idempotence record covers only the
+        # medium entry...
+        window_key = "2026-08-06/09:00"
+        assert outcome.state_after.window_decisions[window_key].entry_ids == ["mav-med"]
+
+        # ...and the high entry's interrupt tracking is independent of the
+        # medium entry's (which never gets an interrupt marker at all).
+        tracking = outcome.state_after.entry_tracking
+        assert tracking["mav-hi"].interrupt_delivered_at is not None
+        assert tracking["mav-med"].interrupt_delivered_at is None

--- a/tests/unit/assumptions/schedule/test_evaluate_windows.py
+++ b/tests/unit/assumptions/schedule/test_evaluate_windows.py
@@ -1,0 +1,413 @@
+"""Window-occurrence evaluation tests (tasks.md T010).
+
+Covers occurrence due/not-yet-due, delayed-cron delivery, idempotence
+(already-delivered), min-batch-size roll-forward, midnight-spanning
+quiet-hours shifting (research R8), DST spring-forward gap / fall-back
+non-double-delivery (research R6), and the empty-batch decision (FR-014).
+
+All calls are direct ``evaluate(entries, schedule, state, now)`` invocations
+with injected aware local datetimes — no freezegun, no ``datetime.now``
+mocking (plan.md Constitution Check, Principle III).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from maverick.assumptions.models import (
+    STATUS_ANSWERED,
+    STATUS_OPEN,
+    AssumptionRecord,
+    AssumptionReportEntry,
+    Severity,
+)
+from maverick.assumptions.schedule.evaluate import evaluate
+from maverick.assumptions.schedule.models import DecisionKind, SkipReason
+from maverick.assumptions.schedule.state import DeliveryState
+from maverick.config import AssumptionScheduleConfig, QuietHoursConfig
+
+NY = ZoneInfo("America/New_York")
+
+
+def _config(
+    *,
+    windows: list[str] | None = None,
+    quiet_hours: QuietHoursConfig | None = None,
+    min_batch_size: int = 1,
+    max_entry_age_hours: int = 24,
+) -> AssumptionScheduleConfig:
+    return AssumptionScheduleConfig(
+        windows=windows if windows is not None else ["09:00"],
+        quiet_hours=quiet_hours,
+        min_batch_size=min_batch_size,
+        max_entry_age_hours=max_entry_age_hours,
+    )
+
+
+def _state() -> DeliveryState:
+    return DeliveryState(updated_at="2026-08-01T00:00:00Z")
+
+
+def _entry(
+    bead_id: str,
+    *,
+    severity: Severity = Severity.MEDIUM,
+    status: str = STATUS_OPEN,
+    owner_spec: str = "054-assumption-batch-scheduler",
+    created_at: str | None = None,
+    is_legacy: bool = False,
+) -> AssumptionReportEntry:
+    return AssumptionReportEntry(
+        record=AssumptionRecord(
+            bead_id=bead_id,
+            question="Q?",
+            adopted_answer="A.",
+            alternatives=(),
+            severity=severity,
+            severity_defaulted=False,
+            status=status,
+            owner_spec=owner_spec,
+            source_bead="mav-source",
+            change_ids=(),
+            is_legacy=is_legacy,
+            created_at=created_at,
+        ),
+        final_answer="Yes." if status == STATUS_ANSWERED else None,
+        waived_by=None,
+        waived_at=None,
+        waive_reason=None,
+        reconcile_status=None,
+        reconciled_answer=None,
+        reconcile_change_id=None,
+        reconcile_reason=None,
+        pending_reconcile=False,
+    )
+
+
+class TestOccurrenceDueness:
+    def test_not_yet_due_before_window_time(self) -> None:
+        schedule = _config(windows=["09:00"])
+        now = datetime(2026, 8, 6, 8, 59, tzinfo=NY)
+
+        outcome = evaluate((), schedule, _state(), now)
+
+        assert outcome.deliveries == ()
+        assert len(outcome.skips) == 1
+        skip = outcome.skips[0]
+        assert skip.reason == SkipReason.NOT_YET_DUE
+        assert skip.occurrence is not None
+        assert skip.occurrence.date == date(2026, 8, 6)
+        assert skip.occurrence.window == "09:00"
+        assert "2026-08-06/09:00" not in outcome.state_after.window_decisions
+
+    def test_due_at_exact_window_time_delivers(self) -> None:
+        schedule = _config(windows=["09:00"])
+        entries = (_entry("mav-1"),)
+        now = datetime(2026, 8, 6, 9, 0, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), now)
+
+        assert len(outcome.deliveries) == 1
+        delivery = outcome.deliveries[0]
+        assert delivery.kind == DecisionKind.WINDOW_BATCH
+        assert delivery.entry_ids == ("mav-1",)
+        key = "2026-08-06/09:00"
+        assert outcome.state_after.window_decisions[key].outcome == "delivered"
+        assert len(outcome.state_after.deliveries) == 1
+        assert outcome.state_after.deliveries[0].kind == "window-batch"
+
+
+class TestDelayedCron:
+    def test_delivers_when_evaluated_well_after_window_time(self) -> None:
+        """A machine asleep at 09:00 still delivers whenever it wakes up (FR-020)."""
+        schedule = _config(windows=["09:00"])
+        entries = (_entry("mav-1"),)
+        now = datetime(2026, 8, 6, 14, 30, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), now)
+
+        assert len(outcome.deliveries) == 1
+        assert outcome.deliveries[0].occurrence is not None
+        assert outcome.deliveries[0].occurrence.due_at.time() == time(9, 0)
+
+
+class TestAlreadyDelivered:
+    def test_rerun_within_same_window_skips(self) -> None:
+        schedule = _config(windows=["09:00"])
+        entries = (_entry("mav-1"),)
+        first_now = datetime(2026, 8, 6, 9, 5, tzinfo=NY)
+
+        first = evaluate(entries, schedule, _state(), first_now)
+        second = evaluate(entries, schedule, first.state_after, first_now + timedelta(minutes=5))
+
+        assert second.deliveries == ()
+        assert len(second.skips) == 1
+        skip = second.skips[0]
+        assert skip.reason == SkipReason.ALREADY_DELIVERED
+        assert skip.entry_ids == ("mav-1",)
+        # Idempotent: the decided record itself doesn't change either.
+        key = "2026-08-06/09:00"
+        assert first.state_after.window_decisions[key] == second.state_after.window_decisions[key]
+        assert len(second.state_after.deliveries) == 1
+
+
+class TestMinBatchSize:
+    def test_skip_rolls_entries_forward_to_next_window(self) -> None:
+        schedule = _config(windows=["09:00", "17:00"], min_batch_size=2)
+        entries_at_first_window = (_entry("mav-1"),)
+
+        first = evaluate(
+            entries_at_first_window, schedule, _state(), datetime(2026, 8, 6, 9, 0, tzinfo=NY)
+        )
+
+        assert first.deliveries == ()
+        min_skip = next(s for s in first.skips if s.reason == SkipReason.MIN_BATCH_SIZE)
+        assert min_skip.entry_ids == ("mav-1",)
+        key_0900 = "2026-08-06/09:00"
+        assert first.state_after.window_decisions[key_0900].outcome == "skipped-min-batch"
+
+        # A second entry accumulates; the same original entry rolls forward
+        # into the 17:00 batch alongside it.
+        entries_at_second_window = (_entry("mav-1"), _entry("mav-2"))
+        second = evaluate(
+            entries_at_second_window,
+            schedule,
+            first.state_after,
+            datetime(2026, 8, 6, 17, 0, tzinfo=NY),
+        )
+
+        assert len(second.deliveries) == 1
+        assert set(second.deliveries[0].entry_ids) == {"mav-1", "mav-2"}
+        key_1700 = "2026-08-06/17:00"
+        assert second.state_after.window_decisions[key_1700].outcome == "delivered"
+        # The original 09:00 occurrence stays settled as skipped-min-batch —
+        # it is never reconsidered.
+        assert second.state_after.window_decisions[key_0900].outcome == "skipped-min-batch"
+
+
+class TestEmptyBatch:
+    def test_no_open_entries_records_empty_decision(self) -> None:
+        schedule = _config(windows=["09:00"])
+        now = datetime(2026, 8, 6, 9, 0, tzinfo=NY)
+
+        outcome = evaluate((), schedule, _state(), now)
+
+        assert outcome.deliveries == ()
+        skip = outcome.skips[0]
+        assert skip.reason == SkipReason.EMPTY_BATCH
+        assert skip.entry_ids == ()
+        key = "2026-08-06/09:00"
+        record = outcome.state_after.window_decisions[key]
+        assert record.outcome == "empty"
+        assert record.entry_ids == []
+
+
+class TestQuietHoursShift:
+    def test_window_inside_quiet_hours_shifts_and_still_delivers_once(self) -> None:
+        schedule = _config(
+            windows=["23:00"], quiet_hours=QuietHoursConfig(start="22:00", end="07:00")
+        )
+        entries = (_entry("mav-1"),)
+
+        # Seed continuity: settle the *previous* day's (08-05) occurrence
+        # first, exactly as a daily-running cron would have — so the
+        # scenario below is isolated to the single 08-06 occurrence under
+        # test rather than also tripping the 08-05 catch-up.
+        seeded = evaluate(entries, schedule, _state(), datetime(2026, 8, 6, 7, 30, tzinfo=NY))
+        assert len(seeded.deliveries) == 1
+        assert seeded.deliveries[0].occurrence is not None
+        assert seeded.deliveries[0].occurrence.date == date(2026, 8, 5)
+
+        # Evaluated after the nominal 23:00 window time but still within
+        # quiet hours: due_at must have shifted to the next day's 07:00,
+        # so nothing delivers yet.
+        before_shift_end = evaluate(
+            entries, schedule, seeded.state_after, datetime(2026, 8, 6, 23, 30, tzinfo=NY)
+        )
+        assert before_shift_end.deliveries == ()
+        pending = next(
+            s
+            for s in before_shift_end.skips
+            if s.occurrence and s.occurrence.date == date(2026, 8, 6)
+        )
+        assert pending.reason == SkipReason.NOT_YET_DUE
+        assert pending.occurrence is not None
+        assert pending.occurrence.due_at == datetime(2026, 8, 7, 7, 0, tzinfo=NY)
+
+        # Evaluated after quiet hours end: the *same* occurrence (still
+        # keyed to 2026-08-06, not 08-07) becomes due and delivers exactly
+        # once.
+        after_shift_end = evaluate(
+            entries, schedule, before_shift_end.state_after, datetime(2026, 8, 7, 7, 30, tzinfo=NY)
+        )
+        assert len(after_shift_end.deliveries) == 1
+        delivered_occ = after_shift_end.deliveries[0].occurrence
+        assert delivered_occ is not None
+        assert delivered_occ.date == date(2026, 8, 6)
+        assert delivered_occ.due_at == datetime(2026, 8, 7, 7, 0, tzinfo=NY)
+        key = "2026-08-06/23:00"
+        assert after_shift_end.state_after.window_decisions[key].outcome == "delivered"
+
+        # Re-running later the same day never re-delivers it.
+        rerun = evaluate(
+            entries, schedule, after_shift_end.state_after, datetime(2026, 8, 7, 8, 0, tzinfo=NY)
+        )
+        assert not any(
+            d.occurrence and d.occurrence.date == date(2026, 8, 6) for d in rerun.deliveries
+        )
+
+    def test_window_before_quiet_hours_is_unaffected(self) -> None:
+        """A window whose nominal time is outside quiet hours delivers at
+        its own time, unshifted."""
+        schedule = _config(
+            windows=["09:00"], quiet_hours=QuietHoursConfig(start="22:00", end="07:00")
+        )
+        entries = (_entry("mav-1"),)
+
+        outcome = evaluate(entries, schedule, _state(), datetime(2026, 8, 6, 9, 0, tzinfo=NY))
+
+        assert len(outcome.deliveries) == 1
+        occ = outcome.deliveries[0].occurrence
+        assert occ is not None
+        assert occ.due_at == datetime(2026, 8, 6, 9, 0, tzinfo=NY)
+
+
+class TestQuietHoursHoldBacklog:
+    """FR-004/FR-020: a window batch is a medium/legacy delivery, so it is
+    held whenever *now* falls inside quiet hours — even when the window's
+    own configured time sits safely outside them. Shifting ``due_at`` at
+    occurrence-build time (``TestQuietHoursShift``) only covers windows
+    whose configured time is itself inside quiet hours; a backlogged
+    evaluation (laptop asleep, cron catching up) needs this second gate.
+    """
+
+    _QUIET = QuietHoursConfig(start="22:00", end="07:00")
+
+    # Aged ~15h at the 23:00 tick and ~23.5h at the 07:30 one: comfortably
+    # inside the default 24h ``max_entry_age_hours`` throughout, so these
+    # scenarios stay isolated to window batching and never cross into US4's
+    # max-age escalation (covered in test_evaluate_escalation.py).
+    _CREATED_AT = "2026-08-06T12:00:00Z"
+
+    def test_backlogged_batch_is_held_when_evaluated_inside_quiet_hours(self) -> None:
+        schedule = _config(windows=["09:00"], quiet_hours=self._QUIET)
+        entries = (_entry("mav-1", created_at=self._CREATED_AT),)
+        # Machine asleep all day; the first evaluation lands at 23:00, deep
+        # inside quiet hours. The 09:00 batch must not push at 23:00.
+        now = datetime(2026, 8, 6, 23, 0, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), now)
+
+        assert outcome.deliveries == ()
+        quiet_skips = [s for s in outcome.skips if s.reason == SkipReason.QUIET_HOURS]
+        assert len(quiet_skips) == 1
+        assert quiet_skips[0].occurrence is not None
+        assert quiet_skips[0].occurrence.date == date(2026, 8, 6)
+        assert quiet_skips[0].entry_ids == ("mav-1",)
+        # No decision recorded: the occurrence stays due (FR-020) and no
+        # audit record claims a delivery that never happened.
+        assert "2026-08-06/09:00" not in outcome.state_after.window_decisions
+        assert outcome.state_after.deliveries == []
+
+    def test_held_batch_delivers_exactly_once_after_quiet_hours_end(self) -> None:
+        schedule = _config(windows=["09:00"], quiet_hours=self._QUIET)
+        entries = (_entry("mav-1", created_at=self._CREATED_AT),)
+
+        held = evaluate(entries, schedule, _state(), datetime(2026, 8, 6, 23, 0, tzinfo=NY))
+        assert held.deliveries == ()
+
+        # 07:30 — the first evaluation quiet hours (22:00-07:00) permit.
+        after_quiet = evaluate(
+            entries, schedule, held.state_after, datetime(2026, 8, 7, 7, 30, tzinfo=NY)
+        )
+        batches = [d for d in after_quiet.deliveries if d.kind == DecisionKind.WINDOW_BATCH]
+        assert len(batches) == 1
+        assert batches[0].entry_ids == ("mav-1",)
+        assert batches[0].occurrence is not None
+        # The *held* occurrence delivers — not a freshly-minted one.
+        assert batches[0].occurrence.date == date(2026, 8, 6)
+        key = "2026-08-06/09:00"
+        assert after_quiet.state_after.window_decisions[key].outcome == "delivered"
+
+        # Exactly once: a later evaluation the same morning re-skips it.
+        rerun = evaluate(
+            entries, schedule, after_quiet.state_after, datetime(2026, 8, 7, 7, 45, tzinfo=NY)
+        )
+        assert [d for d in rerun.deliveries if d.kind == DecisionKind.WINDOW_BATCH] == []
+        assert len(rerun.state_after.deliveries) == 1
+
+    def test_quiet_hours_suppress_deliveries_not_decisions(self) -> None:
+        """An occurrence that would deliver nothing anyway still settles
+        inside quiet hours — quiet hours gate pushes, not bookkeeping."""
+        schedule = _config(windows=["09:00"], quiet_hours=self._QUIET)
+
+        outcome = evaluate((), schedule, _state(), datetime(2026, 8, 6, 23, 0, tzinfo=NY))
+
+        assert outcome.deliveries == ()
+        assert outcome.state_after.window_decisions["2026-08-06/09:00"].outcome == "empty"
+        assert not any(s.reason == SkipReason.QUIET_HOURS for s in outcome.skips)
+
+    def test_fresh_state_does_not_catch_up_a_never_evaluated_prior_occurrence(self) -> None:
+        """The catch-up path reclaims only an occurrence this scheduler
+        actually held, never one nobody ever evaluated — otherwise a
+        brand-new schedule's first run double-fires (yesterday's batch plus
+        today's)."""
+        # `load_state()` stamps a first-ever run's empty state with *now*.
+        now = datetime(2026, 8, 6, 7, 30, tzinfo=NY)
+        fresh = DeliveryState(updated_at="2026-08-06T11:30:00Z")
+        schedule = _config(windows=["09:00"], quiet_hours=self._QUIET)
+        entries = (_entry("mav-1", created_at="2026-08-06T06:00:00Z"),)
+
+        outcome = evaluate(entries, schedule, fresh, now)
+
+        assert outcome.deliveries == ()
+        assert "2026-08-05/09:00" not in outcome.state_after.window_decisions
+
+
+class TestDaylightSaving:
+    """2026-03-08: US Eastern spring-forward (02:00 -> 03:00, 02:30 does
+    not exist). 2026-11-01: US Eastern fall-back (01:00-02:00 repeats)."""
+
+    def test_spring_forward_gap_resolves_to_a_real_instant(self) -> None:
+        schedule = _config(windows=["02:30"])
+        entries = (_entry("mav-1"),)
+        # A real, valid instant shortly after the gap closes.
+        now = datetime(2026, 3, 8, 3, 30, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), now)
+
+        assert len(outcome.deliveries) == 1
+        due_at = outcome.deliveries[0].occurrence.due_at  # type: ignore[union-attr]
+        # due_at must denote a real instant: round-tripping through UTC
+        # reproduces the identical local wall time (PEP 495).
+        assert due_at.astimezone(UTC).astimezone(NY) == due_at
+        assert due_at <= now
+
+    def test_spring_forward_gap_not_yet_due_before_transition(self) -> None:
+        schedule = _config(windows=["02:30"])
+        entries = (_entry("mav-1"),)
+        now = datetime(2026, 3, 8, 1, 0, tzinfo=NY)
+
+        outcome = evaluate(entries, schedule, _state(), now)
+
+        assert outcome.deliveries == ()
+        assert outcome.skips[0].reason == SkipReason.NOT_YET_DUE
+
+    def test_fall_back_ambiguous_hour_does_not_double_deliver(self) -> None:
+        schedule = _config(windows=["01:30"])
+        entries = (_entry("mav-1"),)
+        first_pass = datetime(2026, 11, 1, 1, 35, tzinfo=NY, fold=0)
+
+        first = evaluate(entries, schedule, _state(), first_pass)
+        assert len(first.deliveries) == 1
+
+        # The same wall-clock instant occurs a second time (fold=1, an hour
+        # later in absolute UTC terms) — must not re-deliver.
+        second_pass = datetime(2026, 11, 1, 1, 35, tzinfo=NY, fold=1)
+        second = evaluate(entries, schedule, first.state_after, second_pass)
+
+        assert second.deliveries == ()
+        assert len(second.skips) == 1
+        assert second.skips[0].reason == SkipReason.ALREADY_DELIVERED
+        assert len(second.state_after.deliveries) == 1

--- a/tests/unit/assumptions/schedule/test_models.py
+++ b/tests/unit/assumptions/schedule/test_models.py
@@ -1,0 +1,200 @@
+"""Smoke tests for maverick.assumptions.schedule.models.
+
+Constructs one instance of every dataclass/enum in the module. Downstream
+phases (evaluate.py, deliver.py) exercise these more thoroughly through
+``evaluate()``/``deliver()``; this module has no dedicated test task of its
+own (tasks.md T007).
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, date, datetime
+
+import pytest
+
+from maverick.assumptions.models import Severity
+from maverick.assumptions.schedule.models import (
+    AutoWaiveDecision,
+    BatchSummary,
+    DecisionKind,
+    DeliveryDecision,
+    EvaluationOutcome,
+    SkipDecision,
+    SkipReason,
+    WindowOccurrence,
+)
+from maverick.assumptions.schedule.state import DeliveryState
+
+
+def _make_occurrence() -> WindowOccurrence:
+    return WindowOccurrence(
+        date=date(2026, 8, 6),
+        window="09:00",
+        due_at=datetime(2026, 8, 6, 9, 0, tzinfo=UTC),
+    )
+
+
+def _make_summary() -> BatchSummary:
+    return BatchSummary(
+        counts={Severity.LOW: 1, Severity.MEDIUM: 2, Severity.HIGH: 0},
+        owner_specs=("054-assumption-batch-scheduler",),
+        oldest_age_hours=12.5,
+        review_invocation="maverick review --list --status open",
+    )
+
+
+class TestDecisionKind:
+    def test_members(self) -> None:
+        assert DecisionKind.WINDOW_BATCH == "window-batch"
+        assert DecisionKind.INTERRUPT == "interrupt"
+        assert DecisionKind.ESCALATION == "escalation"
+        assert DecisionKind.RENOTIFY == "renotify"
+
+
+class TestSkipReason:
+    def test_members(self) -> None:
+        assert SkipReason.MIN_BATCH_SIZE == "min-batch-size"
+        assert SkipReason.QUIET_HOURS == "quiet-hours"
+        assert SkipReason.ALREADY_DELIVERED == "already-delivered"
+        assert SkipReason.NOT_YET_DUE == "not-yet-due"
+        assert SkipReason.LOW_NEVER_PROACTIVE == "low-never-proactive"
+        assert SkipReason.EMPTY_BATCH == "empty-batch"
+
+
+class TestWindowOccurrence:
+    def test_construction_and_identity_fields(self) -> None:
+        occurrence = _make_occurrence()
+        assert occurrence.date == date(2026, 8, 6)
+        assert occurrence.window == "09:00"
+        assert occurrence.due_at.tzinfo is not None
+
+    def test_frozen(self) -> None:
+        occurrence = _make_occurrence()
+        with pytest.raises(FrozenInstanceError):
+            occurrence.window = "10:00"  # type: ignore[misc]
+
+
+class TestBatchSummary:
+    def test_construction(self) -> None:
+        summary = _make_summary()
+        assert summary.counts[Severity.MEDIUM] == 2
+        assert summary.owner_specs == ("054-assumption-batch-scheduler",)
+        assert summary.oldest_age_hours == 12.5
+        assert summary.review_invocation == "maverick review --list --status open"
+
+    def test_counts_cannot_be_mutated(self) -> None:
+        """One summary instance is shared by every DeliveryDecision in a run
+        *and* by every persisted DeliveryRecord, so a mutable ``counts``
+        would let one consumer silently rewrite the audit trail."""
+        summary = _make_summary()
+
+        with pytest.raises(TypeError):
+            summary.counts[Severity.HIGH] = 99  # type: ignore[index]
+        with pytest.raises(AttributeError):
+            summary.counts.clear()  # type: ignore[attr-defined]
+
+        assert summary.counts[Severity.HIGH] == 0
+
+    def test_counts_snapshots_the_caller_dict(self) -> None:
+        """Construction takes a plain dict (ergonomics) but detaches from it —
+        mutating the caller's dict afterwards must not reach the summary."""
+        source = {Severity.LOW: 1, Severity.MEDIUM: 2, Severity.HIGH: 0}
+        summary = BatchSummary(
+            counts=source,
+            owner_specs=(),
+            oldest_age_hours=0.0,
+            review_invocation="maverick review --list --status open",
+        )
+
+        source[Severity.HIGH] = 7
+
+        assert summary.counts[Severity.HIGH] == 0
+
+    def test_to_dict_projection_unchanged(self) -> None:
+        assert _make_summary().to_dict() == {
+            "counts": {"low": 1, "medium": 2, "high": 0},
+            "owner_specs": ["054-assumption-batch-scheduler"],
+            "oldest_age_hours": 12.5,
+            "review_invocation": "maverick review --list --status open",
+        }
+
+    def test_equality_still_holds_across_instances(self) -> None:
+        assert _make_summary() == _make_summary()
+
+
+class TestDeliveryDecision:
+    def test_window_batch_carries_occurrence(self) -> None:
+        occurrence = _make_occurrence()
+        decision = DeliveryDecision(
+            kind=DecisionKind.WINDOW_BATCH,
+            entry_ids=("bd-1", "bd-2"),
+            summary=_make_summary(),
+            occurrence=occurrence,
+            rule="window 09:00 due",
+        )
+        assert decision.kind == DecisionKind.WINDOW_BATCH
+        assert decision.occurrence == occurrence
+        assert decision.entry_ids == ("bd-1", "bd-2")
+
+    def test_interrupt_has_no_occurrence(self) -> None:
+        decision = DeliveryDecision(
+            kind=DecisionKind.INTERRUPT,
+            entry_ids=("bd-3",),
+            summary=_make_summary(),
+            occurrence=None,
+            rule="high severity, outside quiet hours",
+        )
+        assert decision.occurrence is None
+
+
+class TestSkipDecision:
+    def test_construction(self) -> None:
+        skip = SkipDecision(
+            reason=SkipReason.MIN_BATCH_SIZE,
+            occurrence=_make_occurrence(),
+            entry_ids=("bd-4",),
+            rule="min_batch_size=3, got 1",
+        )
+        assert skip.reason == SkipReason.MIN_BATCH_SIZE
+        assert skip.entry_ids == ("bd-4",)
+
+
+class TestAutoWaiveDecision:
+    def test_construction(self) -> None:
+        decision = AutoWaiveDecision(
+            entry_id="bd-5",
+            reason_text="auto-waived by schedule policy after 168h: stale low-severity assumption",
+        )
+        assert decision.entry_id == "bd-5"
+        assert "auto-waived" in decision.reason_text
+
+
+class TestEvaluationOutcome:
+    def test_construction(self) -> None:
+        state_after = DeliveryState(updated_at="2026-08-06T09:00:00Z")
+        outcome = EvaluationOutcome(
+            deliveries=(
+                DeliveryDecision(
+                    kind=DecisionKind.WINDOW_BATCH,
+                    entry_ids=("bd-1",),
+                    summary=_make_summary(),
+                    occurrence=_make_occurrence(),
+                    rule="window 09:00 due",
+                ),
+            ),
+            skips=(
+                SkipDecision(
+                    reason=SkipReason.LOW_NEVER_PROACTIVE,
+                    occurrence=None,
+                    entry_ids=("bd-6",),
+                    rule="low severity never delivers proactively",
+                ),
+            ),
+            auto_waives=(AutoWaiveDecision(entry_id="bd-7", reason_text="stale low entry"),),
+            state_after=state_after,
+        )
+        assert len(outcome.deliveries) == 1
+        assert len(outcome.skips) == 1
+        assert len(outcome.auto_waives) == 1
+        assert outcome.state_after is state_after

--- a/tests/unit/assumptions/schedule/test_state.py
+++ b/tests/unit/assumptions/schedule/test_state.py
@@ -1,0 +1,725 @@
+"""Tests for persisted notify delivery state (data-model.md §4,
+contracts/delivery-state-schema.md).
+
+Covers round-trip load/save, atomic write, missing/corrupt file handling,
+schema_version refusal, the pid-stamped lockfile (acquire/release/stale
+reclaim), the FR-023 prune predicate, and (tasks.md T022, US3)
+:func:`~maverick.assumptions.schedule.state.finalize_state` — the
+write-after-success reconciliation between a speculative
+``EvaluationOutcome.state_after`` and which of its delivery decisions
+actually succeeded.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from maverick.assumptions.models import (
+    STATUS_OPEN,
+    AssumptionRecord,
+    AssumptionReportEntry,
+    Severity,
+)
+from maverick.assumptions.schedule.evaluate import evaluate
+from maverick.assumptions.schedule.models import DecisionKind
+from maverick.assumptions.schedule.state import (
+    DeliveryRecord,
+    DeliveryState,
+    DeliveryStateSchemaError,
+    EntryTrackingRecord,
+    TerminalOutcome,
+    WindowDecisionRecord,
+    acquire_lock,
+    finalize_state,
+    load_state,
+    prune,
+    release_lock,
+    save_state,
+)
+from maverick.config import AssumptionScheduleConfig
+
+
+def _make_state() -> DeliveryState:
+    return DeliveryState(
+        updated_at="2026-08-05T13:00:12Z",
+        window_decisions={
+            "2026-08-05/09:00": WindowDecisionRecord(
+                outcome="delivered",
+                decided_at="2026-08-05T13:00:12Z",
+                entry_ids=["mav-abc", "mav-def"],
+                rule="window 09:00 due",
+            ),
+        },
+        entry_tracking={
+            "mav-hi1": EntryTrackingRecord(
+                first_seen="2026-08-05T03:10:00Z",
+                severity="high",
+                interrupt_delivered_at="2026-08-05T03:10:05Z",
+            ),
+        },
+        deliveries=[
+            DeliveryRecord(
+                kind="interrupt",
+                delivered_at="2026-08-05T03:10:05Z",
+                trigger="high severity recorded; high_overrides_quiet=true",
+                entry_ids=["mav-hi1"],
+                summary={
+                    "counts": {"high": 1, "medium": 0, "low": 0},
+                    "owner_specs": ["054-assumption-batch-scheduler"],
+                    "oldest_age_hours": 0.1,
+                    "review_invocation": "maverick review --list --status open",
+                },
+            ),
+        ],
+    )
+
+
+# --- round-trip load/save --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_and_load_round_trip(tmp_path: Path) -> None:
+    state = _make_state()
+
+    await save_state(state, tmp_path)
+    loaded = await load_state(tmp_path)
+
+    assert loaded == state
+
+
+@pytest.mark.asyncio
+async def test_save_writes_expected_path(tmp_path: Path) -> None:
+    state = _make_state()
+
+    await save_state(state, tmp_path)
+
+    state_path = tmp_path / ".maverick" / "notify" / "state.json"
+    assert state_path.is_file()
+    raw = json.loads(state_path.read_text(encoding="utf-8"))
+    assert raw["schema_version"] == 1
+    assert raw["window_decisions"]["2026-08-05/09:00"]["outcome"] == "delivered"
+    assert raw["entry_tracking"]["mav-hi1"]["severity"] == "high"
+    assert raw["deliveries"][0]["kind"] == "interrupt"
+
+
+@pytest.mark.asyncio
+async def test_save_is_atomic_no_partial_file_on_crash(tmp_path: Path) -> None:
+    """atomic_write_json writes via temp-file+rename; verify no `.tmp` litter
+    remains and the final file is valid JSON after a normal save."""
+    state = _make_state()
+    await save_state(state, tmp_path)
+
+    notify_dir = tmp_path / ".maverick" / "notify"
+    leftovers = [p for p in notify_dir.iterdir() if p.name != "state.json"]
+    assert leftovers == []
+
+
+# --- missing / corrupt file -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_missing_file_returns_empty_state(tmp_path: Path) -> None:
+    state = await load_state(tmp_path)
+
+    assert state.schema_version == 1
+    assert state.window_decisions == {}
+    assert state.entry_tracking == {}
+    assert state.deliveries == []
+    assert state.updated_at != ""
+
+
+@pytest.mark.asyncio
+async def test_load_schema_version_mismatch_refuses(tmp_path: Path) -> None:
+    state_path = tmp_path / ".maverick" / "notify" / "state.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        json.dumps({"schema_version": 2, "updated_at": "2026-08-05T13:00:12Z"}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(DeliveryStateSchemaError):
+        await load_state(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_load_corrupt_json_returns_empty_state_with_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    state_path = tmp_path / ".maverick" / "notify" / "state.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text("{not valid json", encoding="utf-8")
+
+    state = await load_state(tmp_path)
+
+    assert state.window_decisions == {}
+    assert state.entry_tracking == {}
+    assert state.deliveries == []
+
+
+@pytest.mark.asyncio
+async def test_load_schema_valid_json_invalid_shape_returns_empty_state(
+    tmp_path: Path,
+) -> None:
+    state_path = tmp_path / ".maverick" / "notify" / "state.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-08-05T13:00:12Z",
+                "window_decisions": "not-a-dict",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    state = await load_state(tmp_path)
+
+    assert state.window_decisions == {}
+    assert state.entry_tracking == {}
+    assert state.deliveries == []
+
+
+# --- pid lockfile ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_acquire_and_release_lock(tmp_path: Path) -> None:
+    acquired = await acquire_lock(tmp_path)
+    assert acquired is True
+
+    lock_path = tmp_path / ".maverick" / "notify" / "lock"
+    assert lock_path.is_file()
+    assert lock_path.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+    await release_lock(tmp_path)
+    assert not lock_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_contention_from_live_pid(tmp_path: Path) -> None:
+    lock_path = tmp_path / ".maverick" / "notify" / "lock"
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text(str(os.getpid()), encoding="utf-8")
+
+    acquired = await acquire_lock(tmp_path)
+
+    assert acquired is False
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_reclaims_stale_dead_pid(tmp_path: Path) -> None:
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead_pid = proc.pid
+    proc.wait()  # reap the child; dead_pid is now guaranteed not to be alive
+
+    lock_path = tmp_path / ".maverick" / "notify" / "lock"
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text(str(dead_pid), encoding="utf-8")
+
+    acquired = await acquire_lock(tmp_path)
+
+    assert acquired is True
+    assert lock_path.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_reclaims_malformed_lockfile(tmp_path: Path) -> None:
+    lock_path = tmp_path / ".maverick" / "notify" / "lock"
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text("not-a-pid", encoding="utf-8")
+
+    acquired = await acquire_lock(tmp_path)
+
+    assert acquired is True
+
+
+@pytest.mark.asyncio
+async def test_release_lock_missing_is_noop(tmp_path: Path) -> None:
+    await release_lock(tmp_path)  # no lockfile exists; must not raise
+
+
+# --- FR-023 prune ------------------------------------------------------------
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def test_prune_removes_terminal_entry_past_retention() -> None:
+    now = datetime(2026, 8, 5, tzinfo=UTC)
+    terminal_at = now - timedelta(days=91)
+    state = DeliveryState(
+        updated_at=_iso(now),
+        entry_tracking={
+            "mav-old": EntryTrackingRecord(
+                first_seen=_iso(terminal_at - timedelta(days=1)),
+                severity="medium",
+                terminal=TerminalOutcome(kind="resolved-by-human", at=_iso(terminal_at)),
+            ),
+        },
+    )
+
+    result = prune(state, now)
+
+    assert result.entry_tracking == {}
+
+
+def test_prune_keeps_terminal_entry_within_retention() -> None:
+    now = datetime(2026, 8, 5, tzinfo=UTC)
+    terminal_at = now - timedelta(days=10)
+    state = DeliveryState(
+        updated_at=_iso(now),
+        entry_tracking={
+            "mav-recent": EntryTrackingRecord(
+                first_seen=_iso(terminal_at - timedelta(days=1)),
+                severity="medium",
+                terminal=TerminalOutcome(kind="resolved-by-human", at=_iso(terminal_at)),
+            ),
+        },
+    )
+
+    result = prune(state, now)
+
+    assert "mav-recent" in result.entry_tracking
+
+
+def test_prune_never_removes_open_entry() -> None:
+    now = datetime(2026, 8, 5, tzinfo=UTC)
+    state = DeliveryState(
+        updated_at=_iso(now),
+        entry_tracking={
+            "mav-open": EntryTrackingRecord(
+                first_seen=_iso(now - timedelta(days=200)),
+                severity="high",
+                terminal=None,
+            ),
+        },
+    )
+
+    result = prune(state, now)
+
+    assert "mav-open" in result.entry_tracking
+
+
+def test_prune_removes_delivery_and_window_decision_when_all_entries_prunable() -> None:
+    now = datetime(2026, 8, 5, tzinfo=UTC)
+    terminal_at = now - timedelta(days=91)
+    state = DeliveryState(
+        updated_at=_iso(now),
+        window_decisions={
+            "2026-01-01/09:00": WindowDecisionRecord(
+                outcome="delivered",
+                decided_at=_iso(terminal_at),
+                entry_ids=["mav-old"],
+                rule="window 09:00 due",
+            ),
+        },
+        entry_tracking={
+            "mav-old": EntryTrackingRecord(
+                first_seen=_iso(terminal_at - timedelta(days=1)),
+                severity="medium",
+                terminal=TerminalOutcome(kind="resolved-by-human", at=_iso(terminal_at)),
+            ),
+        },
+        deliveries=[
+            DeliveryRecord(
+                kind="window-batch",
+                delivered_at=_iso(terminal_at),
+                trigger="2026-01-01/09:00",
+                entry_ids=["mav-old"],
+                summary={"counts": {"medium": 1}},
+            ),
+        ],
+    )
+
+    result = prune(state, now)
+
+    assert result.window_decisions == {}
+    assert result.deliveries == []
+    assert result.entry_tracking == {}
+
+
+def test_prune_never_removes_record_referencing_any_open_entry() -> None:
+    """A window_decisions/deliveries record survives as long as *any*
+    referenced entry is still open — even if a co-referenced terminal entry
+    is independently pruned from entry_tracking on its own 90-day clock
+    (contracts/delivery-state-schema.md invariant 6: the record-level rule
+    and the entry_tracking-row rule are each self-contained)."""
+    now = datetime(2026, 8, 5, tzinfo=UTC)
+    terminal_at = now - timedelta(days=91)
+    state = DeliveryState(
+        updated_at=_iso(now),
+        window_decisions={
+            "2026-01-01/09:00": WindowDecisionRecord(
+                outcome="delivered",
+                decided_at=_iso(terminal_at),
+                entry_ids=["mav-old", "mav-open"],
+                rule="window 09:00 due",
+            ),
+        },
+        entry_tracking={
+            "mav-old": EntryTrackingRecord(
+                first_seen=_iso(terminal_at - timedelta(days=1)),
+                severity="medium",
+                terminal=TerminalOutcome(kind="resolved-by-human", at=_iso(terminal_at)),
+            ),
+            "mav-open": EntryTrackingRecord(
+                first_seen=_iso(terminal_at - timedelta(days=1)),
+                severity="medium",
+                terminal=None,
+            ),
+        },
+        deliveries=[
+            DeliveryRecord(
+                kind="window-batch",
+                delivered_at=_iso(terminal_at),
+                trigger="2026-01-01/09:00",
+                entry_ids=["mav-old", "mav-open"],
+                summary={"counts": {"medium": 2}},
+            ),
+        ],
+    )
+
+    result = prune(state, now)
+
+    assert "2026-01-01/09:00" in result.window_decisions
+    assert len(result.deliveries) == 1
+    # mav-old's own terminal+90days clock has elapsed, independent of the
+    # still-kept record that references it.
+    assert "mav-old" not in result.entry_tracking
+    assert "mav-open" in result.entry_tracking
+
+
+def test_prune_never_removes_record_referencing_unknown_entry() -> None:
+    """An entry id absent from entry_tracking entirely is conservatively
+    treated as not-prunable (unknown status errs toward "open")."""
+    now = datetime(2026, 8, 5, tzinfo=UTC)
+    terminal_at = now - timedelta(days=91)
+    state = DeliveryState(
+        updated_at=_iso(now),
+        window_decisions={
+            "2026-01-01/09:00": WindowDecisionRecord(
+                outcome="delivered",
+                decided_at=_iso(terminal_at),
+                entry_ids=["mav-unknown"],
+                rule="window 09:00 due",
+            ),
+        },
+    )
+
+    result = prune(state, now)
+
+    assert "2026-01-01/09:00" in result.window_decisions
+
+
+def test_prune_keeps_empty_batch_window_decision_within_retention() -> None:
+    """A decision referencing zero entries ('empty' outcome) is dated by its
+    own ``decided_at`` — inside the 90-day horizon the audit trail for "why
+    was nothing delivered at 09:00" must survive."""
+    now = datetime(2026, 8, 5, tzinfo=UTC)
+    recent = now - timedelta(days=10)
+    state = DeliveryState(
+        updated_at=_iso(now),
+        window_decisions={
+            "2026-07-26/09:00": WindowDecisionRecord(
+                outcome="empty",
+                decided_at=_iso(recent),
+                entry_ids=[],
+                rule="0 entries due",
+            ),
+        },
+    )
+
+    result = prune(state, now)
+
+    assert "2026-07-26/09:00" in result.window_decisions
+
+
+def test_prune_removes_empty_batch_window_decision_past_retention() -> None:
+    """Past the 90-day horizon an empty-batch decision prunes on the same
+    rule as any other record (contracts/delivery-state-schema.md invariant 6:
+    "every entry id it references is prunable" holds vacuously) — otherwise
+    every quiet window occurrence is immortal state."""
+    now = datetime(2026, 8, 5, tzinfo=UTC)
+    old = now - timedelta(days=365)
+    state = DeliveryState(
+        updated_at=_iso(now),
+        window_decisions={
+            "2025-08-05/09:00": WindowDecisionRecord(
+                outcome="empty",
+                decided_at=_iso(old),
+                entry_ids=[],
+                rule="0 entries due",
+            ),
+        },
+    )
+
+    result = prune(state, now)
+
+    assert result.window_decisions == {}
+
+
+def test_prune_empty_batch_window_decision_retention_boundary() -> None:
+    """Exactly 90 days old is prunable (``>= _RETENTION``, matching the
+    entry_tracking rule); one second short of it is retained."""
+    now = datetime(2026, 8, 5, tzinfo=UTC)
+    state = DeliveryState(
+        updated_at=_iso(now),
+        window_decisions={
+            "at-horizon": WindowDecisionRecord(
+                outcome="empty",
+                decided_at=_iso(now - timedelta(days=90)),
+                entry_ids=[],
+                rule="0 entries due",
+            ),
+            "inside-horizon": WindowDecisionRecord(
+                outcome="empty",
+                decided_at=_iso(now - timedelta(days=90) + timedelta(seconds=1)),
+                entry_ids=[],
+                rule="0 entries due",
+            ),
+        },
+    )
+
+    result = prune(state, now)
+
+    assert "at-horizon" not in result.window_decisions
+    assert "inside-horizon" in result.window_decisions
+
+
+def test_prune_keeps_empty_record_with_unparseable_timestamp() -> None:
+    """An unparseable own-timestamp errs toward "keep" — the same
+    conservative stance the entry-id rule takes for unknown entries."""
+    now = datetime(2026, 8, 5, tzinfo=UTC)
+    state = DeliveryState(
+        updated_at=_iso(now),
+        window_decisions={
+            "2025-08-05/09:00": WindowDecisionRecord(
+                outcome="empty",
+                decided_at="not-a-timestamp",
+                entry_ids=[],
+                rule="0 entries due",
+            ),
+        },
+    )
+
+    result = prune(state, now)
+
+    assert "2025-08-05/09:00" in result.window_decisions
+
+
+def test_prune_removes_empty_delivery_record_past_retention() -> None:
+    """The same own-timestamp basis applies to a `deliveries` record that
+    references zero entries — dated by ``delivered_at``."""
+    now = datetime(2026, 8, 5, tzinfo=UTC)
+    state = DeliveryState(
+        updated_at=_iso(now),
+        deliveries=[
+            DeliveryRecord(
+                kind="window-batch",
+                delivered_at=_iso(now - timedelta(days=365)),
+                trigger="2025-08-05/09:00",
+                entry_ids=[],
+                summary={"counts": {}},
+            ),
+            DeliveryRecord(
+                kind="window-batch",
+                delivered_at=_iso(now - timedelta(days=10)),
+                trigger="2026-07-26/09:00",
+                entry_ids=[],
+                summary={"counts": {}},
+            ),
+        ],
+    )
+
+    result = prune(state, now)
+
+    assert [record.trigger for record in result.deliveries] == ["2026-07-26/09:00"]
+
+
+def test_prune_does_not_mutate_input_state() -> None:
+    now = datetime(2026, 8, 5, tzinfo=UTC)
+    terminal_at = now - timedelta(days=91)
+    state = DeliveryState(
+        updated_at=_iso(now),
+        entry_tracking={
+            "mav-old": EntryTrackingRecord(
+                first_seen=_iso(terminal_at - timedelta(days=1)),
+                severity="medium",
+                terminal=TerminalOutcome(kind="resolved-by-human", at=_iso(terminal_at)),
+            ),
+        },
+    )
+
+    prune(state, now)
+
+    assert "mav-old" in state.entry_tracking
+
+
+# --- finalize_state (tasks.md T022, US3 write-after-success) ----------------
+#
+# `finalize_state` is the pure counterpart to `evaluate()`'s speculative
+# `state_after` (contracts/delivery-state-schema.md invariant 2): given the
+# real `EvaluationOutcome` from a live `evaluate()` call plus which of its
+# `deliveries` positions actually failed to send, it reverts exactly those
+# decisions' mutations before the CLI persists the result. Building fixtures
+# via the real `evaluate()` (rather than hand-assembling `EvaluationOutcome`)
+# keeps the delivery-record/index alignment these tests assert on identical
+# to what `notify.py` actually receives.
+
+_NOW = datetime(2026, 8, 6, 9, 0, tzinfo=UTC)
+
+
+def _schedule(*, min_batch_size: int = 1) -> AssumptionScheduleConfig:
+    return AssumptionScheduleConfig(windows=["09:00"], min_batch_size=min_batch_size)
+
+
+def _empty_state() -> DeliveryState:
+    return DeliveryState(updated_at="2026-08-01T00:00:00Z")
+
+
+def _entry(bead_id: str, *, severity: Severity = Severity.MEDIUM) -> AssumptionReportEntry:
+    return AssumptionReportEntry(
+        record=AssumptionRecord(
+            bead_id=bead_id,
+            question="Q?",
+            adopted_answer="A.",
+            alternatives=(),
+            severity=severity,
+            severity_defaulted=False,
+            status=STATUS_OPEN,
+            owner_spec="054-assumption-batch-scheduler",
+            source_bead="mav-source",
+            change_ids=(),
+            is_legacy=False,
+            created_at=None,
+        ),
+        final_answer=None,
+        waived_by=None,
+        waived_at=None,
+        waive_reason=None,
+        reconcile_status=None,
+        reconciled_answer=None,
+        reconcile_change_id=None,
+        reconcile_reason=None,
+        pending_reconcile=False,
+    )
+
+
+class TestFinalizeStateNoFailures:
+    def test_all_decisions_succeed_returns_full_state_after(self) -> None:
+        prior = _empty_state()
+        outcome = evaluate((_entry("mav-1"),), _schedule(), prior, _NOW)
+
+        result = finalize_state(outcome=outcome, prior_state=prior, failed_indices=(), now=_NOW)
+
+        assert "2026-08-06/09:00" in result.window_decisions
+        assert result.window_decisions["2026-08-06/09:00"].outcome == "delivered"
+        assert len(result.deliveries) == 1
+
+
+class TestFinalizeStateDeliveryFailureExcluded:
+    """FR-012: a decision whose delivery failed leaves the occurrence/entry
+    undecided in the persisted state — it is due again next time."""
+
+    def test_failed_window_batch_leaves_occurrence_undecided(self) -> None:
+        prior = _empty_state()
+        outcome = evaluate((_entry("mav-1"), _entry("mav-2")), _schedule(), prior, _NOW)
+        assert len(outcome.deliveries) == 1
+        assert outcome.deliveries[0].kind == DecisionKind.WINDOW_BATCH
+
+        result = finalize_state(outcome=outcome, prior_state=prior, failed_indices={0}, now=_NOW)
+
+        assert "2026-08-06/09:00" not in result.window_decisions
+        assert result.deliveries == []
+
+    def test_failed_interrupt_reverts_entry_tracking_marker(self) -> None:
+        prior = _empty_state()
+        outcome = evaluate((_entry("mav-hi", severity=Severity.HIGH),), _schedule(), prior, _NOW)
+        assert len(outcome.deliveries) == 1
+        assert outcome.deliveries[0].kind == DecisionKind.INTERRUPT
+
+        result = finalize_state(outcome=outcome, prior_state=prior, failed_indices={0}, now=_NOW)
+
+        assert result.entry_tracking["mav-hi"].interrupt_delivered_at is None
+        assert result.deliveries == []
+
+    def test_undecided_occurrence_is_due_again_on_reevaluation(self) -> None:
+        """The functional proof: reverting a failed window batch's state
+        must make the *same* occurrence deliver again — not silently
+        vanish, and not be mistaken for `already-delivered`."""
+        entries = (_entry("mav-1"),)
+        prior = _empty_state()
+        outcome = evaluate(entries, _schedule(), prior, _NOW)
+
+        reverted = finalize_state(outcome=outcome, prior_state=prior, failed_indices={0}, now=_NOW)
+        retried = evaluate(entries, _schedule(), reverted, _NOW + timedelta(minutes=5))
+
+        assert len(retried.deliveries) == 1
+        assert retried.deliveries[0].kind == DecisionKind.WINDOW_BATCH
+        assert retried.deliveries[0].entry_ids == ("mav-1",)
+
+
+class TestFinalizeStatePartialSuccess:
+    def test_one_succeeds_one_fails_persists_only_the_success(self) -> None:
+        """A mixed ledger (medium + high) produces two due decisions in one
+        evaluation with no cross-talk (research R9) — a failure on one must
+        not take down the other's persisted state, and each is recorded
+        individually."""
+        entries = (
+            _entry("mav-med", severity=Severity.MEDIUM),
+            _entry("mav-hi", severity=Severity.HIGH),
+        )
+        prior = _empty_state()
+        outcome = evaluate(entries, _schedule(), prior, _NOW)
+        assert len(outcome.deliveries) == 2
+        index_by_kind = {d.kind: i for i, d in enumerate(outcome.deliveries)}
+        failed_index = index_by_kind[DecisionKind.INTERRUPT]
+        succeeded_index = index_by_kind[DecisionKind.WINDOW_BATCH]
+
+        result = finalize_state(
+            outcome=outcome, prior_state=prior, failed_indices={failed_index}, now=_NOW
+        )
+
+        # The succeeded window batch is fully persisted...
+        assert "2026-08-06/09:00" in result.window_decisions
+        assert len(result.deliveries) == 1
+        assert result.deliveries[0].kind == "window-batch"
+        assert result.deliveries[0].entry_ids == ["mav-med"]
+        assert succeeded_index >= 0  # sanity: both indices resolved above
+
+        # ...while the failed interrupt's marker is reverted and it never
+        # lands in the persisted audit trail.
+        assert result.entry_tracking["mav-hi"].interrupt_delivered_at is None
+        assert not any(record.kind == "interrupt" for record in result.deliveries)
+
+
+class TestFinalizeStatePrunesSurvivingState:
+    def test_finalize_state_applies_fr023_pruning(self) -> None:
+        """`finalize_state` must apply the same FR-023 retention rule
+        `prune()` does — it is the sole gateway between `evaluate()`'s
+        candidate state and what `notify.py` persists."""
+        terminal_at = _NOW - timedelta(days=91)
+        prior = DeliveryState(
+            updated_at="2026-08-01T00:00:00Z",
+            entry_tracking={
+                "mav-old": EntryTrackingRecord(
+                    first_seen="2026-05-01T00:00:00Z",
+                    severity="medium",
+                    terminal=TerminalOutcome(kind="resolved-by-human", at=_iso(terminal_at)),
+                ),
+            },
+        )
+        outcome = evaluate((), _schedule(), prior, _NOW)
+
+        result = finalize_state(outcome=outcome, prior_state=prior, failed_indices=(), now=_NOW)
+
+        assert "mav-old" not in result.entry_tracking

--- a/tests/unit/assumptions/test_land_report.py
+++ b/tests/unit/assumptions/test_land_report.py
@@ -31,6 +31,7 @@ def _record(
     is_legacy: bool = False,
     owner_spec: str = "052-conditional-landing",
     change_ids: tuple[str, ...] = (),
+    created_at: str | None = None,
 ) -> AssumptionRecord:
     return AssumptionRecord(
         bead_id=bead_id,
@@ -44,6 +45,7 @@ def _record(
         source_bead="dea-0",
         change_ids=change_ids,
         is_legacy=is_legacy,
+        created_at=created_at,
     )
 
 
@@ -58,6 +60,7 @@ def _entry(
     owner_spec: str = "052-conditional-landing",
     change_ids: tuple[str, ...] = (),
     reconcile_change_id: str | None = None,
+    created_at: str | None = None,
 ) -> AssumptionReportEntry:
     return AssumptionReportEntry(
         record=_record(
@@ -67,6 +70,7 @@ def _entry(
             is_legacy=is_legacy,
             owner_spec=owner_spec,
             change_ids=change_ids,
+            created_at=created_at,
         ),
         final_answer="Yes." if status == STATUS_ANSWERED else None,
         waived_by="alice" if status == STATUS_WAIVED else None,
@@ -267,6 +271,22 @@ class TestBuildReportSchema:
         report = build_report((entry,), LandVerification.BLOCKED, run_id="r1", dry_run=False)
         row = report.to_dict()["specs"][0]["entries"][0]
         assert "pending reconcile" in row["annotations"]
+
+    def test_created_at_present_value_flows_into_row(self) -> None:
+        from maverick.assumptions.land_report import build_report
+
+        entry = _entry(bead_id="dea-1", created_at="2026-07-24T14:00:00+00:00")
+        report = build_report((entry,), LandVerification.VERIFIED, run_id="r1", dry_run=False)
+        row = report.to_dict()["specs"][0]["entries"][0]
+        assert row["created_at"] == "2026-07-24T14:00:00+00:00"
+
+    def test_created_at_absent_is_none_in_row(self) -> None:
+        from maverick.assumptions.land_report import build_report
+
+        entry = _entry(bead_id="dea-1", created_at=None)
+        report = build_report((entry,), LandVerification.VERIFIED, run_id="r1", dry_run=False)
+        row = report.to_dict()["specs"][0]["entries"][0]
+        assert row["created_at"] is None
 
     def test_degraded_flag_and_omitted_verification(self) -> None:
         from maverick.assumptions.land_report import build_report

--- a/tests/unit/assumptions/test_ledger_query.py
+++ b/tests/unit/assumptions/test_ledger_query.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
-from maverick.assumptions.ledger import open_blocking_entries, open_high_entries_before
+from maverick.assumptions.ledger import (
+    open_blocking_entries,
+    open_high_entries_before,
+    report_entries,
+)
 from maverick.assumptions.models import (
     ASSUMPTION_LABEL,
     ASSUMPTION_REVIEW_LABEL,
@@ -32,7 +36,11 @@ def _summary(bead_id: str, status: str = "open") -> BeadSummary:
 
 
 def _entry(
-    bead_id: str, severity: str, status: str = STATUS_OPEN, owner_spec: str = ""
+    bead_id: str,
+    severity: str,
+    status: str = STATUS_OPEN,
+    owner_spec: str = "",
+    created_at: str | None = None,
 ) -> BeadDetails:
     return BeadDetails(
         id=bead_id,
@@ -42,10 +50,11 @@ def _entry(
         status="closed" if status != STATUS_OPEN else "open",
         labels=[ASSUMPTION_LABEL, ASSUMPTION_REVIEW_LABEL, NEEDS_HUMAN_REVIEW_LABEL],
         state={KEY_SEVERITY: severity, KEY_STATUS: status, KEY_OWNER_SPEC: owner_spec},
+        created_at=created_at,
     )
 
 
-def _legacy_entry(bead_id: str) -> BeadDetails:
+def _legacy_entry(bead_id: str, created_at: str | None = None) -> BeadDetails:
     return BeadDetails(
         id=bead_id,
         title="Review: legacy",
@@ -54,6 +63,7 @@ def _legacy_entry(bead_id: str) -> BeadDetails:
         status="open",
         labels=[ASSUMPTION_REVIEW_LABEL, NEEDS_HUMAN_REVIEW_LABEL],
         state={"source_bead": "b-1", "flight_plan": "legacy-plan"},
+        created_at=created_at,
     )
 
 
@@ -176,3 +186,68 @@ class TestOpenHighEntriesBefore:
             result = await open_high_entries_before(client, epic_id="epic-1")
 
         assert result == ()
+
+
+class TestReportEntriesCreatedAt:
+    """``created_at`` propagation (spec 054 research R1) via ``report_entries``."""
+
+    @pytest.mark.asyncio
+    async def test_copies_created_at_from_bead_details(self) -> None:
+        client = _client()
+        details = _entry("dea-1", "medium", created_at="2026-08-05T22:09:49Z")
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            return [_summary("dea-1")]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return details
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            result = await report_entries(client)
+
+        assert len(result) == 1
+        assert result[0].record.created_at == "2026-08-05T22:09:49Z"
+
+    @pytest.mark.asyncio
+    async def test_created_at_none_when_bead_omits_it(self) -> None:
+        client = _client()
+        details = _entry("dea-1", "medium")
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            return [_summary("dea-1")]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return details
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            result = await report_entries(client)
+
+        assert len(result) == 1
+        assert result[0].record.created_at is None
+
+    @pytest.mark.asyncio
+    async def test_legacy_entry_copies_created_at(self) -> None:
+        client = _client()
+        details = _legacy_entry("legacy-1", created_at="2026-08-01T00:00:00Z")
+
+        async def fake_query(self: BeadClient, filter_expr: str) -> list[BeadSummary]:
+            return [_summary("legacy-1")]
+
+        async def fake_show(self: BeadClient, bead_id: str) -> BeadDetails:
+            return details
+
+        with (
+            patch.object(BeadClient, "query", new=fake_query),
+            patch.object(BeadClient, "show", new=fake_show),
+        ):
+            result = await report_entries(client)
+
+        assert len(result) == 1
+        assert result[0].record.is_legacy is True
+        assert result[0].record.created_at == "2026-08-01T00:00:00Z"

--- a/tests/unit/assumptions/test_models.py
+++ b/tests/unit/assumptions/test_models.py
@@ -92,6 +92,24 @@ class TestAssumptionRecord:
         assert record.bead_id == "dea-1"
         assert record.change_ids == ()
         assert record.is_legacy is False
+        assert record.created_at is None
+
+    def test_created_at_carries_bd_timestamp(self) -> None:
+        record = AssumptionRecord(
+            bead_id="dea-1",
+            question="Q?",
+            adopted_answer="A.",
+            alternatives=(),
+            severity=Severity.MEDIUM,
+            severity_defaulted=False,
+            status=STATUS_OPEN,
+            owner_spec="054-assumption-batch-scheduler",
+            source_bead="dea-0",
+            change_ids=(),
+            is_legacy=False,
+            created_at="2026-08-05T22:09:49Z",
+        )
+        assert record.created_at == "2026-08-05T22:09:49Z"
 
 
 class TestPerSpecAssumptionCounts:

--- a/tests/unit/assumptions/test_serialize.py
+++ b/tests/unit/assumptions/test_serialize.py
@@ -34,6 +34,7 @@ def _record(
     question: str = "Q?",
     adopted_answer: str = "A.",
     alternatives: tuple[str, ...] = (),
+    created_at: str | None = None,
 ) -> AssumptionRecord:
     return AssumptionRecord(
         bead_id=bead_id,
@@ -47,6 +48,7 @@ def _record(
         source_bead=source_bead,
         change_ids=change_ids,
         is_legacy=is_legacy,
+        created_at=created_at,
     )
 
 
@@ -64,6 +66,7 @@ def _entry(
     reconciled_answer: str | None = None,
     reconcile_change_id: str | None = None,
     reconcile_reason: str | None = None,
+    created_at: str | None = None,
 ) -> AssumptionReportEntry:
     return AssumptionReportEntry(
         record=_record(
@@ -74,6 +77,7 @@ def _entry(
             is_legacy=is_legacy,
             owner_spec=owner_spec,
             change_ids=change_ids,
+            created_at=created_at,
         ),
         final_answer="Yes." if status == STATUS_ANSWERED else None,
         waived_by="alice" if status == STATUS_WAIVED else None,
@@ -194,6 +198,20 @@ class TestEntryToDictNewFields:
         entry = _entry(status=STATUS_WAIVED)
         row = entry_to_dict(entry)
         assert row["blocks_landing"] is False
+
+
+class TestEntryToDictCreatedAt:
+    """``created_at`` (spec 054 research R1) — additive, shared with the land report."""
+
+    def test_created_at_present(self) -> None:
+        entry = _entry(created_at="2026-08-05T22:09:49Z")
+        row = entry_to_dict(entry)
+        assert row["created_at"] == "2026-08-05T22:09:49Z"
+
+    def test_created_at_none_when_absent(self) -> None:
+        entry = _entry()
+        row = entry_to_dict(entry)
+        assert row["created_at"] is None
 
 
 class TestNullOmissionRule:

--- a/tests/unit/cli/commands/test_notify_json.py
+++ b/tests/unit/cli/commands/test_notify_json.py
@@ -1,0 +1,1145 @@
+"""CLI contract tests for ``maverick notify --json`` (T013, T022) per
+specs/054-assumption-batch-scheduler/contracts/cli-notify-json.md.
+
+House pattern (mirrors ``test_reconcile_json.py`` / ``test_review_json.py``):
+mock ``BeadClient.verify_available``/``.query`` so no real ``bd`` invocation
+occurs, invoke via ``cli_runner``. ``report_entries`` runs for real against
+the mocked ``BeadClient`` (returns an empty ledger sweep in every test here);
+the decision engine itself (``evaluate()``) is stubbed with a canned
+``EvaluationOutcome`` — window/quiet-hours/DST evaluation logic is already
+covered by ``tests/unit/assumptions/schedule/test_evaluate_*.py`` (T010/T011),
+so these tests only need to prove the CLI's effects layer (delivery,
+write-after-success state persistence, envelope shape, error mapping).
+``acquire_lock``/``load_state``/``save_state``/``release_lock`` run for real
+against a temp cwd so the persisted-state assertions are genuine.
+
+T022 (US3, cron-hardening) adds one exception to the "``evaluate()`` is
+stubbed" rule: ``TestRealEvaluateIdempotence`` lets it run for real across
+two actual CLI invocations against the same persisted state, because
+idempotence across process restarts can't be proven against a canned
+outcome — see that class's docstring.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import UTC, date, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner, Result
+
+from maverick.assumptions.errors import AssumptionLedgerError
+from maverick.assumptions.schedule.deliver import DeliveryFailedError
+from maverick.assumptions.schedule.models import (
+    AutoWaiveDecision,
+    BatchSummary,
+    DecisionKind,
+    DeliveryDecision,
+    EvaluationOutcome,
+    SkipDecision,
+    SkipReason,
+    WindowOccurrence,
+)
+from maverick.assumptions.schedule.state import (
+    DeliveryRecord,
+    DeliveryState,
+    EntryTrackingRecord,
+    WindowDecisionRecord,
+)
+from maverick.beads.models import BeadDetails, BeadSummary
+from maverick.cli.common import BD_MISSING
+from maverick.cli.context import ExitCode
+from maverick.main import cli
+
+_CONFIGURED_YAML = """
+assumptions:
+  schedule:
+    windows: ["09:00"]
+
+notifications:
+  enabled: true
+  topic: test-topic
+"""
+
+_NOTIFICATIONS_DISABLED_YAML = """
+assumptions:
+  schedule:
+    windows: ["09:00"]
+
+notifications:
+  enabled: false
+  topic: test-topic
+"""
+
+_NOTIFICATIONS_NO_TOPIC_YAML = """
+assumptions:
+  schedule:
+    windows: ["09:00"]
+
+notifications:
+  enabled: true
+"""
+
+_UNCONFIGURED_YAML = """
+notifications:
+  enabled: true
+  topic: test-topic
+"""
+
+
+def _write_config(temp_dir: Path, yaml_text: str) -> None:
+    (temp_dir / "maverick.yaml").write_text(yaml_text)
+
+
+def _stub_preconditions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass real bd/ledger I/O: bd is ready, the ledger sweep is empty."""
+    monkeypatch.setattr("maverick.cli.commands.notify.bd_ready_reason", lambda cwd: None)
+    monkeypatch.setattr(
+        "maverick.beads.client.BeadClient.verify_available",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "maverick.beads.client.BeadClient.query",
+        AsyncMock(return_value=[]),
+    )
+
+
+def _stub_evaluate(monkeypatch: pytest.MonkeyPatch, outcome: EvaluationOutcome) -> None:
+    def _fake_evaluate(
+        entries: object, schedule: object, state: object, now: object
+    ) -> EvaluationOutcome:
+        return outcome
+
+    monkeypatch.setattr("maverick.cli.commands.notify.evaluate", _fake_evaluate)
+
+
+class _FakeDeliverer:
+    """Fake ``NtfyDeliverer`` replacement: records calls, optionally raises."""
+
+    #: Class-level call log so the factory function signature matches
+    #: ``NtfyDeliverer.__init__`` while still being inspectable by tests.
+    calls: list[tuple[DecisionKind, BatchSummary]] = []
+    fail: bool = False
+
+    def __init__(self, *, server: str, topic: str) -> None:
+        self.server = server
+        self.topic = topic
+
+    async def __aenter__(self) -> _FakeDeliverer:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        return None
+
+    async def deliver(self, kind: DecisionKind, summary: BatchSummary) -> None:
+        type(self).calls.append((kind, summary))
+        if type(self).fail:
+            raise DeliveryFailedError(
+                "ntfy delivery failed after 3 attempts", kind=kind, status_code=503
+            )
+
+
+def _stub_deliverer(monkeypatch: pytest.MonkeyPatch, *, fail: bool) -> type[_FakeDeliverer]:
+    _FakeDeliverer.calls = []
+    _FakeDeliverer.fail = fail
+    monkeypatch.setattr("maverick.cli.commands.notify.NtfyDeliverer", _FakeDeliverer)
+    return _FakeDeliverer
+
+
+def _summary(**overrides: object) -> BatchSummary:
+    from maverick.assumptions.models import Severity
+
+    defaults: dict[str, object] = {
+        "counts": {Severity.HIGH: 0, Severity.MEDIUM: 2, Severity.LOW: 3},
+        "owner_specs": ("054-assumption-batch-scheduler",),
+        "oldest_age_hours": 11.5,
+        "review_invocation": "maverick review --list --status open",
+    }
+    defaults.update(overrides)
+    return BatchSummary(**defaults)  # type: ignore[arg-type]
+
+
+def _occurrence() -> WindowOccurrence:
+    return WindowOccurrence(
+        date=date(2026, 8, 5), window="09:00", due_at=datetime(2026, 8, 5, 9, 0, tzinfo=UTC)
+    )
+
+
+def _delivery_decision(*, entry_ids: tuple[str, ...] = ("mav-abc", "mav-def")) -> DeliveryDecision:
+    return DeliveryDecision(
+        kind=DecisionKind.WINDOW_BATCH,
+        entry_ids=entry_ids,
+        summary=_summary(),
+        occurrence=_occurrence(),
+        rule="window 09:00 due",
+    )
+
+
+def _state_after_one_delivery(
+    prior_state: DeliveryState, decision: DeliveryDecision
+) -> DeliveryState:
+    window_decisions = dict(prior_state.window_decisions)
+    window_decisions["2026-08-05/09:00"] = WindowDecisionRecord(
+        outcome="delivered",
+        decided_at="2026-08-05T09:00:05Z",
+        entry_ids=list(decision.entry_ids),
+        rule=decision.rule,
+    )
+    deliveries = [
+        *prior_state.deliveries,
+        DeliveryRecord(
+            kind="window-batch",
+            delivered_at="2026-08-05T09:00:05Z",
+            trigger="2026-08-05/09:00",
+            entry_ids=list(decision.entry_ids),
+            summary={
+                "counts": {"high": 0, "medium": 2, "low": 3},
+                "owner_specs": ["054-assumption-batch-scheduler"],
+                "oldest_age_hours": 11.5,
+                "review_invocation": "maverick review --list --status open",
+            },
+        ),
+    ]
+    return prior_state.model_copy(
+        update={
+            "updated_at": "2026-08-05T09:00:05Z",
+            "window_decisions": window_decisions,
+            "deliveries": deliveries,
+        }
+    )
+
+
+def _outcome_one_delivery() -> EvaluationOutcome:
+    prior_state = DeliveryState(updated_at="2026-08-05T08:00:00Z")
+    decision = _delivery_decision()
+    return EvaluationOutcome(
+        deliveries=(decision,),
+        skips=(),
+        auto_waives=(),
+        state_after=_state_after_one_delivery(prior_state, decision),
+    )
+
+
+def _summary_high_only() -> BatchSummary:
+    from maverick.assumptions.models import Severity
+
+    return _summary(counts={Severity.HIGH: 1, Severity.MEDIUM: 0, Severity.LOW: 0})
+
+
+def _outcome_one_interrupt() -> EvaluationOutcome:
+    """A single high-severity interrupt decision (T021), analogous to
+    :func:`_outcome_one_delivery` for window batches — ``occurrence`` is
+    ``None`` (interrupts aren't window-scoped) and the state mutation lands
+    on ``entry_tracking``, not ``window_decisions``."""
+    prior_state = DeliveryState(updated_at="2026-08-05T08:00:00Z")
+    decision = DeliveryDecision(
+        kind=DecisionKind.INTERRUPT,
+        entry_ids=("mav-hi",),
+        summary=_summary_high_only(),
+        occurrence=None,
+        rule="high-severity interrupt due",
+    )
+    state_after = prior_state.model_copy(
+        update={
+            "updated_at": "2026-08-05T09:00:05Z",
+            "entry_tracking": {
+                "mav-hi": EntryTrackingRecord(
+                    first_seen="2026-08-05T08:00:00Z",
+                    severity="high",
+                    interrupt_delivered_at="2026-08-05T09:00:05Z",
+                )
+            },
+            "deliveries": [
+                DeliveryRecord(
+                    kind="interrupt",
+                    delivered_at="2026-08-05T09:00:05Z",
+                    trigger="high-severity interrupt due",
+                    entry_ids=["mav-hi"],
+                    summary={
+                        "counts": {"high": 1, "medium": 0, "low": 0},
+                        "owner_specs": ["054-assumption-batch-scheduler"],
+                        "oldest_age_hours": 11.5,
+                        "review_invocation": "maverick review --list --status open",
+                    },
+                )
+            ],
+        }
+    )
+    return EvaluationOutcome(
+        deliveries=(decision,), skips=(), auto_waives=(), state_after=state_after
+    )
+
+
+def _outcome_nothing_due() -> EvaluationOutcome:
+    prior_state = DeliveryState(updated_at="2026-08-05T08:00:00Z")
+    skip = SkipDecision(
+        reason=SkipReason.NOT_YET_DUE,
+        occurrence=_occurrence(),
+        entry_ids=(),
+        rule="window 09:00 not yet due (due 2026-08-05T09:00:00+00:00)",
+    )
+    return EvaluationOutcome(deliveries=(), skips=(skip,), auto_waives=(), state_after=prior_state)
+
+
+def _setup(
+    temp_dir: Path, monkeypatch: pytest.MonkeyPatch, *, yaml_text: str = _CONFIGURED_YAML
+) -> None:
+    os.chdir(temp_dir)
+    monkeypatch.setattr(Path, "home", lambda: temp_dir)
+    _write_config(temp_dir, yaml_text)
+
+
+def _invoke(cli_runner: CliRunner, *args: str) -> Result:
+    return cli_runner.invoke(cli, ["notify", *args])
+
+
+class TestUnconfiguredNoOp:
+    def test_run_exits_success_ok_true(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch, yaml_text=_UNCONFIGURED_YAML)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.SUCCESS
+        data = json.loads(result.stdout)
+        assert data["ok"] is True
+        assert data["verb"] == "notify.run"
+        assert data["result"]["configured"] is False
+        assert data["result"]["skipped"] == "not-configured"
+        assert data["result"]["deliveries"] == []
+        assert data["result"]["skips"] == []
+        assert not (temp_dir / ".maverick" / "notify").exists()
+
+    def test_dry_run_uses_dry_run_verb(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch, yaml_text=_UNCONFIGURED_YAML)
+
+        result = _invoke(cli_runner, "--dry-run", "--json")
+
+        assert result.exit_code == ExitCode.SUCCESS
+        data = json.loads(result.stdout)
+        assert data["verb"] == "notify.dry-run"
+        assert data["result"]["dry_run"] is True
+
+
+class TestNotificationsUnusableValidation:
+    def test_notifications_disabled_names_the_key(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch, yaml_text=_NOTIFICATIONS_DISABLED_YAML)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.FAILURE
+        data = json.loads(result.stdout)
+        assert data["ok"] is False
+        assert data["error"]["kind"] == "validation"
+        assert "notifications.enabled" in data["error"]["message"]
+
+    def test_missing_topic_names_the_key(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch, yaml_text=_NOTIFICATIONS_NO_TOPIC_YAML)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.FAILURE
+        data = json.loads(result.stdout)
+        assert data["ok"] is False
+        assert data["error"]["kind"] == "validation"
+        assert "notifications.topic" in data["error"]["message"]
+        assert not (temp_dir / ".maverick" / "notify").exists()
+
+
+class TestBdUnavailable:
+    def test_bd_ready_reason_missing(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        monkeypatch.setattr("maverick.cli.commands.notify.bd_ready_reason", lambda cwd: BD_MISSING)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.FAILURE
+        data = json.loads(result.stdout)
+        assert data["ok"] is False
+        assert data["error"]["kind"] == "bd-unavailable"
+        assert data["verb"] == "notify.run"
+        assert not (temp_dir / ".maverick" / "notify").exists()
+
+    def test_verify_available_false(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        monkeypatch.setattr("maverick.cli.commands.notify.bd_ready_reason", lambda cwd: None)
+        monkeypatch.setattr(
+            "maverick.beads.client.BeadClient.verify_available",
+            AsyncMock(return_value=False),
+        )
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.FAILURE
+        data = json.loads(result.stdout)
+        assert data["error"]["kind"] == "bd-unavailable"
+
+
+class TestSuccessfulDelivery:
+    def test_single_window_batch_delivers_and_persists_state(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, _outcome_one_delivery())
+        _stub_deliverer(monkeypatch, fail=False)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.SUCCESS
+        data = json.loads(result.stdout)
+        assert data["ok"] is True
+        assert data["result"]["configured"] is True
+        assert data["result"]["skipped"] is None
+        assert len(data["result"]["deliveries"]) == 1
+        delivery = data["result"]["deliveries"][0]
+        assert delivery["kind"] == "window-batch"
+        assert delivery["trigger"] == "2026-08-05/09:00"
+        assert delivery["entry_ids"] == ["mav-abc", "mav-def"]
+        assert delivery["summary"]["counts"] == {"high": 0, "medium": 2, "low": 3}
+        assert delivery["rule"] == "window 09:00 due"
+        assert _FakeDeliverer.calls  # ntfy was actually invoked
+
+        state_path = temp_dir / ".maverick" / "notify" / "state.json"
+        assert state_path.is_file()
+        persisted = json.loads(state_path.read_text())
+        assert persisted["window_decisions"]["2026-08-05/09:00"]["outcome"] == "delivered"
+        assert len(persisted["deliveries"]) == 1
+
+    def test_nothing_due_reports_skips_and_persists_state(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, _outcome_nothing_due())
+        _stub_deliverer(monkeypatch, fail=False)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.SUCCESS
+        data = json.loads(result.stdout)
+        assert data["ok"] is True
+        assert data["result"]["deliveries"] == []
+        assert len(data["result"]["skips"]) == 1
+        assert data["result"]["skips"][0]["reason"] == "not-yet-due"
+        assert not _FakeDeliverer.calls
+
+
+class TestInterruptDelivery:
+    """T021: interrupt decisions flow through the same generic delivery
+    loop as window batches, but priority/title (urgent, per
+    contracts/ntfy-payload.md) are deliver.py's concern — proven directly
+    in ``test_deliver.py``. This class proves the CLI wires the interrupt
+    ``kind`` through to ``NtfyDeliverer.deliver`` unchanged and persists
+    ``interrupt_delivered_at`` correctly (success and failure)."""
+
+    def test_interrupt_delivers_and_persists_interrupt_delivered_at(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        outcome = _outcome_one_interrupt()
+        _stub_evaluate(monkeypatch, outcome)
+        deliverer_cls = _stub_deliverer(monkeypatch, fail=False)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.SUCCESS
+        data = json.loads(result.stdout)
+        assert data["ok"] is True
+        deliveries = data["result"]["deliveries"]
+        assert len(deliveries) == 1
+        assert deliveries[0]["kind"] == "interrupt"
+        assert deliveries[0]["entry_ids"] == ["mav-hi"]
+        assert deliveries[0]["trigger"] == "high-severity interrupt due"
+
+        # The kind reached NtfyDeliverer.deliver unchanged.
+        assert deliverer_cls.calls == [(DecisionKind.INTERRUPT, outcome.deliveries[0].summary)]
+
+        state_path = temp_dir / ".maverick" / "notify" / "state.json"
+        persisted = json.loads(state_path.read_text())
+        assert persisted["entry_tracking"]["mav-hi"]["interrupt_delivered_at"] is not None
+
+    def test_failed_interrupt_reverts_interrupt_delivered_at(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """FR-012: a failed interrupt push must not persist
+        ``interrupt_delivered_at`` — the entry stays due at the next
+        evaluation, mirroring the window-batch failure invariant in
+        ``TestDeliveryFailedExhausted`` below."""
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, _outcome_one_interrupt())
+        _stub_deliverer(monkeypatch, fail=True)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.FAILURE
+        data = json.loads(result.stdout)
+        assert data["ok"] is False
+        assert data["error"]["kind"] == "delivery-failed"
+        assert data["error"]["details"]["failed_deliveries"][0]["kind"] == "interrupt"
+
+        state_path = temp_dir / ".maverick" / "notify" / "state.json"
+        assert state_path.is_file()
+        persisted = json.loads(state_path.read_text())
+        assert persisted["entry_tracking"]["mav-hi"]["interrupt_delivered_at"] is None
+        assert persisted["deliveries"] == []
+
+
+class TestDeliveryFailedExhausted:
+    def test_exit_1_delivery_failed_kind_and_state_excludes_failure(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, _outcome_one_delivery())
+        _stub_deliverer(monkeypatch, fail=True)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.FAILURE
+        data = json.loads(result.stdout)
+        assert data["ok"] is False
+        assert data["error"]["kind"] == "delivery-failed"
+        assert len(data["error"]["details"]["failed_deliveries"]) == 1
+        assert data["error"]["details"]["failed_deliveries"][0]["kind"] == "window-batch"
+
+        # FR-012: a failed decision's mutations must not be persisted — the
+        # occurrence stays undecided (and therefore due again next time).
+        state_path = temp_dir / ".maverick" / "notify" / "state.json"
+        assert state_path.is_file()
+        persisted = json.loads(state_path.read_text())
+        assert "2026-08-05/09:00" not in persisted["window_decisions"]
+        assert persisted["deliveries"] == []
+
+
+class TestPartialSuccessAcrossDecisions:
+    """T022/T024: a run with more than one due decision (e.g. a mixed
+    ledger's window batch *and* interrupt) must record each independently
+    — one failure must not roll back an unrelated decision's success."""
+
+    def test_one_of_two_due_decisions_fails_persists_the_success_independently(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+
+        batch_decision = _delivery_decision(entry_ids=("mav-med",))
+        interrupt_decision = DeliveryDecision(
+            kind=DecisionKind.INTERRUPT,
+            entry_ids=("mav-hi",),
+            summary=_summary_high_only(),
+            occurrence=None,
+            rule="high-severity interrupt due",
+        )
+        prior_state = DeliveryState(updated_at="2026-08-05T08:00:00Z")
+        state_after = prior_state.model_copy(
+            update={
+                "updated_at": "2026-08-05T09:00:05Z",
+                "window_decisions": {
+                    "2026-08-05/09:00": WindowDecisionRecord(
+                        outcome="delivered",
+                        decided_at="2026-08-05T09:00:05Z",
+                        entry_ids=list(batch_decision.entry_ids),
+                        rule=batch_decision.rule,
+                    )
+                },
+                "entry_tracking": {
+                    "mav-hi": EntryTrackingRecord(
+                        first_seen="2026-08-05T08:00:00Z",
+                        severity="high",
+                        interrupt_delivered_at="2026-08-05T09:00:05Z",
+                    )
+                },
+                "deliveries": [
+                    DeliveryRecord(
+                        kind="window-batch",
+                        delivered_at="2026-08-05T09:00:05Z",
+                        trigger="2026-08-05/09:00",
+                        entry_ids=list(batch_decision.entry_ids),
+                        summary={
+                            "counts": {"high": 0, "medium": 2, "low": 3},
+                            "owner_specs": ["054-assumption-batch-scheduler"],
+                            "oldest_age_hours": 11.5,
+                            "review_invocation": "maverick review --list --status open",
+                        },
+                    ),
+                    DeliveryRecord(
+                        kind="interrupt",
+                        delivered_at="2026-08-05T09:00:05Z",
+                        trigger="high-severity interrupt due",
+                        entry_ids=["mav-hi"],
+                        summary={
+                            "counts": {"high": 1, "medium": 0, "low": 0},
+                            "owner_specs": ["054-assumption-batch-scheduler"],
+                            "oldest_age_hours": 11.5,
+                            "review_invocation": "maverick review --list --status open",
+                        },
+                    ),
+                ],
+            }
+        )
+        outcome = EvaluationOutcome(
+            deliveries=(batch_decision, interrupt_decision),
+            skips=(),
+            auto_waives=(),
+            state_after=state_after,
+        )
+        _stub_evaluate(monkeypatch, outcome)
+
+        class _SelectivelyFailingDeliverer:
+            """Fails only the interrupt; the window batch always succeeds."""
+
+            calls: list[DecisionKind] = []
+
+            def __init__(self, *, server: str, topic: str) -> None:
+                pass
+
+            async def __aenter__(self) -> _SelectivelyFailingDeliverer:
+                return self
+
+            async def __aexit__(self, *exc_info: object) -> None:
+                return None
+
+            async def deliver(self, kind: DecisionKind, summary: BatchSummary) -> None:
+                type(self).calls.append(kind)
+                if kind == DecisionKind.INTERRUPT:
+                    raise DeliveryFailedError(
+                        "ntfy delivery failed after 3 attempts", kind=kind, status_code=503
+                    )
+
+        _SelectivelyFailingDeliverer.calls = []
+        monkeypatch.setattr(
+            "maverick.cli.commands.notify.NtfyDeliverer", _SelectivelyFailingDeliverer
+        )
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.FAILURE
+        data = json.loads(result.stdout)
+        assert data["ok"] is False
+        assert data["error"]["kind"] == "delivery-failed"
+        assert len(data["error"]["details"]["failed_deliveries"]) == 1
+        assert data["error"]["details"]["failed_deliveries"][0]["kind"] == "interrupt"
+        # Both decisions were attempted independently — the loop never
+        # short-circuits on the first failure.
+        assert _SelectivelyFailingDeliverer.calls == [
+            DecisionKind.WINDOW_BATCH,
+            DecisionKind.INTERRUPT,
+        ]
+
+        state_path = temp_dir / ".maverick" / "notify" / "state.json"
+        persisted = json.loads(state_path.read_text())
+        # The succeeded window batch is fully, individually persisted...
+        assert persisted["window_decisions"]["2026-08-05/09:00"]["outcome"] == "delivered"
+        assert len(persisted["deliveries"]) == 1
+        assert persisted["deliveries"][0]["kind"] == "window-batch"
+        # ...while the failed interrupt's marker is reverted, exactly as in
+        # the single-decision-failure case.
+        assert persisted["entry_tracking"]["mav-hi"]["interrupt_delivered_at"] is None
+
+
+class TestAutoWaiveEffects:
+    """T026/T028: ``AutoWaiveDecision``s execute via
+    ``assumptions.ledger.waive`` (research R10), recording a
+    :class:`~maverick.assumptions.schedule.state.TerminalOutcome` in
+    persisted state; ``--dry-run`` never touches bd (contract: zero bd
+    calls)."""
+
+    def _outcome_one_auto_waive(self) -> EvaluationOutcome:
+        prior_state = DeliveryState(updated_at="2026-08-05T08:00:00Z")
+        state_after = prior_state.model_copy(
+            update={
+                "updated_at": "2026-08-05T09:00:05Z",
+                "entry_tracking": {
+                    "mav-lo": EntryTrackingRecord(
+                        first_seen="2026-08-01T00:00:00Z",
+                        severity="low",
+                    )
+                },
+            }
+        )
+        decision = AutoWaiveDecision(
+            entry_id="mav-lo",
+            reason_text="auto-waived by schedule policy after 168h: stale, accepted risk",
+        )
+        return EvaluationOutcome(
+            deliveries=(), skips=(), auto_waives=(decision,), state_after=state_after
+        )
+
+    def test_real_run_calls_ledger_waive_and_records_terminal_outcome(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, self._outcome_one_auto_waive())
+        _stub_deliverer(monkeypatch, fail=False)
+
+        waive_calls: list[dict[str, object]] = []
+
+        async def _fake_waive(
+            client: object, *, bead_id: str, reason: str, waived_by: str
+        ) -> None:
+            waive_calls.append({"bead_id": bead_id, "reason": reason, "waived_by": waived_by})
+
+        monkeypatch.setattr("maverick.cli.commands.notify.ledger_waive", _fake_waive)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.SUCCESS
+        data = json.loads(result.stdout)
+        assert data["ok"] is True
+
+        assert len(waive_calls) == 1
+        assert waive_calls[0]["bead_id"] == "mav-lo"
+        assert waive_calls[0]["waived_by"] == "maverick-scheduler"
+        assert "168h" in str(waive_calls[0]["reason"])
+        assert "stale, accepted risk" in str(waive_calls[0]["reason"])
+
+        assert len(data["result"]["auto_waives"]) == 1
+        assert data["result"]["auto_waives"][0]["entry_id"] == "mav-lo"
+
+        state_path = temp_dir / ".maverick" / "notify" / "state.json"
+        persisted = json.loads(state_path.read_text())
+        terminal = persisted["entry_tracking"]["mav-lo"]["terminal"]
+        assert terminal["kind"] == "auto-waived"
+        assert (
+            terminal["detail"] == "auto-waived by schedule policy after 168h: stale, accepted risk"
+        )
+
+    def test_waive_failure_does_not_abort_the_run_or_record_terminal(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A bd failure waiving one entry must not crash the run
+        (Principle III) and must not fabricate a terminal outcome for an
+        entry that was never actually waived (FR-016)."""
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, self._outcome_one_auto_waive())
+        _stub_deliverer(monkeypatch, fail=False)
+
+        async def _failing_waive(
+            client: object, *, bead_id: str, reason: str, waived_by: str
+        ) -> None:
+            raise AssumptionLedgerError(f"Failed to waive {bead_id}: bd exploded")
+
+        monkeypatch.setattr("maverick.cli.commands.notify.ledger_waive", _failing_waive)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.SUCCESS
+        data = json.loads(result.stdout)
+        assert data["ok"] is True
+        assert data["result"]["auto_waives"] == []
+
+        state_path = temp_dir / ".maverick" / "notify" / "state.json"
+        persisted = json.loads(state_path.read_text())
+        assert persisted["entry_tracking"]["mav-lo"].get("terminal") is None
+
+    def test_dry_run_reports_would_waive_with_zero_bd_calls(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, self._outcome_one_auto_waive())
+        _stub_deliverer(monkeypatch, fail=False)
+
+        waive_calls: list[object] = []
+
+        async def _fake_waive(*args: object, **kwargs: object) -> None:
+            waive_calls.append((args, kwargs))
+
+        monkeypatch.setattr("maverick.cli.commands.notify.ledger_waive", _fake_waive)
+
+        result = _invoke(cli_runner, "--dry-run", "--json")
+
+        assert result.exit_code == ExitCode.SUCCESS
+        data = json.loads(result.stdout)
+        assert data["verb"] == "notify.dry-run"
+        assert data["result"]["dry_run"] is True
+        assert len(data["result"]["auto_waives"]) == 1
+        assert data["result"]["auto_waives"][0]["entry_id"] == "mav-lo"
+
+        assert not waive_calls
+        assert not (temp_dir / ".maverick" / "notify").exists()
+
+
+class TestDryRunZeroSideEffects:
+    def test_dry_run_reports_would_deliver_with_zero_side_effects(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, _outcome_one_delivery())
+        _stub_deliverer(monkeypatch, fail=False)
+
+        result = _invoke(cli_runner, "--dry-run", "--json")
+
+        assert result.exit_code == ExitCode.SUCCESS
+        data = json.loads(result.stdout)
+        assert data["verb"] == "notify.dry-run"
+        assert data["result"]["dry_run"] is True
+        assert len(data["result"]["deliveries"]) == 1
+
+        # Zero ntfy calls, zero state writes (contract).
+        assert not _FakeDeliverer.calls
+        assert not (temp_dir / ".maverick" / "notify").exists()
+
+
+class TestConcurrentEvaluationBenignSkip:
+    def test_held_lock_is_ok_true_skipped_exit_zero(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        monkeypatch.setattr(
+            "maverick.cli.commands.notify.acquire_lock", AsyncMock(return_value=False)
+        )
+        # `evaluate`/deliverer must never be reached — no evaluation is
+        # performed at all on a benign lock skip (research R7).
+        _stub_evaluate(monkeypatch, _outcome_one_delivery())
+        _stub_deliverer(monkeypatch, fail=False)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.SUCCESS
+        data = json.loads(result.stdout)
+        assert data["ok"] is True
+        assert data["result"]["skipped"] == "concurrent-evaluation"
+        assert data["result"]["deliveries"] == []
+        assert not _FakeDeliverer.calls
+
+    def test_held_lock_from_real_live_pid_leaves_lockfile_untouched(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Same contract as above, but against a genuine lockfile carrying
+        this test process's own (guaranteed-live) pid, rather than a
+        mocked ``acquire_lock`` — proves the real pid-liveness check, not
+        just the CLI's handling of a canned ``False`` return."""
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, _outcome_one_delivery())
+        _stub_deliverer(monkeypatch, fail=False)
+
+        lock_path = temp_dir / ".maverick" / "notify" / "lock"
+        lock_path.parent.mkdir(parents=True)
+        lock_path.write_text(str(os.getpid()), encoding="utf-8")
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.SUCCESS
+        data = json.loads(result.stdout)
+        assert data["ok"] is True
+        assert data["result"]["skipped"] == "concurrent-evaluation"
+        assert data["result"]["deliveries"] == []
+        assert not _FakeDeliverer.calls
+        # A benign skip never touches the lock it lost the race for.
+        assert lock_path.read_text(encoding="utf-8").strip() == str(os.getpid())
+        assert not (temp_dir / ".maverick" / "notify" / "state.json").exists()
+
+    def test_stale_lock_from_dead_pid_is_reclaimed_and_evaluation_proceeds(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """research R7 is about *live*-pid contention specifically; a lock
+        naming a dead pid (crashed prior run, machine reboot) must not
+        wedge the command forever — ``acquire_lock`` reclaims it and this
+        run evaluates and delivers normally."""
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, _outcome_one_delivery())
+        _stub_deliverer(monkeypatch, fail=False)
+
+        proc = subprocess.Popen([sys.executable, "-c", "pass"])
+        dead_pid = proc.pid
+        proc.wait()  # reap the child; dead_pid is now guaranteed not alive
+
+        lock_path = temp_dir / ".maverick" / "notify" / "lock"
+        lock_path.parent.mkdir(parents=True)
+        lock_path.write_text(str(dead_pid), encoding="utf-8")
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.SUCCESS
+        data = json.loads(result.stdout)
+        assert data["ok"] is True
+        assert data["result"]["skipped"] is None
+        assert len(data["result"]["deliveries"]) == 1
+        assert _FakeDeliverer.calls  # evaluation proceeded for real
+        # Released cleanly after this run completed.
+        assert not lock_path.exists()
+
+
+# --- T022 (US3): ledger-read failure -----------------------------------------
+
+
+class TestLedgerReadFailure:
+    """spec.md edge case: "Ledger unreadable at evaluation time: the run
+    fails with a clear diagnostic; it must not record deliveries or mutate
+    state based on a partial read." Mirrors research R11's mapping
+    (``AssumptionLedgerError`` -> ``validation``, via the existing
+    ``json_error_handler`` dispatch)."""
+
+    def test_ledger_read_failure_maps_to_validation_with_zero_state_mutation(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        monkeypatch.setattr("maverick.cli.commands.notify.bd_ready_reason", lambda cwd: None)
+        monkeypatch.setattr(
+            "maverick.beads.client.BeadClient.verify_available",
+            AsyncMock(return_value=True),
+        )
+        monkeypatch.setattr(
+            "maverick.cli.commands.notify.report_entries",
+            AsyncMock(side_effect=AssumptionLedgerError("Failed to query task beads: boom")),
+        )
+        _stub_deliverer(monkeypatch, fail=False)
+
+        result = _invoke(cli_runner, "--json")
+
+        assert result.exit_code == ExitCode.FAILURE
+        data = json.loads(result.stdout)
+        assert data["ok"] is False
+        assert data["error"]["kind"] == "validation"
+        assert not _FakeDeliverer.calls
+        # No state file was ever created: the failure happens before
+        # `load_state`/`save_state` are reached (the ledger sweep is the
+        # very first thing the evaluate-deliver-save sequence does).
+        assert not (temp_dir / ".maverick" / "notify" / "state.json").exists()
+        # The lock is released on the way out, not left held.
+        assert not (temp_dir / ".maverick" / "notify" / "lock").exists()
+
+
+# --- T022 (US3): real evaluate() idempotence across process restarts --------
+
+
+def _open_medium_bead_details(
+    bead_id: str, *, owner_spec: str = "054-assumption-batch-scheduler"
+) -> BeadDetails:
+    """A minimal, valid ``assumption``-labeled bead: real enough for
+    ``ledger.report_entries()``/``evaluate()`` to process, deliberately
+    inert on everything ``evaluate()`` doesn't look at (question/answer
+    text)."""
+    return BeadDetails(
+        id=bead_id,
+        title=f"Assumption: {bead_id}",
+        description=(
+            "## Question\n\nQ?\n\n"
+            "## Adopted Answer\n\nA.\n\n"
+            "## Alternatives Considered\n\n(none)\n\n"
+            "## Context\n\nSource bead: mav-source — Source\n"
+        ),
+        bead_type="task",
+        status="open",
+        labels=["assumption"],
+        state={
+            "assumption_severity": "medium",
+            "assumption_status": "open",
+            "assumption_owner_spec": owner_spec,
+            "source_bead": "mav-source",
+        },
+    )
+
+
+def _stub_real_ledger_sweep(monkeypatch: pytest.MonkeyPatch, bead_ids: list[str]) -> None:
+    """Wire ``BeadClient.query``/``.show`` so ``report_entries()`` — and
+    therefore ``evaluate()`` — runs for real, unlike :func:`_stub_preconditions`
+    (which returns an empty ledger sweep, requiring ``evaluate()`` itself to
+    be stubbed via :func:`_stub_evaluate` in every other test in this file)."""
+    monkeypatch.setattr("maverick.cli.commands.notify.bd_ready_reason", lambda cwd: None)
+    monkeypatch.setattr(
+        "maverick.beads.client.BeadClient.verify_available",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "maverick.beads.client.BeadClient.query",
+        AsyncMock(
+            return_value=[BeadSummary(id=bid, title=bid, status="open") for bid in bead_ids]
+        ),
+    )
+    details_by_id = {bid: _open_medium_bead_details(bid) for bid in bead_ids}
+
+    async def _fake_show(self: object, bead_id: str) -> BeadDetails:
+        return details_by_id[bead_id]
+
+    monkeypatch.setattr("maverick.beads.client.BeadClient.show", _fake_show)
+
+
+#: ``"00:00"`` is always due for *any* wall-clock ``now`` on the day the
+#: test runs (no quiet hours configured) — this is how these tests avoid
+#: needing a clock-injection seam in the CLI boundary itself (research R6
+#: keeps that seam confined to ``evaluate()``'s own `now` parameter).
+_REAL_EVAL_YAML = """
+assumptions:
+  schedule:
+    windows: ["00:00"]
+
+notifications:
+  enabled: true
+  topic: test-topic
+"""
+
+
+class TestRealEvaluateIdempotence:
+    """T022 (US3): the rest of this file stubs ``evaluate()`` with a canned
+    ``EvaluationOutcome`` — sufficient to prove the CLI's effects layer, but
+    not idempotence *across two real process-boundary invocations* sharing
+    persisted state, which is exactly what a cron-driven re-run is. These
+    tests let ``report_entries()`` and ``evaluate()`` run for real against a
+    real ``.maverick/notify/state.json`` in ``temp_dir``, invoking the CLI
+    twice in sequence."""
+
+    def test_second_run_same_window_skips_with_zero_transport_calls(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch, yaml_text=_REAL_EVAL_YAML)
+        _stub_real_ledger_sweep(monkeypatch, ["mav-1"])
+        _stub_deliverer(monkeypatch, fail=False)
+
+        first = _invoke(cli_runner, "--json")
+        assert first.exit_code == ExitCode.SUCCESS
+        first_data = json.loads(first.stdout)
+        assert len(first_data["result"]["deliveries"]) == 1
+        assert first_data["result"]["deliveries"][0]["kind"] == "window-batch"
+        assert len(_FakeDeliverer.calls) == 1
+
+        second = _invoke(cli_runner, "--json")
+
+        assert second.exit_code == ExitCode.SUCCESS
+        second_data = json.loads(second.stdout)
+        assert second_data["result"]["deliveries"] == []
+        assert any(
+            skip["reason"] == "already-delivered" for skip in second_data["result"]["skips"]
+        )
+        # No second ntfy push for the already-decided occurrence.
+        assert len(_FakeDeliverer.calls) == 1
+
+    def test_new_entry_after_delivery_waits_for_next_window(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """spec.md US3 acceptance scenario 2: a batch already delivered at
+        one window must not re-fire just because a new entry showed up —
+        the new entry waits for the next occurrence, not an immediate
+        second delivery of the same one."""
+        _setup(temp_dir, monkeypatch, yaml_text=_REAL_EVAL_YAML)
+        _stub_real_ledger_sweep(monkeypatch, ["mav-1"])
+        _stub_deliverer(monkeypatch, fail=False)
+
+        first = _invoke(cli_runner, "--json")
+        assert len(json.loads(first.stdout)["result"]["deliveries"]) == 1
+
+        # A second entry shows up after the window already delivered.
+        _stub_real_ledger_sweep(monkeypatch, ["mav-1", "mav-2"])
+        second = _invoke(cli_runner, "--json")
+
+        assert second.exit_code == ExitCode.SUCCESS
+        second_data = json.loads(second.stdout)
+        assert second_data["result"]["deliveries"] == []
+        assert any(
+            skip["reason"] == "already-delivered" for skip in second_data["result"]["skips"]
+        )
+        assert len(_FakeDeliverer.calls) == 1

--- a/tests/unit/cli/commands/test_review_listing.py
+++ b/tests/unit/cli/commands/test_review_listing.py
@@ -33,6 +33,7 @@ def _entry(
     status: str = STATUS_OPEN,
     pending_reconcile: bool = False,
     question: str = "Q?",
+    created_at: str | None = None,
 ) -> AssumptionReportEntry:
     record = AssumptionRecord(
         bead_id=bead_id,
@@ -46,6 +47,7 @@ def _entry(
         source_bead="src-1",
         change_ids=(),
         is_legacy=False,
+        created_at=created_at,
     )
     return AssumptionReportEntry(
         record=record,
@@ -206,6 +208,46 @@ class TestCounts:
         assert counts["by_status"] == {"open": 2, "answered": 1, "waived": 0}
         assert counts["by_severity"] == {"low": 1, "medium": 1, "high": 1}
         assert counts["pending_reconcile"] == 1
+
+
+class TestCreatedAt:
+    def test_created_at_present_value_flows_into_row(self) -> None:
+        entries = (
+            _entry(
+                "dea-1",
+                owner_spec="049-spec",
+                severity=Severity.MEDIUM,
+                status=STATUS_OPEN,
+                created_at="2026-07-24T14:00:00+00:00",
+            ),
+        )
+        verify, sweep = _patched(entries)
+        runner = CliRunner()
+        with verify, sweep:
+            result = runner.invoke(review, ["--list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        row = data["result"]["entries"][0]
+        assert row["created_at"] == "2026-07-24T14:00:00+00:00"
+
+    def test_created_at_absent_is_none_in_row(self) -> None:
+        entries = (
+            _entry(
+                "dea-1",
+                owner_spec="049-spec",
+                severity=Severity.MEDIUM,
+                status=STATUS_OPEN,
+                created_at=None,
+            ),
+        )
+        verify, sweep = _patched(entries)
+        runner = CliRunner()
+        with verify, sweep:
+            result = runner.invoke(review, ["--list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        row = data["result"]["entries"][0]
+        assert row["created_at"] is None
 
 
 class TestEmptyQueue:

--- a/tests/unit/cli/test_json_output.py
+++ b/tests/unit/cli/test_json_output.py
@@ -38,7 +38,7 @@ from maverick.exceptions.beads import BeadQueryError
 
 
 class TestErrorKind:
-    """The 12-value ErrorKind registry is frozen per the contract."""
+    """The 13-value ErrorKind registry is frozen per the contract."""
 
     def test_exact_registry_values(self) -> None:
         expected = {
@@ -54,6 +54,7 @@ class TestErrorKind:
             "curation-failed",
             "vcs",
             "internal",
+            "delivery-failed",
         }
         actual = {member.value for member in ErrorKind}
         assert actual == expected
@@ -61,6 +62,11 @@ class TestErrorKind:
     def test_is_str_enum(self) -> None:
         assert ErrorKind.VALIDATION == "validation"
         assert isinstance(ErrorKind.VALIDATION, str)
+
+    def test_delivery_failed_value(self) -> None:
+        """054's ``notify`` verb maps ``DeliveryFailedError`` to this kind."""
+        assert ErrorKind.DELIVERY_FAILED == "delivery-failed"
+        assert isinstance(ErrorKind.DELIVERY_FAILED, str)
 
 
 # =============================================================================

--- a/tests/unit/cli/test_notify_command.py
+++ b/tests/unit/cli/test_notify_command.py
@@ -1,0 +1,318 @@
+"""Human-mode CLI tests for ``maverick notify`` (T013) per
+specs/054-assumption-batch-scheduler/contracts/cli-notify-json.md's
+"Human-mode output (no --json)" section.
+
+Same mocking style as ``tests/unit/cli/commands/test_notify_json.py`` — see
+that file's module docstring for the rationale (``evaluate()``/
+``NtfyDeliverer`` stubbed; ``BeadClient``/``report_entries`` run for real
+against a mocked ``bd``).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, date, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import pytest
+from click.testing import CliRunner, Result
+
+from maverick.assumptions.models import Severity
+from maverick.assumptions.schedule.deliver import DeliveryFailedError
+from maverick.assumptions.schedule.models import (
+    BatchSummary,
+    DecisionKind,
+    DeliveryDecision,
+    EvaluationOutcome,
+    SkipDecision,
+    SkipReason,
+    WindowOccurrence,
+)
+from maverick.assumptions.schedule.state import DeliveryRecord, DeliveryState, WindowDecisionRecord
+from maverick.cli.context import ExitCode
+from maverick.main import cli
+
+_CONFIGURED_YAML = """
+assumptions:
+  schedule:
+    windows: ["09:00"]
+
+notifications:
+  enabled: true
+  topic: test-topic
+"""
+
+_UNCONFIGURED_YAML = """
+notifications:
+  enabled: true
+  topic: test-topic
+"""
+
+
+def _setup(
+    temp_dir: Path, monkeypatch: pytest.MonkeyPatch, *, yaml_text: str = _CONFIGURED_YAML
+) -> None:
+    os.chdir(temp_dir)
+    monkeypatch.setattr(Path, "home", lambda: temp_dir)
+    (temp_dir / "maverick.yaml").write_text(yaml_text)
+
+
+def _stub_preconditions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("maverick.cli.commands.notify.bd_ready_reason", lambda cwd: None)
+    monkeypatch.setattr(
+        "maverick.beads.client.BeadClient.verify_available",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "maverick.beads.client.BeadClient.query",
+        AsyncMock(return_value=[]),
+    )
+
+
+def _stub_evaluate(
+    monkeypatch: pytest.MonkeyPatch,
+    outcome: EvaluationOutcome,
+    *,
+    captured: list[datetime] | None = None,
+) -> None:
+    def _fake_evaluate(
+        entries: object, schedule: object, state: object, now: datetime
+    ) -> EvaluationOutcome:
+        if captured is not None:
+            captured.append(now)
+        return outcome
+
+    monkeypatch.setattr("maverick.cli.commands.notify.evaluate", _fake_evaluate)
+
+
+class _FakeDeliverer:
+    calls: list[tuple[DecisionKind, BatchSummary]] = []
+    fail: bool = False
+
+    def __init__(self, *, server: str, topic: str) -> None:
+        self.server = server
+        self.topic = topic
+
+    async def __aenter__(self) -> _FakeDeliverer:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        return None
+
+    async def deliver(self, kind: DecisionKind, summary: BatchSummary) -> None:
+        type(self).calls.append((kind, summary))
+        if type(self).fail:
+            raise DeliveryFailedError(
+                "ntfy delivery failed after 3 attempts", kind=kind, status_code=503
+            )
+
+
+def _stub_deliverer(monkeypatch: pytest.MonkeyPatch, *, fail: bool) -> None:
+    _FakeDeliverer.calls = []
+    _FakeDeliverer.fail = fail
+    monkeypatch.setattr("maverick.cli.commands.notify.NtfyDeliverer", _FakeDeliverer)
+
+
+def _summary() -> BatchSummary:
+    return BatchSummary(
+        counts={Severity.HIGH: 0, Severity.MEDIUM: 2, Severity.LOW: 3},
+        owner_specs=("054-assumption-batch-scheduler",),
+        oldest_age_hours=11.5,
+        review_invocation="maverick review --list --status open",
+    )
+
+
+def _occurrence() -> WindowOccurrence:
+    return WindowOccurrence(
+        date=date(2026, 8, 5), window="09:00", due_at=datetime(2026, 8, 5, 9, 0, tzinfo=UTC)
+    )
+
+
+def _delivery_decision() -> DeliveryDecision:
+    return DeliveryDecision(
+        kind=DecisionKind.WINDOW_BATCH,
+        entry_ids=("mav-abc", "mav-def"),
+        summary=_summary(),
+        occurrence=_occurrence(),
+        rule="window 09:00 due",
+    )
+
+
+def _outcome_one_delivery() -> EvaluationOutcome:
+    prior_state = DeliveryState(updated_at="2026-08-05T08:00:00Z")
+    decision = _delivery_decision()
+    window_decisions = {
+        "2026-08-05/09:00": WindowDecisionRecord(
+            outcome="delivered",
+            decided_at="2026-08-05T09:00:05Z",
+            entry_ids=list(decision.entry_ids),
+            rule=decision.rule,
+        )
+    }
+    deliveries = [
+        DeliveryRecord(
+            kind="window-batch",
+            delivered_at="2026-08-05T09:00:05Z",
+            trigger="2026-08-05/09:00",
+            entry_ids=list(decision.entry_ids),
+            summary={
+                "counts": {"high": 0, "medium": 2, "low": 3},
+                "owner_specs": ["054-assumption-batch-scheduler"],
+                "oldest_age_hours": 11.5,
+                "review_invocation": "maverick review --list --status open",
+            },
+        )
+    ]
+    state_after = prior_state.model_copy(
+        update={
+            "updated_at": "2026-08-05T09:00:05Z",
+            "window_decisions": window_decisions,
+            "deliveries": deliveries,
+        }
+    )
+    return EvaluationOutcome(
+        deliveries=(decision,), skips=(), auto_waives=(), state_after=state_after
+    )
+
+
+def _outcome_nothing_due() -> EvaluationOutcome:
+    prior_state = DeliveryState(updated_at="2026-08-05T08:00:00Z")
+    skip = SkipDecision(
+        reason=SkipReason.NOT_YET_DUE,
+        occurrence=_occurrence(),
+        entry_ids=(),
+        rule="window 09:00 not yet due (due 2026-08-05T09:00:00+00:00)",
+    )
+    return EvaluationOutcome(deliveries=(), skips=(skip,), auto_waives=(), state_after=prior_state)
+
+
+def _invoke(cli_runner: CliRunner) -> Result:
+    return cli_runner.invoke(cli, ["notify"])
+
+
+class TestUnconfiguredNoOp:
+    def test_single_line_no_op_exit_zero(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch, yaml_text=_UNCONFIGURED_YAML)
+
+        result = _invoke(cli_runner)
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "not configured" in result.output
+        assert "assumptions.schedule" in result.output
+        assert not (temp_dir / ".maverick" / "notify").exists()
+
+
+class TestNothingDue:
+    def test_prints_nothing_due(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, _outcome_nothing_due())
+        _stub_deliverer(monkeypatch, fail=False)
+
+        result = _invoke(cli_runner)
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "Nothing due." in result.output
+
+
+class TestDeliveryCompletionLine:
+    def test_prints_delivered_completion_line(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, _outcome_one_delivery())
+        _stub_deliverer(monkeypatch, fail=False)
+
+        result = _invoke(cli_runner)
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "✓" in result.output  # ✓
+        assert "Delivered window batch" in result.output
+        assert "2 medium" in result.output
+        assert "3 low" in result.output
+        assert "11.5h" in result.output
+        assert "09:00 window" in result.output
+
+
+def _tzdata_available() -> bool:
+    """Whether this machine's tz database can resolve a DST-observing zone."""
+    try:
+        ZoneInfo("America/New_York")
+    except (ZoneInfoNotFoundError, ValueError, OSError):
+        return False
+    return True
+
+
+@pytest.mark.skipif(not _tzdata_available(), reason="tz database unavailable on this machine")
+class TestInjectedClock:
+    """The evaluation clock handed to ``evaluate()`` must carry a real IANA
+    zone when the machine has one — ``datetime.now().astimezone()`` yields a
+    fixed offset, which silently defeats ``evaluate()``'s DST handling for any
+    occurrence on the far side of a transition."""
+
+    def test_injected_now_carries_resolvable_zone(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("TZ", "America/New_York")
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        captured: list[datetime] = []
+        _stub_evaluate(monkeypatch, _outcome_nothing_due(), captured=captured)
+        _stub_deliverer(monkeypatch, fail=False)
+
+        result = _invoke(cli_runner)
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert len(captured) == 1
+        now = captured[0]
+        assert isinstance(now.tzinfo, ZoneInfo)
+        assert now.tzinfo.key == "America/New_York"
+        # The regression proper: the bound zone's offset varies across DST.
+        assert (
+            datetime(2026, 3, 7, 10, tzinfo=now.tzinfo).utcoffset()
+            != datetime(2026, 3, 9, 10, tzinfo=now.tzinfo).utcoffset()
+        )
+
+
+class TestDeliveryFailure:
+    def test_prints_failure_mark_and_warning_exit_one(
+        self,
+        cli_runner: CliRunner,
+        temp_dir: Path,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _setup(temp_dir, monkeypatch)
+        _stub_preconditions(monkeypatch)
+        _stub_evaluate(monkeypatch, _outcome_one_delivery())
+        _stub_deliverer(monkeypatch, fail=True)
+
+        result = _invoke(cli_runner)
+
+        assert result.exit_code == ExitCode.FAILURE
+        assert "✗" in result.output  # ✗
+        assert "Delivery failed" in result.output
+        assert "Warning:" in result.output

--- a/tests/unit/config/test_assumptions_schedule_config.py
+++ b/tests/unit/config/test_assumptions_schedule_config.py
@@ -1,0 +1,369 @@
+"""Tests for the ``assumptions.schedule`` config block.
+
+See specs/054-assumption-batch-scheduler/data-model.md section 2 and
+specs/054-assumption-batch-scheduler/contracts/config-schema.md for the
+full contract. ``assumptions.schedule`` is the delivery-policy block for
+``maverick notify``; the ntfy endpoint itself continues to come from the
+existing ``NotificationConfig`` (``notifications:`` block) — deliberately
+not duplicated here.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from maverick.config import (
+    AssumptionScheduleConfig,
+    AssumptionsConfig,
+    AutoWaivePolicyConfig,
+    MaverickConfig,
+    QuietHoursConfig,
+    load_config,
+)
+
+
+class TestAssumptionsConfigDefaults:
+    """``AssumptionsConfig`` defaults to an inert scheduler (FR-021)."""
+
+    def test_schedule_defaults_to_none(self) -> None:
+        config = AssumptionsConfig()
+        assert config.schedule is None
+
+    def test_maverick_config_wires_assumptions_with_default_factory(self) -> None:
+        config = MaverickConfig()
+        assert isinstance(config.assumptions, AssumptionsConfig)
+        assert config.assumptions.schedule is None
+
+    def test_maverick_config_assumptions_instances_are_independent(self) -> None:
+        """``default_factory`` must not share mutable state across instances."""
+        a = MaverickConfig()
+        b = MaverickConfig()
+        assert a.assumptions is not b.assumptions
+
+
+class TestAssumptionScheduleConfigDefaults:
+    """Defaults for the fields that have them (windows is required)."""
+
+    def test_requires_windows(self) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionScheduleConfig()
+
+    def test_defaults_match_contract(self) -> None:
+        schedule = AssumptionScheduleConfig(windows=["09:00", "17:00"])
+        assert schedule.windows == ["09:00", "17:00"]
+        assert schedule.quiet_hours is None
+        assert schedule.high_overrides_quiet is True
+        assert schedule.min_batch_size == 1
+        assert schedule.max_entry_age_hours == 24
+        assert schedule.renotify_backoff_hours == [4, 8, 16, 24]
+        assert schedule.auto_waive_low is None
+
+
+class TestWindowsValidation:
+    """``windows`` must be a non-empty list of unique ``HH:MM`` strings."""
+
+    def test_empty_windows_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionScheduleConfig(windows=[])
+
+    @pytest.mark.parametrize(
+        "bad_window",
+        ["9:00", "09:0", "24:00", "09:60", "0900", "9am", "09:00:00", ""],
+    )
+    def test_malformed_window_rejected(self, bad_window: str) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionScheduleConfig(windows=[bad_window])
+
+    def test_valid_window_boundaries_accepted(self) -> None:
+        schedule = AssumptionScheduleConfig(windows=["00:00", "23:59"])
+        assert schedule.windows == ["00:00", "23:59"]
+
+    def test_duplicate_windows_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionScheduleConfig(windows=["09:00", "09:00"])
+
+    def test_single_window_accepted(self) -> None:
+        schedule = AssumptionScheduleConfig(windows=["09:00"])
+        assert schedule.windows == ["09:00"]
+
+
+class TestQuietHoursConfig:
+    """``quiet_hours`` validates HH:MM and rejects ``start == end``."""
+
+    def test_valid_quiet_hours_spanning_midnight(self) -> None:
+        quiet = QuietHoursConfig(start="22:00", end="07:00")
+        assert quiet.start == "22:00"
+        assert quiet.end == "07:00"
+
+    def test_valid_quiet_hours_same_day(self) -> None:
+        quiet = QuietHoursConfig(start="01:00", end="05:00")
+        assert quiet.start == "01:00"
+        assert quiet.end == "05:00"
+
+    def test_start_equals_end_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            QuietHoursConfig(start="22:00", end="22:00")
+
+    @pytest.mark.parametrize("field", ["start", "end"])
+    def test_malformed_time_rejected(self, field: str) -> None:
+        kwargs = {"start": "22:00", "end": "07:00"}
+        kwargs[field] = "25:99"
+        with pytest.raises(ValidationError):
+            QuietHoursConfig(**kwargs)
+
+    def test_quiet_hours_absent_by_default(self) -> None:
+        schedule = AssumptionScheduleConfig(windows=["09:00"])
+        assert schedule.quiet_hours is None
+
+    def test_quiet_hours_wired_on_schedule(self) -> None:
+        schedule = AssumptionScheduleConfig(
+            windows=["09:00"],
+            quiet_hours=QuietHoursConfig(start="22:00", end="07:00"),
+        )
+        assert schedule.quiet_hours is not None
+        assert schedule.quiet_hours.start == "22:00"
+        assert schedule.quiet_hours.end == "07:00"
+
+    def test_quiet_hours_start_equals_end_rejected_via_schedule(self) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionScheduleConfig(
+                windows=["09:00"],
+                quiet_hours={"start": "22:00", "end": "22:00"},
+            )
+
+
+class TestMinBatchSizeAndMaxEntryAge:
+    def test_min_batch_size_ge_one(self) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionScheduleConfig(windows=["09:00"], min_batch_size=0)
+
+    def test_max_entry_age_hours_ge_one(self) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionScheduleConfig(windows=["09:00"], max_entry_age_hours=0)
+
+    def test_min_batch_size_override(self) -> None:
+        schedule = AssumptionScheduleConfig(windows=["09:00"], min_batch_size=3)
+        assert schedule.min_batch_size == 3
+
+    def test_high_overrides_quiet_override(self) -> None:
+        schedule = AssumptionScheduleConfig(windows=["09:00"], high_overrides_quiet=False)
+        assert schedule.high_overrides_quiet is False
+
+
+class TestRenotifyBackoffHours:
+    """Non-empty, each ``> 0``, non-decreasing (FR-007)."""
+
+    def test_empty_backoff_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionScheduleConfig(windows=["09:00"], renotify_backoff_hours=[])
+
+    def test_non_positive_value_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionScheduleConfig(windows=["09:00"], renotify_backoff_hours=[4, 0, 8])
+
+    def test_negative_value_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionScheduleConfig(windows=["09:00"], renotify_backoff_hours=[-1])
+
+    def test_decreasing_sequence_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionScheduleConfig(windows=["09:00"], renotify_backoff_hours=[8, 4])
+
+    def test_non_decreasing_with_repeats_accepted(self) -> None:
+        """Non-decreasing allows equal-value repeats (last value repeats indefinitely)."""
+        schedule = AssumptionScheduleConfig(windows=["09:00"], renotify_backoff_hours=[4, 4, 8])
+        assert schedule.renotify_backoff_hours == [4, 4, 8]
+
+    def test_strictly_increasing_accepted(self) -> None:
+        schedule = AssumptionScheduleConfig(windows=["09:00"], renotify_backoff_hours=[2, 6, 12])
+        assert schedule.renotify_backoff_hours == [2, 6, 12]
+
+    def test_single_value_accepted(self) -> None:
+        schedule = AssumptionScheduleConfig(windows=["09:00"], renotify_backoff_hours=[6])
+        assert schedule.renotify_backoff_hours == [6]
+
+
+class TestAutoWaivePolicyConfig:
+    """``enabled: true`` without ``rationale`` is rejected."""
+
+    def test_defaults(self) -> None:
+        policy = AutoWaivePolicyConfig()
+        assert policy.enabled is False
+        assert policy.after_hours == 168
+        assert policy.rationale is None
+
+    def test_enabled_without_rationale_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AutoWaivePolicyConfig(enabled=True)
+
+    def test_enabled_with_empty_rationale_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AutoWaivePolicyConfig(enabled=True, rationale="")
+
+    def test_enabled_with_rationale_accepted(self) -> None:
+        policy = AutoWaivePolicyConfig(
+            enabled=True,
+            rationale="accepted-risk: low-severity assumptions expire after a week",
+        )
+        assert policy.enabled is True
+        assert policy.rationale == ("accepted-risk: low-severity assumptions expire after a week")
+
+    def test_disabled_without_rationale_accepted(self) -> None:
+        policy = AutoWaivePolicyConfig(enabled=False)
+        assert policy.enabled is False
+        assert policy.rationale is None
+
+    def test_after_hours_ge_one(self) -> None:
+        with pytest.raises(ValidationError):
+            AutoWaivePolicyConfig(enabled=True, after_hours=0, rationale="accepted-risk")
+
+    def test_auto_waive_low_absent_by_default_on_schedule(self) -> None:
+        schedule = AssumptionScheduleConfig(windows=["09:00"])
+        assert schedule.auto_waive_low is None
+
+    def test_auto_waive_low_wired_on_schedule(self) -> None:
+        schedule = AssumptionScheduleConfig(
+            windows=["09:00"],
+            auto_waive_low=AutoWaivePolicyConfig(enabled=True, rationale="accepted-risk"),
+        )
+        assert schedule.auto_waive_low is not None
+        assert schedule.auto_waive_low.enabled is True
+
+    def test_auto_waive_low_enabled_without_rationale_rejected_via_schedule(self) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionScheduleConfig(
+                windows=["09:00"],
+                auto_waive_low={"enabled": True},
+            )
+
+
+class TestYamlAndEnvOverrides:
+    """Loading through ``load_config`` / env-var precedence."""
+
+    def test_yaml_full_schedule_round_trips(self, clean_env: None, temp_dir: Path) -> None:
+        os.chdir(temp_dir)
+        config_path = temp_dir / "maverick.yaml"
+        config_path.write_text(
+            """
+notifications:
+  enabled: true
+  topic: my-maverick-topic
+
+assumptions:
+  schedule:
+    windows: ["09:00", "17:00"]
+    quiet_hours:
+      start: "22:00"
+      end: "07:00"
+    high_overrides_quiet: true
+    min_batch_size: 1
+    max_entry_age_hours: 24
+    renotify_backoff_hours: [4, 8, 16, 24]
+    auto_waive_low:
+      enabled: true
+      after_hours: 168
+      rationale: "accepted-risk: low-severity assumptions expire after a week"
+"""
+        )
+
+        config = load_config()
+        schedule = config.assumptions.schedule
+        assert schedule is not None
+        assert schedule.windows == ["09:00", "17:00"]
+        assert schedule.quiet_hours is not None
+        assert schedule.quiet_hours.start == "22:00"
+        assert schedule.quiet_hours.end == "07:00"
+        assert schedule.high_overrides_quiet is True
+        assert schedule.min_batch_size == 1
+        assert schedule.max_entry_age_hours == 24
+        assert schedule.renotify_backoff_hours == [4, 8, 16, 24]
+        assert schedule.auto_waive_low is not None
+        assert schedule.auto_waive_low.enabled is True
+        assert schedule.auto_waive_low.after_hours == 168
+
+    def test_yaml_absent_schedule_stays_none(self, clean_env: None, temp_dir: Path) -> None:
+        os.chdir(temp_dir)
+        config_path = temp_dir / "maverick.yaml"
+        config_path.write_text(
+            """
+notifications:
+  enabled: false
+"""
+        )
+
+        config = load_config()
+        assert config.assumptions.schedule is None
+
+    def test_env_override_min_batch_size(
+        self, clean_env: None, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        os.chdir(temp_dir)
+        config_path = temp_dir / "maverick.yaml"
+        config_path.write_text(
+            """
+assumptions:
+  schedule:
+    windows: ["09:00"]
+"""
+        )
+        monkeypatch.setenv("MAVERICK_ASSUMPTIONS__SCHEDULE__MIN_BATCH_SIZE", "5")
+
+        config = load_config()
+        assert config.assumptions.schedule is not None
+        assert config.assumptions.schedule.min_batch_size == 5
+
+    def test_env_override_windows_list(
+        self, clean_env: None, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        os.chdir(temp_dir)
+        config_path = temp_dir / "maverick.yaml"
+        config_path.write_text(
+            """
+assumptions:
+  schedule:
+    windows: ["09:00"]
+"""
+        )
+        monkeypatch.setenv("MAVERICK_ASSUMPTIONS__SCHEDULE__WINDOWS", '["08:00", "20:00"]')
+
+        config = load_config()
+        assert config.assumptions.schedule is not None
+        assert config.assumptions.schedule.windows == ["08:00", "20:00"]
+
+    def test_env_override_high_overrides_quiet(
+        self, clean_env: None, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        os.chdir(temp_dir)
+        config_path = temp_dir / "maverick.yaml"
+        config_path.write_text(
+            """
+assumptions:
+  schedule:
+    windows: ["09:00"]
+"""
+        )
+        monkeypatch.setenv("MAVERICK_ASSUMPTIONS__SCHEDULE__HIGH_OVERRIDES_QUIET", "false")
+
+        config = load_config()
+        assert config.assumptions.schedule is not None
+        assert config.assumptions.schedule.high_overrides_quiet is False
+
+
+class TestExports:
+    """New models are part of the public ``maverick.config`` surface."""
+
+    def test_all_exports(self) -> None:
+        from maverick import config as config_module
+
+        for name in (
+            "AssumptionsConfig",
+            "AssumptionScheduleConfig",
+            "QuietHoursConfig",
+            "AutoWaivePolicyConfig",
+        ):
+            assert name in config_module.__all__
+            assert hasattr(config_module, name)


### PR DESCRIPTION
Implements `specs/054-assumption-batch-scheduler/` — all 32 tasks.

## What this adds

`maverick notify [--dry-run] [--json]`: an idempotent, daemonless command that reads the assumption ledger, evaluates it against a configured delivery schedule, and pushes anything due via ntfy. Built for cron or a systemd timer, not a resident process.

Severity drives the delivery policy:

| Severity | Policy |
|---|---|
| `high` | interrupts at the next evaluation after recording |
| `medium` | batches into the next configured review window |
| `low` | accumulates silently, only counted in a batch summary |

A medium/high entry older than `max_entry_age_hours` escalates past the batching rules; an unanswered high-severity interrupt then re-notifies on a backoff ladder (default `4→8→16→24h`, repeating) rather than on every evaluation. An opt-in `auto_waive_low` policy waives aged low entries through the existing `ledger.waive()` path, stamped `waived_by="maverick-scheduler"` — no ledger schema change.

With no `assumptions.schedule` block the command is strictly inert: exit 0, "not configured", zero deliveries. There is no built-in default schedule.

## Design notes

**Evaluation is pure.** `evaluate(entries, schedule, state, now)` does no I/O; `now` is injected at the CLI boundary — the codebase's first clock seam.

**Idempotence is the whole point.** Delivery state persists at `.maverick/notify/state.json` behind a pid-stamped advisory lockfile (mirroring `workflows/reconcile/state.py`). Re-running the same window is a no-op, and every delivery or skip is reconstructible from ledger + config + state alone.

**Lock contention deliberately diverges from `reconcile`.** Overlapping cron fires are expected operation here, not a fault, so a held lock is a benign `SUCCESS` exit with `result.skipped: "concurrent-evaluation"` — not `reconcile`'s `locked` error kind.

**Failed deliveries are never recorded as delivered.** State mutations are reverted per decision kind on failure, so an escalation whose push fails stays escalation-eligible rather than being silently swallowed.

**Quiet-hours policy is severity-scoped.** `high_overrides_quiet` governs high severity only. A medium escalation or a backlogged window batch is always held until quiet hours end (FR-004), then delivered exactly once at the first permissible evaluation.

Zero model calls, zero agents, zero Burr — deterministic library and CLI only.

## Supporting changes

- `created_at` threaded through beads → ledger → serialize, so entry age has a real basis with a `first_seen` fallback
- New `assumptions.schedule` config block; the existing `notifications` block is reused for the ntfy endpoint rather than duplicated
- Additive `ErrorKind.DELIVERY_FAILED` in the shared JSON envelope
- `clock.py` resolves the machine's real IANA zone (TZ → `/etc/localtime` → `/etc/timezone`, stdlib only, degrading to the fixed offset). Without it `datetime.now().astimezone()` yields a fixed offset and the DST fold/gap handling never fires in production.
- `/.maverick/notify` gitignored — per-machine state that jj-colocated checkouts would otherwise auto-snapshot into every commit

## Validation

- `make ci` green: **4713 passed, 1 pre-existing xfail**
- Live end-to-end run of all 6 `quickstart.md` scenarios against a real `bd` repo and a real ntfy topic: unconfigured no-op, dry-run, window-batch delivery + idempotence, high-severity interrupt, delivery-failure-stays-due + recovery, and concurrent-invocation benign skip. Pushes verified by polling the topic directly for exact title/body/priority, confirming zero entry-content leakage (FR-008).
- An `xhigh` code review over the branch found and fixed a set of real defects, notably: failed `ESCALATION`/`RENOTIFY` pushes being persisted as delivered (permanently losing a one-shot escalation), `resolved-by-human` never being stamped so `state.json` grew without bound, a malformed `bd` `created_at` crashing the whole unattended run, and the two quiet-hours leaks above.

## Known follow-up

`--dry-run` is currently blocked by the `notifications` config check before evaluating, so a schedule can't be previewed until ntfy is wired. That matches `contracts/cli-notify-json.md`'s error table as written; relaxing it is a contract amendment, not a bug fix, so it's left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U2VStxQbXt4U2bLRTPBDc
