### PR TITLE
feat(assumptions): learned assumption resolution (055)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/054-assumption-batch-scheduler"
+  "feature_directory": "specs/055-learned-assumption-resolution"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -709,7 +709,9 @@ opt-in `auto_waive_low` policy (research R10) waives aged low-severity
 entries through the existing `assumptions.ledger.waive()` path, stamped
 `waived_by="maverick-scheduler"` with a recorded rationale — already
 distinguishable in `review --list`/land reporting via the existing waiver
-object, no ledger schema change.
+object, no ledger schema change. Sibling machine actor: `maverick-resolver`,
+stamped by 055-learned-assumption-resolution's auto-resolution policy (see
+below) via the same `ledger.waive()` path.
 
 Configuration lives in two blocks (`contracts/config-schema.md`): the new
 `assumptions.schedule` block (`windows`, `quiet_hours`, `high_overrides_quiet`
@@ -829,6 +831,82 @@ the sweep — runs `reconcile --json`, reports the frontier via
 confirmation. The skill never touches jj/git/bd or files directly; see
 `specs/053-assumption-review-console/contracts/skill-review-console.md`
 for its full behavioral contract.
+
+### Learned assumption resolution (055-learned-assumption-resolution)
+
+Every terminal *human* resolution of a ledger entry — `maverick review
+<id> --answer/--waive`, and bulk waive — persists a `DecisionRecord`
+to `.maverick/runway/decisions.jsonl` (`assumptions.suggestions.record_decision`,
+called from `cli/commands/review/entry_actions.py`). Best-effort per
+FR-004: a store write failure warns and never blocks the ledger write
+that triggered it. Re-answering an entry writes a new record; reads
+collapse to one record per `source_entry_id` by latest `resolved_at`
+(`suggestions.collapse_decisions`), so history survives
+(`.maverick/runway/decisions.jsonl`) while matching only sees the
+latest. `decisions.jsonl` and `.maverick/runway/match-feedback.jsonl`
+(below) live at the runway store root, deliberately **outside**
+`episodic/` — `runway consolidate` never prunes them (`runway/store.py`'s
+`_DECISIONS_FILE`/`_MATCH_FEEDBACK_FILE`). Machine-initiated waives —
+the notification scheduler's `auto_waive_low` and this feature's own
+auto-resolution below — are structurally excluded from the corpus
+(FR-005): only the human CLI surfaces call `record_decision`.
+
+When a new assumption is recorded (fly's `record_assumptions`, and the
+spec-chain's standalone-entry recording), it's matched against the
+decision corpus by a pure, deterministic, zero-model-call formula
+(`assumptions/matching.py`): a 50/50 blend of `difflib.SequenceMatcher`
+ratio and token-set Jaccard overlap over `normalize_question`-normalized
+text (casefold, strip punctuation, collapse whitespace), penalized by
+`REJECTION_PENALTY = 0.30` per net rejection and gated at
+`PRESENTATION_THRESHOLD = 0.75` — both fixed contract constants, not
+configurable. `0.30` is sized so a single net rejection always suppresses
+even a perfect match (`1.0 - 0.30 = 0.70 < 0.75`). A match at or above
+threshold persists as a `Suggestion` (`assumptions/models.py`, one
+JSON-encoded bd state key, `KEY_SUGGESTION` = `assumption_suggestion`)
+carrying provenance (source entry/spec/resolved-at/confidence);
+`assumptions.suggestions.attach_suggestions` computes it at recording
+time, `backfill_suggestions` fills it in lazily for entries listed
+before a relevant decision existed — an existing stored suggestion is
+never replaced. The `suggestion`/`auto_resolved` fields ride the single
+shared row projection (`assumptions/serialize.py`'s `entry_to_dict`),
+so `review --list --json` and the land report can never drift; the
+`maverick-review` skill presents the suggestion as the default
+recommended option in its sweep, ahead of the entry's own adopted
+answer (`skills/review_console/SKILL.md`).
+
+Resolving an entry differently than its presented suggestion — a
+different answer, or a waive where an answer was suggested — records
+a `MatchFeedbackRecord` (`.maverick/runway/match-feedback.jsonl`,
+`suggestions.classify_feedback` + `record_feedback`) that lowers that
+exact (normalized question text, source decision id) pairing's future
+effective confidence (`matching.effective_confidence`); accepting a
+suggestion as-is records the opposite outcome and can restore it.
+
+An opt-in `assumptions.resolution.auto_resolve_low` config block
+(`config.AssumptionResolutionConfig` / `AutoResolvePolicyConfig` —
+double opt-in: the block must be present AND `enabled: true`;
+`confidence_threshold` defaults `0.9` and is bounded `>= 0.75` so it
+can never be looser than `PRESENTATION_THRESHOLD`) auto-waives
+low-severity entries at recording time once effective confidence
+clears the threshold — via the *existing* `ledger.waive()` path,
+stamped `waived_by="maverick-resolver"` (`suggestions._AUTO_RESOLVE_ACTOR`)
+with a rationale citing the matched decision, plus `KEY_AUTO_RESOLVED`
+(`assumption_auto_resolved`) on the bead. Because it's an ordinary
+waive, `classify()`/the land frontier gate need zero changes — an
+auto-resolved entry reads as any other waived entry: `land` renders it
+at most `CONDITIONALLY_VERIFIED`, never `VERIFIED`. Auto-resolution
+never applies above low severity and never writes an answer, so a
+machine decision can never enter reconcile's answered-entry detection.
+A human re-answering an auto-resolved entry
+(`cli/commands/review/entry_actions.py`) bypasses the normal
+`ALREADY_RESOLVED` refusal — scoped to `current_entry.auto_resolved`,
+never a human waive — and the override records a rejection against the
+pairing that auto-resolved it.
+
+See `src/maverick/assumptions/matching.py`, `assumptions/suggestions.py`,
+`runway/models.py` (`DecisionRecord`, `MatchFeedbackRecord`), and
+`specs/055-learned-assumption-resolution/` (spec/plan/contracts) for
+the full contract.
 
 ## Dependencies
 

--- a/specs/055-learned-assumption-resolution/checklists/requirements.md
+++ b/specs/055-learned-assumption-resolution/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Learned Assumption Resolution
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on first iteration. The spec references existing project
+  surfaces (`maverick review --list --json`, the maverick-review skill, the land
+  gate, the runway knowledge store) as behavioral context, not design mandates —
+  consistent with how prior specs in this repository are written.
+- "Closely matching" and the confidence formula are deliberately deferred to the
+  plan phase; the spec constrains them to be deterministic, documented, and
+  zero-model-call (FR-008) rather than prescribing an algorithm.
+- Ready for `/speckit-clarify` or `/speckit-plan`.

--- a/specs/055-learned-assumption-resolution/contracts/config-schema.md
+++ b/specs/055-learned-assumption-resolution/contracts/config-schema.md
@@ -1,0 +1,46 @@
+# Contract: `assumptions.resolution` Configuration Block
+
+New optional block in `maverick.yaml`, sibling to 054's `assumptions.schedule`:
+
+```yaml
+assumptions:
+  resolution:
+    auto_resolve_low:
+      enabled: true                # default: false — double opt-in with the block itself
+      confidence_threshold: 0.92   # default 0.9; must be >= 0.75 and <= 1.0
+```
+
+## Semantics
+
+| State | Behavior |
+|---|---|
+| `assumptions.resolution` absent (default) | Suggestions fully functional (they require no config); auto-resolution inert |
+| Block present, `auto_resolve_low` absent or `enabled: false` | Same as absent — suggestions only |
+| `enabled: true` | Low-severity entries with effective confidence ≥ `confidence_threshold` are auto-waived at recording time by `"maverick-resolver"` |
+
+## Validation (fails config load, FR-016)
+
+- `confidence_threshold` bounds: `ge=0.75`, `le=1.0`. The lower bound equals the
+  built-in `PRESENTATION_THRESHOLD` — "auto must be at least as strict as
+  presentation" (clarify Q3) — and a unit test pins the config bound to the
+  constant so they cannot drift.
+- Types per Pydantic; unknown keys ignored per `MaverickConfig` (`extra="ignore"`).
+
+## Model classes (`src/maverick/config.py`)
+
+```python
+class AutoResolvePolicyConfig(BaseModel):
+    enabled: bool = False
+    confidence_threshold: float = Field(default=0.9, ge=0.75, le=1.0)
+
+class AssumptionResolutionConfig(BaseModel):
+    auto_resolve_low: AutoResolvePolicyConfig | None = None
+
+class AssumptionsConfig(BaseModel):
+    schedule: AssumptionScheduleConfig | None = None      # existing (054)
+    resolution: AssumptionResolutionConfig | None = None  # new (055)
+```
+
+The presentation threshold itself is **not** configurable (clarify Q3); there is no
+key for it, and requests to tune it route to the contract in
+[decision-records.md](decision-records.md).

--- a/specs/055-learned-assumption-resolution/contracts/decision-records.md
+++ b/specs/055-learned-assumption-resolution/contracts/decision-records.md
@@ -1,0 +1,88 @@
+# Contract: Decision Records, Match Feedback, and the Matching Formula
+
+## Storage
+
+| File | Format | Writer | Pruned by consolidation? |
+|---|---|---|---|
+| `.maverick/runway/decisions.jsonl` | JSONL, one `DecisionRecord.to_dict()` per line | human review surfaces only (single answer/waive, bulk waive) | **Never** — outside `episodic/` by design |
+| `.maverick/runway/match-feedback.jsonl` | JSONL, one `MatchFeedbackRecord.to_dict()` per line | human review surfaces on resolving an entry that carried a suggestion | **Never** |
+
+Both files are created by `RunwayStore.initialize()` (touch, like the episodic
+files) and tolerated absent (read ⇒ empty corpus). Malformed lines are skipped with
+the store's existing `runway_jsonl_parse_error` warning. The runway root is
+git-committed; these files travel with the repository and never cross repositories.
+
+## RunwayStore API additions
+
+```python
+async def append_decision(self, record: DecisionRecord) -> None
+async def get_decisions(self, *, source_entry_id: str | None = None) -> list[DecisionRecord]
+async def append_match_feedback(self, record: MatchFeedbackRecord) -> None
+async def get_match_feedback(self) -> list[MatchFeedbackRecord]
+```
+
+Same conventions as existing methods: async, `aiofiles` append (non-atomic,
+O_APPEND), read-side filtering by equality.
+
+## Record shapes
+
+See [data-model.md](../data-model.md) for field tables. JSON example lines:
+
+```json
+{"source_entry_id": "mv-142", "question": "Should retries use exponential backoff?", "normalized_question": "should retries use exponential backoff", "adopted_answer": "Yes, tenacity default", "resolution_type": "answered", "resolution": "Yes — AsyncRetrying, 3 attempts", "severity": "medium", "owner_spec": "052-conditional-landing", "resolved_by": "Paul O'Fallon", "resolved_at": "2026-08-06T14:03:22+00:00"}
+```
+
+```json
+{"normalized_question": "should retries use exponential backoff", "source_entry_id": "mv-142", "outcome": "rejected", "recorded_at": "2026-08-07T09:15:02+00:00"}
+```
+
+## Matching formula (normative)
+
+Defined in `assumptions/matching.py`; deterministic, zero model calls (FR-008).
+
+```
+normalize(text)  = collapse_ws(strip_punctuation(casefold(text)))
+tokens(ntext)    = {t for t in ntext.split() if len(t) > 1}
+base(a, b)       = 0.5 * SequenceMatcher(None, na, nb).ratio()
+                 + 0.5 * |tokens(na) ∩ tokens(nb)| / |tokens(na) ∪ tokens(nb)|
+                   (Jaccard term is 0 when both token sets are empty)
+
+penalty(pairing) = 0.30 * max(0, rejections(pairing) - acceptances(pairing))
+effective(entry, candidate) = base(entry.question, candidate.question) - penalty
+```
+
+`REJECTION_PENALTY` is 0.30 by construction, not tuning: the maximum possible base
+score is 1.0, so a single net rejection drops any pairing — including an exact
+match — to ≤ 0.70, below `PRESENTATION_THRESHOLD` (0.75). This is what makes
+FR-015 ("a rejected pairing MUST NOT be presented as a default again") hold
+unconditionally, while a subsequent acceptance (net 0) restores the pairing.
+
+- **Corpus preparation**: collapse records per `source_entry_id` (latest
+  `resolved_at` authoritative); exclude candidates where
+  `source_entry_id == entry.bead_id` (self-match).
+- **Selection**: candidates with `effective >= PRESENTATION_THRESHOLD (0.75)`;
+  pick max by (`effective` desc, `resolved_at` desc, `source_entry_id` asc).
+  Result is exactly zero or one suggestion.
+- **Auto-resolution eligibility** (all required): entry severity is `low` (legacy
+  entries synthesize medium ⇒ ineligible); `assumptions.resolution.auto_resolve_low.enabled`;
+  `effective >= confidence_threshold` (validated `>= 0.75` at config load).
+
+Changing `PRESENTATION_THRESHOLD`, `REJECTION_PENALTY`, or the blend weights is a
+contract change to this file, not a tuning knob.
+
+## Decision capture points (admission contract)
+
+| Path | Writes DecisionRecord? | Writes MatchFeedback? |
+|---|---|---|
+| `maverick review <id> --answer/--waive` (human) | yes | yes, if entry carried a suggestion |
+| `maverick review --spec … --waive` (human bulk) | yes, one per waived entry | yes, per entry carrying a suggestion |
+| `maverick notify` scheduler auto-waive (`waived_by="maverick-scheduler"`) | **no** | no |
+| Auto-resolution (`waived_by="maverick-resolver"`) | **no** | no |
+| Human re-answer of an auto-resolved entry | yes | yes — recorded as **rejected** for the auto-resolving pairing |
+
+Feedback classification: **accepted** iff resolution type equals the suggestion's
+type AND `normalize(resolution text) == normalize(suggestion.resolution)`;
+otherwise **rejected**.
+
+All capture is best-effort: a failed write logs `[yellow]Warning:[/]` and never
+fails the review action (FR-004).

--- a/specs/055-learned-assumption-resolution/contracts/entry-row-suggestion.md
+++ b/specs/055-learned-assumption-resolution/contracts/entry-row-suggestion.md
@@ -1,0 +1,68 @@
+# Contract: Entry-Row Projection and CLI Surface Changes
+
+## `entry_to_dict` additions (additive; shared by every surface)
+
+Two new keys on the canonical row (`src/maverick/assumptions/serialize.py`):
+
+```json
+{
+  "...existing keys...": "unchanged",
+  "suggestion": {
+    "resolution": "Yes — AsyncRetrying, 3 attempts",
+    "resolution_type": "answered",
+    "source_entry_id": "mv-142",
+    "source_spec": "052-conditional-landing",
+    "resolved_at": "2026-08-06T14:03:22+00:00",
+    "confidence": 0.87,
+    "computed_at": "2026-08-07T10:11:12+00:00"
+  },
+  "auto_resolved": false
+}
+```
+
+- `suggestion` is `null` when the entry has no stored suggestion (below threshold,
+  store unavailable, or unparseable stored value).
+- `auto_resolved` is `true` only when the auto-resolve policy waived the entry
+  (`assumption_auto_resolved="true"`); its `waiver.by` is `"maverick-resolver"`.
+- Because the land report aliases the same function, `land-report.json` spec
+  sections pick both keys up unchanged. Additive ⇒ `schema_version` stays `1`.
+  Land surfaces project **stored** suggestions only — back-fill runs exclusively in
+  `review --list` (by design, clarify Q5); an entry never listed since its
+  suggestion became computable may show `suggestion: null` in a land report.
+- `_annotations` gains `"auto-resolved"` when `auto_resolved` is true, so human
+  tables and markdown reports show the distinction (FR-018).
+
+## `maverick review --list [--json]`
+
+- Before building rows, the command back-fills suggestions for entries that have
+  none stored (research R5/clarify Q5): load corpus once, evaluate, persist
+  `assumption_suggestion` per hit. Stored suggestions are never replaced. Store
+  unavailable ⇒ silent skip (debug log), listing proceeds.
+- JSON payload shape unchanged otherwise (`verb: review.list`,
+  `{"entries": [...], "counts": {...}}`); rows carry the new keys.
+- Human table: entries with a suggestion show a `suggested` marker; no new columns
+  beyond that (bare-terminal fallback stays lean).
+
+## `maverick review <id> --answer/--waive [--json]`
+
+- Success payloads (`review.answer` / `review.waive`) carry the updated row
+  (including `suggestion`) as today via `_project_after_write`.
+- **Pre-check change (FR-020)**: a waived entry with `auto_resolved=true` is
+  re-answerable — the `ALREADY_RESOLVED` refusal applies only to human-waived
+  entries. Re-answering an auto-resolved entry follows the normal answer path
+  (reconcile re-arm included) and records a rejection for the auto-resolving
+  pairing.
+- After a successful write the command records the decision and any feedback
+  (see decision-records contract) outside the JSON error handler, fail-soft.
+
+## `maverick review --spec <name> --waive <reason> [--json]`
+
+- Unchanged verb shape (`review.bulk-waive`); per waived entry it writes a decision
+  record and, where a suggestion was stored, a feedback record (accepted iff the
+  bulk reason matches the suggested waive reason under normalization; otherwise
+  rejected).
+
+## Error kinds
+
+No new error kinds. Suggestion/decision machinery failures are warnings by
+contract (FR-004/FR-021) and never map into the JSON error envelope.

--- a/specs/055-learned-assumption-resolution/contracts/skill-review-console-delta.md
+++ b/specs/055-learned-assumption-resolution/contracts/skill-review-console-delta.md
@@ -1,0 +1,49 @@
+# Contract: maverick-review Skill Delta (Suggestion as Default)
+
+Changes to `src/maverick/skills/review_console/SKILL.md` (installed as
+`.claude/skills/maverick-review/SKILL.md`). Everything not listed here is
+unchanged from the 053 contract — one `AskUserQuestion` per entry, immediate
+application through JSON verbs, overflow chaining, single batched reconcile,
+frontier report, land only on explicit confirmation, and the prohibition on
+touching jj/git/bd/files directly.
+
+## Option ordering when the entry row carries `suggestion`
+
+1. **The suggested resolution — first option, recommended.**
+   - Answer-sourced (`resolution_type: "answered"`): label the option with the
+     suggested answer text plus
+     `"(Recommended — prior decision from <source_spec>, <resolved_at date>)"`.
+   - Waive-sourced (`resolution_type: "waived"`): first option is
+     `"Waive this entry (Recommended — prior decision from <source_spec>, <resolved_at date>)"`
+     and, when chosen, the suggested reason is used as the waive reason without a
+     second prompt (the human saw it on the option).
+2. The entry's own `adopted_answer` — second, **without** any "(Recommended)"
+   suffix (the suffix moves to the suggestion; exactly one option is ever marked
+   recommended).
+3. `alternatives[]`, then waive/skip and overflow chaining exactly as today.
+
+When `suggestion` is `null`, the sweep renders exactly as the 053 contract
+specifies (adopted answer first with "(Recommended)").
+
+## Decision mapping additions
+
+- Choosing the suggested answer → `maverick review <id> --answer "<suggested text>" --json`.
+- Choosing the suggested waive → `maverick review <id> --waive "<suggested reason>" --json`.
+- All other choices map exactly as today. The skill never marks
+  acceptance/rejection itself — feedback derivation happens inside the CLI verbs
+  by comparing the applied resolution against the stored suggestion.
+
+## Auto-resolved entries in the sweep
+
+Entries with `auto_resolved: true` are waived, hence outside the default open-only
+sweep. When the human asks to revisit them (e.g. lists waived entries), the skill
+presents them with their provenance and offers re-answer — the CLI permits
+re-answering auto-resolved entries (FR-020).
+
+## Display obligations
+
+- Always show the suggestion's provenance (source spec + date) in the option
+  label or question context — never present a suggested default without saying
+  where it came from.
+- Show `confidence` in the question context when present; do not editorialize
+  beyond the number.

--- a/specs/055-learned-assumption-resolution/data-model.md
+++ b/specs/055-learned-assumption-resolution/data-model.md
@@ -1,0 +1,141 @@
+# Data Model: Learned Assumption Resolution
+
+Entities, fields, validation, and state transitions. Storage locations per
+research.md R1/R4.
+
+## DecisionRecord (runway, `decisions.jsonl`)
+
+Frozen Pydantic model in `runway/models.py`, `to_dict()`/`from_dict()` like its
+siblings. One line per terminal human resolution; append-only.
+
+| Field | Type | Notes |
+|---|---|---|
+| `source_entry_id` | `str` | Assumption bead id the decision resolved — the decision's stable identity (R3) |
+| `question` | `str` | Original question text (from the entry's `## Question` section) |
+| `normalized_question` | `str` | `matching.normalize_question(question)` — precomputed for matching |
+| `adopted_answer` | `str` | What the agent had adopted |
+| `resolution_type` | `Literal["answered", "waived"]` | |
+| `resolution` | `str` | Answer text, or waive reason |
+| `severity` | `str` | `low` / `medium` / `high` (entry's severity at resolution) |
+| `owner_spec` | `str` | Owning spec of the resolved entry |
+| `resolved_by` | `str` | Git user name (same source as `waived_by` today) |
+| `resolved_at` | `str` | UTC ISO-8601 |
+
+**Collapse rule** (read side): group by `source_entry_id`, latest `resolved_at`
+wins as the authoritative version; earlier lines remain as history (FR-003).
+**Admission rule**: written only by the human review surfaces (R6) — never by
+scheduler auto-waives or auto-resolution (FR-005).
+
+## MatchFeedbackRecord (runway, `match-feedback.jsonl`)
+
+Frozen Pydantic model; append-only. One line per accept/reject event.
+
+| Field | Type | Notes |
+|---|---|---|
+| `normalized_question` | `str` | Of the entry that carried the suggestion |
+| `source_entry_id` | `str` | Decision identity the suggestion came from — pairing key = (`normalized_question`, `source_entry_id`) |
+| `outcome` | `Literal["accepted", "rejected"]` | |
+| `recorded_at` | `str` | UTC ISO-8601 |
+
+**Fold rule**: per pairing, `penalty = REJECTION_PENALTY * max(0, rejections - acceptances)`;
+`effective_confidence = base_score - penalty` (R2). One net rejection suppresses any
+pairing: max base 1.0 − 0.30 < 0.75 (FR-015).
+
+## Suggestion (bd state key `assumption_suggestion`, JSON value)
+
+Frozen dataclass in `assumptions/models.py`, serialized as compact JSON into one bd
+state key (atomic single-key write — R4). Parsed into
+`AssumptionReportEntry.suggestion`.
+
+| Field | JSON key | Type | Notes |
+|---|---|---|---|
+| `resolution` | `resolution` | `str` | Suggested answer text or waive reason |
+| `resolution_type` | `resolution_type` | `"answered" \| "waived"` | |
+| `source_entry_id` | `source_entry_id` | `str` | Provenance: which prior entry |
+| `source_spec` | `source_spec` | `str` | Provenance: which spec |
+| `resolved_at` | `resolved_at` | `str` | Provenance: when resolved |
+| `confidence` | `confidence` | `float` | Effective confidence at computation time, [0,1] |
+| `computed_at` | `computed_at` | `str` | UTC ISO-8601 |
+
+**Lifecycle**: written once at recording (or back-filled on first listing without
+one); never silently replaced (clarify Q5). Unparseable value ⇒ treated as absent,
+never overwritten (R11).
+
+**Wire format note**: the "JSON key" column above is the field/`entry_to_dict`
+projection shape only — the shape `review --list --json`/the land report
+actually emit (`contracts/entry-row-suggestion.md`), unchanged. The bd-persisted
+value under `assumption_suggestion` uses **abbreviated internal keys** (`r`,
+`rt`, `sid`, `ss`, `ra`, `c`, `ca`) and compact JSON separators instead, purely
+to fit bd's state-value length budget — see research.md R4's addendum. A
+suggestion whose encoded JSON would risk truncation is never persisted at all
+(treated as no match) rather than stored corrupted.
+
+## New ledger state keys (`assumptions/models.py`)
+
+| Constant | Key | Value |
+|---|---|---|
+| `KEY_SUGGESTION` | `assumption_suggestion` | JSON object above |
+| `KEY_AUTO_RESOLVED` | `assumption_auto_resolved` | `"true"` when the auto-resolve policy waived the entry |
+
+## AssumptionReportEntry (extended, `assumptions/models.py`)
+
+New fields: `suggestion: Suggestion | None = None`,
+`auto_resolved: bool = False` (derived from `KEY_AUTO_RESOLVED`). Populated by
+`report_entry_from_details`; legacy entries always `None`/`False`.
+
+## Config (`config.py`)
+
+```yaml
+assumptions:
+  resolution:            # absent ⇒ auto-resolution inert; suggestions always on
+    auto_resolve_low:
+      enabled: true      # default false; double opt-in
+      confidence_threshold: 0.92   # ge 0.75 (== PRESENTATION_THRESHOLD), le 1.0
+```
+
+`AutoResolvePolicyConfig(enabled: bool = False, confidence_threshold: float =
+Field(default=0.9, ge=0.75, le=1.0))`;
+`AssumptionResolutionConfig(auto_resolve_low: AutoResolvePolicyConfig | None = None)`;
+`AssumptionsConfig.resolution: AssumptionResolutionConfig | None = None`.
+Violating bounds fails config load (FR-016).
+
+## Matching constants (`assumptions/matching.py`)
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `PRESENTATION_THRESHOLD` | `0.75` | Minimum effective confidence to attach/present a suggestion (built-in, fixed) |
+| `REJECTION_PENALTY` | `0.30` | Per net rejection deduction on a pairing (0.30 > 1.0 − 0.75, so one net rejection suppresses even an exact match) |
+
+## State transitions
+
+```
+Entry recorded ──evaluate corpus──▶ no candidate ≥ 0.75 ──▶ no suggestion (back-fill may retry on listing)
+                                  └▶ best candidate ≥ 0.75 ──▶ KEY_SUGGESTION written
+                                       └▶ low severity AND policy enabled AND conf ≥ threshold
+                                            ──▶ ledger.waive(waived_by="maverick-resolver")
+                                                + KEY_AUTO_RESOLVED="true"        [entry: open → waived]
+
+Human resolves entry with suggestion:
+  resolution matches suggestion (type + normalized text) ──▶ feedback: accepted
+  anything else ──▶ feedback: rejected  (lowers pairing's future effective confidence)
+
+Human answers an auto-resolved (waived) entry:
+  ALREADY_RESOLVED pre-check bypassed for auto_resolved=true (FR-020)
+  ──▶ ledger.answer(...) [waived → answered, reconcile re-armed via existing pending status]
+  + feedback: rejected (for the pairing that auto-resolved it)
+  + decision record written (human-initiated)
+```
+
+## Invariants
+
+1. A machine-written resolution (scheduler auto-waive, auto-resolve) never produces
+   a `DecisionRecord` (FR-005) — enforced by capture living only in the human CLI
+   surfaces (R6).
+2. `evaluate_suggestion` never returns a candidate whose `source_entry_id` equals
+   the entry being evaluated (self-match, R12).
+3. Exactly one suggestion per entry; ties broken by (confidence desc,
+   `resolved_at` desc, `source_entry_id` asc) — fully deterministic (FR-010).
+4. Auto-resolution requires: severity == low (legacy ⇒ medium ⇒ ineligible),
+   policy enabled, effective confidence ≥ configured threshold ≥ 0.75 (FR-016/017).
+5. The land gate's `classify()` and `frontier()` are byte-identical to today —
+   auto-resolved entries are ordinary waived entries to them (FR-013/019).

--- a/specs/055-learned-assumption-resolution/plan.md
+++ b/specs/055-learned-assumption-resolution/plan.md
@@ -1,0 +1,136 @@
+# Implementation Plan: Learned Assumption Resolution
+
+**Branch**: `055-learned-assumption-resolution` | **Date**: 2026-08-06 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/055-learned-assumption-resolution/spec.md`
+
+## Summary
+
+Persist every human-initiated terminal assumption-ledger outcome as a decision record
+in the runway knowledge store, deterministically match newly recorded assumptions
+against that corpus, and attach a suggested resolution (with provenance and confidence)
+to matching entries — surfaced in `review --list --json` and as the default option in
+the maverick-review skill's sweep. Rejections lower a pairing's future confidence.
+An opt-in policy may auto-waive low-severity entries above a strict confidence
+threshold; because auto-resolution always waives (never answers), the existing land
+classification (`classify()` downgrades any waived entry to conditionally-verified)
+and reconcile detection (answered-only) are correct **unchanged**.
+
+The entire feature is deterministic library + CLI code: **zero model calls, zero
+agents, zero Burr changes** (the fly graph's existing `record_assumptions` action and
+the spec-chain workflow gain one post-recording library call each).
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (`from __future__ import annotations`)
+
+**Primary Dependencies**: Existing only — Pydantic (frozen models), Click + Rich
+(CLI), structlog, aiofiles (runway store I/O), stdlib `difflib` + tokenization for
+matching. No new dependencies.
+
+**Storage**: Two new append-only JSONL files in the git-committed runway store
+(`.maverick/runway/decisions.jsonl`, `.maverick/runway/match-feedback.jsonl`) —
+deliberately **outside** `episodic/` so `runway consolidate` never prunes them
+(FR-002). Per-entry suggestion state persists as one JSON-encoded bd state key
+(`assumption_suggestion`) so the non-atomic per-key `BeadClient.set_state` writes it
+atomically in a single bd invocation.
+
+**Testing**: pytest + pytest-asyncio + xdist (`make test`, `make test-fast`);
+red-green TDD per Principle V.
+
+**Target Platform**: Linux/macOS developer checkout (same as all Maverick commands).
+
+**Project Type**: CLI + library (existing single-project layout).
+
+**Performance Goals**: SC-006 — suggestion evaluation adds < 1s to recording or
+listing with a 500-record corpus. Pairwise `difflib.SequenceMatcher` + token Jaccard
+over ≤150-char normalized questions is ~µs/pair; 500 pairs ≪ 50ms.
+
+**Constraints**: Zero model calls (FR-008, Guardrail X.10); matching deterministic
+given (entry, corpus, feedback state); degradation never blocks capture, review, or
+landing (FR-021); corpus admission is human-initiated resolutions only (FR-005);
+no cross-repository state (FR-022).
+
+**Scale/Scope**: Corpus of hundreds to low-thousands of decision records per
+repository; entries per sweep in the tens.
+
+## Constitution Check
+
+*GATE: evaluated pre-Phase-0 and re-evaluated post-Phase-1 — PASS, no violations.*
+
+| Gate | Assessment |
+|---|---|
+| I. Async-first | All new I/O paths are async (`RunwayStore` methods, `BeadClient.set_state`); matching itself is pure sync CPU work called from async contexts. No `subprocess.run` anywhere. |
+| II. Separation of concerns | Matching/scoring is a pure library module (`assumptions/matching.py`); orchestration (load corpus → score → persist) is a library helper (`assumptions/suggestions.py`) called from existing workflow actions and CLI commands. No business logic in CLI modules beyond invocation + rendering; no agents involved at all. |
+| III. Dependency injection | `RunwayStore` and `BeadClient` are constructed at boundaries and passed in; no globals, no module state. |
+| IV. Fail gracefully | Decision-record write failure warns and never blocks the ledger write (FR-004); store unavailability degrades to no-suggestion (FR-021); corrupt JSONL lines skipped via the store's existing `_read_jsonl` tolerance. |
+| V. Test-first | Every new public function gets red-green tests; regression tests bind to real code paths (matching module is pure and directly testable). |
+| VI. Typed contracts | New frozen Pydantic models (`DecisionRecord`, `MatchFeedbackRecord`) with `to_dict`/`from_dict`, matching runway conventions; suggestion projection is a frozen dataclass; no `dict[str, Any]` blobs on public surfaces. |
+| VII. Simplicity & DRY | Reuses `entry_to_dict` (one shared projection — FR-011 falls out for free), the runway store's append/read/rewrite patterns, `ledger.waive()` for auto-resolution, and the 054 config-block template. No new wrappers. |
+| X.0 / X.7. cwd threading | Store path and `BeadClient` cwd resolved at CLI/workflow boundary and passed down; no `Path.cwd()` in workflows. |
+| X.2. Agents own no side effects | Stronger: no agents at all — the whole feature is deterministic. |
+| X.8. Canonical libraries | structlog via `get_logger`, existing store atomics; no new git/gh/bd wrappers. |
+| X.10 / XIII. Determinism | The feature's core constraint. Matching is corpus-independent-scored (`difflib` + Jaccard, documented formula), zero model calls, reproducible. |
+| XI. Modularize early | New logic lands in two new focused modules (`matching.py`, `suggestions.py`) instead of growing `ledger.py` (already 1347 LOC — no new features added to it beyond parsing one state key). |
+
+**Post-design re-check**: PASS. The design adds no agents, no new external systems,
+no new subprocess wrappers, and keeps `classify()`/the land gate untouched.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/055-learned-assumption-resolution/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions R1–R13
+├── data-model.md        # Phase 1 — entities, fields, state transitions
+├── quickstart.md        # Phase 1 — end-to-end validation guide
+├── contracts/
+│   ├── decision-records.md        # Runway file formats + matching formula
+│   ├── entry-row-suggestion.md    # entry_to_dict / review --list --json additions
+│   ├── config-schema.md           # assumptions.resolution block
+│   └── skill-review-console-delta.md  # maverick-review sweep changes
+└── tasks.md             # Phase 2 (/speckit-tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/maverick/
+├── runway/
+│   ├── models.py                  # + DecisionRecord, MatchFeedbackRecord
+│   └── store.py                   # + append/get/rewrite for decisions & feedback
+├── assumptions/
+│   ├── matching.py                # NEW — normalize_question, score, thresholds (pure)
+│   ├── suggestions.py             # NEW — attach/back-fill/auto-resolve + decision capture
+│   ├── models.py                  # + KEY_SUGGESTION, KEY_AUTO_RESOLVED, Suggestion dataclass,
+│   │                              #   AssumptionReportEntry.suggestion/auto_resolved
+│   ├── ledger.py                  # parse suggestion state key into report entries
+│   └── serialize.py               # + "suggestion", "auto_resolved" row keys
+├── cli/commands/review/
+│   ├── listing.py                 # back-fill suggestions on --list
+│   └── entry_actions.py           # decision capture + accept/reject feedback (single + bulk)
+├── workflows/
+│   ├── fly_beads/actions.py       # record_assumptions → attach_suggestions call
+│   └── spec_chain/workflow.py     # standalone recording → attach_suggestions call
+├── config.py                      # + AssumptionResolutionConfig / AutoResolvePolicyConfig
+└── skills/review_console/SKILL.md # suggestion-as-default sweep behavior
+
+tests/
+├── unit/runway/test_store_decisions.py          # NEW
+├── unit/assumptions/test_matching.py            # NEW
+├── unit/assumptions/test_suggestions.py         # NEW
+├── unit/assumptions/test_serialize.py           # extend
+├── unit/cli/review/…                            # extend listing + entry_actions tests
+├── unit/workflows/fly_beads/…                   # extend record_assumptions tests
+└── unit/test_config.py                          # extend for new block
+```
+
+**Structure Decision**: single-project layout, existing packages. New behavior is
+concentrated in two new `assumptions/` modules plus additive changes to the runway
+store, keeping `ledger.py` growth to one read-side parse and honoring Principle XI.
+
+## Complexity Tracking
+
+No constitution violations — table intentionally empty.

--- a/specs/055-learned-assumption-resolution/quickstart.md
+++ b/specs/055-learned-assumption-resolution/quickstart.md
@@ -1,0 +1,117 @@
+# Quickstart: Validating Learned Assumption Resolution
+
+Runnable scenarios proving the feature end-to-end. Prerequisites: a Maverick-managed
+repository with `bd` initialized, the runway store initialized
+(`maverick runway init`), and at least one assumption-ledger entry flow available
+(any repo where `maverick fly` or `maverick spec` has recorded entries — the
+sample-maverick-project works).
+
+Contracts referenced: [decision-records.md](contracts/decision-records.md),
+[entry-row-suggestion.md](contracts/entry-row-suggestion.md),
+[config-schema.md](contracts/config-schema.md).
+
+## Scenario 1 — Terminal outcomes become decision records (User Story 1)
+
+```bash
+# Resolve entries through the human surfaces:
+maverick review <entry-1> --answer "Use exponential backoff via tenacity" --json
+maverick review <entry-2> --waive "Accepted risk for v1" --json
+
+# Verify: one JSONL line per resolution, human-attributed
+cat .maverick/runway/decisions.jsonl | python3 -m json.tool --json-lines
+```
+
+Expect: two records with correct `question`, `resolution_type`, `resolution`,
+`severity`, `owner_spec`, `resolved_by` (your git user.name). Re-answer `<entry-1>`
+with different text and confirm a **third** line appears for the same
+`source_entry_id` (history preserved; latest authoritative).
+
+Negative check: run `maverick notify` with an `auto_waive_low` schedule policy that
+waives an aged low entry — confirm **no** new line in `decisions.jsonl`
+(scheduler waives are machine-initiated, excluded by FR-005).
+
+## Scenario 2 — Suggestions surface with provenance (User Story 2)
+
+```bash
+# Record a new assumption closely matching an answered one (e.g. run a bead whose
+# implementer adopts a near-identical question, or use the test fixtures), then:
+maverick review --list --json | python3 -m json.tool
+```
+
+Expect on the matching entry's row: `"suggestion"` object with `resolution`,
+`source_entry_id`, `source_spec`, `resolved_at`, `confidence >= 0.75`; unrelated
+entries carry `"suggestion": null`. The entry still has `"blocks_landing": true` —
+confirm `maverick land --status --json` reports it in `blocking.open` (suggestion
+never bypasses the gate).
+
+Skill check: invoke `/maverick-review` and confirm the suggested resolution is the
+first option, labeled `(Recommended — prior decision from <spec>, <date>)`.
+
+## Scenario 3 — Rejection suppresses the pairing (User Story 3)
+
+```bash
+# Resolve the suggested entry with a DIFFERENT answer:
+maverick review <entry-with-suggestion> --answer "No, fixed interval" --json
+cat .maverick/runway/match-feedback.jsonl   # expect outcome: "rejected"
+
+# Record another assumption with the same question shape; list again:
+maverick review --list --json
+```
+
+Expect: the previously rejected pairing's effective confidence dropped by 0.30 per
+net rejection — enough to suppress even an exact match (max base 1.0 − 0.30 < 0.75)
+— so the new entry carries `"suggestion": null`. Accepting a suggestion verbatim
+instead writes `outcome: "accepted"`.
+
+## Scenario 4 — Opt-in auto-resolution (User Story 4)
+
+```yaml
+# maverick.yaml
+assumptions:
+  resolution:
+    auto_resolve_low:
+      enabled: true
+      confidence_threshold: 0.9
+```
+
+Record a **low**-severity assumption whose question matches a prior decision at
+≥ 0.9 effective confidence. Expect:
+
+- Entry is waived immediately: `review --list --status waived --json` shows
+  `"auto_resolved": true`, `waiver.by == "maverick-resolver"`, waive reason citing
+  the source decision.
+- `maverick land --status --json`: `frontier_clear: true` (if nothing else open),
+  and a real `maverick land` classifies **conditionally-verified** with the
+  auto-resolved entry rendered distinctly in `land-report.md`.
+- A medium-severity entry with the same match confidence stays open (severity
+  ceiling).
+- Human override: `maverick review <auto-resolved-id> --answer "..." --json`
+  succeeds (no `already-resolved` refusal), supersedes the waive, and appends a
+  `rejected` feedback line.
+- Config guard: set `confidence_threshold: 0.5` and confirm config load fails.
+
+## Scenario 5 — Degradation (FR-004 / FR-021, SC-007)
+
+```bash
+mv .maverick/runway .maverick/runway.bak    # simulate store outage
+maverick review --list --json               # entries render, suggestion: null, exit 0
+maverick review <id> --answer "still works" --json   # ledger write succeeds; warning only
+mv .maverick/runway.bak .maverick/runway
+```
+
+Also corrupt one line of `decisions.jsonl` and confirm listing still works
+(malformed line skipped with a warning).
+
+## Automated validation
+
+```bash
+make test-fast                     # unit: matching, suggestions, store, serialize, config
+make test                          # full parallel suite
+make ci                            # pre-push gate (lint + typecheck + tests + format)
+```
+
+Key test modules (see plan.md structure): `tests/unit/assumptions/test_matching.py`
+(formula determinism, normalization, tie-breaks, penalty fold),
+`tests/unit/assumptions/test_suggestions.py` (attach/back-fill/auto-resolve,
+self-match, degradation), `tests/unit/runway/test_store_decisions.py`
+(append/read/collapse, consolidation leaves the files untouched).

--- a/specs/055-learned-assumption-resolution/research.md
+++ b/specs/055-learned-assumption-resolution/research.md
@@ -1,0 +1,278 @@
+# Research: Learned Assumption Resolution
+
+All unknowns from Technical Context resolved. Decisions reference real code as of
+`main` (post-054).
+
+## R1 — Decision records live in new top-level runway JSONL files, exempt from consolidation
+
+**Decision**: Add `.maverick/runway/decisions.jsonl` and
+`.maverick/runway/match-feedback.jsonl` as append-only JSONL logs, addressed by new
+constants in `runway/store.py` alongside `_INDEX_FILE`, with `RunwayStore` methods
+following the existing append/get/rewrite pattern (`_append_jsonl`/`_read_jsonl`).
+They sit at the store root, **not** under `episodic/`.
+
+**Rationale**: `consolidate_runway` (`library/actions/consolidation.py:277`) prunes
+the three episodic JSONL files by age/count and rewrites them. Decision records must
+survive indefinitely (FR-002) — placing them outside the consolidation set is the
+structural guarantee, not a convention. The runway root is git-committed by design
+(`.gitignore` excludes `/.maverick/runs` and `/.maverick/notify` but not
+`/.maverick/runway`), so the corpus survives clones and travels with the repository —
+and stays within FR-022's single-repository scope. The store's existing
+`_read_jsonl` skips malformed lines with a warning, giving corruption tolerance
+(FR-021) for free.
+
+**Alternatives considered**: (a) episodic files with a consolidation carve-out —
+rejected: makes pruning code aware of an exception, easy to break silently.
+(b) bd metadata on a dedicated bead — rejected: bd state is per-bead key/value, wrong
+shape for a growing queryable corpus, and `bd` availability would become a hard
+dependency for suggestion evaluation. (c) semantic markdown — rejected: free-form,
+not deterministically parseable (Guardrail X.10).
+
+## R2 — Matching: normalized-text similarity via stdlib `difflib` + token Jaccard; corpus-independent scores
+
+**Decision**: `assumptions/matching.py` (new, pure, sync) defines:
+
+- `normalize_question(text) -> str`: casefold → strip punctuation → collapse
+  whitespace (exactly the clarified normalization).
+- `base_score(a, b) -> float` in [0, 1]:
+  `0.5 * difflib.SequenceMatcher(None, na, nb).ratio() + 0.5 * jaccard(tokens(na), tokens(nb))`
+  where `tokens` splits normalized text on whitespace and drops 1-char tokens
+  (mirroring the store's `_tokenize` convention).
+- `PRESENTATION_THRESHOLD: Final = 0.75` (built-in, not configurable — clarify Q3).
+- `REJECTION_PENALTY: Final = 0.30` — sized so one net rejection suppresses **any**
+  pairing: max base is 1.0, and 1.0 − 0.30 = 0.70 < 0.75, which is what makes
+  FR-015's "never presented as default again" unconditional rather than
+  base-score-dependent.
+- `effective_confidence = base_score - REJECTION_PENALTY * max(0, rejections - acceptances)`
+  per pairing (clarify Q1: pairing = normalized question text × decision identity).
+
+**Rationale**: Scores must be comparable to a fixed threshold across time, so they
+must not depend on corpus composition. BM25 (`rank_bm25`, already used by
+`RunwayStore.query`) is corpus-dependent — IDF shifts as records accumulate, and raw
+scores are unbounded, making a fixed presentation threshold meaningless.
+`SequenceMatcher` captures phrasing similarity; Jaccard captures shared vocabulary
+regardless of order; the 50/50 blend is simple, documented, and reproducible
+(FR-008). Both are stdlib/existing — no new dependency. Pairwise cost over ≤500
+records of ≤150-char questions is well under SC-006's budget (R13).
+
+**Alternatives considered**: BM25 over the corpus (rejected above); embedding
+similarity (rejected: model call, violates FR-008/X.10); exact-normalized-match only
+(rejected: too brittle — near-identical questions with one differing word would never
+match, failing the feature's purpose).
+
+## R3 — Feedback pairing keys on (normalized question text, source **entry** id); records are versions
+
+**Decision**: A decision's stable identity is the ledger entry it resolved
+(`source_entry_id` = the assumption bead id). Re-answering appends a new
+`DecisionRecord` for the same `source_entry_id`; readers collapse per
+`source_entry_id`, latest `resolved_at` authoritative (FR-003 — history preserved in
+the log). `MatchFeedbackRecord` pairs `normalized_question` with
+`source_entry_id`, so feedback survives re-answers of the underlying decision.
+
+**Rationale**: The clarify session fixed the pairing as (normalized question text,
+source decision record identity). Using a per-append record id would orphan feedback
+whenever a decision is re-answered; the source entry id is the durable identity that
+"the decision" denotes across its versions.
+
+## R4 — Suggestion persists as ONE JSON-encoded bd state key: `assumption_suggestion`
+
+**Decision**: New state keys in `assumptions/models.py`:
+`KEY_SUGGESTION = "assumption_suggestion"` (value: compact JSON object — resolution
+text, resolution type, source entry id, source spec, resolved-at, confidence,
+computed-at) and `KEY_AUTO_RESOLVED = "assumption_auto_resolved"` (`"true"` when the
+policy fired). `ledger.report_entry_from_details` parses `KEY_SUGGESTION` into a
+typed `Suggestion` value on `AssumptionReportEntry`; unparseable JSON degrades to no
+suggestion with a debug log.
+
+**Rationale**: `BeadClient.set_state` issues **one bd invocation per key**
+(`beads/client.py:467-511`) — a multi-key suggestion could be half-written, surfacing
+a suggestion without its provenance. One key = one bd call = atomic. Precedent for
+encoding structure into a single value exists (`assumption_change_ids` is
+comma-joined); JSON is the right shape for seven typed fields. Persisting on the bead
+(rather than recomputing) is what makes suggestions stable within and across sweeps
+(clarify Q5) and lets `entry_to_dict` project them with zero extra I/O.
+
+**Alternatives considered**: one state key per field (rejected: non-atomic);
+recompute-on-read (rejected by clarify Q5 — unstable, and every listing would need
+the runway corpus loaded).
+
+**Addendum (quickstart validation)**: "JSON is the right shape" didn't anticipate
+that `bd set-state` stores this value as part of a `"<dimension>:<value>"` label
+with a total-length budget that **silently truncates on overflow — no error, no
+warning**. Empirically verified against a real bd 1.1.2 sandbox: the safe value
+length is ~254 minus `len(key)`, i.e. ~233 chars for `assumption_suggestion` (21
+chars), and — contrary to an earlier hypothesis involving the event bead's
+500-char title — independent of the bead id or `--reason` text length (neither
+appears in the truncated label string). Full-field-name JSON with default
+separators already costs ~235 chars with an *empty* `resolution` alone, i.e. the
+original wire format overflowed before any real content was added — a
+ship-blocking bug, not an edge case. Fixed by: (1) abbreviated internal keys
+(`r`/`rt`/`sid`/`ss`/`ra`/`c`/`ca`) + compact JSON separators, cutting the
+empty-resolution overhead to ~145 chars (`suggestion_to_json`/
+`suggestion_from_json` in `assumptions/models.py`); (2) a defensive
+`_MAX_SUGGESTION_JSON_LENGTH = 220` guard in `assumptions/suggestions.py`
+(`_evaluate_and_persist`) that skips the `set_state` write entirely — treating
+the suggestion as absent rather than persisting a truncated value — whenever the
+encoded JSON would exceed it, a 13-char margin below the observed 233-char hard
+boundary that still comfortably fits realistic content (a 64-char resolution +
+24-char owner spec + live microsecond `computed_at` encodes to 214 chars).
+This wire-format change is internal-only: `entry_to_dict`'s
+full-field-name projection (`assumptions/serialize.py`, via `dataclasses.asdict`)
+is untouched, so `review --list --json`/the land report are byte-identical to
+before.
+
+## R5 — Orchestration lives in `assumptions/suggestions.py`; ledger and runway stay decoupled
+
+**Decision**: A new module `assumptions/suggestions.py` owns composition:
+
+- `evaluate_suggestion(record, corpus, feedback) -> Suggestion | None` — pure; applies
+  self-match exclusion (`candidate.source_entry_id != record.bead_id`), collapse
+  (R3), scoring + effective confidence (R2), best-candidate selection with the
+  deterministic tie-break (highest confidence, then most recent `resolved_at`, then
+  lexically smallest `source_entry_id`).
+- `attach_suggestions(client, store, records) -> None` — async; loads corpus +
+  feedback once, evaluates each newly recorded entry, persists `KEY_SUGGESTION` for
+  hits, and applies auto-resolution (R7) when the policy allows. Never raises:
+  store-unavailable or write failure logs a warning and returns (FR-021).
+- `backfill_suggestions(client, store, entries) -> updated_entries` — async; for
+  listed entries with no stored suggestion, evaluate + persist; existing stored
+  suggestions never replaced (clarify Q5).
+- `record_decision(store, entry, *, resolution_type, resolution, resolved_by)` and
+  `record_feedback(store, entry, *, accepted)` — async, best-effort (FR-004).
+
+Call sites: `fly_beads/actions.py::record_assumptions` (after each
+`record_assumption`), `spec_chain/workflow.py` (after each
+`record_standalone_assumption`), `cli/commands/review/listing.py::run_list`
+(back-fill), `cli/commands/review/entry_actions.py` (decision capture + feedback,
+single and bulk paths).
+
+**Rationale**: `ledger.py` (1347 LOC, Principle XI refactor-trigger territory) must
+not grow an import on `runway` — the assumptions package deliberately imports no
+workflow/CLI modules today, and keeping matching orchestration in a sibling module
+preserves that layering while giving every call site one shared implementation
+(Principle VII). Composition at call sites also keeps capture semantics untouched
+(spec's out-of-scope: no change to how assumptions are captured — the ledger
+functions' signatures and behavior are unchanged; suggestion attachment is a
+post-step).
+
+## R6 — Corpus capture happens in the human review surfaces, not inside `ledger.answer`/`waive`
+
+**Decision**: `entry_actions.py` writes decision records + feedback after a
+successful ledger write, in both `_review_ledger_entry` (answer/waive) and
+`_bulk_waive_flow` (one record per waived entry). The scheduler's auto-waive path
+(`cli/commands/notify.py::_execute_auto_waives`, `waived_by="maverick-scheduler"`)
+and this feature's auto-resolution never touch these helpers — machine outcomes are
+excluded structurally (FR-005), not by filtering.
+
+**Rationale**: Corpus admission is defined by *who initiated* the resolution.
+`maverick review` (single, bulk) is exactly the human surface; placing capture there
+means no `actor` parameter threading through `ledger.waive` and no risk that a new
+machine caller of `waive()` silently feeds the corpus. Follows the existing
+`_project_after_write` pattern: post-write side work runs outside the JSON error
+handler and fails soft (FR-004).
+
+**Feedback derivation**: after resolution, if the entry carried a stored suggestion —
+accepted iff resolution type matches and `normalize_question`-style normalization of
+the resolution text equals the suggestion's; anything else (different answer, waive
+where an answer was suggested, answer where a waive was suggested) is a rejection.
+
+## R7 — Auto-resolution waives via `ledger.waive` with `waived_by="maverick-resolver"`; land gate and reconcile untouched
+
+**Decision**: When the opt-in policy is enabled and a **low**-severity entry's
+effective confidence ≥ the configured threshold, `attach_suggestions` calls the
+existing `ledger.waive(client, bead_id=..., reason=..., waived_by="maverick-resolver")`
+with a rationale citing the source decision (entry id, spec, date), then sets
+`KEY_AUTO_RESOLVED="true"`. Severity gating uses the entry's recorded severity;
+legacy entries synthesize medium (`_legacy_record_from_details`) so they are
+structurally ineligible (FR-017) — no new code needed.
+
+**Rationale**: The clarify session fixed waive-not-answer precisely because
+`answered_unreconciled_entries` (`ledger.py:983`) would otherwise route machine
+answers into reconcile's history rewriting. Waiving means:
+- `classify()` (`land_report.py:57-69`) already downgrades any waived entry to
+  `CONDITIONALLY_VERIFIED` — FR-019 holds with **zero changes to the land gate**.
+- `waived_by` provenance is already rendered in the land report
+  (`"Waived by {waived_by} at {waived_at}: {waive_reason}"`) and projected in
+  `entry_to_dict`'s `waiver` object — distinguishability (FR-018) needs only the
+  `auto_resolved` flag added to the row projection.
+- Human override: `maverick review <id> --answer` on a waived entry currently fails
+  the `ALREADY_RESOLVED` pre-check (`entry_actions.py:226-239`). FR-020 requires the
+  pre-check to allow re-answering an **auto-resolved** waive (detected via
+  `KEY_AUTO_RESOLVED`); the override records a rejection for the pairing that
+  auto-resolved it. Human-waived entries keep the existing already-resolved refusal.
+
+**Actor constant**: `"maverick-resolver"`, mirroring 054's `"maverick-scheduler"`.
+
+## R8 — Config: new `assumptions.resolution` block beside `assumptions.schedule`
+
+**Decision**: Extend `AssumptionsConfig` (`config.py:571`) with
+`resolution: AssumptionResolutionConfig | None = None`:
+
+```python
+class AutoResolvePolicyConfig(BaseModel):
+    enabled: bool = False
+    confidence_threshold: float = Field(default=0.9, ge=0.75, le=1.0)
+
+class AssumptionResolutionConfig(BaseModel):
+    auto_resolve_low: AutoResolvePolicyConfig | None = None
+```
+
+`ge=0.75` encodes "at least as strict as the built-in presentation threshold"
+(clarify Q3); the module asserts the bound equals
+`matching.PRESENTATION_THRESHOLD` via a unit test so the two cannot drift. Absent
+block ⇒ suggestions still work (they need no config); only auto-resolution is inert.
+
+**Rationale**: Follows 054's proven pattern (`AssumptionScheduleConfig` +
+double-opt-in sub-policy like `AutoWaivePolicyConfig`); Pydantic bound validation
+gives FR-016's fail-on-misconfiguration for free through the existing config-load
+error path.
+
+## R9 — Row projection: additive `suggestion` and `auto_resolved` keys in `entry_to_dict`
+
+**Decision**: `serialize.entry_to_dict` gains `"suggestion"` (object or `None`) and
+`"auto_resolved"` (bool). Because the land report's `_entry_to_dict` aliases the same
+function, `review --list --json`, `review.answer`/`review.waive` payloads,
+bulk-waive rows, and `land-report.json` all pick the fields up in one change —
+FR-011's "cannot drift" is structural. Additive keys; `land-report.json`
+`schema_version` stays 1 (documented in the contract).
+
+## R10 — Skill delta: suggestion becomes the recommended default, attributed
+
+**Decision**: `skills/review_console/SKILL.md` sweep step: when an entry row carries
+`suggestion`, its resolution is presented as the **first** option labeled
+`"(Recommended — prior decision from <source_spec>, <resolved_at date>)"`; the
+adopted answer drops to second (losing its "(Recommended)" suffix); alternatives,
+waive, skip, and overflow chaining are unchanged. A waive-sourced suggestion makes
+"Waive this entry (recommended — prior decision …)" the first option with the prior
+reason pre-filled. Entries without a suggestion render exactly as today (FR-018 of
+053 preserved). The skill still applies decisions through the JSON verbs only.
+
+## R11 — Degradation matrix
+
+| Failure | Behavior | Source |
+|---|---|---|
+| Runway store missing/uninitialized | No suggestions, no decision capture; debug log; all commands proceed | FR-021, `_get_store` pattern (`library/actions/runway.py:33`) |
+| Corrupt JSONL line | Skipped with `runway_jsonl_parse_error` warning (existing) | store `_read_jsonl:499` |
+| Decision-record write fails | `[yellow]Warning:[/]`, ledger write already durable | FR-004, R6 |
+| `KEY_SUGGESTION` write fails during attach | Entry simply has no stored suggestion; back-fill retries on next listing | clarify Q5 |
+| Unparseable stored suggestion JSON | Treated as absent (debug log); back-fill will NOT overwrite (existing key present) — listed without suggestion | R4; conservative: never silently replace |
+| Auto-resolution `waive` fails | Warning; entry stays open with its suggestion; retried never (attach is once) — human resolves normally | FR-021 |
+
+## R12 — Self-match and dedup interplay
+
+`record_assumption` already dedups identical open questions per epic
+(`_find_existing_open_entry`) and `record_standalone_assumption` per owner spec — so
+a *new* entry can still legitimately match a *resolved* prior entry with the same
+question (the resolved bead is closed and invisible to dedup). Self-match exclusion
+in `evaluate_suggestion` (`candidate.source_entry_id != record.bead_id`) covers the
+back-fill path, where an entry could otherwise match the decision record produced by
+its own earlier resolution after a re-open/re-answer cycle.
+
+## R13 — Performance check (SC-006)
+
+500 decision records × `SequenceMatcher.ratio()` on ~100–150-char normalized strings
+≈ 10–30 µs/pair pure-Python ⇒ ~15 ms per entry, plus one JSONL read (~100 KB) per
+attach/back-fill batch (loaded once for the whole batch, not per entry). Recording a
+typical bead's 0–3 assumptions and listing a 30-entry sweep both stay well under the
+1-second budget. No caching or indexing needed at this scale; revisit only if
+corpora exceed ~10k records.

--- a/specs/055-learned-assumption-resolution/spec.md
+++ b/specs/055-learned-assumption-resolution/spec.md
@@ -1,0 +1,389 @@
+# Feature Specification: Learned Assumption Resolution
+
+**Feature Branch**: `055-learned-assumption-resolution`
+
+**Created**: 2026-08-06
+
+**Status**: Draft
+
+**Input**: User description: "Feed resolved assumption-ledger entries into runway as reusable knowledge, so that when an agent adopts an assumption closely matching one the human has already answered, the prior answer is proposed as the default during review — and eventually the fleet stops asking questions the human has already answered. Two capabilities: (1) Decisions as labels — every terminal ledger outcome (answered, waived, edited-then-answered) is persisted as a structured decision record in runway, carrying the question, the adopted answer, the human's resolution, severity, and the owning spec; records survive across specs and runs. (2) Suggested answers at review time — when a new assumption is recorded, it is matched against prior decision records; a sufficiently close prior decision attaches a suggested resolution with provenance, surfaced in `maverick review --list --json` and presented as the default option in the maverick-review skill's sweep; the land gate is unchanged and a suggestion never auto-answers an entry. An explicit opt-in policy may allow auto-resolution for low-severity entries above a configured confidence threshold, marked with provenance and rendering a land at most conditionally-verified. Matching quality matters more than coverage; the feature must define what closely matching means, how confidence is scored, and how false suggestions are suppressed after rejection. Out of scope: cross-repository knowledge sharing; any change to how assumptions are captured."
+
+## Clarifications
+
+### Session 2026-08-06
+
+- Q: When the human rejects a suggestion, what exactly identifies the "pairing" whose future confidence is lowered? → A: Pairing = (normalized question text of the new entry, source decision record identity); normalization is deterministic (case-fold, collapse whitespace, strip punctuation).
+- Q: When the auto-resolution policy fires, does it resolve the entry by writing an answer or by waiving it with a rationale? → A: Always waive, with a recorded rationale citing the matched prior decision; auto-resolution never writes an answer, so machine decisions can never enter reconcile's answered-entry detection or drive history rewriting.
+- Q: Is the presentation threshold user-configurable, or a built-in fixed default? → A: Built-in fixed default, not configurable in v1; only the auto-resolution threshold is configurable and must be at least as strict as the built-in presentation threshold.
+- Q: Which resolutions feed the decision-record corpus — do machine-initiated waives and human bulk waives count? → A: Only human-initiated resolutions feed it — individual answers/waives and human-invoked bulk waives (one record per entry); scheduler auto-waives and this feature's auto-resolutions are excluded.
+- Q: When is an entry's suggestion computed and stored? → A: Computed and persisted at recording time; listing back-fills entries that have no stored suggestion; an existing stored suggestion is never silently replaced.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Terminal ledger outcomes become durable decision records (Priority: P1)
+
+Whenever a human resolves an assumption-ledger entry — answering it, waiving it, or
+re-answering it after an earlier answer — the resolution is persisted as a structured
+decision record in the project's knowledge store. Each record carries the original
+question, the answer the agent had adopted, the human's actual resolution (answer text
+or waive reason), the resolution type, the entry's severity, the owning spec, and when
+it was resolved. Records accumulate across specs and runs: a decision made while
+landing spec 060 is still available when spec 072 raises a similar question months
+later.
+
+**Why this priority**: This is the foundation every other capability builds on —
+without a durable corpus of decisions there is nothing to match against. It also
+delivers standalone value on day one as an auditable history of human judgment: "what
+did we decide about retry semantics, and on which spec?"
+
+**Independent Test**: Answer one entry, waive a second, and re-answer a third via
+`maverick review`; verify three decision records exist in the knowledge store with
+correct question, resolution, resolution type, severity, and owning spec, and that
+they persist after the run ends and across an unrelated new spec's lifecycle.
+
+**Acceptance Scenarios**:
+
+1. **Given** an open assumption-ledger entry, **When** the human answers it via
+   `maverick review <id> --answer`, **Then** a decision record is persisted carrying
+   the question, the adopted answer, the human's answer text, resolution type
+   "answered", the entry's severity, and the owning spec.
+2. **Given** an open entry, **When** the human waives it with a reason, **Then** a
+   decision record is persisted with resolution type "waived" and the waive reason as
+   the resolution.
+3. **Given** an entry that was previously answered, **When** the human re-answers it
+   with different text, **Then** the decision record for that entry reflects the
+   latest answer as authoritative for future matching, and the earlier resolution
+   remains visible as history.
+4. **Given** the knowledge store is unwritable at resolution time, **When** the human
+   answers an entry, **Then** the answer itself still succeeds and is recorded on the
+   ledger, and the missed decision record is reported as a warning — never a failure
+   of the review action.
+
+---
+
+### User Story 2 - Prior decisions surface as suggested resolutions at review time (Priority: P2)
+
+When an agent records a new assumption that closely matches a question the human has
+already resolved, the new ledger entry carries a suggested resolution with full
+provenance: which prior entry it came from, which spec owned it, when it was resolved,
+and how confident the match is. The suggestion appears as a field on the entry row in
+`maverick review --list --json`, and the maverick-review skill presents it as the
+default option in its question sweep — clearly labeled as sourced from a prior
+decision. The human confirms with one selection instead of re-deriving an answer they
+already gave. The land gate is unchanged: a suggestion never answers an entry by
+itself.
+
+**Why this priority**: This is the feature's visible payoff — the human stops
+re-answering questions they have already answered. It depends on User Story 1's corpus
+but is independently testable the moment records exist.
+
+**Independent Test**: Seed the knowledge store with a decision record, record a new
+assumption whose question closely matches it, and verify the new entry's row in
+`review --list --json` carries the suggested resolution with provenance; verify a
+non-matching entry carries no suggestion; verify the entry still counts as open for
+the land gate until the human resolves it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a decision record answering "Should retries use exponential backoff?" and
+   a new assumption entry asking a closely matching question, **When** the entry is
+   recorded, **Then** the entry carries a suggested resolution containing the prior
+   answer, the source entry's identity, the owning spec, the resolution date, and a
+   confidence score.
+2. **Given** a new entry whose question matches no prior decision above the
+   presentation threshold, **When** the entry is listed, **Then** it carries no
+   suggestion — a weak match is silence, not a guess.
+3. **Given** an entry with a suggestion, **When** the human runs the maverick-review
+   sweep, **Then** the suggested resolution is presented as the default option,
+   visibly attributed to the prior decision, alongside the entry's own alternatives
+   and free-form input.
+4. **Given** an entry with a suggestion, **When** `maverick land` evaluates the
+   frontier before the human resolves the entry, **Then** the entry still blocks
+   landing exactly as an entry with no suggestion would.
+5. **Given** several prior decisions match a new entry above threshold, **When** the
+   suggestion is computed, **Then** exactly one suggestion — the highest-confidence
+   match, ties broken deterministically — is attached.
+
+---
+
+### User Story 3 - Rejected suggestions stop being suggested (Priority: P3)
+
+When the human resolves an entry differently from its suggestion — a different answer,
+or a waive where an answer was suggested — that outcome is recorded as a rejection of
+the pairing between that question shape (its normalized question text) and that prior
+decision. The pairing's future
+confidence is lowered so the same wrong default is not presented again. A wrong
+suggestion presented as a default is worse than no suggestion, so the system must
+learn from its misses, not just its hits.
+
+**Why this priority**: This is the quality control that makes User Story 2 safe to
+trust. Without it, one bad match becomes a recurring default the human must fight
+every sweep.
+
+**Independent Test**: Present a suggestion, resolve the entry with a different answer,
+then record a new assumption with the same question shape; verify the previously
+rejected pairing either no longer surfaces as a suggestion or surfaces with a lowered
+confidence below the presentation threshold.
+
+**Acceptance Scenarios**:
+
+1. **Given** an entry whose suggestion came from decision record R, **When** the human
+   answers with different text, **Then** a rejection is recorded for the pairing of
+   that question shape and R, and the pairing's future match confidence is lowered.
+2. **Given** a pairing rejected once, **When** a new entry with the same question
+   shape is recorded, **Then** that pairing does not surface as the default suggestion
+   unless subsequent confirming signal has restored its confidence above threshold.
+3. **Given** an entry whose suggestion the human accepts as-is, **When** the entry is
+   resolved, **Then** the acceptance is recorded on the pairing so match quality is
+   auditable over time.
+
+---
+
+### User Story 4 - Opt-in auto-resolution for high-confidence low-severity entries (Priority: P4)
+
+A project may explicitly enable a policy that auto-resolves low-severity entries whose
+match confidence exceeds a configured threshold. Auto-resolved entries are marked as
+such on the ledger, carry the source decision's provenance, and are visibly distinct
+from human-answered entries everywhere entries render — the review list, the land
+report, and the land banner. A land that relied on any auto-resolved entry is at most
+conditionally-verified, never verified. The policy is off by default and never applies
+to medium or high severity regardless of confidence.
+
+**Why this priority**: This is the "fleet stops asking" end state, but it is only safe
+once the corpus, matching, and rejection feedback (P1–P3) have proven themselves. It
+must remain a deliberate, revocable choice.
+
+**Independent Test**: Enable the policy with a threshold, record a low-severity
+assumption matching a prior decision above that threshold, and verify the entry is
+resolved without human action, marked auto-resolved with provenance, and that a
+subsequent land classifies as conditionally-verified; verify a medium-severity entry
+with the same confidence is not auto-resolved.
+
+**Acceptance Scenarios**:
+
+1. **Given** the auto-resolution policy is not configured, **When** a low-severity
+   entry matches a prior decision with very high confidence, **Then** the entry
+   receives a suggestion only and remains open until a human resolves it.
+2. **Given** the policy is enabled with a confidence threshold, **When** a
+   low-severity entry's best match meets or exceeds that threshold, **Then** the entry
+   is waived automatically with a rationale citing the matched prior decision, stamped
+   as auto-resolved with the source decision's provenance, and no longer blocks the
+   land gate.
+3. **Given** a land whose frontier was cleared partly by auto-resolution, **When**
+   `maverick land` classifies the outcome, **Then** the classification is at most
+   conditionally-verified, and the land report shows auto-resolved entries distinctly
+   from human-answered ones.
+4. **Given** an auto-resolved entry, **When** the human re-answers it with different
+   text via `maverick review`, **Then** the human's answer supersedes the
+   auto-resolution and the override is recorded as a rejection of the pairing that
+   auto-resolved it.
+5. **Given** the policy is enabled, **When** a medium- or high-severity entry matches
+   above the threshold, **Then** it is never auto-resolved.
+
+---
+
+### Edge Cases
+
+- **Knowledge store unavailable or corrupt at match time**: recording a new assumption
+  and listing entries must proceed with no suggestions and a warning — suggestion
+  machinery degrading must never block capture, review, or landing.
+- **Decision-record write fails at resolution time**: the answer or waive itself still
+  succeeds on the ledger; the missed record is a warning, not a review failure.
+- **Self-match**: an entry must never receive a suggestion sourced from its own
+  resolution history.
+- **Duplicate or near-duplicate decision records** (the same question resolved on
+  several specs): matching selects one best candidate deterministically; the corpus
+  growing must not produce duplicate suggestions on one entry.
+- **Conflicting prior decisions** (the same question shape answered differently on two
+  specs): the suggestion mechanism must resolve to a single candidate by its
+  documented scoring and tie-break rules — most recent resolution preferred — rather
+  than presenting both or averaging them.
+- **Legacy entries with no structured severity**: treated as medium for policy
+  purposes (consistent with existing land-gate and scheduler behavior), so they are
+  never auto-resolved.
+- **Entries recorded before any matching corpus existed**: an open entry recorded
+  before a relevant decision record may gain a suggestion when suggestions are next
+  evaluated; absence of a suggestion at recording time is not permanent.
+- **Waive-sourced suggestions**: a prior waive can suggest waiving a closely matching
+  new entry, with the waive reason as the suggested rationale — presented and
+  attributed the same way an answer-sourced suggestion is.
+- **Threshold misconfiguration**: an auto-resolution threshold configured below the
+  presentation threshold, or outside valid bounds, fails validation with a clear
+  message rather than silently auto-resolving on weak matches.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Decision records**
+
+- **FR-001**: Every terminal assumption-ledger outcome — answered, waived, and
+  re-answered-after-a-prior-answer — MUST persist a structured decision record in the
+  project's knowledge store, carrying at minimum: the question, the agent's adopted
+  answer, the human's resolution (answer text or waive reason), the resolution type,
+  the entry's severity, the owning spec, the source entry's identity, and the
+  resolution timestamp.
+- **FR-002**: Decision records MUST survive across specs, runs, and sessions; their
+  lifecycle is independent of any run directory or workflow invocation.
+- **FR-003**: When an entry is re-answered, its decision record MUST treat the latest
+  human resolution as authoritative for future matching while preserving the earlier
+  resolution as visible history.
+- **FR-004**: Failure to persist a decision record MUST NOT fail or block the
+  resolution action that triggered it; the miss is surfaced as a structured warning
+  and the ledger write proceeds.
+- **FR-005**: Only human-initiated resolutions grow the corpus: individual answers and
+  waives, and human-invoked bulk waives (one record per covered entry). Machine-initiated
+  resolutions — the notification scheduler's auto-waives and this feature's own
+  auto-resolutions (FR-016) — MUST NOT feed decision records.
+
+**Matching and suggestions**
+
+- **FR-006**: When a new assumption entry is recorded, it MUST be evaluated against
+  existing decision records, and when the best match's confidence meets or exceeds the
+  presentation threshold, a suggested resolution MUST be attached to the entry and
+  persisted with it. Listing entries back-fills a suggestion for entries that have no
+  stored one; an existing stored suggestion is never silently replaced.
+- **FR-007**: A suggestion MUST carry provenance: the source decision's entry
+  identity, owning spec, resolution date, resolution type, and the match confidence.
+- **FR-008**: The definition of "closely matching" and the confidence score MUST be
+  deterministic and documented: the same entry evaluated against the same corpus and
+  feedback state always yields the same suggestion and score. Suggestion evaluation
+  makes zero model calls.
+- **FR-009**: When no candidate meets the presentation threshold, the entry MUST carry
+  no suggestion — the system prefers silence over a weak guess. The presentation
+  threshold is a built-in fixed default, not user-configurable.
+- **FR-010**: When multiple candidates exceed the threshold, exactly one suggestion —
+  the highest-confidence candidate, ties broken deterministically in favor of the most
+  recent resolution — MUST be attached.
+- **FR-011**: The suggestion MUST appear as a field on the entry row everywhere entry
+  rows render, including `maverick review --list --json` and the land report, using
+  the single shared entry-row projection so surfaces cannot drift; entries without a
+  suggestion carry an explicit absent value.
+- **FR-012**: The maverick-review skill MUST present an entry's suggestion as the
+  default option in its sweep, visibly attributed to the prior decision, alongside the
+  entry's own adopted answer, alternatives, free-form input, and waive/skip.
+- **FR-013**: A suggestion MUST NOT resolve an entry by itself outside the explicit
+  auto-resolution policy (FR-016); the land gate's semantics are unchanged, and an
+  entry with a suggestion blocks landing exactly as one without.
+
+**Rejection feedback**
+
+- **FR-014**: When the human resolves an entry differently from its suggestion, the
+  system MUST record a rejection for the pairing and lower the pairing's future match
+  confidence; when the human accepts a suggestion, the acceptance MUST likewise be
+  recorded. A pairing is identified as (normalized question text of the new entry,
+  source decision record identity), where normalization is deterministic — case-fold,
+  collapse whitespace, strip punctuation.
+- **FR-015**: A rejected pairing MUST NOT be presented as a default suggestion again
+  unless subsequent confirming feedback restores its confidence above the presentation
+  threshold; suppression state persists across runs alongside the decision corpus.
+
+**Auto-resolution policy**
+
+- **FR-016**: An explicitly configured, default-off policy MAY auto-resolve
+  low-severity entries whose best-match confidence meets or exceeds a configured
+  auto-resolution threshold; the threshold MUST be at least as strict as the built-in
+  presentation threshold, and configuration violating this MUST fail validation.
+  Auto-resolution always resolves via the waive path with a recorded rationale citing
+  the matched prior decision — it never writes an answer, so a machine decision can
+  never enter reconcile's answered-entry detection or drive history rewriting.
+- **FR-017**: Auto-resolution MUST never apply to medium- or high-severity entries
+  (including legacy entries with no structured severity, which are treated as medium),
+  regardless of confidence.
+- **FR-018**: An auto-resolved entry MUST be marked as auto-resolved on the ledger —
+  a waive stamped with the source decision's provenance and rationale, attributable to
+  the resolving machinery rather than a human — and MUST be visually and structurally
+  distinguishable from human-resolved entries in the review list, the land report, and
+  any JSON projection.
+- **FR-019**: A land whose frontier evaluation relied on one or more auto-resolved
+  entries MUST classify as at most conditionally-verified.
+- **FR-020**: A human re-answering an auto-resolved entry MUST supersede the
+  auto-resolution; the override counts as a rejection of the pairing that produced it
+  and re-enters the entry into normal downstream lifecycle (including reconcile
+  detection where applicable).
+
+**Degradation and safety**
+
+- **FR-021**: Unavailability or corruption of the knowledge store MUST degrade to
+  no-suggestion behavior with a structured warning; it MUST NOT block assumption
+  capture, review listing, entry resolution, or landing.
+- **FR-022**: All new behavior MUST be scoped to the current repository's knowledge
+  store; no decision record, suggestion, or feedback signal crosses repositories.
+
+### Key Entities
+
+- **Decision record**: the durable trace of one human resolution of one
+  assumption-ledger entry — question, adopted answer, human resolution, resolution
+  type (answered / waived / re-answered), severity, owning spec, source entry
+  identity, timestamp, and resolution history. Lives in the project knowledge store,
+  outliving specs and runs.
+- **Suggestion**: a proposal attached to an open ledger entry, derived from the single
+  best-matching decision record — suggested resolution text, resolution type,
+  provenance (source entry, spec, date), and confidence score. Advisory only.
+- **Match feedback**: the accumulated accept/reject history for a pairing, keyed by
+  (normalized question text, source decision record identity) — normalization is
+  deterministic: case-fold, collapse whitespace, strip punctuation. Used to raise or
+  lower that pairing's future confidence. Persists alongside the decision corpus.
+- **Auto-resolution policy**: project configuration declaring whether auto-resolution
+  is enabled, its confidence threshold, and (implicitly) its severity ceiling of low.
+  Absent configuration means the capability is inert.
+- **Auto-resolution stamp**: the ledger-side marking on an entry resolved by policy —
+  distinguishable resolution kind, source decision provenance, and rationale — feeding
+  the land report's distinct rendering and the at-most-conditionally-verified
+  classification.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of terminal ledger outcomes performed through the review surfaces
+  produce a retrievable decision record with complete provenance, verified across at
+  least two consecutive specs' lifecycles in one repository.
+- **SC-002**: When a newly recorded assumption's question closely matches a prior
+  decision, the prior resolution is available as the entry's default at the very next
+  review interaction — the human confirms it with a single selection instead of
+  composing an answer.
+- **SC-003**: After a suggestion is rejected once, the same question shape does not
+  surface that pairing as a default again in subsequent sweeps (absent new confirming
+  feedback), verified over repeated recording of matching entries.
+- **SC-004**: Zero entries carry a suggestion whose confidence is below the
+  presentation threshold, and zero entries are auto-resolved below the auto-resolution
+  threshold or above low severity — across the full test matrix.
+- **SC-005**: Every land that relied on any auto-resolved entry is classified at most
+  conditionally-verified, and its report distinguishes auto-resolved from
+  human-answered entries in 100% of cases.
+- **SC-006**: With a corpus of at least 500 decision records, suggestion evaluation
+  adds no human-perceptible delay to recording or listing entries (under one second of
+  added latency).
+- **SC-007**: A simulated knowledge-store outage during capture, review, and land
+  produces zero blocked operations and zero lost ledger writes — only absent
+  suggestions and warnings.
+
+## Assumptions
+
+- **Matching is deterministic, not model-driven.** Consistent with the project's
+  determinism-over-inference principle, "closely matching" is defined by a
+  deterministic, documented similarity mechanism over question text and structure;
+  the concrete algorithm and score formula are plan-phase decisions, but zero model
+  calls is a requirement (FR-008), not a preference.
+- **The knowledge store is the existing per-repository runway store.** Decision
+  records and match feedback live in the same durable knowledge layer the project
+  already maintains under the repository's Maverick state, not a new external system.
+- **Suggestions are computed and persisted at recording time**; listing back-fills a
+  suggestion only for entries that have no stored one, so entries that predate a
+  relevant decision can still gain suggestions. An existing stored suggestion is never
+  silently replaced, so a suggestion is stable within and across sweeps.
+- **Rejection is defined behaviorally**: resolving an entry with anything other than
+  the suggested resolution (different answer text, or waive where an answer was
+  suggested) counts as rejecting the pairing; accepting the presented default counts
+  as confirmation.
+- **The existing severity semantics are unchanged**: severity continues to come from
+  the capturing agent; legacy entries without structured severity are treated as
+  medium, matching current land-gate and scheduler behavior.
+- **Auto-resolution reuses the existing waive lifecycle** rather than a new terminal
+  state, so downstream consumers (land gate, reports, reconcile) see a coherent
+  lifecycle; the distinguishing mark is carried as provenance on the entry. Waiving —
+  never answering — is what keeps machine decisions out of reconcile's history
+  rewriting.
+- **Cross-repository sharing is out of scope**, as is any change to how agents capture
+  assumptions; the capture payloads and recording flow are untouched.

--- a/specs/055-learned-assumption-resolution/tasks.md
+++ b/specs/055-learned-assumption-resolution/tasks.md
@@ -1,0 +1,219 @@
+# Tasks: Learned Assumption Resolution
+
+**Input**: Design documents from `/specs/055-learned-assumption-resolution/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included — the constitution (Principle V) mandates red-green TDD. Every
+test task MUST be observed failing before its implementation task lands.
+
+**Organization**: Grouped by user story so each story is an independently testable
+increment.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different files, no dependency on an incomplete task)
+- **[Story]**: US1–US4, mapping to spec.md's prioritized stories
+- Paths are repository-relative; single-project layout per plan.md
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm a clean baseline — no new project scaffolding is needed (all
+work lands in existing packages).
+
+- [X] T001 Verify clean baseline: run `make check` on the feature branch and confirm green before any change; note the runway/assumptions test layout (`tests/unit/runway/`, `tests/unit/assumptions/`, `tests/unit/workflows/fly_beads/`) for the new test modules below
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The pure matching module — every story consumes it (US1 stores
+normalized questions; US2 scores; US3 folds feedback penalties; US4 gates on its
+threshold constant).
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 [P] Write failing tests for the matching module in `tests/unit/assumptions/test_matching.py`: `normalize_question` (casefold, strip punctuation, collapse whitespace — exact clarify-Q1 semantics), token extraction (drop 1-char tokens), `base_score` determinism and [0,1] bounds (SequenceMatcher/Jaccard 50/50 blend, empty-token-set guard), `PRESENTATION_THRESHOLD == 0.75`, `REJECTION_PENALTY == 0.30`, effective-confidence fold (`base - 0.30 * max(0, rejections - acceptances)`; assert one net rejection drops a base of 1.0 below the presentation threshold — the FR-015 suppression guarantee), and the deterministic best-candidate comparator (confidence desc, resolved_at desc, source_entry_id asc)
+- [X] T003 Implement `src/maverick/assumptions/matching.py` per `contracts/decision-records.md`: pure sync module with `normalize_question`, `base_score`, `PRESENTATION_THRESHOLD: Final = 0.75`, `REJECTION_PENALTY: Final = 0.30`, effective-confidence helper, and best-candidate selection; no I/O, no model calls, full type hints, Google docstrings
+
+**Checkpoint**: `make test-fast` green including `test_matching.py` — user stories can begin.
+
+---
+
+## Phase 3: User Story 1 — Terminal ledger outcomes become durable decision records (Priority: P1) 🎯 MVP
+
+**Goal**: Every human answer/waive/re-answer persists a `DecisionRecord` in the
+git-committed runway store, surviving specs and runs; machine waives are excluded;
+failures degrade to warnings.
+
+**Independent Test**: Answer, waive, and re-answer entries via `maverick review`;
+verify `.maverick/runway/decisions.jsonl` lines with full provenance (quickstart
+Scenario 1), persistence across runs, and zero records from a scheduler auto-waive.
+
+### Tests for User Story 1 ⚠️ write first, observe failing
+
+- [X] T004 [P] [US1] Write failing tests in `tests/unit/runway/test_store_decisions.py`: `DecisionRecord` to_dict/from_dict round-trip; `RunwayStore.append_decision`/`get_decisions` (append-only, filter by `source_entry_id`); `initialize()` touches `decisions.jsonl` and `match-feedback.jsonl`; malformed lines skipped with warning; `consolidate_runway` leaves both files byte-identical (regression binding to the real consolidation path)
+- [X] T005 [P] [US1] Write failing tests in `tests/unit/cli/commands/review/test_decision_capture.py` (mirror the existing review CLI test layout): `--answer` and `--waive` each append one collapsed-correct record post-write; re-answer appends a second record for the same `source_entry_id` (latest authoritative via `collapse_decisions`); bulk waive appends one record per waived entry; a store write failure emits `[yellow]Warning:[/]` and the review action still succeeds (FR-004); `notify`'s `_execute_auto_waives` path appends nothing (FR-005)
+
+### Implementation for User Story 1
+
+- [X] T006 [P] [US1] Add frozen `DecisionRecord` Pydantic model to `src/maverick/runway/models.py` with fields per data-model.md (source_entry_id, question, normalized_question, adopted_answer, resolution_type, resolution, severity, owner_spec, resolved_by, resolved_at) and `to_dict`/`from_dict`, matching sibling conventions
+- [X] T007 [US1] Add `_DECISIONS_FILE`/`_MATCH_FEEDBACK_FILE` constants, `append_decision`, `get_decisions`, and `initialize()` touch for both files to `src/maverick/runway/store.py`, following the existing `_append_jsonl`/`_read_jsonl` pattern (files at store root, NOT under `episodic/`)
+- [X] T008 [US1] Create `src/maverick/assumptions/suggestions.py` with `record_decision(store, entry, *, resolution_type, resolution, resolved_by)` (best-effort: catches store errors, logs warning, never raises) and `collapse_decisions(records)` (group by `source_entry_id`, latest `resolved_at` authoritative), using `matching.normalize_question` for the stored `normalized_question`
+- [X] T009 [US1] Wire decision capture into `_review_ledger_entry` in `src/maverick/cli/commands/review/entry_actions.py`: after a successful ledger write and outside the JSON error handler (the `_project_after_write` pattern), build the store from the command's cwd and call `record_decision`; `resolved_by` from the existing git user-name resolution
+- [X] T010 [US1] Wire decision capture into `_bulk_waive_flow` in `src/maverick/cli/commands/review/entry_actions.py`: one record per successfully waived entry, same fail-soft contract
+
+**Checkpoint**: US1 fully functional — quickstart Scenario 1 passes; MVP deliverable
+as a standalone audit trail.
+
+---
+
+## Phase 4: User Story 2 — Prior decisions surface as suggested resolutions (Priority: P2)
+
+**Goal**: New assumptions matched against the corpus carry a persisted suggestion
+with provenance, projected on every entry-row surface and presented as the skill's
+default; the land gate is untouched.
+
+**Independent Test**: Seed a decision record, record a closely matching assumption,
+verify the `suggestion` object in `review --list --json` with provenance and
+`confidence >= 0.75`, `null` on non-matching entries, and unchanged land blocking
+(quickstart Scenario 2).
+
+### Tests for User Story 2 ⚠️ write first, observe failing
+
+- [X] T011 [P] [US2] Write failing tests in `tests/unit/assumptions/test_suggestions.py`: `evaluate_suggestion` (below-threshold ⇒ None; self-match excluded; collapse applied so only the latest version of a re-answered decision matches; deterministic tie-break; exactly one suggestion); `attach_suggestions` (persists single JSON `assumption_suggestion` key via one `set_state` call; store-unavailable ⇒ no-op with debug log; set_state failure ⇒ warning, other entries still processed); `backfill_suggestions` (fills only entries with no stored key; never replaces an existing or unparseable stored value); and the SC-006 performance bound — evaluating one entry against a generated 500-record corpus (with feedback) completes in well under 1 second (assert < 1s wall clock)
+- [X] T012 [P] [US2] Write failing tests in `tests/unit/assumptions/test_suggestion_projection.py`: `Suggestion` dataclass JSON round-trip; `report_entry_from_details` parses `assumption_suggestion` into `AssumptionReportEntry.suggestion` and `assumption_auto_resolved` into `.auto_resolved` (unparseable JSON ⇒ None + debug log); `entry_to_dict` emits `suggestion` object / `null` and `auto_resolved` bool; `_annotations` gains `"auto-resolved"`; land report `_entry_to_dict` alias picks the keys up unchanged; and the FR-013 guard — an open entry carrying a suggestion still projects `blocks_landing: true` and `frontier()`/`classify()` treat it identically to a suggestion-less open entry
+- [X] T013 [P] [US2] Write failing tests in `tests/unit/cli/commands/review/test_listing_backfill.py`: `run_list` back-fills suggestions for entries lacking one before building rows (corpus loaded once), skips silently when the store is unavailable, and the human table marks suggested entries; JSON rows carry the new keys
+- [X] T014 [P] [US2] Write failing tests for the recording call sites: extend `tests/unit/workflows/fly_beads/test_runway_recording.py` (or the `record_assumptions` action tests) to assert `attach_suggestions` is invoked with the newly recorded entries and that its failure is non-fatal to the action; add the equivalent assertion for `record_standalone_assumption` follow-up in the spec_chain workflow tests
+
+### Implementation for User Story 2
+
+- [X] T015 [US2] Add to `src/maverick/assumptions/models.py`: `KEY_SUGGESTION = "assumption_suggestion"`, `KEY_AUTO_RESOLVED = "assumption_auto_resolved"`, frozen `Suggestion` dataclass (resolution, resolution_type, source_entry_id, source_spec, resolved_at, confidence, computed_at) with JSON encode/decode helpers, and `AssumptionReportEntry.suggestion: Suggestion | None = None` / `auto_resolved: bool = False`
+- [X] T016 [US2] Wire `KEY_SUGGESTION`/`KEY_AUTO_RESOLVED` into `report_entry_from_details` in `src/maverick/assumptions/ledger.py` as a minimal delta — the JSON decode/degrade logic lives in the `Suggestion` helper from T015 (`models.py`), and `ledger.py` (already past Principle XI's 1000-LOC hard stop) gains only the two field-populating call lines (degrade unparseable to absent with debug log; legacy entries always None/False)
+- [X] T017 [US2] Extend `entry_to_dict` and `_annotations` in `src/maverick/assumptions/serialize.py` with `suggestion`/`auto_resolved` keys per `contracts/entry-row-suggestion.md`
+- [X] T018 [US2] Implement `evaluate_suggestion`, `attach_suggestions`, and `backfill_suggestions` in `src/maverick/assumptions/suggestions.py` per research R5 (corpus + feedback loaded once per batch; single-key atomic `set_state` write; full degradation matrix from research R11)
+- [X] T019 [US2] Call `attach_suggestions` from the `record_assumptions` action in `src/maverick/workflows/fly_beads/actions.py` after the recording loop (build `RunwayStore` from the action's `cwd`; failures logged, never fail the action)
+- [X] T020 [US2] Call `attach_suggestions` after the `record_standalone_assumption` loop in `src/maverick/workflows/spec_chain/workflow.py` (user-checkout cwd, same non-fatal contract)
+- [X] T021 [US2] Add back-fill + suggested-entry marker to `run_list` in `src/maverick/cli/commands/review/listing.py` (back-fill before `_filter_and_sort`; store unavailable ⇒ silent skip)
+- [X] T022 [US2] Update the sweep in `src/maverick/skills/review_console/SKILL.md` per `contracts/skill-review-console-delta.md`: suggestion first with `(Recommended — prior decision from <spec>, <date>)`, adopted answer second without the suffix, waive-sourced suggestion pre-fills the reason, provenance always displayed
+
+**Checkpoint**: US1 + US2 independently green — quickstart Scenarios 1–2 pass.
+
+---
+
+## Phase 5: User Story 3 — Rejected suggestions stop being suggested (Priority: P3)
+
+**Goal**: Resolving contrary to a suggestion records a rejection that lowers the
+pairing's effective confidence below the presentation threshold on repeat;
+acceptances are recorded for auditability.
+
+**Independent Test**: Present a suggestion, resolve differently, record a
+same-shape assumption, verify no suggestion (or lowered confidence) and the
+`rejected` feedback line (quickstart Scenario 3).
+
+### Tests for User Story 3 ⚠️ write first, observe failing
+
+- [X] T023 [P] [US3] Write failing tests: `MatchFeedbackRecord` round-trip + `append_match_feedback`/`get_match_feedback` in `tests/unit/runway/test_store_decisions.py`; feedback classification in `tests/unit/assumptions/test_suggestions.py` (accepted iff type matches AND normalized resolution text equals normalized suggestion text; waive-over-suggested-answer ⇒ rejected; answer-over-suggested-waive ⇒ rejected); end-to-end suppression (one net rejection drops the pairing 0.30 — below the presentation threshold even from a perfect base score, per FR-015; a subsequent acceptance restores it); capture wiring in `tests/unit/cli/commands/review/test_decision_capture.py` (single answer/waive + bulk waive each append feedback only when the entry carried a stored suggestion)
+
+### Implementation for User Story 3
+
+- [X] T024 [P] [US3] Add frozen `MatchFeedbackRecord` model (normalized_question, source_entry_id, outcome, recorded_at) to `src/maverick/runway/models.py`
+- [X] T025 [US3] Add `append_match_feedback`/`get_match_feedback` to `src/maverick/runway/store.py` (same JSONL conventions; file already touched by T007's `initialize()`)
+- [X] T026 [US3] Add `classify_feedback(entry, suggestion, *, resolution_type, resolution) -> Literal["accepted","rejected"]` and `record_feedback(store, entry, *, accepted)` to `src/maverick/assumptions/suggestions.py`, and make `evaluate_suggestion` consume the feedback fold (penalty per pairing) — the parameter exists since T018 with an empty default, so US2 behavior is unchanged until feedback exists
+- [X] T027 [US3] Wire feedback capture into `src/maverick/cli/commands/review/entry_actions.py`: in `_review_ledger_entry` and `_bulk_waive_flow`, when the resolved entry carried a stored suggestion, classify and append feedback alongside the decision record (same fail-soft block)
+
+**Checkpoint**: US1–US3 green — quickstart Scenarios 1–3 pass.
+
+---
+
+## Phase 6: User Story 4 — Opt-in auto-resolution for high-confidence low-severity entries (Priority: P4)
+
+**Goal**: A default-off policy auto-waives low-severity entries at recording time
+when effective confidence ≥ the configured threshold; stamped `maverick-resolver`
+with provenance; land classifies at most conditionally-verified (existing
+`classify()` — no gate changes); human override re-arms the entry and records a
+rejection.
+
+**Independent Test**: Enable the policy, record a matching low entry, verify
+auto-waive with provenance + `auto_resolved: true`, conditionally-verified land,
+medium-severity ineligibility, and the override path (quickstart Scenario 4).
+
+### Tests for User Story 4 ⚠️ write first, observe failing
+
+- [X] T028 [P] [US4] Write failing tests in `tests/unit/test_config.py` (or the existing config test module): `AssumptionResolutionConfig`/`AutoResolvePolicyConfig` defaults, `confidence_threshold` bounds (`0.5` fails, `0.75` passes, `1.0` passes), absent block ⇒ None, and the drift-pin asserting the Field's `ge` equals `matching.PRESENTATION_THRESHOLD`
+- [X] T029 [P] [US4] Write failing tests in `tests/unit/assumptions/test_suggestions.py` + `tests/unit/cli/commands/review/test_decision_capture.py`: auto-resolve fires only for severity==low with policy enabled and confidence ≥ threshold (medium/high/legacy ineligible); waives via `ledger.waive` with `waived_by="maverick-resolver"` and a rationale citing source entry/spec/date; sets `assumption_auto_resolved="true"`; writes NO decision record and NO feedback; back-fill path never auto-resolves; `--answer` on an auto-resolved entry bypasses `ALREADY_RESOLVED` (human-waived still refused) and records a `rejected` feedback line for the auto-resolving pairing
+- [X] T030 [P] [US4] Write failing rendering tests: auto-resolved entry counts in the `waived` bucket, `classify()` returns `CONDITIONALLY_VERIFIED`, land-report markdown row shows the `maverick-resolver` waiver and `auto-resolved` annotation — extend the existing `tests/unit/assumptions/` land-report tests
+
+### Implementation for User Story 4
+
+- [X] T031 [P] [US4] Add `AutoResolvePolicyConfig` and `AssumptionResolutionConfig` to `src/maverick/config.py` and mount `resolution` on `AssumptionsConfig`, per `contracts/config-schema.md` — use the literal bound `ge=0.75` (no import from `assumptions.matching`; the T028 drift-pin test is what keeps the literal equal to `PRESENTATION_THRESHOLD`)
+- [X] T032 [US4] Implement the auto-resolve branch in `attach_suggestions` in `src/maverick/assumptions/suggestions.py`: `_AUTO_RESOLVE_ACTOR: Final = "maverick-resolver"`; eligibility per data-model invariant 4; waive + `KEY_AUTO_RESOLVED` write; failure degrades to warning leaving the entry open with its suggestion (research R11); recording-time only — `backfill_suggestions` never auto-resolves
+- [X] T033 [US4] Thread the resolution policy config into the `attach_suggestions` call sites: `record_assumptions` bind in `src/maverick/workflows/fly_beads/actions.py`/`burr_graph.py` and the spec_chain call in `src/maverick/workflows/spec_chain/workflow.py`
+- [X] T034 [US4] Update the `ALREADY_RESOLVED` pre-check in `src/maverick/cli/commands/review/entry_actions.py`: waived entries with `auto_resolved` are re-answerable (FR-020); on override, record the `rejected` feedback (uses T026) and let the normal answer path re-arm reconcile
+
+**Checkpoint**: All four stories independently functional — quickstart Scenarios 1–4 pass.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T035 [P] Update `CLAUDE.md`: extend the assumption-ledger / review-console sections with decision records, suggestions, the `assumptions.resolution` block, and the `maverick-resolver` actor; note the runway `decisions.jsonl`/`match-feedback.jsonl` files are consolidation-exempt
+- [X] T036 [P] Run all five `quickstart.md` scenarios end-to-end against a scratch repository (degradation Scenario 5 included) and record outcomes in the PR description — report faithfully anything not exercised
+- [X] T037 Run `make format-fix && make ci`; verify Principle XI budgets (`matching.py` and `suggestions.py` each well under 500 LOC; `ledger.py` grew only by the state-key parse) and fix any collateral failures encountered (Principle XII)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: none
+- **Phase 2 (Foundational)**: after Phase 1 — BLOCKS all stories (matching module)
+- **US1 (Phase 3)**: after Phase 2 only
+- **US2 (Phase 4)**: after Phase 2; consumes US1's `DecisionRecord`/store methods (T006–T008) — start its test tasks in parallel with US1 implementation if desired, but T018 depends on T007/T008
+- **US3 (Phase 5)**: after US2 (feedback folds into `evaluate_suggestion`, capture rides `entry_actions` wiring from T009/T010)
+- **US4 (Phase 6)**: after US2; T034's override-feedback depends on US3's T026
+- **Phase 7 (Polish)**: after all delivered stories
+
+### Within each story
+
+Tests first and observed failing → models → store/library → CLI/workflow wiring →
+checkpoint. `runway/models.py` and `store.py` are touched by US1 and US3 —
+sequential within/across those stories (T024/T25 after T006/T007), hence no [P] on
+T025.
+
+### Parallel opportunities
+
+- T002 alongside T001
+- US1: T004 ∥ T005 (different files); T006 ∥ nothing until tests exist
+- US2: T011 ∥ T012 ∥ T013 ∥ T014 (four different test files)
+- US4: T028 ∥ T029 ∥ T030, then T031 ∥ (T032 → T033 → T034)
+- Polish: T035 ∥ T036
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch all US2 test authoring together (different files):
+Task: "Failing tests for evaluate/attach/backfill in tests/unit/assumptions/test_suggestions.py"
+Task: "Failing tests for projection in tests/unit/assumptions/test_suggestion_projection.py"
+Task: "Failing tests for listing back-fill in tests/unit/cli/commands/review/test_listing_backfill.py"
+Task: "Failing tests for recording call sites in tests/unit/workflows/fly_beads/test_runway_recording.py"
+```
+
+## Implementation Strategy
+
+**MVP first (US1)**: Phases 1–3 deliver a durable, auditable decision corpus with
+zero behavior change to review/land — independently valuable and shippable.
+
+**Incremental delivery**: US2 turns the corpus into visible suggestions (the
+feature's payoff); US3 makes them trustworthy; US4 is the deliberate, revocable
+automation step. Each checkpoint maps to a quickstart scenario, so `maverick fly`
+can stop and validate after any phase.
+
+## Notes
+
+- Zero model calls anywhere — any task that seems to need one is mis-scoped (Guardrail X.10)
+- The land gate (`classify()`, `frontier()`) is intentionally untouched; a diff there is a red flag
+- Commit after each task or logical group; every test task must go red before its implementation task goes green

--- a/src/maverick/assumptions/ledger.py
+++ b/src/maverick/assumptions/ledger.py
@@ -21,6 +21,7 @@ from maverick.assumptions.models import (
     EPIC_KEY_FLIGHT_PLAN_NAME,
     EPIC_KEY_SPECKIT_FEATURE,
     KEY_ANSWER,
+    KEY_AUTO_RESOLVED,
     KEY_CHANGE_IDS,
     KEY_OWNER_SPEC,
     KEY_RECONCILE_CHANGE_ID,
@@ -33,6 +34,7 @@ from maverick.assumptions.models import (
     KEY_SOURCE_BEAD,
     KEY_SOURCE_REF,
     KEY_STATUS,
+    KEY_SUGGESTION,
     KEY_WAIVE_REASON,
     KEY_WAIVED_AT,
     KEY_WAIVED_BY,
@@ -51,6 +53,7 @@ from maverick.assumptions.models import (
     coerce_severity,
     nnn_prefix,
     normalize_answer,
+    suggestion_from_json,
 )
 from maverick.exceptions.beads import BeadError
 from maverick.logging import get_logger
@@ -1074,6 +1077,10 @@ def report_entry_from_details(details: object) -> AssumptionReportEntry | None:
     state: dict[str, str] = dict(getattr(details, "state", None) or {})
 
     if ASSUMPTION_LABEL in labels:
+        raw_suggestion = state.get(KEY_SUGGESTION)
+        suggestion = suggestion_from_json(raw_suggestion) if raw_suggestion is not None else None
+        if raw_suggestion is not None and suggestion is None:
+            logger.debug("suggestion_unparseable", bead_id=getattr(details, "id", None))
         return AssumptionReportEntry(
             record=_record_from_details(details),
             final_answer=state.get(KEY_ANSWER),
@@ -1085,6 +1092,8 @@ def report_entry_from_details(details: object) -> AssumptionReportEntry | None:
             reconcile_change_id=state.get(KEY_RECONCILE_CHANGE_ID),
             reconcile_reason=state.get(KEY_RECONCILE_REASON),
             pending_reconcile=is_answered_unreconciled(details),
+            suggestion=suggestion,
+            auto_resolved=state.get(KEY_AUTO_RESOLVED) == "true",
         )
     is_open_legacy = getattr(details, "status", None) not in _CLOSED_STATUSES
     if ASSUMPTION_REVIEW_LABEL in labels and is_open_legacy:

--- a/src/maverick/assumptions/matching.py
+++ b/src/maverick/assumptions/matching.py
@@ -1,0 +1,211 @@
+"""Pure, deterministic text-matching for learned assumption resolution.
+
+Implements the normative matching formula from
+``specs/055-learned-assumption-resolution/contracts/decision-records.md``:
+normalized-text similarity via stdlib ``difflib.SequenceMatcher`` blended
+with token-set Jaccard similarity, a rejection-feedback penalty fold, and a
+deterministic best-candidate selector.
+
+This module is pure and synchronous: no I/O, no model calls, no third-party
+dependencies beyond the standard library (``difflib``, ``re``, ``string``).
+Callers own corpus preparation (collapsing records, self-match exclusion)
+and persistence; this module only scores and selects.
+
+``PRESENTATION_THRESHOLD`` and ``REJECTION_PENALTY`` are contract constants,
+not tuning knobs — see the contract doc for the derivation. Changing either
+value, or the 50/50 blend weights in :func:`base_score`, is a contract
+change, not a tuning adjustment.
+"""
+
+from __future__ import annotations
+
+import string
+from difflib import SequenceMatcher
+from typing import Final, NamedTuple, TypeVar
+
+__all__ = [
+    "PRESENTATION_THRESHOLD",
+    "REJECTION_PENALTY",
+    "ScoredCandidate",
+    "base_score",
+    "effective_confidence",
+    "normalize_question",
+    "select_best",
+]
+
+#: Minimum effective confidence required to present a suggestion (FR-015).
+#: Built-in and fixed — not configurable. See contract doc for derivation.
+PRESENTATION_THRESHOLD: Final[float] = 0.75
+
+#: Per-net-rejection deduction applied to a pairing's base score. Sized so
+#: that a single net rejection suppresses even an exact match: the maximum
+#: possible base score is 1.0, and 1.0 - 0.30 = 0.70 < PRESENTATION_THRESHOLD.
+REJECTION_PENALTY: Final[float] = 0.30
+
+#: Translation table dropping every ASCII punctuation character.
+_PUNCTUATION_TABLE: Final[dict[int, int | None]] = str.maketrans("", "", string.punctuation)
+
+#: Minimum token length retained by :func:`_tokenize` (mirrors the runway
+#: store's ``_tokenize`` convention of dropping single-character tokens).
+_MIN_TOKEN_LENGTH: Final[int] = 2
+
+T = TypeVar("T")
+
+
+class ScoredCandidate(NamedTuple):
+    """One candidate in a best-match selection pool.
+
+    Attributes:
+        confidence: Effective confidence score for this pairing, already
+            penalty-adjusted (see :func:`effective_confidence`).
+        resolved_at: ISO timestamp string of when the candidate's underlying
+            decision was resolved. Used as a tie-break (descending).
+        source_entry_id: Stable identity of the candidate's originating
+            ledger entry. Used as the final tie-break (ascending).
+        payload: Arbitrary caller-owned value carried through selection
+            unchanged (e.g. the full suggestion record).
+    """
+
+    confidence: float
+    resolved_at: str
+    source_entry_id: str
+    payload: object
+
+
+def normalize_question(text: str) -> str:
+    """Normalize question text for matching.
+
+    Applies casefold, strips ASCII punctuation, and collapses whitespace
+    (including leading/trailing) to single spaces. This is the exact
+    normalization referenced throughout the matching contract.
+
+    Args:
+        text: Raw question text.
+
+    Returns:
+        Normalized text: casefolded, punctuation-free, whitespace-collapsed.
+    """
+    folded = text.casefold()
+    stripped = folded.translate(_PUNCTUATION_TABLE)
+    return " ".join(stripped.split())
+
+
+def _tokenize(normalized_text: str) -> set[str]:
+    """Split already-normalized text into a token set, dropping short tokens.
+
+    Args:
+        normalized_text: Text already passed through :func:`normalize_question`.
+
+    Returns:
+        Set of whitespace-delimited tokens with length > 1.
+    """
+    return {t for t in normalized_text.split() if len(t) >= _MIN_TOKEN_LENGTH}
+
+
+def base_score(a: str, b: str) -> float:
+    """Compute the corpus-independent base similarity score for two questions.
+
+    Both inputs are normalized internally via :func:`normalize_question`, so
+    callers may pass raw, un-normalized text.
+
+    The score is a 50/50 blend of ``difflib.SequenceMatcher`` phrasing
+    similarity and token-set Jaccard vocabulary overlap:
+
+        base(a, b) = 0.5 * SequenceMatcher(None, na, nb).ratio()
+                   + 0.5 * |tokens(na) & tokens(nb)| / |tokens(na) | tokens(nb)|
+
+    The Jaccard term is defined as 0 when both token sets are empty (guards
+    the divide-by-zero that would otherwise occur).
+
+    Args:
+        a: First question text (raw or normalized).
+        b: Second question text (raw or normalized).
+
+    Returns:
+        Blended similarity score in [0, 1]. Deterministic for identical
+        inputs; symmetric in ``a``/``b``.
+    """
+    na = normalize_question(a)
+    nb = normalize_question(b)
+
+    sequence_ratio = SequenceMatcher(None, na, nb).ratio()
+
+    tokens_a = _tokenize(na)
+    tokens_b = _tokenize(nb)
+    union = tokens_a | tokens_b
+    jaccard = len(tokens_a & tokens_b) / len(union) if union else 0.0
+
+    return 0.5 * sequence_ratio + 0.5 * jaccard
+
+
+def effective_confidence(base: float, *, rejections: int, acceptances: int) -> float:
+    """Fold rejection feedback into a base score to get effective confidence.
+
+    Implements ``effective = base - REJECTION_PENALTY * max(0, rejections - acceptances)``:
+    each net rejection (rejections in excess of acceptances) deducts
+    ``REJECTION_PENALTY`` from the base score; net-zero or net-positive
+    acceptance history leaves the base score unchanged (no bonus above base).
+
+    Args:
+        base: Base similarity score for the pairing, typically from
+            :func:`base_score`.
+        rejections: Count of prior "rejected" feedback outcomes for this
+            pairing.
+        acceptances: Count of prior "accepted" feedback outcomes for this
+            pairing.
+
+    Returns:
+        Effective confidence score. Not clamped to [0, 1] — callers compare
+        against :data:`PRESENTATION_THRESHOLD`, where negative values simply
+        fail the threshold.
+    """
+    net_rejections = max(0, rejections - acceptances)
+    return base - REJECTION_PENALTY * net_rejections
+
+
+def select_best(
+    candidates: list[tuple[float, str, str, T]],
+) -> tuple[float, str, str, T] | None:
+    """Deterministically select the best candidate from a scored pool.
+
+    Filters candidates to those with ``confidence >= PRESENTATION_THRESHOLD``,
+    then picks the maximum by (``confidence`` descending, ``resolved_at``
+    descending, ``source_entry_id`` ascending).
+
+    Args:
+        candidates: Iterable of ``(confidence, resolved_at, source_entry_id,
+            payload)`` tuples. ``resolved_at`` is expected to be an
+            ISO-8601 timestamp string (lexical ordering matches chronological
+            ordering for that format); ``source_entry_id`` is any
+            lexically-ordered identifier.
+
+    Returns:
+        The winning tuple unchanged, or ``None`` if no candidate meets
+        :data:`PRESENTATION_THRESHOLD` (including an empty input).
+    """
+    eligible = [c for c in candidates if c[0] >= PRESENTATION_THRESHOLD]
+    if not eligible:
+        return None
+
+    # Two fields (confidence, resolved_at) sort descending, one
+    # (source_entry_id) sorts ascending — a single sort key can't mix
+    # directions, so select via explicit pairwise reduction instead.
+    best = eligible[0]
+    for candidate in eligible[1:]:
+        if _is_better(candidate, best):
+            best = candidate
+    return best
+
+
+def _is_better(
+    candidate: tuple[float, str, str, T], current_best: tuple[float, str, str, T]
+) -> bool:
+    """Return True if ``candidate`` outranks ``current_best`` under the tie-break order."""
+    c_confidence, c_resolved_at, c_source_id, _ = candidate
+    b_confidence, b_resolved_at, b_source_id, _ = current_best
+
+    if c_confidence != b_confidence:
+        return c_confidence > b_confidence
+    if c_resolved_at != b_resolved_at:
+        return c_resolved_at > b_resolved_at
+    return c_source_id < b_source_id

--- a/src/maverick/assumptions/models.py
+++ b/src/maverick/assumptions/models.py
@@ -8,6 +8,7 @@ CLI surfaces (Constitution VI — no magic strings at call sites).
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from enum import StrEnum
@@ -84,6 +85,11 @@ KEY_RECONCILED_AT = "assumption_reconciled_at"
 KEY_RECONCILED_ANSWER = "assumption_reconciled_answer"
 KEY_RECONCILE_CHANGE_ID = "assumption_reconcile_change_id"
 KEY_RECONCILE_REASON = "assumption_reconcile_reason"
+
+# Suggestion state keys (data-model.md "1. Ledger extension"; spec
+# 055-learned-assumption-resolution, research R4).
+KEY_SUGGESTION = "assumption_suggestion"
+KEY_AUTO_RESOLVED = "assumption_auto_resolved"
 
 # Epic-level state keys read to derive ``assumption_owner_spec``
 # (research R3 — first match wins).
@@ -207,6 +213,119 @@ class LandVerification(StrEnum):
 
 
 @dataclass(frozen=True, slots=True)
+class Suggestion:
+    """A learned-resolution match surfaced for one open ledger entry.
+
+    Persisted on the bead as a single JSON-encoded state value under
+    ``KEY_SUGGESTION`` (research R4) — never its own bead, never a separate
+    state key per field. See
+    ``specs/055-learned-assumption-resolution/data-model.md`` "Suggestion".
+
+    Attributes:
+        resolution: The candidate's resolution text — the answer (when
+            ``resolution_type == "answered"``) or the waive reason (when
+            ``"waived"``).
+        resolution_type: ``"answered"`` or ``"waived"``.
+        source_entry_id: The decision-corpus entry this suggestion matched.
+        source_spec: The matched decision's owning spec.
+        resolved_at: UTC ISO-8601 timestamp the matched decision was
+            resolved at (not when the suggestion was computed).
+        confidence: Effective confidence score for the match (already
+            penalty-adjusted; see ``matching.effective_confidence``).
+        computed_at: UTC ISO-8601 timestamp this suggestion was computed.
+    """
+
+    resolution: str
+    resolution_type: str
+    source_entry_id: str
+    source_spec: str
+    resolved_at: str
+    confidence: float
+    computed_at: str
+
+
+#: Field names in JSON-key order (data-model.md "Suggestion" table), mapped
+#: to the short internal keys actually used on the wire (see
+#: ``suggestion_to_json``/``suggestion_from_json`` docstrings for why).
+#: This mapping is the single source of truth for that abbreviation — never
+#: introduce a second one.
+_SUGGESTION_FIELDS: tuple[str, ...] = (
+    "resolution",
+    "resolution_type",
+    "source_entry_id",
+    "source_spec",
+    "resolved_at",
+    "confidence",
+    "computed_at",
+)
+
+#: Short wire-format keys for ``_SUGGESTION_FIELDS``, in the same order.
+#: Keep in sync with ``_SUGGESTION_FIELDS`` — order and length must match.
+_SUGGESTION_SHORT_KEYS: tuple[str, ...] = ("r", "rt", "sid", "ss", "ra", "c", "ca")
+
+#: {full field name -> short wire key}, derived once.
+_SUGGESTION_FIELD_TO_SHORT: dict[str, str] = dict(
+    zip(_SUGGESTION_FIELDS, _SUGGESTION_SHORT_KEYS, strict=True)
+)
+
+
+def suggestion_to_json(suggestion: Suggestion) -> str:
+    """Encode *suggestion* as the JSON string stored under ``KEY_SUGGESTION``.
+
+    **This is an internal bd-storage wire format, not a public contract.**
+    It uses abbreviated single/short keys (``r``, ``rt``, ``sid``, ``ss``,
+    ``ra``, ``c``, ``ca`` — see ``_SUGGESTION_FIELD_TO_SHORT``) and compact
+    JSON separators (no spaces), deliberately *unlike* the full-field-name
+    shape ``entry_to_dict`` projects for `review --list --json`/the land
+    report. The reason is bd, not us: ``bd set-state`` stores this value as
+    part of a ``"<dimension>:<value>"`` label whose total length is capped
+    (empirically ~254 minus the dimension-key length for this bd version) —
+    silently truncating on overflow with zero error. Full field names alone
+    exceed that budget before any real ``resolution`` text is added, which
+    is why the wire format must stay this compact. See
+    ``specs/055-learned-assumption-resolution/research.md`` R4 addendum.
+    """
+    payload = {
+        _SUGGESTION_FIELD_TO_SHORT[name]: getattr(suggestion, name) for name in _SUGGESTION_FIELDS
+    }
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def suggestion_from_json(raw: str) -> Suggestion | None:
+    """Decode a ``KEY_SUGGESTION`` state value into a :class:`Suggestion`.
+
+    Decodes the same short-key wire format ``suggestion_to_json`` writes
+    (see that function's docstring for why it isn't the dataclass's full
+    field names). Never raises (R11) — any malformed, truncated,
+    non-object, or field-incomplete input degrades to ``None`` so a bad
+    stored value never breaks report/listing reads.
+    """
+    try:
+        decoded = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    try:
+        # Decoded through `_SUGGESTION_FIELD_TO_SHORT` rather than literal
+        # short keys, so the mapping stays the single source of truth for
+        # the abbreviation and a rename can't silently desync writer and
+        # reader. `KeyError` is caught for the same reason.
+        values = {field: decoded[short] for field, short in _SUGGESTION_FIELD_TO_SHORT.items()}
+        return Suggestion(
+            resolution=str(values["resolution"]),
+            resolution_type=str(values["resolution_type"]),
+            source_entry_id=str(values["source_entry_id"]),
+            source_spec=str(values["source_spec"]),
+            resolved_at=str(values["resolved_at"]),
+            confidence=float(values["confidence"]),
+            computed_at=str(values["computed_at"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+@dataclass(frozen=True, slots=True)
 class AssumptionReportEntry:
     """Full read-side view of one ledger entry — everything the land
     frontier gate and provenance report need in one place.
@@ -228,6 +347,14 @@ class AssumptionReportEntry:
         pending_reconcile: True when this entry appears in
             ``ledger.answered_unreconciled_entries()`` — its human answer
             has drifted from the ledger record and hasn't been reconciled.
+        suggestion: The learned-resolution match surfaced for this entry
+            (``KEY_SUGGESTION``), if any. Never affects land-gate/frontier
+            behavior (FR-013/FR-019) — an open entry with a suggestion
+            blocks landing identically to one without.
+        auto_resolved: True when this entry was resolved by the
+            auto-resolution policy (``KEY_AUTO_RESOLVED``) rather than a
+            human — an ordinary answered/waived entry in every other
+            respect (User Story 4, not yet implemented as of this field).
     """
 
     record: AssumptionRecord
@@ -240,6 +367,8 @@ class AssumptionReportEntry:
     reconcile_change_id: str | None
     reconcile_reason: str | None
     pending_reconcile: bool
+    suggestion: Suggestion | None = None
+    auto_resolved: bool = False
 
     @property
     def bucket(self) -> str:
@@ -262,6 +391,34 @@ class AssumptionReportEntry:
     def blocks_landing(self) -> bool:
         """True when this entry blocks ``maverick land`` (strict, any severity)."""
         return self.bucket == "open" or self.pending_reconcile
+
+
+def report_entry_from_record(record: AssumptionRecord) -> AssumptionReportEntry:
+    """Wrap a bare :class:`AssumptionRecord` in a minimal report entry.
+
+    Several call sites hold an :class:`AssumptionRecord` (what
+    ``ledger.record_assumption``/``ledger.bulk_waive`` return) but need the
+    :class:`AssumptionReportEntry` shape that suggestion matching and
+    decision capture consume. Every field an ``AssumptionRecord`` cannot
+    know — the answer/waiver/reconcile/suggestion state a just-created or
+    just-waived entry carries on its bead — is set to its "not set"
+    default. Use this rather than passing a bare record where an entry is
+    expected: matching reads ``entry.record.*``, so an unwrapped record
+    raises ``AttributeError`` inside a best-effort handler and silently
+    disables the feature on that path.
+    """
+    return AssumptionReportEntry(
+        record=record,
+        final_answer=None,
+        waived_by=None,
+        waived_at=None,
+        waive_reason=None,
+        reconcile_status=None,
+        reconciled_answer=None,
+        reconcile_change_id=None,
+        reconcile_reason=None,
+        pending_reconcile=False,
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/maverick/assumptions/serialize.py
+++ b/src/maverick/assumptions/serialize.py
@@ -10,6 +10,8 @@ share one projection instead of maintaining two copies. ``land_report``'s
 
 from __future__ import annotations
 
+from dataclasses import asdict
+
 from maverick.assumptions.models import (
     RECONCILE_STATUS_NEEDS_REVIEW,
     AssumptionReportEntry,
@@ -34,6 +36,8 @@ def _annotations(entry: AssumptionReportEntry) -> tuple[str, ...]:
         tags.append(f"reconcile: {entry.reconcile_status}")
     if entry.pending_reconcile:
         tags.append("pending reconcile")
+    if entry.auto_resolved:
+        tags.append("auto-resolved")
     return tuple(tags)
 
 
@@ -73,5 +77,7 @@ def entry_to_dict(entry: AssumptionReportEntry) -> dict[str, object]:
             "reason": entry.reconcile_reason,
         },
         "pending_reconcile": entry.pending_reconcile,
+        "suggestion": asdict(entry.suggestion) if entry.suggestion is not None else None,
+        "auto_resolved": entry.auto_resolved,
         "annotations": list(_annotations(entry)),
     }

--- a/src/maverick/assumptions/suggestions.py
+++ b/src/maverick/assumptions/suggestions.py
@@ -1,0 +1,593 @@
+"""Learned-resolution orchestration: decision capture and corpus collapse.
+
+Composes ``assumptions`` (ledger domain) with ``runway`` (storage) without
+either side importing the other directly — ``ledger.py`` deliberately imports
+no workflow/CLI/runway modules (research R5,
+``specs/055-learned-assumption-resolution/research.md``). This module is the
+one shared implementation call sites (``cli/commands/review/entry_actions.py``
+today; matching/suggestion evaluation in later phases) compose against.
+
+See ``specs/055-learned-assumption-resolution/contracts/decision-records.md``
+for the storage and admission contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Final, Literal
+
+from maverick.assumptions import ledger
+from maverick.assumptions.matching import (
+    base_score,
+    effective_confidence,
+    normalize_question,
+    select_best,
+)
+from maverick.assumptions.models import (
+    KEY_AUTO_RESOLVED,
+    KEY_SUGGESTION,
+    Severity,
+    Suggestion,
+    suggestion_to_json,
+)
+from maverick.logging import get_logger
+
+if TYPE_CHECKING:
+    from maverick.assumptions.models import AssumptionReportEntry
+    from maverick.beads.client import BeadClient
+    from maverick.config import AutoResolvePolicyConfig
+    from maverick.runway.models import DecisionRecord, MatchFeedbackRecord
+    from maverick.runway.store import RunwayStore
+
+__all__ = [
+    "attach_suggestions",
+    "backfill_suggestions",
+    "classify_feedback",
+    "collapse_decisions",
+    "evaluate_suggestion",
+    "record_decision",
+    "record_feedback",
+]
+
+logger = get_logger(__name__)
+
+_AUTO_RESOLVE_ACTOR: Final = "maverick-resolver"
+
+#: Defensive ceiling on the encoded ``Suggestion`` JSON persisted under
+#: ``KEY_SUGGESTION``. ``bd set-state`` stores this value as part of a
+#: ``"<dimension>:<value>"`` label with a total-length cap that silently
+#: TRUNCATES on overflow (no error) — empirically ~254 chars minus
+#: ``len("assumption_suggestion")`` (21) = 233 chars for this key, verified
+#: against a real bd 1.1.2 sandbox (binary search around the boundary) and
+#: found independent of bead-id/reason length (see the 055
+#: quickstart-validation writeup and research.md R4's addendum). 220 leaves a
+#: 13-char safety margin below that observed hard boundary while still
+#: comfortably fitting realistic content — e.g. a 64-char resolution
+#: ("Yes, use AsyncRetrying with 3 attempts and exponential backoff") with a
+#: 24-char owner spec and a live microsecond-precision ``computed_at``
+#: encodes to 214 chars. A suggestion that would exceed this ceiling is
+#: never persisted (never truncated) — see ``_evaluate_and_persist``.
+_MAX_SUGGESTION_JSON_LENGTH: Final = 220
+
+
+async def record_decision(
+    store: RunwayStore,
+    entry: AssumptionReportEntry,
+    *,
+    resolution_type: Literal["answered", "waived"],
+    resolution: str,
+    resolved_by: str,
+) -> bool:
+    """Append a :class:`DecisionRecord` for a human-initiated resolution.
+
+    Best-effort (FR-004): catches any exception the store append raises,
+    logs a warning, and returns ``False`` instead of raising. Callers (the
+    human review surfaces — R6) use the return value to decide whether to
+    surface a ``[yellow]Warning:[/]`` to the user; the ledger write that
+    prompted this call has already succeeded and must never be reported as
+    failed because the corpus write failed.
+
+    Args:
+        store: Runway store to append into. Callers are responsible for
+            resolving it and confirming it's initialized (best-effort
+            degradation per FR-021 — an uninitialized store is not this
+            function's concern).
+        entry: The resolved ledger entry, read *before* the write (its
+            question/adopted-answer/severity/owner-spec do not change as a
+            result of answering or waiving).
+        resolution_type: ``"answered"`` or ``"waived"``.
+        resolution: The answer text, or the waive reason.
+        resolved_by: Git user name attributed to the resolution.
+
+    Returns:
+        ``True`` on a successful append, ``False`` on any failure (already
+        logged as a warning).
+    """
+    from maverick.runway.models import DecisionRecord
+
+    record = entry.record
+    try:
+        decision = DecisionRecord(
+            source_entry_id=record.bead_id,
+            question=record.question,
+            normalized_question=normalize_question(record.question),
+            adopted_answer=record.adopted_answer,
+            resolution_type=resolution_type,
+            resolution=resolution,
+            severity=record.severity.value,
+            owner_spec=record.owner_spec,
+            resolved_by=resolved_by,
+            resolved_at=datetime.now(UTC).isoformat(),
+        )
+        await store.append_decision(decision)
+    except Exception as exc:  # noqa: BLE001 — best-effort corpus write (FR-004)
+        logger.warning(
+            "decision_record_write_failed",
+            source_entry_id=record.bead_id,
+            error=str(exc),
+        )
+        return False
+    return True
+
+
+def collapse_decisions(records: list[DecisionRecord]) -> list[DecisionRecord]:
+    """Collapse decision-corpus history to one authoritative record per entry.
+
+    Groups *records* by ``source_entry_id`` and keeps only the record with
+    the latest ``resolved_at`` in each group (data-model.md's "Collapse
+    rule") — earlier lines remain in the JSONL corpus as history (FR-003)
+    but are not authoritative for matching/suggestion purposes.
+
+    Args:
+        records: Decision records, in any order (typically append order
+            from :meth:`RunwayStore.get_decisions`).
+
+    Returns:
+        One record per distinct ``source_entry_id``, order not guaranteed.
+    """
+    latest: dict[str, DecisionRecord] = {}
+    for record in records:
+        current = latest.get(record.source_entry_id)
+        if current is None or _resolved_at_key(record) > _resolved_at_key(current):
+            latest[record.source_entry_id] = record
+    return list(latest.values())
+
+
+def _resolved_at_key(record: DecisionRecord) -> tuple[float, str]:
+    """Sort key for ``resolved_at`` comparison.
+
+    Parses ISO-8601 via :meth:`datetime.fromisoformat` where possible
+    (falls back to the raw string, which still sorts sanely for the
+    zero-padded ISO-8601 timestamps every writer in this codebase produces)
+    so both parsed and lexical comparison agree.
+    """
+    try:
+        return (datetime.fromisoformat(record.resolved_at).timestamp(), record.resolved_at)
+    except ValueError:
+        return (float("-inf"), record.resolved_at)
+
+
+#: {(normalized question, candidate entry id) -> (acceptances, rejections)}.
+_FeedbackIndex = dict[tuple[str, str], tuple[int, int]]
+
+
+def _index_feedback(feedback: Sequence[MatchFeedbackRecord]) -> _FeedbackIndex:
+    """Tally *feedback* into accept/reject counts per exact pairing.
+
+    Built once per batch by :func:`attach_suggestions` /
+    :func:`backfill_suggestions` so scoring a record is a dict lookup per
+    candidate instead of a full scan of the feedback log — the batch paths
+    would otherwise be O(records x candidates x feedback).
+    """
+    index: _FeedbackIndex = {}
+    for item in feedback:
+        key = (item.normalized_question, item.source_entry_id)
+        acceptances, rejections = index.get(key, (0, 0))
+        if item.outcome == "accepted":
+            index[key] = (acceptances + 1, rejections)
+        elif item.outcome == "rejected":
+            index[key] = (acceptances, rejections + 1)
+    return index
+
+
+def evaluate_suggestion(
+    record: AssumptionReportEntry,
+    corpus: list[DecisionRecord],
+    feedback: Sequence[MatchFeedbackRecord] = (),
+) -> Suggestion | None:
+    """Match *record* against the decision corpus and score a suggestion.
+
+    Pure and synchronous — no I/O. Implements the matching formula from
+    ``contracts/decision-records.md`` (research R5/R12):
+
+    1. Collapse *corpus* to one authoritative record per
+       ``source_entry_id`` (:func:`collapse_decisions`).
+    2. Exclude a self-match — a candidate whose ``source_entry_id`` equals
+       *record*'s own bead id (R12: a re-opened/re-answered entry must
+       never match the decision record produced by its own earlier
+       resolution).
+    3. Score each remaining candidate via :func:`matching.base_score`,
+       penalized by :func:`matching.effective_confidence` using net
+       rejection/acceptance counts from *feedback* for that exact
+       (normalized question, candidate) pairing.
+    4. Select the best-scoring candidate at or above
+       :data:`matching.PRESENTATION_THRESHOLD` via
+       :func:`matching.select_best` (deterministic tie-break).
+
+    Args:
+        record: The open ledger entry to find a suggestion for.
+        corpus: Decision records to match against (any order, may contain
+            multiple versions per ``source_entry_id`` — collapsed here).
+        feedback: Prior accept/reject decisions on presented suggestions.
+            Empty by default — User Story 3 wires real feedback records.
+
+    Returns:
+        A single :class:`Suggestion` for the best-matching candidate, or
+        ``None`` when no candidate clears the presentation threshold.
+    """
+    return _evaluate(record, collapse_decisions(corpus), _index_feedback(feedback))
+
+
+def _evaluate(
+    record: AssumptionReportEntry,
+    candidates: Sequence[DecisionRecord],
+    feedback_index: _FeedbackIndex,
+) -> Suggestion | None:
+    """Score *record* against a pre-collapsed, pre-indexed corpus.
+
+    The batch-friendly core of :func:`evaluate_suggestion`: *candidates*
+    must already be collapsed (:func:`collapse_decisions`) and
+    *feedback_index* already tallied (:func:`_index_feedback`), both of
+    which are per-corpus rather than per-record work.
+    """
+    self_id = record.record.bead_id
+    scoreable = [c for c in candidates if c.source_entry_id != self_id]
+    if not scoreable:
+        return None
+
+    normalized_record_question = normalize_question(record.record.question)
+    scored: list[tuple[float, str, str, DecisionRecord]] = []
+    for candidate in scoreable:
+        acceptances, rejections = feedback_index.get(
+            (normalized_record_question, candidate.source_entry_id), (0, 0)
+        )
+        base = base_score(record.record.question, candidate.question)
+        confidence = effective_confidence(base, rejections=rejections, acceptances=acceptances)
+        scored.append((confidence, candidate.resolved_at, candidate.source_entry_id, candidate))
+
+    winner = select_best(scored)
+    if winner is None:
+        return None
+
+    confidence, resolved_at, source_entry_id, candidate = winner
+    return Suggestion(
+        resolution=candidate.resolution,
+        resolution_type=candidate.resolution_type,
+        source_entry_id=source_entry_id,
+        source_spec=candidate.owner_spec,
+        resolved_at=resolved_at,
+        confidence=confidence,
+        computed_at=datetime.now(UTC).isoformat(),
+    )
+
+
+def classify_feedback(
+    entry: AssumptionReportEntry,
+    suggestion: Suggestion,
+    *,
+    resolution_type: Literal["answered", "waived"],
+    resolution: str,
+) -> Literal["accepted", "rejected"]:
+    """Classify a human resolution against the suggestion it was shown.
+
+    Pure and synchronous. Per ``contracts/decision-records.md`` "Decision
+    capture points": ``"accepted"`` iff *resolution_type* matches
+    ``suggestion.resolution_type`` AND the normalized *resolution* text
+    matches the normalized ``suggestion.resolution`` text. A type mismatch
+    is always ``"rejected"``, even when the text happens to be identical.
+
+    Resolution text is compared with :func:`matching.normalize_question`
+    (casefold + strip punctuation + collapse whitespace) per the contract's
+    ``normalize()``, **not** the whitespace/case-only
+    :func:`~maverick.assumptions.models.normalize_answer` that reconcile's
+    changed-answer detection uses. The two answer different questions and
+    are meant to diverge: this one asks "is the human's resolution the same
+    *decision* the suggestion proposed", where punctuation is noise;
+    reconcile asks "did the recorded answer text change at all", where it
+    is not. A resolution can therefore be ``"accepted"`` here and still
+    count as a changed answer there, by design.
+
+    Args:
+        entry: The resolved ledger entry (unused beyond documenting the
+            call site's shape — classification only needs *suggestion*
+            and the actual resolution).
+        suggestion: The suggestion that was presented for *entry* prior to
+            resolution.
+        resolution_type: How the entry was actually resolved.
+        resolution: The actual answer text, or waive reason.
+
+    Returns:
+        ``"accepted"`` if the resolution matches the suggestion in both
+        type and normalized text, ``"rejected"`` otherwise.
+    """
+    del entry  # unused: classification depends only on suggestion + actual resolution
+    if resolution_type != suggestion.resolution_type:
+        return "rejected"
+    if normalize_question(resolution) != normalize_question(suggestion.resolution):
+        return "rejected"
+    return "accepted"
+
+
+async def record_feedback(
+    store: RunwayStore, entry: AssumptionReportEntry, *, accepted: bool
+) -> bool:
+    """Append a :class:`MatchFeedbackRecord` for a human's accept/reject
+    decision on a presented suggestion.
+
+    Best-effort (mirrors :func:`record_decision`'s never-raises/bool-return
+    contract): catches any exception the store append raises, logs a
+    warning, and returns ``False`` instead of raising.
+
+    **Precondition**: callers must only invoke this when ``entry.suggestion
+    is not None`` — the suggestion presented is exactly what this feedback
+    penalizes/rewards on future matches. If ``entry.suggestion`` is
+    ``None``, this returns ``False`` immediately without writing anything
+    (defensive, consistent with the never-raises contract) rather than
+    raising.
+
+    Args:
+        store: Runway store to append into.
+        entry: The resolved ledger entry that carried the suggestion.
+        accepted: Whether the human's resolution matched the suggestion.
+
+    Returns:
+        ``True`` on a successful append, ``False`` on any failure or when
+        *entry* carried no suggestion (already logged as a warning in the
+        failure case).
+    """
+    from maverick.runway.models import MatchFeedbackRecord
+
+    suggestion = entry.suggestion
+    if suggestion is None:
+        logger.warning(
+            "match_feedback_missing_suggestion",
+            bead_id=entry.record.bead_id,
+        )
+        return False
+
+    try:
+        record = MatchFeedbackRecord(
+            normalized_question=normalize_question(entry.record.question),
+            source_entry_id=suggestion.source_entry_id,
+            outcome="accepted" if accepted else "rejected",
+            recorded_at=datetime.now(UTC).isoformat(),
+        )
+        await store.append_match_feedback(record)
+    except Exception as exc:  # noqa: BLE001 — best-effort corpus write (FR-004 pattern)
+        logger.warning(
+            "match_feedback_write_failed",
+            source_entry_id=entry.record.bead_id,
+            error=str(exc),
+        )
+        return False
+    return True
+
+
+async def _load_corpus(store: RunwayStore) -> tuple[list[DecisionRecord], _FeedbackIndex]:
+    """Load and pre-process the decision corpus for a batch, never raising.
+
+    ``decisions.jsonl`` / ``match-feedback.jsonl`` are append-only and
+    outlive schema changes, so a read can fail on a row the current wheel
+    can't validate. :func:`attach_suggestions` and
+    :func:`backfill_suggestions` both document a never-raises contract;
+    degrading to an empty corpus (no suggestions this batch) keeps it true
+    rather than leaving every caller responsible for wrapping the call.
+
+    Returns the corpus already collapsed to one authoritative record per
+    entry and the feedback already tallied — both per-corpus, not
+    per-record, work.
+    """
+    try:
+        corpus = await store.get_decisions()
+        feedback = await store.get_match_feedback()
+    except Exception as exc:  # noqa: BLE001 — best-effort corpus read (FR-004 pattern)
+        logger.warning("decision_corpus_read_failed", path=str(store.path), error=str(exc))
+        return [], {}
+    return collapse_decisions(corpus), _index_feedback(feedback)
+
+
+async def _evaluate_and_persist(
+    client: BeadClient,
+    record: AssumptionReportEntry,
+    candidates: Sequence[DecisionRecord],
+    feedback_index: _FeedbackIndex,
+) -> Suggestion | None:
+    """Evaluate one entry and persist a resulting suggestion, best-effort.
+
+    Shared by :func:`attach_suggestions` and :func:`backfill_suggestions` so
+    the evaluate-then-``set_state`` sequence — and its failure handling —
+    lives in exactly one place. Never raises: any failure in evaluation or
+    the bd write is logged as a warning and treated as "no suggestion",
+    so one bad record never blocks the rest of a batch.
+
+    This is also the natural extension point for auto-resolution
+    (User Story 4, not implemented here): a future policy check would slot
+    in after a suggestion is computed and before/instead of the plain
+    ``set_state`` persist below.
+
+    A suggestion whose encoded JSON would risk bd's silent state-value
+    truncation (``_MAX_SUGGESTION_JSON_LENGTH``) is never persisted — it is
+    treated exactly like "no candidate matched" (debug log, ``None``
+    returned) rather than being written corrupted/truncated. This is
+    expected, graceful degradation (R11), not an error, so it logs at
+    debug rather than warning.
+    """
+    try:
+        suggestion = _evaluate(record, candidates, feedback_index)
+        if suggestion is None:
+            return None
+        encoded = suggestion_to_json(suggestion)
+        if len(encoded) > _MAX_SUGGESTION_JSON_LENGTH:
+            logger.debug(
+                "suggestion_too_long_to_persist_safely",
+                bead_id=record.record.bead_id,
+                encoded_length=len(encoded),
+                max_length=_MAX_SUGGESTION_JSON_LENGTH,
+            )
+            return None
+        await client.set_state(
+            record.record.bead_id,
+            {KEY_SUGGESTION: encoded},
+            reason="suggestion",
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort batch write (FR-004 pattern)
+        logger.warning(
+            "suggestion_persist_failed",
+            bead_id=record.record.bead_id,
+            error=str(exc),
+        )
+        return None
+    return suggestion
+
+
+async def attach_suggestions(
+    client: BeadClient,
+    store: RunwayStore,
+    records: list[AssumptionReportEntry],
+    *,
+    auto_resolve: AutoResolvePolicyConfig | None = None,
+) -> None:
+    """Evaluate and persist a suggestion for each of *records*, best-effort.
+
+    Never raises. A store that hasn't been initialized (FR-021-style
+    best-effort degradation) is a silent no-op — no corpus to match
+    against. Otherwise loads the decision corpus once and evaluates every
+    record against it, persisting each match via one ``set_state`` call;
+    a failure on any single record (evaluation or persistence) is logged
+    and does not block the rest of the batch (see :func:`_evaluate_and_persist`).
+
+    When *auto_resolve* is provided, enabled, and a computed suggestion's
+    confidence clears its ``confidence_threshold`` on a ``low``-severity
+    record, the entry is auto-waived (User Story 4) instead of being left
+    for human review — machine-initiated, so no :class:`DecisionRecord` or
+    :class:`MatchFeedbackRecord` is ever written for it (FR-005). This is
+    recording-time only; :func:`backfill_suggestions` never auto-resolves.
+
+    Args:
+        client: bd client used to persist matched suggestions.
+        store: Runway store to read the decision corpus from.
+        records: Ledger entries to evaluate (typically newly recorded or
+            newly listed open entries).
+        auto_resolve: Opt-in auto-resolution policy. ``None`` (the
+            default) preserves prior behavior exactly.
+    """
+    if not store.is_initialized:
+        logger.debug("attach_suggestions_store_uninitialized", path=str(store.path))
+        return
+
+    candidates, feedback_index = await _load_corpus(store)
+
+    for record in records:
+        suggestion = await _evaluate_and_persist(client, record, candidates, feedback_index)
+        if suggestion is None:
+            continue
+        await _maybe_auto_resolve(client, record, suggestion, auto_resolve)
+
+
+async def _maybe_auto_resolve(
+    client: BeadClient,
+    record: AssumptionReportEntry,
+    suggestion: Suggestion,
+    auto_resolve: AutoResolvePolicyConfig | None,
+) -> None:
+    """Auto-waive *record* when it's eligible under *auto_resolve*.
+
+    Eligibility (all must hold): the record is ``low`` severity,
+    *auto_resolve* is provided and enabled, and *suggestion*'s confidence
+    clears ``auto_resolve.confidence_threshold``. Never raises — a
+    stamp/waive failure is logged and the entry is left as-is (never
+    retried; :func:`attach_suggestions` runs once per record).
+
+    ``KEY_AUTO_RESOLVED`` is stamped **before** the waive, deliberately.
+    ``bd set-state`` is one subprocess call per key, so the two writes are
+    not atomic and either can fail on its own; the stamp is exactly what
+    lets a human override the machine's decision (``maverick review <id>``
+    bypasses its already-waived refusal only for auto-resolved entries).
+    Waiving first would mean a failure in between leaves an entry waived by
+    ``maverick-resolver`` that no human can ever reopen. Stamping first
+    inverts the failure into the harmless direction: an *open* entry
+    carrying a stale ``auto_resolved`` marker, which nothing gates on.
+    """
+    if record.record.severity != Severity.LOW:
+        return
+    if auto_resolve is None or not auto_resolve.enabled:
+        return
+    if suggestion.confidence < auto_resolve.confidence_threshold:
+        return
+
+    reason = (
+        f"Auto-resolved: matches prior decision {suggestion.source_entry_id} "
+        f"from {suggestion.source_spec} ({suggestion.resolved_at}) "
+        f"at {suggestion.confidence:.2f} confidence"
+    )
+    try:
+        await client.set_state(
+            record.record.bead_id, {KEY_AUTO_RESOLVED: "true"}, reason="auto-resolved"
+        )
+        await ledger.waive(
+            client, bead_id=record.record.bead_id, reason=reason, waived_by=_AUTO_RESOLVE_ACTOR
+        )
+    except Exception as exc:  # noqa: BLE001 — never let auto-resolve failure break the batch
+        # Entry is left open with its suggestion (research R11) and never
+        # retried (attach runs once per record), so this warning is the
+        # only signal an operator gets — it must carry the actual cause.
+        logger.warning(
+            "assumption_auto_resolve_failed",
+            bead_id=record.record.bead_id,
+            error=str(exc),
+        )
+
+
+async def backfill_suggestions(
+    client: BeadClient,
+    store: RunwayStore,
+    entries: list[AssumptionReportEntry],
+) -> list[AssumptionReportEntry]:
+    """Evaluate and persist suggestions for entries that lack one.
+
+    Entries whose ``.suggestion`` is already set — whether a genuinely
+    matched suggestion or (R11) a stored-but-unparseable value that
+    degraded to ``None`` upstream in ``report_entry_from_details`` and
+    therefore looks identical to "absent" here — are left untouched by
+    this simplest-correct implementation: only entries observed with
+    ``suggestion is None`` from a *missing* key are distinguishable from
+    "present but unparseable" without also threading the raw state value
+    through, which nothing tested here currently requires. Never raises.
+
+    Args:
+        client: bd client used to persist newly matched suggestions.
+        store: Runway store to read the decision corpus from.
+        entries: Ledger entries to consider for back-fill.
+
+    Returns:
+        *entries* with a freshly computed ``suggestion`` attached (via
+        ``dataclasses.replace``) for every entry that got one; entries
+        left alone (already had a suggestion, or no match found) are
+        returned unchanged.
+    """
+    if not store.is_initialized:
+        logger.debug("backfill_suggestions_store_uninitialized", path=str(store.path))
+        return entries
+
+    candidates, feedback_index = await _load_corpus(store)
+
+    updated: list[AssumptionReportEntry] = []
+    for entry in entries:
+        if entry.suggestion is not None:
+            updated.append(entry)
+            continue
+        suggestion = await _evaluate_and_persist(client, entry, candidates, feedback_index)
+        updated.append(replace(entry, suggestion=suggestion) if suggestion is not None else entry)
+    return updated

--- a/src/maverick/cli/commands/review/entry_actions.py
+++ b/src/maverick/cli/commands/review/entry_actions.py
@@ -11,18 +11,176 @@ never both.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, NoReturn
+from typing import TYPE_CHECKING, Literal, NoReturn
 
 import click
 from rich.markup import escape
 
 from maverick.assumptions.models import STATUS_WAIVED
-from maverick.cli.console import console
+from maverick.cli.console import console, err_console
 from maverick.cli.context import ExitCode
+from maverick.logging import get_logger
 
 if TYPE_CHECKING:
+    from maverick.assumptions.models import AssumptionReportEntry
     from maverick.beads.client import BeadClient
     from maverick.beads.models import BeadDetails
+    from maverick.runway.store import RunwayStore
+
+logger = get_logger(__name__)
+
+
+def _warn_capture_failed(*, bead_id: str, artifact: str, json_mode: bool) -> None:
+    """Surface a best-effort corpus-write failure without failing the command.
+
+    Human mode prints to stdout via ``console``; JSON mode prints to stderr
+    via ``err_console``, since JSON mode's stdout carries exactly one
+    envelope document.
+    """
+    out = err_console if json_mode else console
+    out.print(
+        f"[yellow]Warning:[/] Could not record {artifact} for {bead_id} "
+        "— the review action itself succeeded."
+    )
+
+
+async def _capture_decision(
+    store: RunwayStore | None,
+    entry: AssumptionReportEntry,
+    *,
+    resolution_type: Literal["answered", "waived"],
+    resolution: str,
+    resolved_by: str,
+    json_mode: bool,
+) -> None:
+    """Best-effort decision-corpus capture after a successful ledger write.
+
+    **Must be called outside any ``json_error_handler`` scope** — same
+    rationale as :func:`_project_after_write`: the ledger write this
+    follows has already succeeded, so a corpus-write failure must never
+    turn a successful review action into a reported failure (FR-004). A
+    failure is surfaced as a visible ``[yellow]Warning:[/]`` and otherwise
+    ignored.
+
+    Args:
+        store: The resolved runway store, or ``None`` when the project has
+            none — resolved once by the caller (FR-021: no store, no
+            decision capture, no warning). Callers that resolve per-entry
+            would re-``stat`` the store for every row of a bulk waive.
+    """
+    from maverick.assumptions.suggestions import record_decision
+
+    if store is None:
+        return
+
+    ok = await record_decision(
+        store,
+        entry,
+        resolution_type=resolution_type,
+        resolution=resolution,
+        resolved_by=resolved_by,
+    )
+    if not ok:
+        _warn_capture_failed(
+            bead_id=entry.record.bead_id,
+            artifact="decision history (runway decisions.jsonl)",
+            json_mode=json_mode,
+        )
+
+
+async def _capture_feedback(
+    store: RunwayStore | None,
+    entry: AssumptionReportEntry,
+    *,
+    resolution_type: Literal["answered", "waived"],
+    resolution: str,
+    json_mode: bool,
+    force_rejected: bool = False,
+) -> None:
+    """Best-effort match-feedback capture after a successful ledger write.
+
+    Only fires when *entry* carried a stored suggestion (``entry.suggestion
+    is not None``) — no suggestion means there is nothing to classify or
+    record. Same store-resolved-by-the-caller, outside-any-
+    ``json_error_handler``-scope, fail-soft contract as
+    :func:`_capture_decision` (FR-004 pattern).
+
+    Args:
+        force_rejected: Skip :func:`classify_feedback` and record a
+            rejection unconditionally. Set for a human override of an
+            auto-resolved entry (FR-020, User Story 4): re-resolving an
+            entry the policy already waived *is* a rejection of the
+            machine's decision, even when the override's type and text
+            happen to coincide with the suggestion's — which
+            ``classify_feedback`` would otherwise score as ``"accepted"``.
+    """
+    if entry.suggestion is None or store is None:
+        return
+
+    from maverick.assumptions.suggestions import classify_feedback, record_feedback
+
+    accepted = False
+    if not force_rejected:
+        outcome = classify_feedback(
+            entry,
+            entry.suggestion,
+            resolution_type=resolution_type,
+            resolution=resolution,
+        )
+        accepted = outcome == "accepted"
+
+    ok = await record_feedback(store, entry, accepted=accepted)
+    if not ok:
+        _warn_capture_failed(
+            bead_id=entry.record.bead_id,
+            artifact="match feedback (runway match-feedback.jsonl)",
+            json_mode=json_mode,
+        )
+
+
+async def _clear_auto_resolved(client: BeadClient, bead_id: str) -> None:
+    """Un-stamp ``KEY_AUTO_RESOLVED`` after a human resolves *bead_id* itself.
+
+    Once a human answers or waives an auto-resolved entry, the machine no
+    longer owns that decision: reports must stop annotating the row
+    ``auto-resolved`` (it would misattribute a human decision), and the
+    already-resolved refusal in :func:`_review_ledger_entry` — which the
+    stamp deliberately bypasses — must come back into force so the entry
+    can't be silently re-resolved forever.
+
+    Writes ``"false"`` rather than clearing the key: bd rejects empty state
+    values, and the readers compare against ``"true"``. Best-effort — the
+    ledger write it follows has already succeeded, so a failure here is
+    logged, never surfaced as a failed review action (FR-004 pattern).
+    """
+    from maverick.assumptions.models import KEY_AUTO_RESOLVED
+
+    try:
+        await client.set_state(bead_id, {KEY_AUTO_RESOLVED: "false"}, reason="human-override")
+    except Exception:  # noqa: BLE001 — the ledger write already succeeded
+        logger.warning("auto_resolved_unstamp_failed", bead_id=bead_id)
+
+
+async def _fetch_entry_after_write(
+    client: BeadClient, bead_id: str
+) -> AssumptionReportEntry | None:
+    """Re-read *bead_id* and project it into an :class:`AssumptionReportEntry`.
+
+    Shared by :func:`_project_after_write` (JSON-mode row projection) and
+    bulk-waive's per-entry match-feedback capture — both need the
+    freshly-read entry, including its ``suggestion`` (waiving never touches
+    ``KEY_SUGGESTION``, so a post-waive re-read still carries whatever
+    suggestion was stored beforehand). Fails soft (``None``) on any read
+    error — the write already succeeded; a transient re-read failure must
+    never be reported as a write failure.
+    """
+    from maverick.assumptions.ledger import report_entry_from_details
+
+    try:
+        details = await client.show(bead_id)
+    except Exception:  # noqa: BLE001 — the write already succeeded; never fail on the read
+        return None
+    return report_entry_from_details(details)
 
 
 async def _project_after_write(client: BeadClient, bead_id: str) -> dict[str, object] | None:
@@ -36,14 +194,9 @@ async def _project_after_write(client: BeadClient, bead_id: str) -> dict[str, ob
     Failing soft (``None``, surfaced as ``degraded: true`` on the success
     envelope) keeps the envelope honest about what actually happened.
     """
-    from maverick.assumptions.ledger import report_entry_from_details
     from maverick.assumptions.serialize import entry_to_dict
 
-    try:
-        details = await client.show(bead_id)
-    except Exception:  # noqa: BLE001 — the write already succeeded; never fail on the read
-        return None
-    entry = report_entry_from_details(details)
+    entry = await _fetch_entry_after_write(client, bead_id)
     return entry_to_dict(entry) if entry is not None else None
 
 
@@ -70,12 +223,15 @@ async def _bulk_waive_flow(
     """
     from maverick.assumptions.errors import AssumptionLedgerError
     from maverick.assumptions.ledger import bulk_waive
-    from maverick.assumptions.models import Severity
+    from maverick.assumptions.models import Severity, report_entry_from_record
     from maverick.cli.commands.review import _resolve_git_user_name
     from maverick.cli.json_output import JsonEnvelope, emit_json, json_error_handler
+    from maverick.runway.store import resolve_runway_store
 
     severity_set = frozenset(Severity(s) for s in severities)
     waived_by = _resolve_git_user_name(Path.cwd())
+    # Resolved once for the whole batch, not per waived entry.
+    store = resolve_runway_store(Path.cwd())
 
     if json_mode:
         with json_error_handler("review.bulk-waive"):
@@ -94,14 +250,32 @@ async def _bulk_waive_flow(
         # (A single repo-wide `report_entries()` sweep would look cheaper
         # but isn't — it queries every task bead and shows each one, which
         # is strictly more work than showing just the entries waived here.)
+        from maverick.assumptions.serialize import entry_to_dict
+
         waived_rows: list[dict[str, object]] = []
         unprojected: list[str] = []
         for record in result.waived:
-            row = await _project_after_write(client, record.bead_id)
-            if row is None:
+            entry = await _fetch_entry_after_write(client, record.bead_id)
+            if entry is None:
                 unprojected.append(record.bead_id)
             else:
-                waived_rows.append(row)
+                waived_rows.append(entry_to_dict(entry))
+            await _capture_decision(
+                store,
+                report_entry_from_record(record),
+                resolution_type="waived",
+                resolution=reason,
+                resolved_by=waived_by,
+                json_mode=True,
+            )
+            if entry is not None:
+                await _capture_feedback(
+                    store,
+                    entry,
+                    resolution_type="waived",
+                    resolution=reason,
+                    json_mode=True,
+                )
 
         payload: dict[str, object] = {
             "owner_spec": owner_spec,
@@ -138,6 +312,28 @@ async def _bulk_waive_flow(
         severities_label = "/".join(sorted(s.value for s in severity_set))
         console.print(f"No open {severities_label}-severity assumptions for {owner_spec}.")
         return
+
+    # Human mode has no row projection to build, so the per-entry re-read
+    # exists only to feed match-feedback capture — skip it entirely (and
+    # its `bd show` subprocess per waived entry) when there's no store.
+    for record in result.waived if store is not None else ():
+        entry = await _fetch_entry_after_write(client, record.bead_id)
+        await _capture_decision(
+            store,
+            report_entry_from_record(record),
+            resolution_type="waived",
+            resolution=reason,
+            resolved_by=waived_by,
+            json_mode=False,
+        )
+        if entry is not None:
+            await _capture_feedback(
+                store,
+                entry,
+                resolution_type="waived",
+                resolution=reason,
+                json_mode=False,
+            )
 
     if result.waived:
         console.print(
@@ -188,7 +384,12 @@ async def _review_ledger_entry(
     (research R6) reads the entry's *current* status from *details*
     (already fetched by the caller moments earlier) before any write: a
     ``waived`` target is ``already-resolved`` in both modes — re-answering
-    an ``answered`` entry stays legal (051 FR-017).
+    an ``answered`` entry stays legal (051 FR-017). FR-020 (User Story 4,
+    055-learned-assumption-resolution) scopes that refusal to *human*
+    waives only — an entry the auto-resolution policy waived
+    (``current_entry.auto_resolved``) bypasses the pre-check and falls
+    through to the normal answer/waive flow below, since a human is
+    allowed to override a machine decision.
     """
     from maverick.assumptions.errors import AssumptionLedgerError
     from maverick.assumptions.ledger import answer as ledger_answer
@@ -207,6 +408,7 @@ async def _review_ledger_entry(
     from maverick.assumptions.serialize import entry_to_dict
     from maverick.cli.commands.review import _resolve_git_user_name
     from maverick.cli.json_output import ErrorKind, JsonEnvelope, emit_json, json_error_handler
+    from maverick.runway.store import resolve_runway_store
 
     is_waive_only = waive_reason is not None and answer_text is None
     verb = "review.waive" if is_waive_only else "review.answer"
@@ -223,7 +425,7 @@ async def _review_ledger_entry(
     # here for ledger entries), so this never returns None.
     current_entry = report_entry_from_details(details)
     assert current_entry is not None  # ledger entries always project
-    if current_entry.record.status == STATUS_WAIVED:
+    if current_entry.record.status == STATUS_WAIVED and not current_entry.auto_resolved:
         message = f"Bead {bead_id} is already waived — no further action possible"
         if json_mode:
             emit_json(
@@ -237,6 +439,13 @@ async def _review_ledger_entry(
         else:
             console.print(f"[red]Error:[/] {message}")
         raise SystemExit(ExitCode.FAILURE)
+
+    # Resolved once — every capture helper below shares it.
+    store = resolve_runway_store(Path.cwd())
+    # A human resolving an entry the policy auto-resolved is an override:
+    # the machine's decision is being replaced, so the stamp comes off and
+    # the feedback is a rejection regardless of what the human chose.
+    is_override = current_entry.auto_resolved
 
     if not json_mode:
         state = details.state or {}
@@ -288,12 +497,34 @@ async def _review_ledger_entry(
                 message="Answer text must not be empty",
             )
 
+        answered_by = _resolve_git_user_name(Path.cwd())
+
         if json_mode:
             with json_error_handler("review.answer"):
                 await ledger_answer(client, bead_id=bead_id, answer_text=answer_text)
-            # Projection re-read is outside the handler on purpose — see
-            # `_project_after_write`. The write is already committed here.
+            # Un-stamp, projection re-read and decision capture are outside
+            # the handler on purpose — see `_project_after_write`. The write
+            # is already committed here. Un-stamping precedes the re-read so
+            # the emitted row reflects the human's ownership of the entry.
+            if is_override:
+                await _clear_auto_resolved(client, bead_id)
             row = await _project_after_write(client, bead_id)
+            await _capture_decision(
+                store,
+                current_entry,
+                resolution_type="answered",
+                resolution=answer_text,
+                resolved_by=answered_by,
+                json_mode=True,
+            )
+            await _capture_feedback(
+                store,
+                current_entry,
+                resolution_type="answered",
+                resolution=answer_text,
+                json_mode=True,
+                force_rejected=is_override,
+            )
             payload: dict[str, object] = {"entry": row, "action": "answered"}
             if row is None:
                 payload["degraded"] = True
@@ -305,6 +536,24 @@ async def _review_ledger_entry(
         except AssumptionLedgerError as exc:
             console.print(f"[red]Error:[/] {exc}")
             raise SystemExit(ExitCode.FAILURE) from exc
+        if is_override:
+            await _clear_auto_resolved(client, bead_id)
+        await _capture_decision(
+            store,
+            current_entry,
+            resolution_type="answered",
+            resolution=answer_text,
+            resolved_by=answered_by,
+            json_mode=False,
+        )
+        await _capture_feedback(
+            store,
+            current_entry,
+            resolution_type="answered",
+            resolution=answer_text,
+            json_mode=False,
+            force_rejected=is_override,
+        )
         console.print(f"\n[green]✓[/] Bead {bead_id} answered and closed.")
     else:
         if not waive_reason or not waive_reason.strip():
@@ -322,7 +571,25 @@ async def _review_ledger_entry(
                     client, bead_id=bead_id, reason=waive_reason, waived_by=waived_by
                 )
             # Outside the handler — same rationale as the answer path above.
+            if is_override:
+                await _clear_auto_resolved(client, bead_id)
             row = await _project_after_write(client, bead_id)
+            await _capture_decision(
+                store,
+                current_entry,
+                resolution_type="waived",
+                resolution=waive_reason,
+                resolved_by=waived_by,
+                json_mode=True,
+            )
+            await _capture_feedback(
+                store,
+                current_entry,
+                resolution_type="waived",
+                resolution=waive_reason,
+                json_mode=True,
+                force_rejected=is_override,
+            )
             payload = {"entry": row, "action": "waived"}
             if row is None:
                 payload["degraded"] = True
@@ -334,4 +601,22 @@ async def _review_ledger_entry(
         except AssumptionLedgerError as exc:
             console.print(f"[red]Error:[/] {exc}")
             raise SystemExit(ExitCode.FAILURE) from exc
+        if is_override:
+            await _clear_auto_resolved(client, bead_id)
+        await _capture_decision(
+            store,
+            current_entry,
+            resolution_type="waived",
+            resolution=waive_reason,
+            resolved_by=waived_by,
+            json_mode=False,
+        )
+        await _capture_feedback(
+            store,
+            current_entry,
+            resolution_type="waived",
+            resolution=waive_reason,
+            json_mode=False,
+            force_rejected=is_override,
+        )
         console.print(f"\n[yellow]⚠[/] Bead {bead_id} waived by {waived_by} and closed.")

--- a/src/maverick/cli/commands/review/listing.py
+++ b/src/maverick/cli/commands/review/listing.py
@@ -19,11 +19,15 @@ from rich.table import Table
 from maverick.assumptions.models import STATUS_OPEN
 from maverick.cli.console import console
 from maverick.cli.context import ExitCode
+from maverick.logging import get_logger
 
 if TYPE_CHECKING:
     from maverick.assumptions.models import AssumptionReportEntry
+    from maverick.beads.client import BeadClient
 
 __all__ = ["run_list"]
+
+logger = get_logger(__name__)
 
 #: Presentation-order rank — high severity sorts first (data-model.md
 #: "canonical ordering": owner_spec asc, then severity high->low, then
@@ -63,6 +67,47 @@ def _filter_and_sort(
     return [entry for _, entry in selected]
 
 
+async def _backfill_entries(
+    client: BeadClient,
+    entries: list[AssumptionReportEntry],
+) -> list[AssumptionReportEntry]:
+    """Back-fill suggestions for the *open* entries among *entries*.
+
+    Restricted to open entries with no stored suggestion, deliberately:
+    back-fill persists what it computes with a ``bd set-state`` write, and
+    an answered/waived entry will never be reviewed again, so writing a
+    suggestion onto one is pure cost on a read-only verb (the
+    ``maverick-review`` skill calls ``review --list`` on every sweep).
+    Callers pass the already-filtered, already-sorted selection so the
+    write set is exactly what the caller will render.
+
+    Best-effort (FR-021): a runway store that isn't initialized degrades
+    silently inside :func:`backfill_suggestions` itself; any other failure
+    raised at this call site is caught here and also degrades to a
+    debug-logged no-op — the original *entries* are returned unchanged, in
+    their original order.
+    """
+    from maverick.assumptions.suggestions import backfill_suggestions
+    from maverick.runway.store import RunwayStore, runway_path_for
+
+    targets = [e for e in entries if e.record.status == STATUS_OPEN and e.suggestion is None]
+    if not targets:
+        return entries
+
+    # No `is_initialized` short-circuit here: `backfill_suggestions` already
+    # treats an uninitialized store as a debug-logged no-op (FR-021), so
+    # that single check stays in one place.
+    store = RunwayStore(runway_path_for(Path.cwd()))
+    try:
+        updated = await backfill_suggestions(client, store, targets)
+    except Exception:
+        logger.debug("review_list_backfill_failed", exc_info=True)
+        return entries
+
+    by_id = {entry.record.bead_id: entry for entry in updated}
+    return [by_id.get(entry.record.bead_id, entry) for entry in entries]
+
+
 def _build_counts(entries: list[AssumptionReportEntry]) -> dict[str, object]:
     """The ``counts`` object — reflects the filtered selection (contract)."""
     by_status = {"open": 0, "answered": 0, "waived": 0}
@@ -95,6 +140,7 @@ def _render_table(entries: list[AssumptionReportEntry], counts: dict[str, object
     table.add_column("Severity")
     table.add_column("Spec")
     table.add_column("Question")
+    table.add_column("Suggestion")
 
     for entry in entries:
         question = entry.record.question or entry.record.bead_id
@@ -107,6 +153,7 @@ def _render_table(entries: list[AssumptionReportEntry], counts: dict[str, object
             entry.record.severity.value,
             escape(entry.record.owner_spec),
             escape(question),
+            "suggested" if entry.suggestion is not None else "",
         )
 
     console.print(table)
@@ -154,12 +201,16 @@ async def run_list(
             console.print(f"[red]Error:[/] {exc}")
             raise SystemExit(ExitCode.FAILURE) from exc
 
+    # Back-fill runs on the filtered selection, never the whole repo sweep:
+    # it writes what it computes, so evaluating rows the caller filtered out
+    # would turn this read verb into a repo-wide write.
     selected = _filter_and_sort(
         entries,
         statuses=effective_statuses,
         owner_specs=owner_specs,
         severities=severities,
     )
+    selected = await _backfill_entries(client, selected)
     counts = _build_counts(selected)
 
     if json_mode:

--- a/src/maverick/config.py
+++ b/src/maverick/config.py
@@ -14,6 +14,7 @@ from pydantic_settings import (
     SettingsConfigDict,
 )
 
+from maverick.assumptions.matching import PRESENTATION_THRESHOLD
 from maverick.exceptions import ConfigError
 from maverick.logging import get_logger
 
@@ -22,8 +23,10 @@ __all__ = [
     "ActorConfig",
     "AgentBindingConfig",
     "AgentsConfig",
+    "AssumptionResolutionConfig",
     "AssumptionScheduleConfig",
     "AssumptionsConfig",
+    "AutoResolvePolicyConfig",
     "AutoWaivePolicyConfig",
     "CustomToolConfig",
     "GitHubConfig",
@@ -568,6 +571,44 @@ class AssumptionScheduleConfig(BaseModel):
         return v
 
 
+class AutoResolvePolicyConfig(BaseModel):
+    """Opt-in policy to auto-resolve (waive) high-confidence low-severity entries.
+
+    Absent from :class:`AssumptionResolutionConfig`
+    (``auto_resolve_low: None``), auto-resolution never fires. When
+    present, ``enabled`` is itself a second explicit opt-in — double
+    opt-in by design, mirroring :class:`AutoWaivePolicyConfig`.
+
+    Attributes:
+        enabled: Whether auto-resolution is active.
+        confidence_threshold: Minimum effective confidence required
+            before an entry is auto-resolved. Lower-bounded by
+            :data:`maverick.assumptions.matching.PRESENTATION_THRESHOLD`
+            itself (imported, not duplicated), so auto-resolution can
+            never be configured looser than presentation even if that
+            contract constant moves. Default ``0.9``.
+    """
+
+    enabled: bool = False
+    confidence_threshold: float = Field(default=0.9, ge=PRESENTATION_THRESHOLD, le=1.0)
+
+
+class AssumptionResolutionConfig(BaseModel):
+    """Root config block for opt-in automated assumption resolution.
+
+    Sibling to :class:`AssumptionScheduleConfig` under
+    ``assumptions:`` — independent of it (setting one leaves the other
+    at its own default).
+
+    Attributes:
+        auto_resolve_low: Optional policy to auto-waive high-confidence
+            low-severity entries at recording time. Absent (``None``,
+            the default) means auto-resolution is inert.
+    """
+
+    auto_resolve_low: AutoResolvePolicyConfig | None = None
+
+
 class AssumptionsConfig(BaseModel):
     """Root config block for assumption-ledger behavior.
 
@@ -576,9 +617,13 @@ class AssumptionsConfig(BaseModel):
             ``maverick notify``. Absent (``None``, the default) means the
             scheduler is inert — ``maverick notify`` exits 0 as a no-op
             (FR-021).
+        resolution: Optional automated-resolution policy block. Absent
+            (``None``, the default) means auto-resolution is inert;
+            suggestions remain fully functional regardless.
     """
 
     schedule: AssumptionScheduleConfig | None = None
+    resolution: AssumptionResolutionConfig | None = None
 
 
 class AgentBindingConfig(BaseModel, frozen=True):
@@ -845,7 +890,8 @@ class MaverickConfig(BaseSettings):
         default_factory=AssumptionsConfig,
         description=(
             "Assumption-ledger behavior, including the optional "
-            "'schedule' batch-delivery policy for `maverick notify`."
+            "'schedule' batch-delivery policy for `maverick notify` and "
+            "the optional 'resolution' automated-resolution policy."
         ),
     )
     validation: ValidationConfig = Field(default_factory=ValidationConfig)

--- a/src/maverick/library/actions/runway.py
+++ b/src/maverick/library/actions/runway.py
@@ -18,7 +18,7 @@ from maverick.library.actions.types import (
 )
 from maverick.logging import get_logger
 from maverick.runway.models import BeadOutcome, FixAttemptRecord, RunwayReviewFinding
-from maverick.runway.store import RunwayStore
+from maverick.runway.store import RunwayStore, resolve_runway_store
 
 __all__ = [
     "record_bead_outcome",
@@ -31,13 +31,12 @@ logger = get_logger(__name__)
 
 
 def _get_store(cwd: str | Path | None) -> RunwayStore | None:
-    """Resolve runway store from cwd. Returns None if not initialized."""
-    base = Path(cwd) if cwd else Path.cwd()
-    runway_path = base / ".maverick" / "runway"
-    store = RunwayStore(runway_path)
-    if not store.is_initialized:
-        return None
-    return store
+    """Resolve runway store from cwd. Returns None if not initialized.
+
+    Thin alias for :func:`maverick.runway.store.resolve_runway_store`, kept
+    for this module's existing call sites.
+    """
+    return resolve_runway_store(cwd)
 
 
 async def _get_run_store(run_dir: str | Path) -> RunwayStore | None:

--- a/src/maverick/runway/models.py
+++ b/src/maverick/runway/models.py
@@ -7,14 +7,16 @@ Follows the pattern from ``maverick.models.review_models``.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
 __all__ = [
     "BeadOutcome",
     "CostEntry",
+    "DecisionRecord",
     "FixAttemptRecord",
+    "MatchFeedbackRecord",
     "RunwayIndex",
     "RunwayPassage",
     "RunwayQueryResult",
@@ -186,6 +188,101 @@ class CostEntry(BaseModel):
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CostEntry:
         """Create CostEntry from dictionary."""
+        return cls.model_validate(data)
+
+
+class DecisionRecord(BaseModel):
+    """Append-only record of one terminal human resolution of an assumption.
+
+    Lives in ``.maverick/runway/decisions.jsonl`` (store root, not
+    ``episodic/`` — never pruned by consolidation; see
+    ``specs/055-learned-assumption-resolution/data-model.md``). Written only
+    by the human review surfaces (``maverick review``, single and bulk
+    waive) — never by scheduler auto-waives or auto-resolution (FR-005).
+
+    Collapse rule (read side): group by ``source_entry_id``, latest
+    ``resolved_at`` wins as the authoritative version; earlier lines remain
+    as history (FR-003).
+
+    Attributes:
+        source_entry_id: Assumption bead id the decision resolved — the
+            decision's stable identity.
+        question: Original question text (from the entry's ``## Question``
+            section).
+        normalized_question: ``matching.normalize_question(question)`` at
+            the time of writing, carried by the JSONL schema
+            (contracts/decision-records.md) so the corpus is greppable and
+            diffable on its own. Deliberately **not** a matching input:
+            ``evaluate_suggestion`` re-normalizes ``question`` on every
+            comparison instead, so rows written before a normalizer change
+            can never silently score against stale text. Treat this field
+            as derived output, and don't optimize matching to read it.
+        adopted_answer: What the agent had adopted.
+        resolution_type: ``"answered"`` or ``"waived"``.
+        resolution: Answer text, or waive reason.
+        severity: Entry severity at resolution (``low``/``medium``/``high``).
+        owner_spec: Owning spec of the resolved entry.
+        resolved_by: Git user name (same source as ``waived_by`` today).
+        resolved_at: UTC ISO-8601 timestamp.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    source_entry_id: str
+    question: str
+    normalized_question: str
+    adopted_answer: str
+    resolution_type: Literal["answered", "waived"]
+    resolution: str
+    severity: str
+    owner_spec: str
+    resolved_by: str
+    resolved_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Alias for ``model_dump()``."""
+        return self.model_dump()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DecisionRecord:
+        """Create DecisionRecord from dictionary."""
+        return cls.model_validate(data)
+
+
+class MatchFeedbackRecord(BaseModel):
+    """Append-only record of a human's accept/reject decision on one
+    presented suggestion — the feedback loop that penalizes a pairing's
+    future match confidence (User Story 3, 055-learned-assumption-resolution).
+
+    Lives in ``.maverick/runway/match-feedback.jsonl`` (store root, same
+    never-pruned placement as ``decisions.jsonl`` — spec 055 R1). Written
+    only by the human review surfaces, mirroring :class:`DecisionRecord`.
+
+    Attributes:
+        normalized_question: ``matching.normalize_question(question)`` of
+            the entry the suggestion was presented against — paired with
+            ``source_entry_id`` to identify which (entry, candidate)
+            pairing this feedback penalizes/rewards.
+        source_entry_id: The decision-corpus entry the presented suggestion
+            matched.
+        outcome: ``"accepted"`` or ``"rejected"``.
+        recorded_at: UTC ISO-8601 timestamp the feedback was recorded.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    normalized_question: str
+    source_entry_id: str
+    outcome: Literal["accepted", "rejected"]
+    recorded_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Alias for ``model_dump()``."""
+        return self.model_dump()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MatchFeedbackRecord:
+        """Create MatchFeedbackRecord from dictionary."""
         return cls.model_validate(data)
 
 

--- a/src/maverick/runway/store.py
+++ b/src/maverick/runway/store.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import aiofiles
 
@@ -18,7 +18,9 @@ from maverick.logging import get_logger
 from maverick.runway.models import (
     BeadOutcome,
     CostEntry,
+    DecisionRecord,
     FixAttemptRecord,
+    MatchFeedbackRecord,
     RunwayIndex,
     RunwayPassage,
     RunwayQueryResult,
@@ -27,7 +29,7 @@ from maverick.runway.models import (
 )
 from maverick.utils.atomic import atomic_write_json, atomic_write_text
 
-__all__ = ["RunwayStore", "make_cost_sink"]
+__all__ = ["RunwayStore", "make_cost_sink", "resolve_runway_store", "runway_path_for"]
 
 logger = get_logger(__name__)
 
@@ -41,6 +43,39 @@ _BEAD_OUTCOMES_FILE = "bead-outcomes.jsonl"
 _REVIEW_FINDINGS_FILE = "review-findings.jsonl"
 _FIX_ATTEMPTS_FILE = "fix-attempts.jsonl"
 _COST_ENTRIES_FILE = "cost-entries.jsonl"
+
+# JSONL file names at the store root (NOT under episodic/) — outside
+# consolidate_runway's pruning by design (spec 055 R1). Never rewritten,
+# only appended.
+_DECISIONS_FILE = "decisions.jsonl"
+_MATCH_FEEDBACK_FILE = "match-feedback.jsonl"
+
+#: The store-root record models that :meth:`RunwayStore._parse_root_record`
+#: tolerates schema drift for.
+_RootRecordT = TypeVar("_RootRecordT", DecisionRecord, MatchFeedbackRecord)
+
+
+def runway_path_for(cwd: str | Path | None = None) -> Path:
+    """The conventional runway-store root for *cwd* (``<cwd>/.maverick/runway``).
+
+    One place owns this path convention. ``cwd`` of ``None`` falls back to
+    :func:`Path.cwd` for CLI-boundary callers; workflow layers must always
+    pass an explicit path (Guardrail 7).
+    """
+    base = Path(cwd) if cwd else Path.cwd()
+    return base / ".maverick" / "runway"
+
+
+def resolve_runway_store(cwd: str | Path | None = None) -> RunwayStore | None:
+    """Resolve *cwd*'s runway store, or ``None`` when it isn't initialized.
+
+    The single shared implementation behind every "use the runway store if
+    the project has one, otherwise degrade silently" call site
+    (``library/actions/runway.py``, the review CLI, fly's suggestion
+    attachment). ``None`` means "no store" — callers degrade, never fail.
+    """
+    store = RunwayStore(runway_path_for(cwd))
+    return store if store.is_initialized else None
 
 
 class RunwayStore:
@@ -109,6 +144,13 @@ class RunwayStore:
         if not gitkeep.exists():
             gitkeep.touch()
 
+        # Touch decision-corpus files at the store root (never episodic/ —
+        # they must survive consolidation pruning indefinitely).
+        for fname in (_DECISIONS_FILE, _MATCH_FEEDBACK_FILE):
+            fpath = self._path / fname
+            if not fpath.exists():
+                fpath.touch()
+
         logger.info("runway_initialized", path=str(self._path))
 
     # -----------------------------------------------------------------
@@ -171,6 +213,88 @@ class RunwayStore:
         if limit is not None:
             results = results[-limit:]
         return results
+
+    async def append_decision(self, record: DecisionRecord) -> None:
+        """Append a decision record to the JSONL file.
+
+        Lives at the store root (not ``episodic/``) — never pruned by
+        consolidation (spec 055 R1).
+        """
+        await self._append_jsonl(self._path / _DECISIONS_FILE, record.to_dict())
+
+    async def get_decisions(
+        self,
+        *,
+        source_entry_id: str | None = None,
+    ) -> list[DecisionRecord]:
+        """Read decision records, optionally filtered.
+
+        Args:
+            source_entry_id: Filter by the assumption bead id the decision
+                resolved.
+
+        Returns:
+            List of matching DecisionRecord records, in append order.
+            Schema-invalid rows are skipped with a warning rather than
+            raising — this file is append-only and never rewritten, so it
+            outlives schema changes and a single bad line must not take
+            down every reader (the same tolerance ``_read_jsonl`` already
+            applies to malformed JSON).
+        """
+        records = await self._read_jsonl(self._path / _DECISIONS_FILE)
+        results: list[DecisionRecord] = []
+        for raw in records:
+            decision = self._parse_root_record(DecisionRecord, raw, _DECISIONS_FILE)
+            if decision is None:
+                continue
+            if source_entry_id is not None and decision.source_entry_id != source_entry_id:
+                continue
+            results.append(decision)
+        return results
+
+    async def append_match_feedback(self, record: MatchFeedbackRecord) -> None:
+        """Append a match-feedback record to the JSONL file.
+
+        Lives at the store root (not ``episodic/``) — never pruned by
+        consolidation (spec 055 R1).
+        """
+        await self._append_jsonl(self._path / _MATCH_FEEDBACK_FILE, record.to_dict())
+
+    async def get_match_feedback(self) -> list[MatchFeedbackRecord]:
+        """Read all match-feedback records, in append order.
+
+        Returns:
+            List of MatchFeedbackRecord records, in append order.
+            Schema-invalid rows are skipped with a warning — see
+            :meth:`get_decisions` for the rationale.
+        """
+        records = await self._read_jsonl(self._path / _MATCH_FEEDBACK_FILE)
+        parsed = (
+            self._parse_root_record(MatchFeedbackRecord, raw, _MATCH_FEEDBACK_FILE)
+            for raw in records
+        )
+        return [record for record in parsed if record is not None]
+
+    def _parse_root_record(
+        self, model: type[_RootRecordT], raw: dict[str, Any], filename: str
+    ) -> _RootRecordT | None:
+        """Parse one store-root JSONL row, degrading to ``None`` on schema drift.
+
+        ``decisions.jsonl`` / ``match-feedback.jsonl`` are append-only and
+        never rewritten, so rows written by an older or newer wheel can
+        fail validation long after they were valid. Callers of
+        :meth:`get_decisions` / :meth:`get_match_feedback` document a
+        never-raises contract; this keeps it true.
+        """
+        try:
+            return model.from_dict(raw)
+        except Exception as exc:  # noqa: BLE001 — one bad row must not break every reader
+            logger.warning(
+                "runway_jsonl_schema_error",
+                file=str(self._path / filename),
+                error=str(exc),
+            )
+            return None
 
     # -----------------------------------------------------------------
     # Episodic: Read + filter

--- a/src/maverick/skills/review_console/SKILL.md
+++ b/src/maverick/skills/review_console/SKILL.md
@@ -60,19 +60,42 @@ Never re-sort or re-group it yourself; present it exactly as returned.
      (`severity_defaulted`).
    - The affected change ids (`affected_change_ids`), so the human knows
      what this decision touches.
+   - When the entry row carries a non-null `suggestion` object, its
+     provenance — source spec (`suggestion.source_spec`) and resolved-at
+     date (`suggestion.resolved_at`) — in the question context, and, when
+     present, its `confidence` as a plain number (e.g. "confidence:
+     0.87"; do not editorialize or describe it beyond the number). Never
+     present a suggested default without saying where it came from.
 
    Build the options in this order:
-   - The adopted answer (`adopted_answer`) first, its label suffixed
-     with "(Recommended)".
+   - **Leading option(s)** depend on whether the entry carries a
+     non-null `suggestion`:
+     - When `suggestion` is present:
+       1. The suggested resolution first, marked recommended:
+          - Answer-sourced (`suggestion.resolution_type == "answered"`):
+            the option text is `suggestion.resolution`, suffixed
+            `"(Recommended — prior decision from <source_spec>,
+            <resolved_at date>)"`.
+          - Waive-sourced (`suggestion.resolution_type == "waived"`): the
+            option is `"Waive this entry (Recommended — prior decision
+            from <source_spec>, <resolved_at date>)"`; choosing it uses
+            `suggestion.resolution` as the waive reason directly — no
+            second prompt.
+       2. The adopted answer (`adopted_answer`) second, **without** the
+          "(Recommended)" suffix — that suffix now belongs to the
+          suggestion; exactly one option is ever marked recommended.
+     - When `suggestion` is `null`: render exactly as before — the
+       adopted answer (`adopted_answer`) first, its label suffixed with
+       "(Recommended)".
    - Each recorded alternative from `alternatives[]`, up to however many
-     the option surface can hold alongside the recommended answer and a
+     the option surface can hold alongside the leading option(s) and a
      waive/skip route.
    - If there are more alternatives than fit, add a "Waive / more…"
      option as the last slot. Choosing it opens a **follow-up question**
      listing the remaining alternatives plus explicit "Waive this entry"
      and "Skip for now" choices. Never drop an alternative silently — if
      a follow-up itself overflows, chain another follow-up the same way.
-   - When all alternatives fit alongside the recommended answer, still
+   - When all alternatives fit alongside the leading option(s), still
      include explicit "Waive this entry" and "Skip for now" options
      directly (no need for the "Waive / more…" indirection in that
      case).
@@ -81,8 +104,17 @@ Never re-sort or re-group it yourself; present it exactly as returned.
 
 6. Map the human's decision to a verb call, applied **immediately** (no
    batching, no deferral):
-   - Confirms the recommended answer → `maverick review <bead_id>
-     --answer "<adopted_answer>" --json`.
+   - Chooses the suggested answer (only present when `suggestion` is
+     non-null and `resolution_type == "answered"`) → `maverick review
+     <bead_id> --answer "<suggestion.resolution>" --json`.
+   - Chooses the suggested waive (only present when `suggestion` is
+     non-null and `resolution_type == "waived"`) → `maverick review
+     <bead_id> --waive "<suggestion.resolution>" --json` — the
+     suggestion's text is the waive reason directly; do not ask for a
+     second reason.
+   - Confirms the adopted answer (`adopted_answer` — the recommended
+     option when `suggestion` is `null`, otherwise the second option) →
+     `maverick review <bead_id> --answer "<adopted_answer>" --json`.
    - Picks a recorded alternative → `maverick review <bead_id> --answer
      "<alternative text>" --json`.
    - Free-form via "Other" → if the text is empty or whitespace-only,
@@ -92,6 +124,11 @@ Never re-sort or re-group it yourself; present it exactly as returned.
      `maverick review <bead_id> --waive "<reason>" --json`.
    - Chooses "Skip for now" → make no invocation; the entry stays open;
      move on to the next entry.
+
+   In every branch above, you never mark acceptance or rejection of a
+   suggestion yourself — that judgment is derived server-side, inside the
+   CLI verbs, by comparing the applied resolution against the stored
+   suggestion.
 
 7. Handle the verb's result before moving to the next entry:
    - `ok: true` → briefly acknowledge the recorded decision (answered or
@@ -215,17 +252,39 @@ Never re-sort or re-group it yourself; present it exactly as returned.
     - The frontier state from step 12.
     - The landing result, if any action was taken in steps 13-14.
 
+## Revisiting auto-resolved entries
+
+This is an on-demand branch, not part of the default Preflight → Sweep
+flow above — enter it only when the human explicitly asks to revisit
+waived or auto-resolved entries (e.g. "show me what got auto-waived",
+"let's look at the auto-resolved ones").
+
+Entries with `auto_resolved: true` were waived automatically and sit
+outside the default open-only listing used in Preflight and Sweep. To
+surface them, re-list with `maverick review --list --status waived
+--json`. For each auto-resolved entry:
+
+- Present its provenance the same way a suggestion is presented above:
+  the resolution text, `resolution_type`, `source_spec`, and
+  `resolved_at` date.
+- Offer to re-answer it — the CLI already permits re-answering an
+  auto-resolved entry. A re-answer uses the same verb as any other
+  answer: `maverick review <bead_id> --answer "<text>" --json`.
+- Handle the result exactly as step 7 describes (`ok: true`,
+  `already-resolved`, or any other `error.kind`).
+
 ## Prohibitions
 
 These apply to every section above — Identity, Preflight, Sweep, Batched
-reconcile, and Frontier report & landing alike:
+reconcile, Frontier report & landing, and Revisiting auto-resolved
+entries alike:
 
 - Never run `jj`, `git`, or `bd` directly, and never edit files
   yourself. Your only effect channel is the verbs already named in this
-  document: `maverick review --list/--answer/--waive`, `maverick review
-  --spec <spec> --waive <reason>`, `maverick reconcile [--dry-run]`,
-  `maverick land --status`, and `maverick land --yes`. Never invoke any
-  other verb or flag combination.
+  document: `maverick review --list [--status <status>]/--answer/
+  --waive`, `maverick review --spec <spec> --waive <reason>`, `maverick
+  reconcile [--dry-run]`, `maverick land --status`, and `maverick land
+  --yes`. Never invoke any other verb or flag combination.
 - Never blindly retry a failed invocation. Every failure branch in this
   document ends in reporting to the human, not in trying again — a
   failed verb is only re-invoked if the human explicitly asks you to.

--- a/src/maverick/workflows/fly_beads/actions.py
+++ b/src/maverick/workflows/fly_beads/actions.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from burr.core import State, action
 
+from maverick.assumptions.suggestions import attach_suggestions
 from maverick.events import (
     AgentCompleted,
     AgentStarted,
@@ -1255,6 +1256,7 @@ async def record_assumptions(
     cwd: str,
     epic_id: str,
     events: asyncio.Queue[ProgressEvent | None],
+    config: MaverickConfig | None = None,
 ) -> tuple[dict[str, Any], State]:
     """Create ledger entries for assumptions accumulated during this bead.
 
@@ -1262,11 +1264,23 @@ async def record_assumptions(
     pattern (FR-012 / research R4): a ledger write failure never blocks
     commit. Runs between review/create_human_bead and commit so the
     same bead's commit can stamp the entries moments later.
+
+    After recording, hands the newly recorded entries to
+    ``assumptions.suggestions.attach_suggestions`` so a matching prior
+    resolution can be surfaced later (055-learned-assumption-resolution
+    T019, research R5) — also non-fatal, and skipped entirely when
+    nothing was recorded or no runway store is initialized. ``config``
+    (bound from the workflow's ``MaverickConfig``, same threading as
+    ``reconcile_answers``) supplies the optional
+    ``assumptions.resolution.auto_resolve_low`` policy so a matching
+    resolution can be auto-applied (055 T033).
     """
     from maverick.assumptions.errors import AssumptionLedgerError
     from maverick.assumptions.ledger import record_assumption
+    from maverick.assumptions.models import AssumptionRecord, report_entry_from_record
     from maverick.beads.client import BeadClient
     from maverick.payloads import AssumptionPayload
+    from maverick.runway.store import resolve_runway_store
 
     bead_id = state["current_bead_id"]
     pending: list[dict[str, Any]] = list(state.get("pending_assumptions") or ())
@@ -1275,6 +1289,7 @@ async def record_assumptions(
 
     client = BeadClient(cwd=Path(cwd))
     recorded_ids: list[str] = []
+    recorded_records: list[AssumptionRecord] = []
     for raw in pending:
         try:
             payload = AssumptionPayload.model_validate(raw)
@@ -1300,6 +1315,7 @@ async def record_assumptions(
             continue
         if record is not None:
             recorded_ids.append(record.bead_id)
+            recorded_records.append(record)
 
     if recorded_ids:
         await _put_output(
@@ -1308,6 +1324,35 @@ async def record_assumptions(
             f"Recorded {len(recorded_ids)} assumption(s) for {bead_id}",
             metadata={"recorded_assumption_ids": recorded_ids},
         )
+
+        store = resolve_runway_store(cwd)
+        if store is not None:
+            # No bd re-read here: `record_assumption` already returned the
+            # full `AssumptionRecord` for each entry, and that carries
+            # everything suggestion matching reads (bead_id, question,
+            # adopted_answer, severity, owner_spec). The remaining
+            # `AssumptionReportEntry` fields are answer/waiver/reconcile
+            # state a just-created entry cannot have yet, which is exactly
+            # what `report_entry_from_record` fills in.
+            entries = [report_entry_from_record(record) for record in recorded_records]
+
+            if entries:
+                resolution_config = config.assumptions.resolution if config else None
+                auto_resolve = resolution_config.auto_resolve_low if resolution_config else None
+                try:
+                    await attach_suggestions(
+                        client,
+                        store,
+                        entries,
+                        auto_resolve=auto_resolve,
+                    )
+                except Exception as exc:  # noqa: BLE001 — non-fatal (research R5)
+                    await _put_output(
+                        events,
+                        "fly",
+                        f"Failed to attach suggestions for {bead_id}: {exc}",
+                        level="warning",
+                    )
 
     return {"recorded": len(recorded_ids)}, state.update(recorded_assumption_ids=recorded_ids)
 

--- a/src/maverick/workflows/fly_beads/burr_graph.py
+++ b/src/maverick/workflows/fly_beads/burr_graph.py
@@ -169,6 +169,7 @@ def build_fly_application(
                 cwd=cwd,
                 epic_id=epic_id,
                 events=event_queue,
+                config=reconcile_config,
             ),
             commit=fly_actions.commit.bind(cwd=cwd, events=event_queue),
             abandon_bead=fly_actions.abandon_bead.bind(events=event_queue),

--- a/src/maverick/workflows/spec_chain/workflow.py
+++ b/src/maverick/workflows/spec_chain/workflow.py
@@ -29,12 +29,15 @@ from tenacity import (
 )
 
 from maverick.assumptions.ledger import record_standalone_assumption
+from maverick.assumptions.models import AssumptionRecord, report_entry_from_record
+from maverick.assumptions.suggestions import attach_suggestions
 from maverick.beads.client import BeadClient
 from maverick.exceptions import WorkflowError
 from maverick.jj.client import JjClient
 from maverick.library.actions.beads import create_remediation_beads
 from maverick.logging import get_logger
 from maverick.payloads import AssumptionPayload
+from maverick.runway.store import RunwayStore, runway_path_for
 from maverick.squadron.spec_chain import SpecChainSquadron
 from maverick.workflows.base import PythonWorkflow
 from maverick.workflows.spec_chain.clarify import (
@@ -694,6 +697,7 @@ class SpecChainWorkflow(PythonWorkflow):
 
         bead_client = BeadClient(cwd=checkout)
         filed: list[ClarifyDecision] = []
+        filed_records: list[AssumptionRecord] = []
         for decision in parsed_decisions:
             payload = AssumptionPayload(
                 question=decision.question,
@@ -723,12 +727,48 @@ class SpecChainWorkflow(PythonWorkflow):
                 continue
             bead_id = record.bead_id if record is not None else None
             filed.append(replace(decision, ledger_bead_id=bead_id))
+            if record is not None:
+                filed_records.append(record)
 
         logger.info(
             "spec_chain_clarify_decisions_filed",
             count=len(filed),
             ledger_entries=sum(1 for d in filed if d.ledger_bead_id),
         )
+
+        if filed_records:
+            # No ``store.is_initialized`` gate here (unlike
+            # ``library.actions.runway._get_store``): ``attach_suggestions``
+            # already treats an uninitialized store as a silent no-op
+            # (research R5), so gating a second time here would just be a
+            # redundant check that can drift out of sync with it.
+            store = RunwayStore(runway_path_for(checkout))
+            # No bd re-read here: the ledger already returned the full
+            # `AssumptionRecord` for each filed entry, and that carries
+            # everything suggestion matching reads (bead_id, question,
+            # adopted_answer, severity, owner_spec). The remaining
+            # `AssumptionReportEntry` fields are answer/waiver/reconcile
+            # state a just-created entry cannot have yet, which is exactly
+            # what `report_entry_from_record` fills in.
+            entries = [report_entry_from_record(record) for record in filed_records]
+
+            if entries:
+                resolution_config = self._config.assumptions.resolution
+                auto_resolve = resolution_config.auto_resolve_low if resolution_config else None
+                try:
+                    await attach_suggestions(
+                        bead_client,
+                        store,
+                        entries,
+                        auto_resolve=auto_resolve,
+                    )
+                except Exception as exc:  # noqa: BLE001 — suggestions are advisory, never fatal
+                    logger.warning(
+                        "spec_chain_clarify_suggestion_attachment_failed",
+                        count=len(entries),
+                        error=str(exc),
+                    )
+
         # Merge by normalized question rather than blindly appending: on a
         # resume that re-runs clarify (e.g. it halted after filing but
         # before the next step landed), `state.clarify_decisions` already

--- a/tests/unit/assumptions/test_land_report.py
+++ b/tests/unit/assumptions/test_land_report.py
@@ -61,6 +61,9 @@ def _entry(
     change_ids: tuple[str, ...] = (),
     reconcile_change_id: str | None = None,
     created_at: str | None = None,
+    waived_by: str = "alice",
+    waive_reason: str = "n/a",
+    auto_resolved: bool = False,
 ) -> AssumptionReportEntry:
     return AssumptionReportEntry(
         record=_record(
@@ -73,14 +76,15 @@ def _entry(
             created_at=created_at,
         ),
         final_answer="Yes." if status == STATUS_ANSWERED else None,
-        waived_by="alice" if status == STATUS_WAIVED else None,
+        waived_by=waived_by if status == STATUS_WAIVED else None,
         waived_at="2026-07-24T14:00:00Z" if status == STATUS_WAIVED else None,
-        waive_reason="n/a" if status == STATUS_WAIVED else None,
+        waive_reason=waive_reason if status == STATUS_WAIVED else None,
         reconcile_status=reconcile_status,
         reconciled_answer=None,
         reconcile_change_id=reconcile_change_id,
         reconcile_reason=None,
         pending_reconcile=pending_reconcile,
+        auto_resolved=auto_resolved,
     )
 
 
@@ -121,6 +125,14 @@ class TestFrontier:
         result = frontier((entry,))
         assert result.is_empty is True
 
+    def test_auto_resolved_waived_entry_does_not_block(self) -> None:
+        """055 T030 regression/proof (data-model.md invariant 5): an
+        auto-resolved entry is an ordinary waived entry to `frontier()` —
+        `waived_by="maverick-resolver"` needs no special-casing."""
+        entry = _entry(status=STATUS_WAIVED, waived_by="maverick-resolver", auto_resolved=True)
+        result = frontier((entry,))
+        assert result.is_empty is True
+
     def test_answered_entry_does_not_block(self) -> None:
         entry = _entry(status=STATUS_ANSWERED)
         result = frontier((entry,))
@@ -150,6 +162,20 @@ class TestClassify:
         answered = _entry(bead_id="dea-answered", status=STATUS_ANSWERED)
         waived = _entry(bead_id="dea-waived", status=STATUS_WAIVED)
         assert classify((answered, waived)) == LandVerification.CONDITIONALLY_VERIFIED
+
+    def test_auto_resolved_waived_only_is_conditionally_verified(self) -> None:
+        """055 T030 regression/proof (data-model.md invariant 5): `classify()`
+        needed zero changes for User Story 4 — the only waived entry being
+        auto-resolved (`waived_by="maverick-resolver"`) still classifies as
+        conditionally-verified, identically to a human waive."""
+        answered = _entry(bead_id="dea-answered", status=STATUS_ANSWERED)
+        auto_resolved = _entry(
+            bead_id="dea-auto",
+            status=STATUS_WAIVED,
+            waived_by="maverick-resolver",
+            auto_resolved=True,
+        )
+        assert classify((answered, auto_resolved)) == LandVerification.CONDITIONALLY_VERIFIED
 
     def test_all_answered_is_verified(self) -> None:
         e1 = _entry(bead_id="dea-1", status=STATUS_ANSWERED)
@@ -351,6 +377,33 @@ class TestRenderMarkdown:
         md = render_markdown(report)
         assert "alice" in md
         assert "n/a" in md
+
+    def test_auto_resolved_row_shows_resolver_actor_and_annotation(self) -> None:
+        """055 T030 regression/proof (research R7): the existing
+        ``"Waived by {waived_by} at {waived_at}: {waive_reason}"`` template
+        is actor-agnostic — it renders ``waived_by="maverick-resolver"``
+        verbatim, no special formatting needed. The row also carries the
+        "auto-resolved" annotation (`serialize._annotations`, landed by a
+        prior User Story 2 agent) unchanged."""
+        from maverick.assumptions.land_report import build_report, render_markdown
+
+        entries = (
+            _entry(
+                bead_id="dea-1",
+                status=STATUS_WAIVED,
+                waived_by="maverick-resolver",
+                waive_reason=(
+                    "Matched prior decision dea-142 (052-conditional-landing) at 0.87 confidence"
+                ),
+                auto_resolved=True,
+            ),
+        )
+        report = build_report(
+            entries, LandVerification.CONDITIONALLY_VERIFIED, run_id="r1", dry_run=False
+        )
+        md = render_markdown(report)
+        assert "Waived by maverick-resolver at 2026-07-24T14:00:00Z" in md
+        assert "auto-resolved" in md
 
     def test_zero_entries_prints_no_assumptions_adopted(self) -> None:
         from maverick.assumptions.land_report import build_report, render_markdown

--- a/tests/unit/assumptions/test_matching.py
+++ b/tests/unit/assumptions/test_matching.py
@@ -1,0 +1,174 @@
+"""Tests for the pure, deterministic matching module (assumptions/matching.py).
+
+See specs/055-learned-assumption-resolution/contracts/decision-records.md for
+the normative matching formula this module implements.
+"""
+
+from __future__ import annotations
+
+from maverick.assumptions.matching import (
+    PRESENTATION_THRESHOLD,
+    REJECTION_PENALTY,
+    base_score,
+    effective_confidence,
+    normalize_question,
+    select_best,
+)
+
+
+class TestNormalizeQuestion:
+    def test_casefold_strip_punctuation_collapse_whitespace(self) -> None:
+        assert normalize_question("Should Retries use EXPONENTIAL backoff?") == (
+            normalize_question("should retries use exponential backoff")
+        )
+
+    def test_result_has_no_punctuation(self) -> None:
+        result = normalize_question("Should retries use exponential backoff?")
+        assert result == "should retries use exponential backoff"
+
+    def test_collapses_internal_whitespace(self) -> None:
+        result = normalize_question("Should   retries    use\tbackoff?")
+        assert result == "should retries use backoff"
+
+    def test_strips_leading_and_trailing_whitespace(self) -> None:
+        assert normalize_question("  Should retries use backoff?  ") == (
+            "should retries use backoff"
+        )
+
+    def test_casefold_handles_unicode(self) -> None:
+        # casefold() is stronger than lower() for some unicode (e.g. German ß).
+        assert normalize_question("STRASSE") == normalize_question("straße".upper())
+
+    def test_empty_string(self) -> None:
+        assert normalize_question("") == ""
+
+    def test_only_punctuation_becomes_empty(self) -> None:
+        assert normalize_question("???!!!...") == ""
+
+
+class TestBaseScoreDeterminism:
+    def test_same_args_same_result(self) -> None:
+        a = "Should retries use exponential backoff?"
+        b = "Should we use exponential backoff for retries?"
+        first = base_score(a, b)
+        second = base_score(a, b)
+        assert first == second
+
+    def test_bounded_in_zero_one(self) -> None:
+        pairs = [
+            ("Should retries use exponential backoff?", "Completely unrelated text."),
+            ("", ""),
+            ("a b c", "c b a"),
+            ("Same question?", "Same question?"),
+        ]
+        for a, b in pairs:
+            score = base_score(a, b)
+            assert 0.0 <= score <= 1.0
+
+    def test_identical_strings_score_at_one(self) -> None:
+        text = "Should retries use exponential backoff?"
+        assert base_score(text, text) == 1.0
+
+    def test_identical_after_normalization_scores_at_one(self) -> None:
+        assert base_score("Should Retries Use Backoff?", "should retries use backoff") == 1.0
+
+    def test_disjoint_strings_score_low(self) -> None:
+        score = base_score(
+            "Should retries use exponential backoff for network calls",
+            "Where should the deployment artifacts be archived permanently",
+        )
+        assert score < 0.3
+
+    def test_empty_vs_nonempty_does_not_error(self) -> None:
+        # Guards the Jaccard divide-by-zero when one side has no tokens.
+        score = base_score("", "Should retries use backoff?")
+        assert 0.0 <= score <= 1.0
+
+    def test_both_empty_scores_one(self) -> None:
+        # SequenceMatcher.ratio() on two empty strings is 1.0; Jaccard term
+        # is defined as 0 when both token sets are empty per the contract.
+        assert base_score("", "") == 0.5
+
+    def test_symmetric(self) -> None:
+        a = "Should retries use exponential backoff?"
+        b = "Should backoff be exponential for retries?"
+        assert base_score(a, b) == base_score(b, a)
+
+
+class TestModuleConstants:
+    def test_presentation_threshold(self) -> None:
+        assert PRESENTATION_THRESHOLD == 0.75
+
+    def test_rejection_penalty(self) -> None:
+        assert REJECTION_PENALTY == 0.30
+
+
+class TestEffectiveConfidence:
+    def test_no_history_returns_base_unchanged(self) -> None:
+        assert effective_confidence(1.0, rejections=0, acceptances=0) == 1.0
+        assert effective_confidence(0.5, rejections=0, acceptances=0) == 0.5
+
+    def test_one_net_rejection_suppresses_exact_match(self) -> None:
+        # FR-015: a single net rejection must drop even a perfect base score
+        # below PRESENTATION_THRESHOLD.
+        result = effective_confidence(1.0, rejections=1, acceptances=0)
+        assert result < PRESENTATION_THRESHOLD
+        assert result == 0.70
+
+    def test_equal_rejections_and_acceptances_net_zero(self) -> None:
+        assert effective_confidence(1.0, rejections=2, acceptances=2) == 1.0
+
+    def test_acceptances_exceeding_rejections_do_not_boost(self) -> None:
+        # max(0, rejections - acceptances) floors at zero — no bonus above base.
+        assert effective_confidence(0.8, rejections=0, acceptances=5) == 0.8
+
+    def test_multiple_net_rejections_compound(self) -> None:
+        result = effective_confidence(1.0, rejections=3, acceptances=0)
+        assert result == 1.0 - (0.30 * 3)
+
+
+class TestSelectBest:
+    def test_empty_input_returns_none(self) -> None:
+        assert select_best([]) is None
+
+    def test_all_below_threshold_returns_none(self) -> None:
+        candidates = [
+            (0.5, "2026-08-01T00:00:00+00:00", "mv-1", "payload-1"),
+            (0.6, "2026-08-02T00:00:00+00:00", "mv-2", "payload-2"),
+        ]
+        assert select_best(candidates) is None
+
+    def test_picks_highest_confidence(self) -> None:
+        candidates = [
+            (0.80, "2026-08-01T00:00:00+00:00", "mv-1", "payload-1"),
+            (0.95, "2026-08-02T00:00:00+00:00", "mv-2", "payload-2"),
+            (0.76, "2026-08-03T00:00:00+00:00", "mv-3", "payload-3"),
+        ]
+        assert select_best(candidates) == candidates[1]
+
+    def test_tie_breaks_on_resolved_at_descending(self) -> None:
+        candidates = [
+            (0.90, "2026-08-01T00:00:00+00:00", "mv-1", "payload-1"),
+            (0.90, "2026-08-05T00:00:00+00:00", "mv-2", "payload-2"),
+            (0.90, "2026-08-03T00:00:00+00:00", "mv-3", "payload-3"),
+        ]
+        assert select_best(candidates) == candidates[1]
+
+    def test_tie_breaks_on_source_entry_id_ascending(self) -> None:
+        candidates = [
+            (0.90, "2026-08-01T00:00:00+00:00", "mv-99", "payload-1"),
+            (0.90, "2026-08-01T00:00:00+00:00", "mv-2", "payload-2"),
+            (0.90, "2026-08-01T00:00:00+00:00", "mv-42", "payload-3"),
+        ]
+        assert select_best(candidates) == candidates[1]
+
+    def test_below_threshold_candidates_excluded_even_if_highest(self) -> None:
+        candidates = [
+            (0.74, "2026-08-05T00:00:00+00:00", "mv-1", "payload-1"),
+            (0.75, "2026-08-01T00:00:00+00:00", "mv-2", "payload-2"),
+        ]
+        assert select_best(candidates) == candidates[1]
+
+    def test_single_candidate_at_exact_threshold_wins(self) -> None:
+        candidates = [(0.75, "2026-08-01T00:00:00+00:00", "mv-1", "payload-1")]
+        assert select_best(candidates) == candidates[0]

--- a/tests/unit/assumptions/test_models.py
+++ b/tests/unit/assumptions/test_models.py
@@ -251,11 +251,13 @@ def _entry(
     change_ids: tuple[str, ...] = (),
     reconcile_change_id: str | None = None,
     pending_reconcile: bool = False,
+    waived_by: str | None = None,
+    auto_resolved: bool = False,
 ) -> AssumptionReportEntry:
     return AssumptionReportEntry(
         record=_record(status=status, severity=severity, change_ids=change_ids),
         final_answer=None,
-        waived_by=None,
+        waived_by=waived_by,
         waived_at=None,
         waive_reason=None,
         reconcile_status=None,
@@ -263,6 +265,7 @@ def _entry(
         reconcile_change_id=reconcile_change_id,
         reconcile_reason=None,
         pending_reconcile=pending_reconcile,
+        auto_resolved=auto_resolved,
     )
 
 
@@ -276,6 +279,13 @@ class TestLandVerification:
 class TestAssumptionReportEntryBucket:
     def test_waived_status_buckets_waived(self) -> None:
         assert _entry(status=STATUS_WAIVED).bucket == "waived"
+
+    def test_auto_resolved_waived_status_buckets_waived(self) -> None:
+        """055 T030 regression/proof: an auto-resolved entry
+        (``waived_by="maverick-resolver"``, ``auto_resolved=True``) is an
+        ordinary waived entry to ``.bucket`` — no special-casing."""
+        entry = _entry(status=STATUS_WAIVED, waived_by="maverick-resolver", auto_resolved=True)
+        assert entry.bucket == "waived"
 
     def test_answered_status_buckets_resolved(self) -> None:
         assert _entry(status=STATUS_ANSWERED).bucket == "resolved"

--- a/tests/unit/assumptions/test_suggestion_projection.py
+++ b/tests/unit/assumptions/test_suggestion_projection.py
@@ -1,0 +1,417 @@
+"""Tests for the suggestion projection surface (055-learned-assumption-resolution,
+User Story 2, T012).
+
+Covers data-model.md's ``Suggestion`` dataclass (bd state key
+``assumption_suggestion``, one JSON-encoded value — research R4),
+``report_entry_from_details``'s parsing of ``KEY_SUGGESTION``/``KEY_AUTO_RESOLVED``
+into ``AssumptionReportEntry.suggestion``/``.auto_resolved``, ``entry_to_dict``'s
+additive ``"suggestion"``/``"auto_resolved"`` keys (contracts/entry-row-suggestion.md),
+``_annotations``'s new ``"auto-resolved"`` tag, the land report's ``_entry_to_dict``
+alias picking both up unchanged, and invariant 5 (FR-013/FR-019): the land gate's
+``classify()``/``frontier()`` treat a suggestion-carrying open entry identically to
+a plain open entry.
+
+Naming contract shared with the parallel T011 suite
+(``tests/unit/assumptions/test_suggestions.py``, ``evaluate_suggestion``): the
+``Suggestion`` dataclass lives in ``maverick.assumptions.models`` with fields
+``resolution: str``, ``resolution_type: Literal["answered", "waived"]``,
+``source_entry_id: str``, ``source_spec: str``, ``resolved_at: str``,
+``confidence: float``, ``computed_at: str`` (data-model.md field/JSON-key table —
+JSON keys are identical to the field names, no aliasing). Encode/decode helpers,
+also in ``models.py``: ``suggestion_to_json(suggestion: Suggestion) -> str`` and
+``suggestion_from_json(raw: str) -> Suggestion | None`` (returns ``None`` on any
+unparseable/malformed input — R11, never raises).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from maverick.assumptions.land_report import _entry_to_dict, classify, frontier
+from maverick.assumptions.ledger import report_entry_from_details
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    ASSUMPTION_REVIEW_LABEL,
+    KEY_AUTO_RESOLVED,
+    KEY_OWNER_SPEC,
+    KEY_SEVERITY,
+    KEY_STATUS,
+    KEY_SUGGESTION,
+    NEEDS_HUMAN_REVIEW_LABEL,
+    STATUS_ANSWERED,
+    STATUS_OPEN,
+    STATUS_WAIVED,
+    AssumptionRecord,
+    AssumptionReportEntry,
+    LandVerification,
+    Severity,
+    Suggestion,
+    suggestion_from_json,
+    suggestion_to_json,
+)
+from maverick.assumptions.serialize import _annotations, entry_to_dict
+from maverick.beads.models import BeadDetails
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_SAMPLE_SUGGESTION_KWARGS: dict[str, object] = {
+    "resolution": "Yes — AsyncRetrying, 3 attempts",
+    "resolution_type": "answered",
+    "source_entry_id": "mv-142",
+    "source_spec": "052-conditional-landing",
+    "resolved_at": "2026-08-06T14:03:22+00:00",
+    "confidence": 0.87,
+    "computed_at": "2026-08-07T10:11:12+00:00",
+}
+
+
+def _sample_suggestion(**overrides: object) -> Suggestion:
+    kwargs = dict(_SAMPLE_SUGGESTION_KWARGS)
+    kwargs.update(overrides)
+    return Suggestion(**kwargs)  # type: ignore[arg-type]
+
+
+def _record(
+    *,
+    bead_id: str = "dea-1",
+    status: str = STATUS_OPEN,
+    severity: Severity = Severity.LOW,
+    severity_defaulted: bool = False,
+    is_legacy: bool = False,
+    owner_spec: str = "053-assumption-review-console",
+    source_bead: str = "dea-0",
+    change_ids: tuple[str, ...] = (),
+    question: str = "Q?",
+    adopted_answer: str = "A.",
+    alternatives: tuple[str, ...] = (),
+    created_at: str | None = None,
+) -> AssumptionRecord:
+    return AssumptionRecord(
+        bead_id=bead_id,
+        question=question,
+        adopted_answer=adopted_answer,
+        alternatives=alternatives,
+        severity=severity,
+        severity_defaulted=severity_defaulted,
+        status=status,
+        owner_spec=owner_spec,
+        source_bead=source_bead,
+        change_ids=change_ids,
+        is_legacy=is_legacy,
+        created_at=created_at,
+    )
+
+
+def _entry(
+    *,
+    bead_id: str = "dea-1",
+    status: str = STATUS_OPEN,
+    severity: Severity = Severity.LOW,
+    is_legacy: bool = False,
+    owner_spec: str = "053-assumption-review-console",
+    pending_reconcile: bool = False,
+    suggestion: Suggestion | None = None,
+    auto_resolved: bool = False,
+) -> AssumptionReportEntry:
+    return AssumptionReportEntry(
+        record=_record(
+            bead_id=bead_id,
+            status=status,
+            severity=severity,
+            is_legacy=is_legacy,
+            owner_spec=owner_spec,
+        ),
+        final_answer="Yes." if status == STATUS_ANSWERED else None,
+        waived_by="alice" if status == STATUS_WAIVED else None,
+        waived_at="2026-07-24T14:00:00Z" if status == STATUS_WAIVED else None,
+        waive_reason="n/a" if status == STATUS_WAIVED else None,
+        reconcile_status=None,
+        reconciled_answer=None,
+        reconcile_change_id=None,
+        reconcile_reason=None,
+        pending_reconcile=pending_reconcile,
+        suggestion=suggestion,
+        auto_resolved=auto_resolved,
+    )
+
+
+def _bead_details(
+    bead_id: str = "dea-9",
+    *,
+    status: str = STATUS_OPEN,
+    severity: str = "medium",
+    bd_status: str | None = None,
+    owner_spec: str = "052-conditional-landing",
+    extra_state: dict[str, str] | None = None,
+) -> BeadDetails:
+    """Mirrors ``test_ledger_frontier.py``'s ``_entry`` helper (a real
+    ``BeadDetails`` — ``report_entry_from_details`` takes duck-typed
+    objects, but the codebase's convention is to exercise it against the
+    real bd response model)."""
+    state = {KEY_SEVERITY: severity, KEY_STATUS: status, KEY_OWNER_SPEC: owner_spec}
+    if extra_state:
+        state.update(extra_state)
+    return BeadDetails(
+        id=bead_id,
+        title=f"Assumption: {bead_id}",
+        description="## Question\n\nQ?\n\n## Adopted Answer\n\nOriginal answer.\n\n",
+        bead_type="task",
+        status=bd_status or ("closed" if status != STATUS_OPEN else "open"),
+        labels=[ASSUMPTION_LABEL],
+        state=state,
+    )
+
+
+def _legacy_bead_details(bead_id: str = "legacy-1", *, bd_status: str = "open") -> BeadDetails:
+    return BeadDetails(
+        id=bead_id,
+        title="Review: legacy",
+        description="legacy escalation",
+        bead_type="task",
+        status=bd_status,
+        labels=[ASSUMPTION_REVIEW_LABEL, NEEDS_HUMAN_REVIEW_LABEL],
+        state={"source_bead": "b-1", "flight_plan": "legacy-plan"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Suggestion JSON round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestionJsonRoundTrip:
+    def test_encode_produces_compact_short_key_json(self) -> None:
+        """``suggestion_to_json`` is bd's internal storage wire format, not
+        the public contract shape — it uses abbreviated keys and compact
+        separators to stay well under bd's ~233-char state-value length
+        budget for this key (see research.md R4 addendum and
+        ``suggestions._MAX_SUGGESTION_JSON_LENGTH``). The full-field-name
+        shape lives only in ``entry_to_dict``'s projection, exercised
+        separately below (``TestEntryToDictSuggestionProjection``) — that
+        surface is untouched by this wire-format change."""
+        suggestion = _sample_suggestion()
+        raw = suggestion_to_json(suggestion)
+        assert isinstance(raw, str)
+        assert raw == json.dumps(json.loads(raw), separators=(",", ":")), (
+            "compact JSON separators — no space after ',' or ':'"
+        )
+        decoded = json.loads(raw)
+        assert decoded == {
+            "r": _SAMPLE_SUGGESTION_KWARGS["resolution"],
+            "rt": _SAMPLE_SUGGESTION_KWARGS["resolution_type"],
+            "sid": _SAMPLE_SUGGESTION_KWARGS["source_entry_id"],
+            "ss": _SAMPLE_SUGGESTION_KWARGS["source_spec"],
+            "ra": _SAMPLE_SUGGESTION_KWARGS["resolved_at"],
+            "c": _SAMPLE_SUGGESTION_KWARGS["confidence"],
+            "ca": _SAMPLE_SUGGESTION_KWARGS["computed_at"],
+        }
+
+    def test_encode_fixed_overhead_stays_well_under_bd_length_budget(self) -> None:
+        """Fixed overhead (empty ``resolution``) must stay comfortably under
+        bd's observed ~233-char truncation boundary for this state key, so
+        real resolution text still has usable budget."""
+        raw = suggestion_to_json(_sample_suggestion(resolution=""))
+        assert len(raw) < 160
+
+    def test_round_trip_equality(self) -> None:
+        suggestion = _sample_suggestion()
+        raw = suggestion_to_json(suggestion)
+        restored = suggestion_from_json(raw)
+        assert restored == suggestion
+
+    def test_round_trip_preserves_confidence_as_float(self) -> None:
+        suggestion = _sample_suggestion(confidence=0.756)
+        restored = suggestion_from_json(suggestion_to_json(suggestion))
+        assert restored is not None
+        assert restored.confidence == 0.756
+
+    def test_decode_invalid_json_returns_none(self) -> None:
+        assert suggestion_from_json("not json") is None
+
+    def test_decode_truncated_json_returns_none(self) -> None:
+        raw = suggestion_to_json(_sample_suggestion())
+        assert suggestion_from_json(raw[: len(raw) // 2]) is None
+
+    def test_decode_non_object_json_returns_none(self) -> None:
+        assert suggestion_from_json(json.dumps(["not", "an", "object"])) is None
+
+    def test_decode_missing_required_field_returns_none(self) -> None:
+        incomplete = dict(_SAMPLE_SUGGESTION_KWARGS)
+        del incomplete["confidence"]
+        assert suggestion_from_json(json.dumps(incomplete)) is None
+
+    def test_decode_empty_string_returns_none(self) -> None:
+        assert suggestion_from_json("") is None
+
+
+# ---------------------------------------------------------------------------
+# 2/3. report_entry_from_details parsing (+ degrade-on-unparseable)
+# ---------------------------------------------------------------------------
+
+
+class TestReportEntryFromDetailsSuggestionParsing:
+    def test_parses_valid_suggestion_json(self) -> None:
+        suggestion = _sample_suggestion()
+        details = _bead_details(extra_state={KEY_SUGGESTION: suggestion_to_json(suggestion)})
+        entry = report_entry_from_details(details)
+        assert entry is not None
+        assert entry.suggestion == suggestion
+
+    def test_parses_auto_resolved_true(self) -> None:
+        details = _bead_details(extra_state={KEY_AUTO_RESOLVED: "true"})
+        entry = report_entry_from_details(details)
+        assert entry is not None
+        assert entry.auto_resolved is True
+
+    def test_auto_resolved_false_when_key_absent(self) -> None:
+        details = _bead_details()
+        entry = report_entry_from_details(details)
+        assert entry is not None
+        assert entry.auto_resolved is False
+
+    def test_auto_resolved_false_when_key_not_literal_true(self) -> None:
+        details = _bead_details(extra_state={KEY_AUTO_RESOLVED: "false"})
+        entry = report_entry_from_details(details)
+        assert entry is not None
+        assert entry.auto_resolved is False
+
+    def test_suggestion_none_when_key_absent(self) -> None:
+        details = _bead_details()
+        entry = report_entry_from_details(details)
+        assert entry is not None
+        assert entry.suggestion is None
+
+    def test_unparseable_suggestion_degrades_to_none(self) -> None:
+        details = _bead_details(extra_state={KEY_SUGGESTION: "not json"})
+        with patch("maverick.assumptions.ledger.logger") as mock_logger:
+            entry = report_entry_from_details(details)
+        assert entry is not None
+        assert entry.suggestion is None
+        assert mock_logger.debug.called
+
+    def test_legacy_entry_suggestion_and_auto_resolved_always_default(self) -> None:
+        """Legacy escalation beads never carry ledger state — both new
+        fields must stay at their defaults regardless of arbitrary state
+        keys on the bead (legacy beads predate this feature)."""
+        details = _legacy_bead_details()
+        entry = report_entry_from_details(details)
+        assert entry is not None
+        assert entry.record.is_legacy is True
+        assert entry.suggestion is None
+        assert entry.auto_resolved is False
+
+
+# ---------------------------------------------------------------------------
+# 4. entry_to_dict projection
+# ---------------------------------------------------------------------------
+
+
+class TestEntryToDictSuggestionProjection:
+    def test_suggestion_dict_shape_when_present(self) -> None:
+        suggestion = _sample_suggestion()
+        entry = _entry(suggestion=suggestion)
+        row = entry_to_dict(entry)
+        assert row["suggestion"] == _SAMPLE_SUGGESTION_KWARGS
+
+    def test_suggestion_null_when_absent(self) -> None:
+        entry = _entry(suggestion=None)
+        row = entry_to_dict(entry)
+        assert row["suggestion"] is None
+
+    def test_auto_resolved_true_in_row(self) -> None:
+        entry = _entry(status=STATUS_WAIVED, auto_resolved=True)
+        row = entry_to_dict(entry)
+        assert row["auto_resolved"] is True
+
+    def test_auto_resolved_false_in_row(self) -> None:
+        entry = _entry()
+        row = entry_to_dict(entry)
+        assert row["auto_resolved"] is False
+
+
+# ---------------------------------------------------------------------------
+# 5. _annotations gains "auto-resolved"
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotationsAutoResolved:
+    def test_auto_resolved_annotation_present(self) -> None:
+        entry = _entry(status=STATUS_WAIVED, auto_resolved=True)
+        tags = _annotations(entry)
+        assert "auto-resolved" in tags
+
+    def test_auto_resolved_annotation_absent_when_false(self) -> None:
+        entry = _entry(status=STATUS_WAIVED, auto_resolved=False)
+        tags = _annotations(entry)
+        assert "auto-resolved" not in tags
+
+    def test_auto_resolved_annotation_alongside_legacy(self) -> None:
+        entry = _entry(status=STATUS_WAIVED, auto_resolved=True, is_legacy=True)
+        tags = _annotations(entry)
+        assert "auto-resolved" in tags
+        assert "legacy" in tags
+
+    def test_entry_to_dict_annotations_list_includes_auto_resolved(self) -> None:
+        entry = _entry(status=STATUS_WAIVED, auto_resolved=True)
+        row = entry_to_dict(entry)
+        assert "auto-resolved" in row["annotations"]
+
+
+# ---------------------------------------------------------------------------
+# 6. land_report._entry_to_dict alias picks up the new keys unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestLandReportAliasPicksUpNewKeys:
+    def test_alias_includes_suggestion_key(self) -> None:
+        suggestion = _sample_suggestion()
+        entry = _entry(suggestion=suggestion)
+        row = _entry_to_dict(entry)
+        assert row["suggestion"] == _SAMPLE_SUGGESTION_KWARGS
+
+    def test_alias_includes_auto_resolved_key(self) -> None:
+        entry = _entry(status=STATUS_WAIVED, auto_resolved=True)
+        row = _entry_to_dict(entry)
+        assert row["auto_resolved"] is True
+
+    def test_alias_matches_entry_to_dict_exactly(self) -> None:
+        entry = _entry(status=STATUS_WAIVED, auto_resolved=True, suggestion=_sample_suggestion())
+        assert _entry_to_dict(entry) == entry_to_dict(entry)
+
+
+# ---------------------------------------------------------------------------
+# 7. FR-013/FR-019 guard: suggestion presence never changes gate behavior
+# ---------------------------------------------------------------------------
+
+
+class TestFR013SuggestionDoesNotAffectLandGate:
+    def test_open_entry_with_suggestion_still_blocks_landing(self) -> None:
+        entry = _entry(status=STATUS_OPEN, suggestion=_sample_suggestion())
+        assert entry.record.status == STATUS_OPEN
+        assert entry.blocks_landing is True
+
+    def test_frontier_treats_suggestion_carrying_open_entry_identically(self) -> None:
+        plain_open = _entry(bead_id="dea-plain", status=STATUS_OPEN, suggestion=None)
+        suggested_open = _entry(
+            bead_id="dea-suggested", status=STATUS_OPEN, suggestion=_sample_suggestion()
+        )
+        result = frontier((plain_open, suggested_open))
+        assert {e.record.bead_id for e in result.open_entries} == {"dea-plain", "dea-suggested"}
+        assert result.pending_reconcile_entries == ()
+
+    def test_classify_blocked_identically_with_or_without_suggestion(self) -> None:
+        plain_open = _entry(bead_id="dea-plain", status=STATUS_OPEN, suggestion=None)
+        suggested_open = _entry(
+            bead_id="dea-suggested", status=STATUS_OPEN, suggestion=_sample_suggestion()
+        )
+        assert classify((plain_open,)) == LandVerification.BLOCKED
+        assert classify((suggested_open,)) == LandVerification.BLOCKED
+
+    def test_classify_conditionally_verified_for_auto_resolved_waived_entry(self) -> None:
+        """Invariant 5: an auto-resolved entry is an ordinary waived entry
+        to classify() — no special-casing."""
+        entry = _entry(status=STATUS_WAIVED, auto_resolved=True, suggestion=_sample_suggestion())
+        assert classify((entry,)) == LandVerification.CONDITIONALLY_VERIFIED

--- a/tests/unit/assumptions/test_suggestions.py
+++ b/tests/unit/assumptions/test_suggestions.py
@@ -1,0 +1,1187 @@
+"""Tests for learned-resolution suggestion evaluation and persistence.
+
+Covers spec 055-learned-assumption-resolution, User Story 2 (T011): matching
+a newly recorded/listed assumption entry against the decision corpus, and
+persisting/back-filling the result on the bead as ``assumption_suggestion``.
+
+Target functions under test (not yet implemented as of this task — see
+research.md R5 for the normative signatures):
+
+    def evaluate_suggestion(
+        record: AssumptionReportEntry,
+        corpus: list[DecisionRecord],
+        feedback: list[MatchFeedbackRecord],
+    ) -> Suggestion | None
+
+    async def attach_suggestions(
+        client: BeadClient,
+        store: RunwayStore,
+        records: list[AssumptionReportEntry],
+    ) -> None
+
+    async def backfill_suggestions(
+        client: BeadClient,
+        store: RunwayStore,
+        entries: list[AssumptionReportEntry],
+    ) -> list[AssumptionReportEntry]
+
+``feedback`` is exercised only with an empty list here (US3/T023 owns
+feedback-penalty behavior; the parameter exists from T018 with an empty
+default so US2 behavior is unchanged until feedback records exist).
+
+See:
+- specs/055-learned-assumption-resolution/research.md R5, R11, R12, R13
+- specs/055-learned-assumption-resolution/data-model.md (Suggestion, invariants 1-4)
+- specs/055-learned-assumption-resolution/contracts/decision-records.md
+
+``AssumptionReportEntry.suggestion``/``.auto_resolved`` (T015) and
+``Suggestion``/``KEY_SUGGESTION``/``KEY_AUTO_RESOLVED`` (T015/T017) have not
+landed yet as of this task — constructing test fixtures against them, and
+importing ``evaluate_suggestion``/``attach_suggestions``/
+``backfill_suggestions`` (T016/T018), are expected to fail at collection or
+construction time. That failure IS the red state this test file asserts;
+T015-T018 land together and make this file pass.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from maverick.assumptions.matching import PRESENTATION_THRESHOLD, normalize_question
+from maverick.assumptions.models import (
+    STATUS_OPEN,
+    AssumptionRecord,
+    AssumptionReportEntry,
+    Severity,
+    Suggestion,
+    suggestion_to_json,
+)
+from maverick.assumptions.suggestions import (
+    _MAX_SUGGESTION_JSON_LENGTH,
+    attach_suggestions,
+    backfill_suggestions,
+    evaluate_suggestion,
+)
+from maverick.beads.client import BeadClient
+from maverick.runway.models import DecisionRecord, MatchFeedbackRecord
+from maverick.runway.store import RunwayStore
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _client() -> BeadClient:
+    return BeadClient(cwd=Path("/tmp/repo"))
+
+
+def _record(
+    bead_id: str,
+    question: str,
+    *,
+    severity: Severity = Severity.LOW,
+    owner_spec: str = "052-conditional-landing",
+) -> AssumptionRecord:
+    return AssumptionRecord(
+        bead_id=bead_id,
+        question=question,
+        adopted_answer="Some adopted answer to keep working.",
+        alternatives=(),
+        severity=severity,
+        severity_defaulted=False,
+        status=STATUS_OPEN,
+        owner_spec=owner_spec,
+        source_bead="src-bead-1",
+        change_ids=(),
+        is_legacy=False,
+    )
+
+
+def _entry(
+    bead_id: str,
+    question: str,
+    *,
+    severity: Severity = Severity.LOW,
+    owner_spec: str = "052-conditional-landing",
+    suggestion: Suggestion | None = None,
+    auto_resolved: bool = False,
+) -> AssumptionReportEntry:
+    return AssumptionReportEntry(
+        record=_record(bead_id, question, severity=severity, owner_spec=owner_spec),
+        final_answer=None,
+        waived_by=None,
+        waived_at=None,
+        waive_reason=None,
+        reconcile_status=None,
+        reconciled_answer=None,
+        reconcile_change_id=None,
+        reconcile_reason=None,
+        pending_reconcile=False,
+        suggestion=suggestion,
+        auto_resolved=auto_resolved,
+    )
+
+
+def _decision(
+    source_entry_id: str,
+    question: str,
+    *,
+    resolution: str = "Yes, that's correct.",
+    resolution_type: str = "answered",
+    resolved_at: str = "2026-08-01T00:00:00+00:00",
+    owner_spec: str = "052-conditional-landing",
+) -> DecisionRecord:
+    return DecisionRecord(
+        source_entry_id=source_entry_id,
+        question=question,
+        normalized_question=normalize_question(question),
+        adopted_answer="What the agent had adopted.",
+        resolution_type=resolution_type,  # type: ignore[arg-type]
+        resolution=resolution,
+        severity="medium",
+        owner_spec=owner_spec,
+        resolved_by="Test User",
+        resolved_at=resolved_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# evaluate_suggestion
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSuggestionBelowThreshold:
+    def test_empty_corpus_returns_none(self) -> None:
+        entry = _entry("mv-1", "Should retries use exponential backoff?")
+        assert evaluate_suggestion(entry, [], feedback=[]) is None
+
+    def test_low_similarity_candidate_returns_none(self) -> None:
+        entry = _entry("mv-1", "Should retries use exponential backoff for network calls?")
+        corpus = [_decision("mv-2", "Where should database backups be archived indefinitely?")]
+        assert evaluate_suggestion(entry, corpus, feedback=[]) is None
+
+
+class TestEvaluateSuggestionSelfMatchExcluded:
+    def test_self_match_never_suggested_even_when_identical(self) -> None:
+        # R12: an entry re-opened/re-answered must never match the decision
+        # record produced by its own earlier resolution.
+        question = "Should retries use exponential backoff?"
+        entry = _entry("mv-1", question)
+        corpus = [_decision("mv-1", question)]  # source_entry_id == entry.bead_id
+        assert evaluate_suggestion(entry, corpus, feedback=[]) is None
+
+    def test_self_match_excluded_leaving_lower_candidates_below_threshold(self) -> None:
+        question = "Should retries use exponential backoff?"
+        entry = _entry("mv-1", question)
+        corpus = [
+            _decision("mv-1", question),  # self-match: excluded regardless of score
+            _decision("mv-2", "Where should database backups be archived indefinitely?"),
+        ]
+        assert evaluate_suggestion(entry, corpus, feedback=[]) is None
+
+
+class TestEvaluateSuggestionMatch:
+    def test_match_returns_suggestion_with_expected_shape(self) -> None:
+        question = "Should retries use exponential backoff?"
+        entry = _entry("mv-1", question)
+        decision = _decision(
+            "mv-2",
+            question,
+            resolution="Yes, use exponential backoff via tenacity.",
+            resolution_type="answered",
+            resolved_at="2026-08-01T00:00:00+00:00",
+            owner_spec="052-conditional-landing",
+        )
+
+        result = evaluate_suggestion(entry, [decision], feedback=[])
+
+        # Exactly one suggestion is ever returned — never a list.
+        assert isinstance(result, Suggestion)
+        assert result.source_entry_id == "mv-2"
+        assert result.resolution == "Yes, use exponential backoff via tenacity."
+        assert result.resolution_type == "answered"
+        assert result.source_spec == "052-conditional-landing"
+        assert result.resolved_at == "2026-08-01T00:00:00+00:00"
+        assert result.confidence >= PRESENTATION_THRESHOLD
+
+
+class TestEvaluateSuggestionCollapse:
+    def test_only_latest_version_participates_in_matching(self) -> None:
+        # Two DecisionRecords for the same source_entry_id (a re-answered
+        # decision). The EARLIER version is a near-perfect textual match
+        # (score 1.0) with an "old" resolution; the LATER version has
+        # slightly different phrasing (still >= threshold) with a "new"
+        # resolution. Without collapse, select_best would pick the earlier,
+        # higher-scoring record — this test fails unless only the latest
+        # version participates.
+        question = "Should retries use exponential backoff for network calls?"
+        entry = _entry("mv-1", question)
+        earlier = _decision(
+            "mv-2",
+            question,  # exact match -> base score 1.0
+            resolution="Old answer: fixed delay retries.",
+            resolved_at="2026-01-01T00:00:00+00:00",
+        )
+        later = _decision(
+            "mv-2",
+            "Should retries use exponential backoff for network requests?",
+            resolution="New answer: exponential backoff via tenacity.",
+            resolved_at="2026-06-01T00:00:00+00:00",
+        )
+
+        result = evaluate_suggestion(entry, [earlier, later], feedback=[])
+
+        assert result is not None
+        assert result.source_entry_id == "mv-2"
+        assert result.resolution == "New answer: exponential backoff via tenacity."
+        assert result.resolved_at == "2026-06-01T00:00:00+00:00"
+
+
+class TestEvaluateSuggestionTieBreak:
+    def test_tie_breaks_on_resolved_at_descending(self) -> None:
+        question = "Should retries use exponential backoff?"
+        entry = _entry("mv-1", question)
+        older = _decision("mv-2", question, resolved_at="2026-01-01T00:00:00+00:00")
+        newer = _decision("mv-3", question, resolved_at="2026-06-01T00:00:00+00:00")
+
+        result = evaluate_suggestion(entry, [older, newer], feedback=[])
+
+        assert result is not None
+        assert result.source_entry_id == "mv-3"
+        assert result.resolved_at == "2026-06-01T00:00:00+00:00"
+
+    def test_tie_breaks_on_source_entry_id_ascending(self) -> None:
+        question = "Should retries use exponential backoff?"
+        entry = _entry("mv-1", question)
+        same_time = "2026-06-01T00:00:00+00:00"
+        candidates = [
+            _decision("mv-99", question, resolved_at=same_time),
+            _decision("mv-2", question, resolved_at=same_time),
+            _decision("mv-42", question, resolved_at=same_time),
+        ]
+
+        result = evaluate_suggestion(entry, candidates, feedback=[])
+
+        assert result is not None
+        assert result.source_entry_id == "mv-2"
+
+
+class TestEvaluateSuggestionPerformance:
+    def test_scales_to_500_records_under_one_second(self) -> None:
+        # SC-006: a single evaluation against a ~500-record corpus must
+        # complete well under one second.
+        entry = _entry("mv-1", "Should retries use exponential backoff for network calls?")
+        corpus = [
+            _decision(
+                f"mv-corpus-{i}",
+                f"Should component {i} use retry strategy variant {i} "
+                "for outbound network calls to a downstream service?",
+                resolved_at=f"2026-01-{(i % 28) + 1:02d}T00:00:00+00:00",
+            )
+            for i in range(500)
+        ]
+
+        start = time.perf_counter()
+        evaluate_suggestion(entry, corpus, feedback=[])
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 1.0
+
+
+# ---------------------------------------------------------------------------
+# classify_feedback / record_feedback (spec 055, US3, T023)
+#
+# ``classify_feedback``/``record_feedback`` do not exist yet in
+# ``maverick.assumptions.suggestions`` as of this task (T026 adds them) — the
+# module-level imports above deliberately do NOT name them, so a missing
+# symbol doesn't break collection of the rest of this file (evaluate_suggestion
+# / attach_suggestions / backfill_suggestions tests, already green, must keep
+# passing). Each test below imports the two functions locally instead; until
+# T026 lands, every test in these classes fails with an ImportError, which IS
+# the red state this task asserts.
+# ---------------------------------------------------------------------------
+
+
+def _suggestion(
+    *,
+    resolution: str = "Yes, use exponential backoff via tenacity.",
+    resolution_type: str = "answered",
+    source_entry_id: str = "mv-2",
+    source_spec: str = "052-conditional-landing",
+    resolved_at: str = "2026-08-01T00:00:00+00:00",
+    confidence: float = 0.9,
+) -> Suggestion:
+    return Suggestion(
+        resolution=resolution,
+        resolution_type=resolution_type,
+        source_entry_id=source_entry_id,
+        source_spec=source_spec,
+        resolved_at=resolved_at,
+        confidence=confidence,
+        computed_at="2026-08-01T00:00:00+00:00",
+    )
+
+
+class TestClassifyFeedback:
+    """classify_feedback(entry, suggestion, *, resolution_type, resolution).
+
+    Per contracts/decision-records.md "Decision capture points": accepted
+    iff resolution_type matches the suggestion's AND normalized resolution
+    text matches the suggestion's normalized resolution text; anything else
+    (different text, or a type mismatch regardless of text) is rejected.
+    """
+
+    def test_same_type_same_text_is_accepted(self) -> None:
+        from maverick.assumptions.suggestions import classify_feedback
+
+        suggestion = _suggestion(
+            resolution="Yes, use exponential backoff via tenacity.",
+            resolution_type="answered",
+        )
+        entry = _entry("mv-1", "Should retries use exponential backoff?", suggestion=suggestion)
+
+        result = classify_feedback(
+            entry,
+            suggestion,
+            resolution_type="answered",
+            resolution="Yes, use exponential backoff via tenacity.",
+        )
+        assert result == "accepted"
+
+    def test_same_type_same_text_is_accepted_case_and_punctuation_insensitive(self) -> None:
+        from maverick.assumptions.suggestions import classify_feedback
+
+        suggestion = _suggestion(
+            resolution="Yes, use exponential backoff via tenacity.",
+            resolution_type="answered",
+        )
+        entry = _entry("mv-1", "Should retries use exponential backoff?", suggestion=suggestion)
+
+        result = classify_feedback(
+            entry,
+            suggestion,
+            resolution_type="answered",
+            resolution="YES USE EXPONENTIAL BACKOFF VIA TENACITY",
+        )
+        assert result == "accepted"
+
+    def test_same_type_different_text_is_rejected(self) -> None:
+        from maverick.assumptions.suggestions import classify_feedback
+
+        suggestion = _suggestion(
+            resolution="Yes, use exponential backoff via tenacity.",
+            resolution_type="answered",
+        )
+        entry = _entry("mv-1", "Should retries use exponential backoff?", suggestion=suggestion)
+
+        result = classify_feedback(
+            entry,
+            suggestion,
+            resolution_type="answered",
+            resolution="No, use a fixed delay instead.",
+        )
+        assert result == "rejected"
+
+    def test_answer_suggested_but_waived_is_rejected(self) -> None:
+        """Type mismatch is rejected even when the text is identical."""
+        from maverick.assumptions.suggestions import classify_feedback
+
+        suggestion = _suggestion(
+            resolution="Yes, use exponential backoff via tenacity.",
+            resolution_type="answered",
+        )
+        entry = _entry("mv-1", "Should retries use exponential backoff?", suggestion=suggestion)
+
+        result = classify_feedback(
+            entry,
+            suggestion,
+            resolution_type="waived",
+            resolution="Yes, use exponential backoff via tenacity.",
+        )
+        assert result == "rejected"
+
+    def test_waive_suggested_but_answered_is_rejected(self) -> None:
+        """Type mismatch is rejected even when the text is identical."""
+        from maverick.assumptions.suggestions import classify_feedback
+
+        suggestion = _suggestion(
+            resolution="No longer applicable.",
+            resolution_type="waived",
+        )
+        entry = _entry("mv-1", "Should retries use exponential backoff?", suggestion=suggestion)
+
+        result = classify_feedback(
+            entry,
+            suggestion,
+            resolution_type="answered",
+            resolution="No longer applicable.",
+        )
+        assert result == "rejected"
+
+
+class TestRecordFeedback:
+    """record_feedback(store, entry, *, accepted) -> bool.
+
+    Mirrors ``record_decision``'s never-raises/bool-return fail-soft
+    contract (FR-004): a store-write failure returns ``False`` instead of
+    raising; a successful append returns ``True``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_appends_accepted_feedback_record(self, tmp_path: Path) -> None:
+        from maverick.assumptions.suggestions import record_feedback
+
+        store = RunwayStore(tmp_path / "runway")
+        await store.initialize()
+        suggestion = _suggestion()
+        entry = _entry("mv-1", "Should retries use exponential backoff?", suggestion=suggestion)
+
+        ok = await record_feedback(store, entry, accepted=True)
+
+        assert ok is True
+        records = await store.get_match_feedback()
+        assert len(records) == 1
+        assert records[0].outcome == "accepted"
+        assert records[0].source_entry_id == "mv-2"
+        assert records[0].normalized_question == normalize_question(
+            "Should retries use exponential backoff?"
+        )
+
+    @pytest.mark.asyncio
+    async def test_appends_rejected_feedback_record(self, tmp_path: Path) -> None:
+        from maverick.assumptions.suggestions import record_feedback
+
+        store = RunwayStore(tmp_path / "runway")
+        await store.initialize()
+        suggestion = _suggestion()
+        entry = _entry("mv-1", "Should retries use exponential backoff?", suggestion=suggestion)
+
+        ok = await record_feedback(store, entry, accepted=False)
+
+        assert ok is True
+        records = await store.get_match_feedback()
+        assert len(records) == 1
+        assert records[0].outcome == "rejected"
+        assert records[0].source_entry_id == "mv-2"
+
+    @pytest.mark.asyncio
+    async def test_store_failure_returns_false_never_raises(self, tmp_path: Path) -> None:
+        from maverick.assumptions.suggestions import record_feedback
+
+        store = RunwayStore(tmp_path / "runway")
+        await store.initialize()
+        suggestion = _suggestion()
+        entry = _entry("mv-1", "Should retries use exponential backoff?", suggestion=suggestion)
+
+        with patch.object(
+            RunwayStore,
+            "append_match_feedback",
+            new=AsyncMock(side_effect=RuntimeError("disk full")),
+        ):
+            ok = await record_feedback(store, entry, accepted=True)
+
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: rejection feedback suppresses even a perfect base-score match
+# (FR-015), a subsequent acceptance restores it (spec 055, US3, T023).
+#
+# Unlike the classes above, ``evaluate_suggestion`` and ``MatchFeedbackRecord``
+# already exist and the fold logic in ``evaluate_suggestion`` already applies
+# ``matching.effective_confidence`` correctly — these tests exercise that
+# existing behavior end-to-end with real MatchFeedbackRecord data, not a
+# not-yet-implemented function. They are the regression guard T026 must keep
+# green (the parameter has been feedback-driven since T018; only the
+# *capture* of real feedback records is new in this story).
+# ---------------------------------------------------------------------------
+
+
+class TestFeedbackFoldSuppressesAndRestoresSuggestion:
+    def test_perfect_match_without_feedback_is_suggested(self) -> None:
+        question = "Should retries use exponential backoff?"
+        entry = _entry("mv-1", question)
+        decision = _decision("mv-2", question)
+
+        result = evaluate_suggestion(entry, [decision], feedback=[])
+
+        assert result is not None
+        assert result.confidence >= PRESENTATION_THRESHOLD
+        # Identical normalized text -> base score at/near 1.0.
+        assert result.confidence >= 0.99
+
+    def test_one_net_rejection_suppresses_even_a_perfect_match(self) -> None:
+        question = "Should retries use exponential backoff?"
+        entry = _entry("mv-1", question)
+        decision = _decision("mv-2", question)
+
+        rejection = MatchFeedbackRecord(
+            normalized_question=normalize_question(question),
+            source_entry_id="mv-2",
+            outcome="rejected",
+            recorded_at="2026-08-07T09:15:02+00:00",
+        )
+
+        # Sanity: without feedback this pairing IS suggested.
+        assert evaluate_suggestion(entry, [decision], feedback=[]) is not None
+
+        result = evaluate_suggestion(entry, [decision], feedback=[rejection])
+
+        assert result is None, (
+            "one net rejection (1.0 - REJECTION_PENALTY(0.30) = 0.70 < "
+            "PRESENTATION_THRESHOLD(0.75)) must drop even a perfect base "
+            "score below the presentation threshold (FR-015)"
+        )
+
+    def test_subsequent_acceptance_restores_the_suggestion(self) -> None:
+        question = "Should retries use exponential backoff?"
+        entry = _entry("mv-1", question)
+        decision = _decision("mv-2", question)
+
+        rejection = MatchFeedbackRecord(
+            normalized_question=normalize_question(question),
+            source_entry_id="mv-2",
+            outcome="rejected",
+            recorded_at="2026-08-07T09:15:02+00:00",
+        )
+        acceptance = MatchFeedbackRecord(
+            normalized_question=normalize_question(question),
+            source_entry_id="mv-2",
+            outcome="accepted",
+            recorded_at="2026-08-08T09:15:02+00:00",
+        )
+
+        result = evaluate_suggestion(entry, [decision], feedback=[rejection, acceptance])
+
+        assert result is not None, (
+            "net rejections-acceptances == 0 must restore the suggestion (no penalty applied)"
+        )
+        assert result.source_entry_id == "mv-2"
+
+    def test_unrelated_rejection_does_not_suppress_a_different_pairing(self) -> None:
+        """The pairing key is (normalized_question, source_entry_id) — a
+        rejection recorded against a different candidate must not penalize
+        this one (R3)."""
+        question = "Should retries use exponential backoff?"
+        entry = _entry("mv-1", question)
+        decision = _decision("mv-2", question)
+
+        unrelated_rejection = MatchFeedbackRecord(
+            normalized_question=normalize_question(question),
+            source_entry_id="mv-different-candidate",
+            outcome="rejected",
+            recorded_at="2026-08-07T09:15:02+00:00",
+        )
+
+        result = evaluate_suggestion(entry, [decision], feedback=[unrelated_rejection])
+
+        assert result is not None
+        assert result.source_entry_id == "mv-2"
+
+
+# ---------------------------------------------------------------------------
+# attach_suggestions
+# ---------------------------------------------------------------------------
+
+
+class TestAttachSuggestionsStoreUnavailable:
+    @pytest.mark.asyncio
+    async def test_uninitialized_store_is_noop(self, tmp_path: Path) -> None:
+        client = _client()
+        store = RunwayStore(tmp_path / "runway")  # never initialize()d
+        entry = _entry("mv-1", "Should retries use exponential backoff?")
+
+        with patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state:
+            # Must not raise.
+            await attach_suggestions(client, store, [entry])
+
+        mock_set_state.assert_not_awaited()
+
+
+class TestAttachSuggestionsPartialFailure:
+    @pytest.mark.asyncio
+    async def test_set_state_failure_for_one_does_not_block_others(self, tmp_path: Path) -> None:
+        store = RunwayStore(tmp_path / "runway")
+        await store.initialize()
+        await store.append_decision(
+            _decision("mv-src-1", "Should retries use exponential backoff?")
+        )
+        await store.append_decision(
+            _decision("mv-src-2", "Should caching use a write-through policy?")
+        )
+
+        client = _client()
+        entry_a = _entry("mv-a", "Should retries use exponential backoff?")
+        entry_b = _entry("mv-b", "Should caching use a write-through policy?")
+
+        async def flaky_set_state(*args: object, **kwargs: object) -> None:
+            bead_id = args[0] if args else kwargs.get("bead_id")
+            if bead_id == "mv-a":
+                raise RuntimeError("bd set-state failed")
+            # mv-b (and anything else) succeeds silently.
+
+        mock_set_state = AsyncMock(side_effect=flaky_set_state)
+        with patch.object(BeadClient, "set_state", new=mock_set_state):
+            # Must not raise even though the first record's write fails.
+            await attach_suggestions(client, store, [entry_a, entry_b])
+
+        called_bead_ids = [
+            call.args[0] if call.args else call.kwargs.get("bead_id")
+            for call in mock_set_state.await_args_list
+        ]
+        assert "mv-b" in called_bead_ids
+
+
+# ---------------------------------------------------------------------------
+# backfill_suggestions
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillSuggestions:
+    @pytest.mark.asyncio
+    async def test_evaluates_and_persists_for_entries_without_suggestion(
+        self, tmp_path: Path
+    ) -> None:
+        store = RunwayStore(tmp_path / "runway")
+        await store.initialize()
+        await store.append_decision(
+            _decision("mv-src-1", "Should retries use exponential backoff?")
+        )
+
+        client = _client()
+        entry = _entry("mv-a", "Should retries use exponential backoff?", suggestion=None)
+
+        with patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state:
+            await backfill_suggestions(client, store, [entry])
+
+        mock_set_state.assert_awaited_once()
+        called_bead_id = mock_set_state.await_args.args[0]
+        assert called_bead_id == "mv-a"
+
+    @pytest.mark.asyncio
+    async def test_never_replaces_an_existing_stored_suggestion(self, tmp_path: Path) -> None:
+        store = RunwayStore(tmp_path / "runway")
+        await store.initialize()
+        # A much better-matching decision now exists in the corpus, but the
+        # entry already carries a (possibly stale-looking) suggestion —
+        # backfill must never overwrite it (clarify Q5 / R11).
+        await store.append_decision(
+            _decision("mv-src-1", "Should retries use exponential backoff?")
+        )
+
+        existing_suggestion = Suggestion(
+            resolution="Some prior recorded value.",
+            resolution_type="answered",
+            source_entry_id="mv-src-weird",
+            source_spec="000-unrelated-spec",
+            resolved_at="2020-01-01T00:00:00+00:00",
+            confidence=0.5,
+            computed_at="2020-01-01T00:00:00+00:00",
+        )
+        client = _client()
+        entry = _entry(
+            "mv-a",
+            "Should retries use exponential backoff?",
+            suggestion=existing_suggestion,
+        )
+
+        with patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state:
+            await backfill_suggestions(client, store, [entry])
+
+        mock_set_state.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# attach_suggestions auto-resolution (spec 055, User Story 4, T029)
+#
+# Target signature under test (not yet implemented as of this task — a
+# parallel T031 agent adds ``AutoResolvePolicyConfig``/
+# ``AssumptionResolutionConfig`` to ``maverick.config``; a parallel T032
+# agent adds the ``auto_resolve`` parameter + branch below to
+# ``attach_suggestions`` itself):
+#
+#     async def attach_suggestions(
+#         client: BeadClient,
+#         store: RunwayStore,
+#         records: list[AssumptionReportEntry],
+#         *,
+#         auto_resolve: AutoResolvePolicyConfig | None = None,
+#     ) -> None
+#
+# Every test below that passes ``auto_resolve=...`` currently fails with a
+# ``TypeError`` (unexpected keyword argument) — that IS the red state this
+# task asserts. ``AutoResolvePolicyConfig`` is imported locally per test
+# (not at module level) so a not-yet-landed config class doesn't break
+# collection of the rest of this file — same convention this module already
+# uses for classify_feedback/record_feedback above.
+#
+# The auto-resolve branch is expected to call ``ledger.waive`` via
+# ``maverick.assumptions.suggestions.ledger.waive`` — i.e. ``suggestions.py``
+# imports the ``ledger`` *module* (``from maverick.assumptions import
+# ledger``) rather than the bare function, so patching that attribute path
+# stays stable regardless of exactly where in the function body the call
+# happens. Until that import exists, every ``patch(...)`` call below raises
+# ``AttributeError`` (module has no attribute ``ledger``) — also part of the
+# expected red state.
+#
+# ``backfill_suggestions`` deliberately does NOT grow an ``auto_resolve``
+# parameter at all (auto-resolution is recording-time only, per the spec) —
+# see ``TestBackfillSuggestionsNeverAutoResolves`` below.
+# ---------------------------------------------------------------------------
+
+_MATCHING_QUESTION = "Should retries use exponential backoff?"
+
+# A pair of near-but-not-identical questions with a base score of ~0.841
+# (matching.py's SequenceMatcher+Jaccard blend) — comfortably above
+# PRESENTATION_THRESHOLD (0.75, so a suggestion IS attached) but below any
+# confidence_threshold >= 0.9 (so auto-resolve does NOT fire). Used by the
+# "confidence below threshold" test.
+_PARTIAL_ENTRY_QUESTION = "Should retries use exponential backoff for network calls?"
+_PARTIAL_DECISION_QUESTION = "Should retries use exponential backoff for network requests?"
+
+
+def _matching_decision(**overrides: object) -> DecisionRecord:
+    """A decision whose question is an exact textual match for
+    ``_MATCHING_QUESTION`` — base score ~1.0, comfortably above every
+    threshold used in this section."""
+    return _decision("mv-src", _MATCHING_QUESTION, **overrides)  # type: ignore[arg-type]
+
+
+async def _store_with_decision(tmp_path: Path, decision: DecisionRecord) -> RunwayStore:
+    store = RunwayStore(tmp_path / "runway")
+    await store.initialize()
+    await store.append_decision(decision)
+    return store
+
+
+class TestAttachSuggestionsAutoResolveFires:
+    @pytest.mark.asyncio
+    async def test_low_severity_enabled_policy_above_threshold_waives_and_marks(
+        self, tmp_path: Path
+    ) -> None:
+        from maverick.assumptions.models import KEY_AUTO_RESOLVED, KEY_SUGGESTION
+        from maverick.config import AutoResolvePolicyConfig
+
+        store = await _store_with_decision(tmp_path, _matching_decision())
+        client = _client()
+        entry = _entry("mv-1", _MATCHING_QUESTION, severity=Severity.LOW)
+        policy = AutoResolvePolicyConfig(enabled=True, confidence_threshold=0.75)
+
+        mock_set_state = AsyncMock()
+        with (
+            patch.object(BeadClient, "set_state", new=mock_set_state),
+            patch("maverick.assumptions.suggestions.ledger.waive", new=AsyncMock()) as mock_waive,
+        ):
+            await attach_suggestions(client, store, [entry], auto_resolve=policy)
+
+        mock_waive.assert_awaited_once()
+        _, kwargs = mock_waive.await_args
+        assert kwargs["bead_id"] == "mv-1"
+        assert kwargs["waived_by"] == "maverick-resolver"
+        # Reason cites the source entry id, source spec, and date/confidence
+        # context (research R7).
+        assert "mv-src" in kwargs["reason"]
+        assert "052-conditional-landing" in kwargs["reason"]
+
+        # KEY_AUTO_RESOLVED ends up set alongside KEY_SUGGESTION — however
+        # many `set_state` calls it takes to get there.
+        written: dict[str, str] = {}
+        for call in mock_set_state.await_args_list:
+            state = call.args[1] if len(call.args) > 1 else call.kwargs.get("state", {})
+            written.update(state)
+        assert written.get(KEY_AUTO_RESOLVED) == "true"
+        assert KEY_SUGGESTION in written
+
+    @pytest.mark.asyncio
+    async def test_auto_resolved_stamp_lands_before_the_waive(self, tmp_path: Path) -> None:
+        """``KEY_AUTO_RESOLVED`` must be written BEFORE ``ledger.waive``.
+
+        ``bd set-state`` is one subprocess call per key, so the stamp and
+        the waive are not atomic and either can fail alone. The stamp is
+        exactly what lets a human override the machine's decision
+        (``maverick review <id>`` bypasses its already-waived refusal only
+        for auto-resolved entries), so waiving first would mean a failure
+        in between leaves an entry waived by ``maverick-resolver`` that no
+        human can ever reopen. Stamping first inverts the failure into the
+        harmless direction: an open entry with a stale marker nothing gates
+        on.
+        """
+        from maverick.assumptions.models import KEY_AUTO_RESOLVED
+        from maverick.config import AutoResolvePolicyConfig
+
+        store = await _store_with_decision(tmp_path, _matching_decision())
+        client = _client()
+        entry = _entry("mv-1", _MATCHING_QUESTION, severity=Severity.LOW)
+        policy = AutoResolvePolicyConfig(enabled=True, confidence_threshold=0.75)
+
+        order: list[str] = []
+
+        async def _set_state(_self, _bead_id, state, **_kwargs):  # noqa: ANN001, ANN202
+            if KEY_AUTO_RESOLVED in state:
+                order.append("stamp")
+
+        async def _waive(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202
+            order.append("waive")
+
+        with (
+            patch.object(BeadClient, "set_state", new=_set_state),
+            patch("maverick.assumptions.suggestions.ledger.waive", new=_waive),
+        ):
+            await attach_suggestions(client, store, [entry], auto_resolve=policy)
+
+        assert order == ["stamp", "waive"]
+
+    @pytest.mark.asyncio
+    async def test_waive_failure_leaves_entry_unwaived_and_logs_the_cause(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A failed auto-waive is the operator's only signal — it must
+        carry the actual exception, not just the bead id."""
+        from maverick.config import AutoResolvePolicyConfig
+
+        store = await _store_with_decision(tmp_path, _matching_decision())
+        client = _client()
+        entry = _entry("mv-1", _MATCHING_QUESTION, severity=Severity.LOW)
+        policy = AutoResolvePolicyConfig(enabled=True, confidence_threshold=0.75)
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch(
+                "maverick.assumptions.suggestions.ledger.waive",
+                new=AsyncMock(side_effect=RuntimeError("bd rejected the waive")),
+            ),
+        ):
+            await attach_suggestions(client, store, [entry], auto_resolve=policy)
+
+        assert "bd rejected the waive" in caplog.text
+
+
+class TestAttachSuggestionsAutoResolveConditions:
+    """Each condition's negation, tested independently — auto-resolve only
+    fires when ALL of {severity == low, policy enabled, confidence >=
+    threshold} hold simultaneously."""
+
+    @pytest.mark.asyncio
+    async def test_medium_severity_not_auto_resolved(self, tmp_path: Path) -> None:
+        from maverick.config import AutoResolvePolicyConfig
+
+        store = await _store_with_decision(tmp_path, _matching_decision())
+        client = _client()
+        entry = _entry("mv-1", _MATCHING_QUESTION, severity=Severity.MEDIUM)
+        policy = AutoResolvePolicyConfig(enabled=True, confidence_threshold=0.75)
+
+        mock_set_state = AsyncMock()
+        with (
+            patch.object(BeadClient, "set_state", new=mock_set_state),
+            patch("maverick.assumptions.suggestions.ledger.waive", new=AsyncMock()) as mock_waive,
+        ):
+            await attach_suggestions(client, store, [entry], auto_resolve=policy)
+
+        mock_waive.assert_not_awaited()
+        # A suggestion is still computed and persisted — only auto-resolve
+        # is gated on severity.
+        mock_set_state.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_high_severity_not_auto_resolved(self, tmp_path: Path) -> None:
+        from maverick.config import AutoResolvePolicyConfig
+
+        store = await _store_with_decision(tmp_path, _matching_decision())
+        client = _client()
+        entry = _entry("mv-1", _MATCHING_QUESTION, severity=Severity.HIGH)
+        policy = AutoResolvePolicyConfig(enabled=True, confidence_threshold=0.75)
+
+        with (
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch("maverick.assumptions.suggestions.ledger.waive", new=AsyncMock()) as mock_waive,
+        ):
+            await attach_suggestions(client, store, [entry], auto_resolve=policy)
+
+        mock_waive.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_legacy_synthesized_medium_severity_not_auto_resolved(
+        self, tmp_path: Path
+    ) -> None:
+        """Legacy entries synthesize ``severity=medium``
+        (``_legacy_record_from_details``) — functionally identical to the
+        medium-severity case above, so eligibility is already excluded by
+        the severity check with no special-casing needed. Constructed
+        directly with ``severity=Severity.MEDIUM`` per the task's fixture
+        guidance rather than threading a separate legacy-bead fixture
+        through this evaluate-only path."""
+        from maverick.config import AutoResolvePolicyConfig
+
+        store = await _store_with_decision(tmp_path, _matching_decision())
+        client = _client()
+        entry = _entry("mv-1", _MATCHING_QUESTION, severity=Severity.MEDIUM)
+        policy = AutoResolvePolicyConfig(enabled=True, confidence_threshold=0.75)
+
+        with (
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch("maverick.assumptions.suggestions.ledger.waive", new=AsyncMock()) as mock_waive,
+        ):
+            await attach_suggestions(client, store, [entry], auto_resolve=policy)
+
+        mock_waive.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_policy_none_not_auto_resolved_even_with_perfect_confidence(
+        self, tmp_path: Path
+    ) -> None:
+        store = await _store_with_decision(tmp_path, _matching_decision())
+        client = _client()
+        entry = _entry("mv-1", _MATCHING_QUESTION, severity=Severity.LOW)
+
+        with (
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch("maverick.assumptions.suggestions.ledger.waive", new=AsyncMock()) as mock_waive,
+        ):
+            # auto_resolve defaults to None — backward compatible no-op.
+            await attach_suggestions(client, store, [entry])
+
+        mock_waive.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_policy_disabled_not_auto_resolved_even_with_perfect_confidence(
+        self, tmp_path: Path
+    ) -> None:
+        from maverick.config import AutoResolvePolicyConfig
+
+        store = await _store_with_decision(tmp_path, _matching_decision())
+        client = _client()
+        entry = _entry("mv-1", _MATCHING_QUESTION, severity=Severity.LOW)
+        # confidence_threshold must be >= 0.75 (config-schema.md guard,
+        # pinned by T028) — 0.99 still exercises "perfect confidence"
+        # while staying within the valid range; enabled=False alone must
+        # suppress auto-resolve regardless of threshold.
+        policy = AutoResolvePolicyConfig(enabled=False, confidence_threshold=0.99)
+
+        with (
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch("maverick.assumptions.suggestions.ledger.waive", new=AsyncMock()) as mock_waive,
+        ):
+            await attach_suggestions(client, store, [entry], auto_resolve=policy)
+
+        mock_waive.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_confidence_below_threshold_suggestion_attached_but_not_waived(
+        self, tmp_path: Path
+    ) -> None:
+        from maverick.config import AutoResolvePolicyConfig
+
+        store = await _store_with_decision(
+            tmp_path, _decision("mv-src", _PARTIAL_DECISION_QUESTION)
+        )
+        client = _client()
+        entry = _entry("mv-1", _PARTIAL_ENTRY_QUESTION, severity=Severity.LOW)
+        # base score ~0.841 clears PRESENTATION_THRESHOLD (0.75) — a
+        # suggestion IS attached — but is below this policy's threshold, so
+        # auto-resolve does NOT fire.
+        policy = AutoResolvePolicyConfig(enabled=True, confidence_threshold=0.9)
+
+        mock_set_state = AsyncMock()
+        with (
+            patch.object(BeadClient, "set_state", new=mock_set_state),
+            patch("maverick.assumptions.suggestions.ledger.waive", new=AsyncMock()) as mock_waive,
+        ):
+            await attach_suggestions(client, store, [entry], auto_resolve=policy)
+
+        mock_waive.assert_not_awaited()
+        mock_set_state.assert_awaited()  # the suggestion itself is still persisted
+
+
+class TestAttachSuggestionsAutoResolveExcludedFromCorpus:
+    """FR-005: auto-resolution is machine-initiated and structurally
+    excluded from the human decision corpus — no DecisionRecord, no
+    MatchFeedbackRecord."""
+
+    @pytest.mark.asyncio
+    async def test_auto_resolve_writes_no_decision_or_feedback_record(
+        self, tmp_path: Path
+    ) -> None:
+        from maverick.config import AutoResolvePolicyConfig
+
+        store = await _store_with_decision(tmp_path, _matching_decision())
+        client = _client()
+        entry = _entry("mv-1", _MATCHING_QUESTION, severity=Severity.LOW)
+        policy = AutoResolvePolicyConfig(enabled=True, confidence_threshold=0.75)
+
+        with (
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch("maverick.assumptions.suggestions.ledger.waive", new=AsyncMock()),
+            patch.object(RunwayStore, "append_decision", new=AsyncMock()) as mock_decision,
+            patch.object(RunwayStore, "append_match_feedback", new=AsyncMock()) as mock_feedback,
+        ):
+            await attach_suggestions(client, store, [entry], auto_resolve=policy)
+
+        mock_decision.assert_not_awaited()
+        mock_feedback.assert_not_awaited()
+
+
+class TestAttachSuggestionsLengthGuard:
+    """``_MAX_SUGGESTION_JSON_LENGTH`` guard (quickstart-validation fix):
+    ``bd set-state`` silently truncates a state value that overflows its
+    internal label-length budget — no error. A suggestion whose encoded
+    JSON would risk that must never be persisted; it's treated exactly like
+    "no candidate matched" instead."""
+
+    @pytest.mark.asyncio
+    async def test_oversized_suggestion_never_persisted_and_stays_none(
+        self, tmp_path: Path
+    ) -> None:
+        # A very long resolution text pushes the encoded JSON comfortably
+        # past _MAX_SUGGESTION_JSON_LENGTH.
+        long_resolution = "This is a very long adopted answer. " * 10
+        store = await _store_with_decision(
+            tmp_path,
+            _decision(
+                "mv-src-long",
+                _MATCHING_QUESTION,
+                resolution=long_resolution,
+            ),
+        )
+        client = _client()
+        entry = _entry("mv-a", _MATCHING_QUESTION)
+
+        with patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state:
+            await attach_suggestions(client, store, [entry])
+
+        mock_set_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_oversized_suggestion_does_not_block_other_records_in_batch(
+        self, tmp_path: Path
+    ) -> None:
+        long_resolution = "This is a very long adopted answer. " * 10
+        store = RunwayStore(tmp_path / "runway")
+        await store.initialize()
+        await store.append_decision(
+            _decision("mv-src-long", _MATCHING_QUESTION, resolution=long_resolution)
+        )
+        await store.append_decision(
+            _decision(
+                "mv-src-short",
+                "Should caching use a write-through policy?",
+                resolution="Yes.",
+            )
+        )
+
+        client = _client()
+        oversized_entry = _entry("mv-oversized", _MATCHING_QUESTION)
+        fits_entry = _entry("mv-fits", "Should caching use a write-through policy?")
+
+        with patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state:
+            await attach_suggestions(client, store, [oversized_entry, fits_entry])
+
+        called_bead_ids = [
+            call.args[0] if call.args else call.kwargs.get("bead_id")
+            for call in mock_set_state.await_args_list
+        ]
+        assert called_bead_ids == ["mv-fits"]
+
+    @pytest.mark.asyncio
+    async def test_oversized_suggestion_never_auto_resolves(self, tmp_path: Path) -> None:
+        """An unpersistable suggestion must not trigger auto-resolution
+        either — eligibility is only ever reached after a successful
+        persist."""
+        from maverick.config import AutoResolvePolicyConfig
+
+        long_resolution = "This is a very long adopted answer. " * 10
+        store = await _store_with_decision(
+            tmp_path,
+            _decision("mv-src-long", _MATCHING_QUESTION, resolution=long_resolution),
+        )
+        client = _client()
+        entry = _entry("mv-a", _MATCHING_QUESTION, severity=Severity.LOW)
+        policy = AutoResolvePolicyConfig(enabled=True, confidence_threshold=0.75)
+
+        with (
+            patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state,
+            patch("maverick.assumptions.suggestions.ledger.waive", new=AsyncMock()) as mock_waive,
+        ):
+            await attach_suggestions(client, store, [entry], auto_resolve=policy)
+
+        mock_set_state.assert_not_awaited()
+        mock_waive.assert_not_awaited()
+
+    @staticmethod
+    def _resolution_for_target_encoded_length(target: int) -> str:
+        """Find a resolution string whose real ``evaluate_suggestion`` output
+        (with a live ``computed_at`` timestamp, not a fixed fixture one)
+        encodes to exactly *target* chars — avoids drift from
+        microsecond-precision timestamp length variance."""
+        resolution = ""
+        while True:
+            entry = _entry("mv-a", _MATCHING_QUESTION)
+            decision = _decision("mv-src", _MATCHING_QUESTION, resolution=resolution)
+            suggestion = evaluate_suggestion(entry, [decision], feedback=[])
+            assert suggestion is not None
+            encoded_len = len(suggestion_to_json(suggestion))
+            if encoded_len >= target:
+                return resolution
+            resolution += "x" * (target - encoded_len)
+
+    @pytest.mark.asyncio
+    async def test_just_under_limit_is_persisted(self, tmp_path: Path) -> None:
+        # A resolution sized so the encoded suggestion lands just under
+        # _MAX_SUGGESTION_JSON_LENGTH.
+        resolution = self._resolution_for_target_encoded_length(_MAX_SUGGESTION_JSON_LENGTH - 1)
+
+        store = await _store_with_decision(
+            tmp_path, _decision("mv-src", _MATCHING_QUESTION, resolution=resolution)
+        )
+        client = _client()
+        entry = _entry("mv-a", _MATCHING_QUESTION)
+
+        with patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state:
+            await attach_suggestions(client, store, [entry])
+
+        mock_set_state.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_just_over_limit_is_not_persisted(self, tmp_path: Path) -> None:
+        # A resolution sized so the encoded suggestion lands just over
+        # _MAX_SUGGESTION_JSON_LENGTH.
+        resolution = self._resolution_for_target_encoded_length(_MAX_SUGGESTION_JSON_LENGTH + 1)
+
+        store = await _store_with_decision(
+            tmp_path, _decision("mv-src", _MATCHING_QUESTION, resolution=resolution)
+        )
+        client = _client()
+        entry = _entry("mv-a", _MATCHING_QUESTION)
+
+        with patch.object(BeadClient, "set_state", new=AsyncMock()) as mock_set_state:
+            await attach_suggestions(client, store, [entry])
+
+        mock_set_state.assert_not_awaited()
+
+
+class TestBackfillSuggestionsNeverAutoResolves:
+    """``backfill_suggestions`` has no ``auto_resolve`` parameter at all
+    (recording-time only, per the spec) — auto-resolution can never fire
+    from this path regardless of how eligible the entry looks."""
+
+    @pytest.mark.asyncio
+    async def test_backfill_never_calls_waive_even_with_eligible_conditions(
+        self, tmp_path: Path
+    ) -> None:
+        store = await _store_with_decision(tmp_path, _matching_decision())
+        client = _client()
+        entry = _entry("mv-1", _MATCHING_QUESTION, severity=Severity.LOW, suggestion=None)
+
+        with (
+            patch.object(BeadClient, "set_state", new=AsyncMock()),
+            patch("maverick.assumptions.suggestions.ledger.waive", new=AsyncMock()) as mock_waive,
+        ):
+            # No `auto_resolve` kwarg exists to pass here — that's the point.
+            await backfill_suggestions(client, store, [entry])
+
+        mock_waive.assert_not_awaited()

--- a/tests/unit/cli/commands/review/test_decision_capture.py
+++ b/tests/unit/cli/commands/review/test_decision_capture.py
@@ -1,0 +1,798 @@
+"""Decision-capture wiring tests for ``maverick review`` (T005,
+055-learned-assumption-resolution, User Story 1).
+
+**RED-STATE MARKER**: at the time this module was written,
+``entry_actions.py``'s ``_review_ledger_entry``/``_bulk_waive_flow`` do not
+write anything to the runway decisions corpus — ``RunwayStore`` has no
+``append_decision``/``get_decisions`` methods and ``runway/models.py`` has
+no ``DecisionRecord`` yet. These tests assert directly on
+``.maverick/runway/decisions.jsonl`` content (raw JSON dicts, not a
+``DecisionRecord`` model) rather than importing that model, so a missing
+class doesn't break collection of this module — see
+specs/055-learned-assumption-resolution/contracts/decision-records.md
+("Decision capture points") and research.md R6. They are expected to FAIL
+until that wiring lands; do not "fix" them by loosening the assertions —
+the next task implements the production wiring these tests pin down.
+
+Mirrors the mocking style of ``tests/unit/cli/test_review_command.py`` /
+``tests/unit/cli/commands/test_review_json.py`` — patch ``BeadClient``
+methods and the ``maverick.assumptions.ledger`` functions (function-local
+imports in the command modules), never real ``bd``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from maverick.assumptions.models import (
+    ASSUMPTION_LABEL,
+    KEY_SEVERITY,
+    KEY_STATUS,
+    KEY_SUGGESTION,
+    STATUS_OPEN,
+    AssumptionRecord,
+    BulkWaiveResult,
+    Severity,
+    Suggestion,
+    suggestion_to_json,
+)
+from maverick.beads.models import BeadDetails
+from maverick.cli.commands.review import review
+
+_LEDGER_DESCRIPTION = (
+    "## Question\n\nShould retries be per bead?\n\n"
+    "## Adopted Answer\n\nPer bead — matches existing scoping.\n\n"
+    "## Alternatives Considered\n\n(none)\n\n"
+    "## Context\n\nSource bead: src-1 — Implement the thing\n"
+)
+
+
+def _ledger_details(bead_id: str = "dea-1", **state: str) -> BeadDetails:
+    return BeadDetails(
+        id=bead_id,
+        title="Assumption: Should retries be per bead?",
+        description=_LEDGER_DESCRIPTION,
+        bead_type="task",
+        status="open",
+        labels=[ASSUMPTION_LABEL],
+        state=state,
+    )
+
+
+def _patch_client(details: BeadDetails):
+    """Single-response ``BeadClient`` patch — human mode never re-reads
+    the bead after a write (that re-read is a ``--json``-only concern in
+    ``_project_after_write``), so one canned ``show()`` response is
+    sufficient for every test in this module."""
+    return (
+        patch(
+            "maverick.beads.client.BeadClient.verify_available",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "maverick.beads.client.BeadClient.show",
+            new=AsyncMock(return_value=details),
+        ),
+    )
+
+
+def _waived_record(bead_id: str, question: str = "Q?") -> AssumptionRecord:
+    return AssumptionRecord(
+        bead_id=bead_id,
+        question=question,
+        adopted_answer="A.",
+        alternatives=(),
+        severity=Severity.LOW,
+        severity_defaulted=False,
+        status="waived",
+        owner_spec="052-conditional-landing",
+        source_bead="dea-0",
+        change_ids=(),
+        is_legacy=False,
+    )
+
+
+@pytest.fixture
+def project_cwd(temp_dir: Path) -> Path:
+    """Chdir into a temp dir with an initialized runway store, mirroring
+    the review CLI's ``Path.cwd()`` resolution and the runway path
+    convention (``<cwd>/.maverick/runway`` — see
+    ``library/actions/runway.py::_get_store``).
+
+    ``RunwayStore.initialize()`` today only touches the ``episodic/``
+    files; per contracts/decision-records.md, ``decisions.jsonl`` lives
+    directly under the runway root (never inside ``episodic/``, so it
+    survives consolidation pruning) and — like the episodic files — is
+    meant to be touched by ``initialize()`` once the feature lands. This
+    fixture deliberately does NOT pre-create it: its absence after
+    ``initialize()`` is part of the red state the implementing agent
+    closes.
+
+    Uses the module-level ``temp_dir`` fixture (``tests/conftest.py``),
+    which also saves/restores cwd — same convention as sibling CLI tests
+    (e.g. ``tests/unit/cli/test_notify_command.py``).
+    """
+    os.chdir(temp_dir)
+    from maverick.runway.store import RunwayStore
+
+    asyncio.run(RunwayStore(temp_dir / ".maverick" / "runway").initialize())
+    return temp_dir
+
+
+def _decisions_path(cwd: Path) -> Path:
+    return cwd / ".maverick" / "runway" / "decisions.jsonl"
+
+
+def _read_decision_lines(cwd: Path) -> list[dict[str, object]]:
+    """Read ``decisions.jsonl`` as raw dicts (no ``DecisionRecord`` model
+    exists yet — see module docstring)."""
+    path = _decisions_path(cwd)
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _feedback_path(cwd: Path) -> Path:
+    return cwd / ".maverick" / "runway" / "match-feedback.jsonl"
+
+
+def _read_feedback_lines(cwd: Path) -> list[dict[str, object]]:
+    """Read ``match-feedback.jsonl`` as raw dicts (no ``MatchFeedbackRecord``
+    round-trip needed here — same convention as ``_read_decision_lines``)."""
+    path = _feedback_path(cwd)
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _suggestion_state(
+    *,
+    resolution: str = "Per bead — matches existing scoping.",
+    resolution_type: str = "answered",
+    source_entry_id: str = "dea-0",
+) -> dict[str, str]:
+    """Build a ``{KEY_SUGGESTION: <json>}`` state fragment to seed a
+    ``BeadDetails.state`` dict with a stored suggestion — mirrors
+    ``report_entry_from_details``'s ``KEY_SUGGESTION`` parsing (T027
+    consumes ``current_entry.suggestion``, populated this way)."""
+    suggestion = Suggestion(
+        resolution=resolution,
+        resolution_type=resolution_type,
+        source_entry_id=source_entry_id,
+        source_spec="052-conditional-landing",
+        resolved_at="2026-08-01T00:00:00+00:00",
+        confidence=0.9,
+        computed_at="2026-08-01T00:00:00+00:00",
+    )
+    return {KEY_SUGGESTION: suggestion_to_json(suggestion)}
+
+
+class TestAnswerAppendsDecisionRecord:
+    def test_single_answer_appends_one_record(self, project_cwd: Path) -> None:
+        details = _ledger_details(**{KEY_SEVERITY: "medium", KEY_STATUS: STATUS_OPEN})
+        verify, show = _patch_client(details)
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch("maverick.assumptions.ledger.answer", new=AsyncMock()) as mock_answer,
+        ):
+            result = runner.invoke(review, ["dea-1", "--answer", "Per bead."])
+
+        assert result.exit_code == 0, result.output
+        mock_answer.assert_awaited_once()
+
+        lines = _read_decision_lines(project_cwd)
+        assert len(lines) == 1, (
+            "expected exactly one DecisionRecord appended to decisions.jsonl "
+            f"after a successful --answer, found {len(lines)}: {lines}"
+        )
+        record = lines[0]
+        assert record["source_entry_id"] == "dea-1"
+        assert record["resolution_type"] == "answered"
+        assert record["resolution"] == "Per bead."
+
+
+class TestWaiveAppendsDecisionRecord:
+    def test_single_waive_appends_one_record(self, project_cwd: Path) -> None:
+        details = _ledger_details(**{KEY_SEVERITY: "low", KEY_STATUS: STATUS_OPEN})
+        verify, show = _patch_client(details)
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch(
+                "maverick.cli.commands.review._resolve_git_user_name",
+                return_value="alice",
+            ),
+            patch("maverick.assumptions.ledger.waive", new=AsyncMock()) as mock_waive,
+        ):
+            result = runner.invoke(review, ["dea-1", "--waive", "no longer applicable"])
+
+        assert result.exit_code == 0, result.output
+        mock_waive.assert_awaited_once()
+
+        lines = _read_decision_lines(project_cwd)
+        assert len(lines) == 1, (
+            "expected exactly one DecisionRecord appended to decisions.jsonl "
+            f"after a successful --waive, found {len(lines)}: {lines}"
+        )
+        record = lines[0]
+        assert record["source_entry_id"] == "dea-1"
+        assert record["resolution_type"] == "waived"
+        assert record["resolution"] == "no longer applicable"
+        assert record["resolved_by"] == "alice"
+
+
+class TestReAnswerAppendsSecondRecord:
+    def test_re_answering_appends_history_not_overwrite(self, project_cwd: Path) -> None:
+        """Collapse/latest-wins is a read-side concern (data-model.md's
+        "Collapse rule" for DecisionRecord) — the write side must never
+        overwrite; both resolutions of the same entry must be present in
+        the corpus (FR-003)."""
+        details = _ledger_details(**{KEY_SEVERITY: "medium", KEY_STATUS: STATUS_OPEN})
+        runner = CliRunner()
+
+        verify, show = _patch_client(details)
+        with (
+            verify,
+            show,
+            patch("maverick.assumptions.ledger.answer", new=AsyncMock()),
+        ):
+            first = runner.invoke(review, ["dea-1", "--answer", "First answer."])
+        assert first.exit_code == 0, first.output
+
+        verify, show = _patch_client(details)
+        with (
+            verify,
+            show,
+            patch("maverick.assumptions.ledger.answer", new=AsyncMock()),
+        ):
+            second = runner.invoke(review, ["dea-1", "--answer", "Updated answer."])
+        assert second.exit_code == 0, second.output
+
+        lines = _read_decision_lines(project_cwd)
+        assert len(lines) == 2, (
+            "re-answering the same entry must append a SECOND DecisionRecord "
+            f"(history preserved, no overwrite), found {len(lines)}: {lines}"
+        )
+        assert {line["source_entry_id"] for line in lines} == {"dea-1"}
+        assert [line["resolution"] for line in lines] == ["First answer.", "Updated answer."]
+
+
+class TestBulkWaiveAppendsOneRecordPerEntry:
+    def test_bulk_waive_appends_one_record_per_waived_entry(self, project_cwd: Path) -> None:
+        result_obj = BulkWaiveResult(
+            waived=(_waived_record("dea-1", "Q1?"), _waived_record("dea-2", "Q2?")),
+            failed={},
+        )
+        runner = CliRunner()
+        with (
+            patch(
+                "maverick.beads.client.BeadClient.verify_available",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "maverick.cli.commands.review._resolve_git_user_name",
+                return_value="alice",
+            ),
+            patch(
+                "maverick.assumptions.ledger.bulk_waive",
+                new=AsyncMock(return_value=result_obj),
+            ),
+        ):
+            result = runner.invoke(
+                review,
+                ["--spec", "052-conditional-landing", "--waive", "accepted for MVP"],
+            )
+
+        assert result.exit_code == 0, result.output
+
+        lines = _read_decision_lines(project_cwd)
+        assert len(lines) == 2, (
+            "expected one DecisionRecord per successfully-waived entry from "
+            f"bulk waive, found {len(lines)}: {lines}"
+        )
+        assert {line["source_entry_id"] for line in lines} == {"dea-1", "dea-2"}
+        assert all(line["resolution_type"] == "waived" for line in lines)
+        assert all(line["resolution"] == "accepted for MVP" for line in lines)
+
+
+class TestAnswerAppendsMatchFeedbackWhenSuggestionPresent:
+    """T023/T027 (User Story 3): resolving an entry that carried a stored
+    suggestion also appends a ``MatchFeedbackRecord`` alongside the decision
+    record — classified per contracts/decision-records.md's "Decision
+    capture points" rule (accepted iff type + normalized text match)."""
+
+    def test_answer_matching_suggested_answer_appends_accepted_feedback(
+        self, project_cwd: Path
+    ) -> None:
+        details = _ledger_details(
+            **{
+                KEY_SEVERITY: "medium",
+                KEY_STATUS: STATUS_OPEN,
+                **_suggestion_state(
+                    resolution="Per bead — matches existing scoping.",
+                    resolution_type="answered",
+                ),
+            }
+        )
+        verify, show = _patch_client(details)
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch("maverick.assumptions.ledger.answer", new=AsyncMock()) as mock_answer,
+        ):
+            result = runner.invoke(
+                review, ["dea-1", "--answer", "Per bead — matches existing scoping."]
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_answer.assert_awaited_once()
+
+        feedback_lines = _read_feedback_lines(project_cwd)
+        assert len(feedback_lines) == 1, (
+            "expected one MatchFeedbackRecord appended when the resolved "
+            f"entry carried a stored suggestion, found {len(feedback_lines)}: "
+            f"{feedback_lines}"
+        )
+        record = feedback_lines[0]
+        assert record["outcome"] == "accepted"
+        assert record["source_entry_id"] == "dea-0"
+
+    def test_answer_diverging_from_suggested_answer_appends_rejected_feedback(
+        self, project_cwd: Path
+    ) -> None:
+        details = _ledger_details(
+            **{
+                KEY_SEVERITY: "medium",
+                KEY_STATUS: STATUS_OPEN,
+                **_suggestion_state(
+                    resolution="Per bead — matches existing scoping.",
+                    resolution_type="answered",
+                ),
+            }
+        )
+        verify, show = _patch_client(details)
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch("maverick.assumptions.ledger.answer", new=AsyncMock()),
+        ):
+            result = runner.invoke(review, ["dea-1", "--answer", "Something entirely different."])
+
+        assert result.exit_code == 0, result.output
+
+        feedback_lines = _read_feedback_lines(project_cwd)
+        assert len(feedback_lines) == 1
+        assert feedback_lines[0]["outcome"] == "rejected"
+
+
+class TestWaiveAppendsMatchFeedbackWhenSuggestionPresent:
+    def test_waive_matching_suggested_waive_appends_accepted_feedback(
+        self, project_cwd: Path
+    ) -> None:
+        details = _ledger_details(
+            **{
+                KEY_SEVERITY: "low",
+                KEY_STATUS: STATUS_OPEN,
+                **_suggestion_state(resolution="no longer applicable", resolution_type="waived"),
+            }
+        )
+        verify, show = _patch_client(details)
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch(
+                "maverick.cli.commands.review._resolve_git_user_name",
+                return_value="alice",
+            ),
+            patch("maverick.assumptions.ledger.waive", new=AsyncMock()) as mock_waive,
+        ):
+            result = runner.invoke(review, ["dea-1", "--waive", "no longer applicable"])
+
+        assert result.exit_code == 0, result.output
+        mock_waive.assert_awaited_once()
+
+        feedback_lines = _read_feedback_lines(project_cwd)
+        assert len(feedback_lines) == 1
+        assert feedback_lines[0]["outcome"] == "accepted"
+        assert feedback_lines[0]["source_entry_id"] == "dea-0"
+
+    def test_waive_when_suggestion_was_an_answer_appends_rejected_feedback(
+        self, project_cwd: Path
+    ) -> None:
+        """A waive-type resolution never matches an answer-type suggestion,
+        regardless of text — type mismatch always classifies as rejected."""
+        details = _ledger_details(
+            **{
+                KEY_SEVERITY: "low",
+                KEY_STATUS: STATUS_OPEN,
+                **_suggestion_state(
+                    resolution="Per bead — matches existing scoping.",
+                    resolution_type="answered",
+                ),
+            }
+        )
+        verify, show = _patch_client(details)
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch(
+                "maverick.cli.commands.review._resolve_git_user_name",
+                return_value="alice",
+            ),
+            patch("maverick.assumptions.ledger.waive", new=AsyncMock()),
+        ):
+            result = runner.invoke(review, ["dea-1", "--waive", "no longer applicable"])
+
+        assert result.exit_code == 0, result.output
+
+        feedback_lines = _read_feedback_lines(project_cwd)
+        assert len(feedback_lines) == 1
+        assert feedback_lines[0]["outcome"] == "rejected"
+
+
+class TestBulkWaiveAppendsMatchFeedbackPerEntryWithSuggestion:
+    """Bulk waive: each waived entry that carried a stored suggestion gets a
+    feedback record; entries without one don't.
+
+    ``bulk_waive``'s ``BulkWaiveResult.waived`` carries bare
+    ``AssumptionRecord``s (no ``suggestion`` field) — the implementing agent
+    is expected to re-fetch each waived record's pre-waive suggestion state
+    via ``BeadClient.show`` (the same seam ``_project_after_write`` already
+    uses in this module for JSON-mode row projection), so this test mocks
+    ``BeadClient.show`` with a per-bead-id ``side_effect`` rather than the
+    single canned response ``_patch_client`` provides.
+    """
+
+    def test_bulk_waive_appends_feedback_only_for_entries_carrying_a_suggestion(
+        self, project_cwd: Path
+    ) -> None:
+        result_obj = BulkWaiveResult(
+            waived=(
+                _waived_record("dea-1", "Q1?"),
+                _waived_record("dea-2", "Q2?"),
+            ),
+            failed={},
+        )
+
+        details_with_suggestion = _ledger_details(
+            "dea-1",
+            **{
+                KEY_SEVERITY: "low",
+                KEY_STATUS: STATUS_OPEN,
+                **_suggestion_state(resolution="accepted for MVP", resolution_type="waived"),
+            },
+        )
+        details_without_suggestion = _ledger_details(
+            "dea-2", **{KEY_SEVERITY: "low", KEY_STATUS: STATUS_OPEN}
+        )
+
+        async def _show(bead_id: str) -> BeadDetails:
+            if bead_id == "dea-1":
+                return details_with_suggestion
+            return details_without_suggestion
+
+        runner = CliRunner()
+        with (
+            patch(
+                "maverick.beads.client.BeadClient.verify_available",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "maverick.beads.client.BeadClient.show",
+                new=AsyncMock(side_effect=_show),
+            ),
+            patch(
+                "maverick.cli.commands.review._resolve_git_user_name",
+                return_value="alice",
+            ),
+            patch(
+                "maverick.assumptions.ledger.bulk_waive",
+                new=AsyncMock(return_value=result_obj),
+            ),
+        ):
+            result = runner.invoke(
+                review,
+                ["--spec", "052-conditional-landing", "--waive", "accepted for MVP"],
+            )
+
+        assert result.exit_code == 0, result.output
+
+        feedback_lines = _read_feedback_lines(project_cwd)
+        assert len(feedback_lines) == 1, (
+            "expected exactly one MatchFeedbackRecord — only dea-1 carried a "
+            f"stored suggestion — found {len(feedback_lines)}: {feedback_lines}"
+        )
+        assert feedback_lines[0]["source_entry_id"] == "dea-0"
+        assert feedback_lines[0]["outcome"] == "accepted"
+
+        # Both entries still get a DecisionRecord regardless of suggestion
+        # presence — feedback capture is additive, never a substitute.
+        decision_lines = _read_decision_lines(project_cwd)
+        assert {line["source_entry_id"] for line in decision_lines} == {"dea-1", "dea-2"}
+
+
+class TestNoFeedbackWhenNoSuggestionStored:
+    """Regression guard: an entry without a stored suggestion must never
+    produce a feedback record — only the decision record. This already
+    holds given the pre-T027 wiring (no feedback capture exists at all
+    yet); asserted explicitly so it can't silently regress once T027 lands.
+    """
+
+    def test_answer_without_stored_suggestion_appends_no_feedback_record(
+        self, project_cwd: Path
+    ) -> None:
+        details = _ledger_details(**{KEY_SEVERITY: "medium", KEY_STATUS: STATUS_OPEN})
+        verify, show = _patch_client(details)
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch("maverick.assumptions.ledger.answer", new=AsyncMock()),
+        ):
+            result = runner.invoke(review, ["dea-1", "--answer", "Per bead."])
+
+        assert result.exit_code == 0, result.output
+        assert _read_decision_lines(project_cwd), "the decision record must still be appended"
+        feedback_lines = _read_feedback_lines(project_cwd)
+        assert feedback_lines == [], (
+            "no stored suggestion on the entry -> no MatchFeedbackRecord should "
+            f"be appended, found: {feedback_lines}"
+        )
+
+    def test_waive_without_stored_suggestion_appends_no_feedback_record(
+        self, project_cwd: Path
+    ) -> None:
+        details = _ledger_details(**{KEY_SEVERITY: "low", KEY_STATUS: STATUS_OPEN})
+        verify, show = _patch_client(details)
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch(
+                "maverick.cli.commands.review._resolve_git_user_name",
+                return_value="alice",
+            ),
+            patch("maverick.assumptions.ledger.waive", new=AsyncMock()),
+        ):
+            result = runner.invoke(review, ["dea-1", "--waive", "no longer applicable"])
+
+        assert result.exit_code == 0, result.output
+        assert _read_decision_lines(project_cwd), "the decision record must still be appended"
+        feedback_lines = _read_feedback_lines(project_cwd)
+        assert feedback_lines == [], (
+            "no stored suggestion on the entry -> no MatchFeedbackRecord should "
+            f"be appended, found: {feedback_lines}"
+        )
+
+
+class TestDecisionCaptureFailureIsNonBlocking:
+    """FR-004: decision capture is best-effort. A failed write must warn,
+    never block or fail the review action — the ledger write already
+    succeeded and is the source of truth."""
+
+    def test_unwritable_decisions_store_warns_but_answer_still_succeeds(
+        self, project_cwd: Path
+    ) -> None:
+        # Force any future write to decisions.jsonl to fail: make the path
+        # a directory instead of a file, so an `open(path, "a")` raises
+        # IsADirectoryError regardless of how the store implements the append.
+        # `project_cwd`'s initialize() call already touched decisions.jsonl
+        # as an empty file (T007) — remove it first so `mkdir()` can claim
+        # the path.
+        decisions_path = _decisions_path(project_cwd)
+        decisions_path.unlink(missing_ok=True)
+        decisions_path.mkdir(parents=True)
+
+        details = _ledger_details(**{KEY_SEVERITY: "medium", KEY_STATUS: STATUS_OPEN})
+        verify, show = _patch_client(details)
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch("maverick.assumptions.ledger.answer", new=AsyncMock()) as mock_answer,
+        ):
+            result = runner.invoke(review, ["dea-1", "--answer", "Per bead."])
+
+        # The ledger write is the source of truth; a decision-capture
+        # failure must never block or fail the review action itself.
+        assert result.exit_code == 0, result.output
+        mock_answer.assert_awaited_once()
+        assert "Bead dea-1 answered and closed" in result.output
+
+        # ...but it must be visibly reported, not silently swallowed.
+        assert "Warning" in result.output, (
+            "expected a `[yellow]Warning:[/]`-style message when decision "
+            f"capture fails; got output:\n{result.output!r}"
+        )
+
+
+class TestNotifyAutoWaiveExcludedFromCorpus:
+    """FR-005 / research.md R6: the scheduler's auto-waive path is
+    structurally excluded from the decision corpus — ``notify``'s
+    ``_execute_auto_waives`` never touches ``entry_actions.py``'s capture
+    helpers, unlike ``maverick review`` (human surface).
+
+    Unlike the tests above, this one is a *guard*, not a red-state probe:
+    it holds both before and after the capture wiring lands (that's the
+    point — it pins down that the machine path must stay excluded even
+    once decision capture exists elsewhere in the codebase).
+    """
+
+    def test_execute_auto_waives_writes_no_decision_record(self, project_cwd: Path) -> None:
+        from maverick.assumptions.schedule.models import AutoWaiveDecision
+        from maverick.beads.client import BeadClient
+        from maverick.cli.commands.notify import _execute_auto_waives
+
+        decision = AutoWaiveDecision(
+            entry_id="dea-lo",
+            reason_text="auto-waived by schedule policy after 168h: stale, accepted risk",
+        )
+        client = BeadClient(cwd=project_cwd)
+
+        async def _fake_ledger_waive(
+            client: object, *, bead_id: str, reason: str, waived_by: str
+        ) -> None:
+            return None
+
+        with patch("maverick.cli.commands.notify.ledger_waive", new=_fake_ledger_waive):
+            succeeded = asyncio.run(_execute_auto_waives(client=client, decisions=(decision,)))
+
+        assert succeeded == [decision]
+
+        lines = _read_decision_lines(project_cwd)
+        assert lines == [], (
+            "scheduler auto-waive (`waived_by='maverick-scheduler'`) must never "
+            f"write to the human decision corpus (FR-005); found: {lines}"
+        )
+
+
+class TestAlreadyResolvedBypassForAutoResolvedEntries:
+    """T029 (User Story 4, FR-020): ``maverick review <id> --answer`` on an
+    entry the auto-resolution policy already waived
+    (``assumption_auto_resolved=true``) bypasses the ``ALREADY_RESOLVED``
+    pre-check (``entry_actions.py``'s ``_review_ledger_entry``, ~line 226)
+    and proceeds to answer normally. A plain human-waived entry
+    (``auto_resolved`` false/absent) must still be refused — asserted here
+    as a companion regression guard.
+
+    Not yet implemented as of this task: the pre-check currently refuses
+    *any* ``STATUS_WAIVED`` entry regardless of ``KEY_AUTO_RESOLVED`` — the
+    bypass test below fails today because the refusal still fires (exit
+    code != 0, ``ledger.answer`` never called) rather than proceeding.
+    """
+
+    def test_answer_bypasses_refusal_when_entry_was_auto_resolved(self, project_cwd: Path) -> None:
+        from maverick.assumptions.models import KEY_AUTO_RESOLVED
+
+        details = _ledger_details(
+            **{
+                KEY_SEVERITY: "low",
+                KEY_STATUS: "waived",
+                KEY_AUTO_RESOLVED: "true",
+                **_suggestion_state(
+                    resolution="Per bead — matches existing scoping.",
+                    resolution_type="answered",
+                ),
+            }
+        )
+        verify, show = _patch_client(details)
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch("maverick.assumptions.ledger.answer", new=AsyncMock()) as mock_answer,
+        ):
+            result = runner.invoke(
+                review, ["dea-1", "--answer", "Per bead — matches existing scoping."]
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_answer.assert_awaited_once()
+        assert "already waived" not in result.output.lower()
+        assert "Bead dea-1 answered and closed" in result.output
+
+    def test_answer_still_refused_when_entry_was_human_waived(self, project_cwd: Path) -> None:
+        """Regression guard: a plain human-waived entry (no
+        ``assumption_auto_resolved``) keeps the existing already-resolved
+        refusal — the bypass above must be scoped to auto-resolved entries
+        only, never to waived entries generally."""
+        details = _ledger_details(**{KEY_SEVERITY: "low", KEY_STATUS: "waived"})
+        verify, show = _patch_client(details)
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch("maverick.assumptions.ledger.answer", new=AsyncMock()) as mock_answer,
+        ):
+            result = runner.invoke(review, ["dea-1", "--answer", "Per bead."])
+
+        assert result.exit_code != 0
+        mock_answer.assert_not_awaited()
+        assert "already waived" in result.output.lower()
+
+
+class TestHumanOverrideClearsAutoResolvedStamp:
+    """A human resolving an auto-resolved entry takes ownership of it, so
+    ``assumption_auto_resolved`` must come back off the bead.
+
+    Two things break if the stamp survives: reports keep annotating a
+    human-resolved row ``auto-resolved`` (misattributing the decision), and
+    the already-resolved refusal — which the stamp deliberately bypasses —
+    stays disabled forever, so the entry can be silently re-resolved any
+    number of times.
+    """
+
+    def _auto_resolved_details(self):  # noqa: ANN202
+        from maverick.assumptions.models import KEY_AUTO_RESOLVED
+
+        return _ledger_details(
+            **{
+                KEY_SEVERITY: "low",
+                KEY_STATUS: "waived",
+                KEY_AUTO_RESOLVED: "true",
+                **_suggestion_state(
+                    resolution="Per bead — matches existing scoping.",
+                    resolution_type="answered",
+                ),
+            }
+        )
+
+    def test_answer_unstamps_auto_resolved(self, project_cwd: Path) -> None:
+        from maverick.assumptions.models import KEY_AUTO_RESOLVED
+
+        verify, show = _patch_client(self._auto_resolved_details())
+        mock_set_state = AsyncMock()
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch("maverick.assumptions.ledger.answer", new=AsyncMock()),
+            patch("maverick.beads.client.BeadClient.set_state", new=mock_set_state),
+        ):
+            result = runner.invoke(review, ["dea-1", "--answer", "A different answer entirely."])
+
+        assert result.exit_code == 0, result.output
+        written: dict[str, str] = {}
+        for call in mock_set_state.await_args_list:
+            state = call.args[1] if len(call.args) > 1 else call.kwargs.get("state", {})
+            written.update(state)
+        # "false", not cleared: bd rejects empty state values, and readers
+        # compare against "true".
+        assert written.get(KEY_AUTO_RESOLVED) == "false"
+
+    def test_human_waive_of_non_auto_resolved_entry_never_writes_the_key(
+        self, project_cwd: Path
+    ) -> None:
+        """Scoped to overrides — an ordinary open entry's resolution must
+        not start stamping ``assumption_auto_resolved`` at all."""
+        from maverick.assumptions.models import KEY_AUTO_RESOLVED
+
+        verify, show = _patch_client(_ledger_details(**{KEY_SEVERITY: "low"}))
+        mock_set_state = AsyncMock()
+        runner = CliRunner()
+        with (
+            verify,
+            show,
+            patch("maverick.assumptions.ledger.waive", new=AsyncMock()),
+            patch("maverick.beads.client.BeadClient.set_state", new=mock_set_state),
+        ):
+            result = runner.invoke(review, ["dea-1", "--waive", "Accepted risk."])
+
+        assert result.exit_code == 0, result.output
+        for call in mock_set_state.await_args_list:
+            state = call.args[1] if len(call.args) > 1 else call.kwargs.get("state", {})
+            assert KEY_AUTO_RESOLVED not in state

--- a/tests/unit/cli/commands/review/test_listing_backfill.py
+++ b/tests/unit/cli/commands/review/test_listing_backfill.py
@@ -1,0 +1,352 @@
+"""Failing tests for the ``run_list`` suggestion back-fill wiring (T013,
+User Story 2, 055-learned-assumption-resolution).
+
+Contract:
+``specs/055-learned-assumption-resolution/contracts/entry-row-suggestion.md``
+("``maverick review --list [--json]``") — before building rows, ``run_list``
+back-fills suggestions for entries that have none stored: load the runway
+corpus once (not per-entry), evaluate, persist hits. Store unavailable
+degrades to a silent skip (debug log only, no warning to the user). JSON
+payload shape is unchanged otherwise (rows carry the new ``suggestion`` /
+``auto_resolved`` keys). The human table marks suggestion-carrying entries
+with a ``suggested`` marker; no new columns.
+
+This module tests the CALL-SITE wiring in
+``src/maverick/cli/commands/review/listing.py`` only — not
+``backfill_suggestions``'s own internals (that's
+``tests/unit/assumptions/test_suggestions.py``, a sibling T011 task), and not
+``entry_to_dict``'s projection logic in isolation (that's
+``tests/unit/assumptions/test_suggestion_projection.py``, T012).
+
+**RED-STATE MARKER**: at the time this module was written,
+``src/maverick/assumptions/suggestions.py`` has no ``backfill_suggestions``
+function, and ``AssumptionReportEntry`` (``src/maverick/assumptions/
+models.py``) has no ``suggestion`` field. Every test here is expected to FAIL
+until:
+
+* T016 (parallel task) wires a module-level
+  ``from maverick.assumptions.suggestions import backfill_suggestions``
+  import into ``listing.py`` and calls it from ``run_list`` before
+  ``_filter_and_sort`` — assumed signature
+  ``backfill_suggestions(client, store, entries) -> list[AssumptionReportEntry]``
+  per research.md R5 (async; loads corpus once; persists hits; never
+  replaces an existing stored suggestion; silently no-ops when the runway
+  store is uninitialized).
+* T015 adds ``AssumptionReportEntry.suggestion`` / ``.auto_resolved``.
+* T017 extends ``entry_to_dict`` with the ``suggestion`` / ``auto_resolved``
+  keys.
+* A parallel listing change teaches ``_render_table`` to mark
+  suggestion-carrying rows.
+
+Do not "fix" these tests by loosening the assertions — later tasks close
+the gaps these tests pin down.
+
+Mirrors the mocking style of ``tests/unit/cli/commands/test_review_listing.py``
+(053-assumption-review-console): patch ``BeadClient.verify_available`` and
+``maverick.assumptions.ledger.report_entries``, drive everything through the
+``review`` Click command via ``CliRunner`` (never real ``bd``).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, patch
+
+from click.testing import CliRunner
+
+from maverick.assumptions.models import (
+    STATUS_ANSWERED,
+    STATUS_OPEN,
+    STATUS_WAIVED,
+    AssumptionRecord,
+    AssumptionReportEntry,
+    Severity,
+)
+from maverick.cli.commands.review import review
+
+#: Import path the tests patch. ``listing.py`` imports
+#: ``backfill_suggestions`` function-locally (every other maverick import in
+#: that module is deferred too, to keep Click command registration cheap),
+#: so the definition site is the only stable patch target — there is no
+#: module-level name in ``listing`` to look up.
+_BACKFILL_PATCH_TARGET = "maverick.assumptions.suggestions.backfill_suggestions"
+
+
+@dataclass(frozen=True)
+class _FakeSuggestion:
+    """Stand-in for the not-yet-existing ``Suggestion`` dataclass (T015).
+
+    Shape mirrors ``contracts/entry-row-suggestion.md``'s example object,
+    but this module intentionally does NOT import the real ``Suggestion``
+    class — that class doesn't exist yet, and importing it at module scope
+    would turn every test here into a collection error instead of a clean
+    per-test failure. Only truthiness / attribute presence matters for
+    these call-site tests.
+    """
+
+    resolution: str = "Yes — AsyncRetrying, 3 attempts"
+    resolution_type: str = "answered"
+    source_entry_id: str = "dea-old"
+    source_spec: str = "052-conditional-landing"
+    resolved_at: str = "2026-08-06T14:03:22+00:00"
+    confidence: float = 0.87
+    computed_at: str = "2026-08-07T10:11:12+00:00"
+
+
+def _entry(
+    bead_id: str,
+    *,
+    owner_spec: str,
+    severity: Severity,
+    status: str = STATUS_OPEN,
+    question: str = "Q?",
+    suggestion: object | None = None,
+) -> AssumptionReportEntry:
+    record = AssumptionRecord(
+        bead_id=bead_id,
+        question=question,
+        adopted_answer="A.",
+        alternatives=(),
+        severity=severity,
+        severity_defaulted=False,
+        status=status,
+        owner_spec=owner_spec,
+        source_bead="src-1",
+        change_ids=(),
+        is_legacy=False,
+    )
+    kwargs: dict[str, object] = {
+        "record": record,
+        "final_answer": "A." if status == STATUS_ANSWERED else None,
+        "waived_by": "alice" if status == STATUS_WAIVED else None,
+        "waived_at": "2026-01-01T00:00:00+00:00" if status == STATUS_WAIVED else None,
+        "waive_reason": "n/a" if status == STATUS_WAIVED else None,
+        "reconcile_status": None,
+        "reconciled_answer": None,
+        "reconcile_change_id": None,
+        "reconcile_reason": None,
+        "pending_reconcile": False,
+    }
+    if suggestion is not None:
+        # `AssumptionReportEntry` has no `suggestion` field until T015 —
+        # this is expected to raise `TypeError: unexpected keyword
+        # argument 'suggestion'` until then. That's the intended red
+        # state for tests that pass `suggestion=...`.
+        kwargs["suggestion"] = suggestion
+    return AssumptionReportEntry(**kwargs)  # type: ignore[arg-type]
+
+
+def _patched(
+    entries: tuple[AssumptionReportEntry, ...],
+    *,
+    available: bool = True,
+    backfill_mock: AsyncMock | None = None,
+):
+    """Same trio of patches as ``test_review_listing.py``'s ``_patched``,
+    plus a patch for the new ``backfill_suggestions`` call site.
+
+    *backfill_mock*, when omitted, defaults to an identity no-op
+    (``AsyncMock(return_value=entries)``) — the "store unavailable" /
+    "nothing to back-fill" behavior, since this module tests wiring, not
+    ``backfill_suggestions``'s own degradation logic.
+    """
+    mock = backfill_mock if backfill_mock is not None else AsyncMock(return_value=entries)
+    return (
+        patch(
+            "maverick.beads.client.BeadClient.verify_available",
+            new=AsyncMock(return_value=available),
+        ),
+        patch(
+            "maverick.assumptions.ledger.report_entries",
+            new=AsyncMock(return_value=entries),
+        ),
+        patch(_BACKFILL_PATCH_TARGET, new=mock),
+        mock,
+    )
+
+
+class TestBackfillScopedToOpenSelection:
+    def test_backfill_skips_entries_the_listing_dropped(self) -> None:
+        """``run_list`` must back-fill only the OPEN entries it is about to
+        render, never the whole ``report_entries`` sweep.
+
+        Back-fill is a write path — it persists each hit with a
+        ``bd set-state`` call. ``review --list`` is a read verb the
+        ``maverick-review`` skill runs on every sweep, and an
+        answered/waived entry will never be reviewed again, so evaluating
+        rows the caller filtered out would write suggestions onto closed
+        beads for no one's benefit.
+        """
+        entries = (
+            _entry("dea-1", owner_spec="049-spec", severity=Severity.HIGH, status=STATUS_OPEN),
+            _entry(
+                "dea-2", owner_spec="049-spec", severity=Severity.MEDIUM, status=STATUS_ANSWERED
+            ),
+            _entry("dea-3", owner_spec="049-spec", severity=Severity.LOW, status=STATUS_WAIVED),
+        )
+        verify, sweep, backfill_patch, mock_backfill = _patched(entries)
+        runner = CliRunner()
+        with verify, sweep, backfill_patch:
+            result = runner.invoke(review, ["--list", "--json"])
+
+        assert result.exit_code == 0, result.output
+        mock_backfill.assert_awaited_once()
+
+        call_args, call_kwargs = mock_backfill.call_args
+        candidates = list(call_args) + list(call_kwargs.values())
+        entries_arg = next((c for c in candidates if isinstance(c, (list, tuple))), None)
+        assert entries_arg is not None, (
+            f"expected a list/tuple of entries among backfill_suggestions's call "
+            f"args, got args={call_args!r} kwargs={call_kwargs!r}"
+        )
+        passed_ids = {e.record.bead_id for e in entries_arg}
+        # Only the open entry — the answered/waived pair the default status
+        # filter drops must never reach the write path.
+        assert passed_ids == {"dea-1"}
+
+        data = json.loads(result.output)
+        ids = [row["bead_id"] for row in data["result"]["entries"]]
+        assert ids == ["dea-1"]
+
+    def test_backfill_not_called_when_selection_is_all_closed(self) -> None:
+        """An explicitly answered/waived-only listing does zero writes."""
+        entries = (
+            _entry(
+                "dea-2", owner_spec="049-spec", severity=Severity.MEDIUM, status=STATUS_ANSWERED
+            ),
+            _entry("dea-3", owner_spec="049-spec", severity=Severity.LOW, status=STATUS_WAIVED),
+        )
+        verify, sweep, backfill_patch, mock_backfill = _patched(entries)
+        runner = CliRunner()
+        with verify, sweep, backfill_patch:
+            result = runner.invoke(
+                review, ["--list", "--status", "answered", "--status", "waived", "--json"]
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_backfill.assert_not_awaited()
+
+        data = json.loads(result.output)
+        ids = sorted(row["bead_id"] for row in data["result"]["entries"])
+        assert ids == ["dea-2", "dea-3"]
+
+
+class TestBackfillLoadedOncePerListing:
+    def test_backfill_invoked_exactly_once_regardless_of_entry_count(self) -> None:
+        """Corpus load is a per-listing-call concern, not per-entry — the
+        call-site contract is that ``run_list`` calls
+        ``backfill_suggestions`` exactly once per invocation, however many
+        entries ``report_entries`` returns."""
+        entries = tuple(
+            _entry(f"dea-{i}", owner_spec="049-spec", severity=Severity.MEDIUM) for i in range(5)
+        )
+        verify, sweep, backfill_patch, mock_backfill = _patched(entries)
+        runner = CliRunner()
+        with verify, sweep, backfill_patch:
+            result = runner.invoke(review, ["--list", "--json"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_backfill.await_count == 1
+
+
+class TestStoreUnavailableSkipsSilently:
+    """FR-021 / research R11: a missing/uninitialized runway store degrades
+    to a debug-logged no-op — never a warning surfaced to the user, and
+    never a failed command. Modeled here by a ``backfill_suggestions`` mock
+    that behaves as the real function would when the store is unavailable:
+    it returns the entries unchanged.
+    """
+
+    def test_json_mode_completes_normally(self) -> None:
+        entries = (
+            _entry("dea-1", owner_spec="049-spec", severity=Severity.HIGH, status=STATUS_OPEN),
+        )
+        verify, sweep, backfill_patch, mock_backfill = _patched(entries)
+        runner = CliRunner()
+        with verify, sweep, backfill_patch:
+            result = runner.invoke(review, ["--list", "--json"])
+
+        assert result.exit_code == 0, result.output
+        mock_backfill.assert_awaited_once()
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert "warning" not in result.output.lower()
+
+    def test_human_mode_completes_normally_without_warning(self) -> None:
+        entries = (
+            _entry("dea-1", owner_spec="049-spec", severity=Severity.HIGH, status=STATUS_OPEN),
+        )
+        verify, sweep, backfill_patch, mock_backfill = _patched(entries)
+        runner = CliRunner()
+        with verify, sweep, backfill_patch:
+            result = runner.invoke(review, ["--list"])
+
+        assert result.exit_code == 0, result.output
+        mock_backfill.assert_awaited_once()
+        assert "dea-1" in result.output
+        assert "warning" not in result.output.lower()
+
+
+class TestHumanTableMarksSuggestedEntries:
+    """Contract: "Human table: entries with a suggestion show a `suggested`
+    marker; no new columns beyond that." Constructing an entry with a
+    non-None ``suggestion`` requires the not-yet-existing field from T015
+    — this is the documented red state (see module docstring).
+    """
+
+    def test_entry_with_suggestion_shows_marker(self) -> None:
+        entries = (
+            _entry(
+                "dea-1",
+                owner_spec="049-spec",
+                severity=Severity.HIGH,
+                status=STATUS_OPEN,
+                suggestion=_FakeSuggestion(),
+            ),
+        )
+        verify, sweep, backfill_patch, _mock_backfill = _patched(entries)
+        runner = CliRunner()
+        with verify, sweep, backfill_patch:
+            result = runner.invoke(review, ["--list"])
+
+        assert result.exit_code == 0, result.output
+        assert "suggested" in result.output.lower()
+
+    def test_entry_without_suggestion_has_no_marker(self) -> None:
+        entries = (
+            _entry("dea-1", owner_spec="049-spec", severity=Severity.HIGH, status=STATUS_OPEN),
+        )
+        verify, sweep, backfill_patch, _mock_backfill = _patched(entries)
+        runner = CliRunner()
+        with verify, sweep, backfill_patch:
+            result = runner.invoke(review, ["--list"])
+
+        assert result.exit_code == 0, result.output
+        assert "suggested" not in result.output.lower()
+
+
+class TestJsonRowsCarrySuggestionKeys:
+    """End-to-end through ``run_list`` — the projection function itself is
+    covered by ``tests/unit/assumptions/test_suggestion_projection.py``
+    (T012); this pins down that the listing command surface actually
+    delivers the new keys to the caller.
+    """
+
+    def test_rows_carry_suggestion_and_auto_resolved_keys(self) -> None:
+        entries = (
+            _entry("dea-1", owner_spec="049-spec", severity=Severity.HIGH, status=STATUS_OPEN),
+            _entry("dea-2", owner_spec="049-spec", severity=Severity.MEDIUM, status=STATUS_OPEN),
+        )
+        verify, sweep, backfill_patch, _mock_backfill = _patched(entries)
+        runner = CliRunner()
+        with verify, sweep, backfill_patch:
+            result = runner.invoke(review, ["--list", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        rows = data["result"]["entries"]
+        assert rows, "expected at least one row in the JSON envelope"
+        for row in rows:
+            assert "suggestion" in row, f"row missing 'suggestion' key: {row!r}"
+            assert "auto_resolved" in row, f"row missing 'auto_resolved' key: {row!r}"

--- a/tests/unit/cli/commands/test_review_listing.py
+++ b/tests/unit/cli/commands/test_review_listing.py
@@ -34,6 +34,8 @@ def _entry(
     pending_reconcile: bool = False,
     question: str = "Q?",
     created_at: str | None = None,
+    waived_by: str = "alice",
+    auto_resolved: bool = False,
 ) -> AssumptionReportEntry:
     record = AssumptionRecord(
         bead_id=bead_id,
@@ -52,7 +54,7 @@ def _entry(
     return AssumptionReportEntry(
         record=record,
         final_answer="A." if status == STATUS_ANSWERED else None,
-        waived_by="alice" if status == STATUS_WAIVED else None,
+        waived_by=waived_by if status == STATUS_WAIVED else None,
         waived_at="2026-01-01T00:00:00+00:00" if status == STATUS_WAIVED else None,
         waive_reason="n/a" if status == STATUS_WAIVED else None,
         reconcile_status=None,
@@ -60,6 +62,7 @@ def _entry(
         reconcile_change_id=None,
         reconcile_reason=None,
         pending_reconcile=pending_reconcile,
+        auto_resolved=auto_resolved,
     )
 
 
@@ -208,6 +211,35 @@ class TestCounts:
         assert counts["by_status"] == {"open": 2, "answered": 1, "waived": 0}
         assert counts["by_severity"] == {"low": 1, "medium": 1, "high": 1}
         assert counts["pending_reconcile"] == 1
+
+    def test_auto_resolved_entry_counts_in_waived_bucket(self) -> None:
+        """055 T030 regression/proof: an auto-resolved entry
+        (``waived_by="maverick-resolver"``, ``auto_resolved=True``) counts
+        in the "waived" bucket in `_build_counts` exactly like any human
+        waive — no special-casing needed, since counting keys off
+        ``entry.record.status`` (equivalently ``entry.bucket``), which is
+        ``STATUS_WAIVED`` regardless of who waived it."""
+        entries = (
+            _entry(
+                "dea-1",
+                owner_spec="055-spec",
+                severity=Severity.LOW,
+                status=STATUS_WAIVED,
+                waived_by="maverick-resolver",
+                auto_resolved=True,
+            ),
+        )
+        verify, sweep = _patched(entries)
+        runner = CliRunner()
+        with verify, sweep:
+            result = runner.invoke(review, ["--list", "--status", "waived", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        counts = data["result"]["counts"]
+        assert counts["by_status"]["waived"] == 1
+        row = data["result"]["entries"][0]
+        assert row["bucket"] == "waived"
+        assert row["auto_resolved"] is True
 
 
 class TestCreatedAt:

--- a/tests/unit/config/test_assumptions_schedule_config.py
+++ b/tests/unit/config/test_assumptions_schedule_config.py
@@ -1,11 +1,16 @@
-"""Tests for the ``assumptions.schedule`` config block.
+"""Tests for the ``assumptions.schedule`` and ``assumptions.resolution`` config blocks.
 
 See specs/054-assumption-batch-scheduler/data-model.md section 2 and
 specs/054-assumption-batch-scheduler/contracts/config-schema.md for the
-full contract. ``assumptions.schedule`` is the delivery-policy block for
-``maverick notify``; the ntfy endpoint itself continues to come from the
-existing ``NotificationConfig`` (``notifications:`` block) — deliberately
-not duplicated here.
+full ``schedule`` contract. ``assumptions.schedule`` is the delivery-policy
+block for ``maverick notify``; the ntfy endpoint itself continues to come
+from the existing ``NotificationConfig`` (``notifications:`` block) —
+deliberately not duplicated here.
+
+``assumptions.resolution`` (spec 055-learned-assumption-resolution) is a
+sibling block gating auto-resolution of low-severity assumption entries;
+see specs/055-learned-assumption-resolution/contracts/config-schema.md and
+data-model.md's "Config" section for its full contract.
 """
 
 from __future__ import annotations
@@ -16,14 +21,18 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from maverick.assumptions import matching
 from maverick.config import (
+    AssumptionResolutionConfig,
     AssumptionScheduleConfig,
     AssumptionsConfig,
+    AutoResolvePolicyConfig,
     AutoWaivePolicyConfig,
     MaverickConfig,
     QuietHoursConfig,
     load_config,
 )
+from maverick.exceptions import ConfigError
 
 
 class TestAssumptionsConfigDefaults:
@@ -33,10 +42,16 @@ class TestAssumptionsConfigDefaults:
         config = AssumptionsConfig()
         assert config.schedule is None
 
+    def test_resolution_defaults_to_none(self) -> None:
+        """New (055): ``resolution`` absent means auto-resolution is inert."""
+        config = AssumptionsConfig()
+        assert config.resolution is None
+
     def test_maverick_config_wires_assumptions_with_default_factory(self) -> None:
         config = MaverickConfig()
         assert isinstance(config.assumptions, AssumptionsConfig)
         assert config.assumptions.schedule is None
+        assert config.assumptions.resolution is None
 
     def test_maverick_config_assumptions_instances_are_independent(self) -> None:
         """``default_factory`` must not share mutable state across instances."""
@@ -241,6 +256,105 @@ class TestAutoWaivePolicyConfig:
             )
 
 
+class TestAutoResolvePolicyConfig:
+    """``assumptions.resolution.auto_resolve_low`` (055): double opt-in.
+
+    ``enabled`` defaults to ``False`` and ``confidence_threshold`` defaults
+    to ``0.9``, bounded ``[0.75, 1.0]``. The lower bound is pinned to
+    ``matching.PRESENTATION_THRESHOLD`` — "auto must be at least as strict
+    as presentation" (clarify Q3) — see research.md R8.
+    """
+
+    def test_defaults(self) -> None:
+        policy = AutoResolvePolicyConfig()
+        assert policy.enabled is False
+        assert policy.confidence_threshold == 0.9
+
+    def test_enabled_override(self) -> None:
+        policy = AutoResolvePolicyConfig(enabled=True)
+        assert policy.enabled is True
+        # confidence_threshold keeps its default even when enabled is overridden.
+        assert policy.confidence_threshold == 0.9
+
+    def test_confidence_threshold_override(self) -> None:
+        policy = AutoResolvePolicyConfig(confidence_threshold=0.92)
+        assert policy.confidence_threshold == 0.92
+
+    def test_confidence_threshold_below_lower_bound_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AutoResolvePolicyConfig(confidence_threshold=0.5)
+
+    def test_confidence_threshold_lower_boundary_accepted(self) -> None:
+        policy = AutoResolvePolicyConfig(confidence_threshold=0.75)
+        assert policy.confidence_threshold == 0.75
+
+    def test_confidence_threshold_upper_boundary_accepted(self) -> None:
+        policy = AutoResolvePolicyConfig(confidence_threshold=1.0)
+        assert policy.confidence_threshold == 1.0
+
+    def test_confidence_threshold_above_upper_bound_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AutoResolvePolicyConfig(confidence_threshold=1.1)
+
+    def test_confidence_threshold_lower_bound_pinned_to_presentation_threshold(self) -> None:
+        """Drift-pin (research.md R8): the ``ge`` bound must equal
+        ``matching.PRESENTATION_THRESHOLD`` exactly — not merely near it.
+
+        Two-sided check: the constant's own value must be accepted (proves
+        the lower bound is not *stricter* than the constant), and one cent
+        below it must be rejected (proves the lower bound is not *looser*
+        than the constant). Together these pin ``ge=`` to the constant
+        without introspecting Pydantic's internal constraint metadata.
+        """
+        # At-the-constant value is accepted (bound is not stricter than 0.75).
+        policy = AutoResolvePolicyConfig(confidence_threshold=matching.PRESENTATION_THRESHOLD)
+        assert policy.confidence_threshold == matching.PRESENTATION_THRESHOLD
+
+        # Just below the constant is rejected (bound is not looser than 0.75).
+        with pytest.raises(ValidationError):
+            AutoResolvePolicyConfig(confidence_threshold=matching.PRESENTATION_THRESHOLD - 0.01)
+
+
+class TestAssumptionResolutionConfig:
+    """``assumptions.resolution``: ``auto_resolve_low`` absent by default."""
+
+    def test_auto_resolve_low_defaults_to_none(self) -> None:
+        config = AssumptionResolutionConfig()
+        assert config.auto_resolve_low is None
+
+    def test_auto_resolve_low_wired(self) -> None:
+        config = AssumptionResolutionConfig(
+            auto_resolve_low=AutoResolvePolicyConfig(enabled=True, confidence_threshold=0.92)
+        )
+        assert config.auto_resolve_low is not None
+        assert config.auto_resolve_low.enabled is True
+        assert config.auto_resolve_low.confidence_threshold == 0.92
+
+    def test_auto_resolve_low_invalid_threshold_rejected_via_resolution(self) -> None:
+        with pytest.raises(ValidationError):
+            AssumptionResolutionConfig(auto_resolve_low={"confidence_threshold": 0.5})
+
+    def test_resolution_wired_on_assumptions_config(self) -> None:
+        config = AssumptionsConfig(
+            resolution=AssumptionResolutionConfig(
+                auto_resolve_low=AutoResolvePolicyConfig(enabled=True)
+            )
+        )
+        assert config.resolution is not None
+        assert config.resolution.auto_resolve_low is not None
+        assert config.resolution.auto_resolve_low.enabled is True
+
+    def test_schedule_and_resolution_independent(self) -> None:
+        """Sibling blocks: setting one leaves the other at its own default."""
+        config = AssumptionsConfig(
+            resolution=AssumptionResolutionConfig(
+                auto_resolve_low=AutoResolvePolicyConfig(enabled=True)
+            )
+        )
+        assert config.schedule is None
+        assert config.resolution is not None
+
+
 class TestYamlAndEnvOverrides:
     """Loading through ``load_config`` / env-var precedence."""
 
@@ -297,6 +411,108 @@ notifications:
 
         config = load_config()
         assert config.assumptions.schedule is None
+
+    def test_yaml_full_resolution_round_trips(self, clean_env: None, temp_dir: Path) -> None:
+        os.chdir(temp_dir)
+        config_path = temp_dir / "maverick.yaml"
+        config_path.write_text(
+            """
+assumptions:
+  resolution:
+    auto_resolve_low:
+      enabled: true
+      confidence_threshold: 0.92
+"""
+        )
+
+        config = load_config()
+        resolution = config.assumptions.resolution
+        assert resolution is not None
+        assert resolution.auto_resolve_low is not None
+        assert resolution.auto_resolve_low.enabled is True
+        assert resolution.auto_resolve_low.confidence_threshold == 0.92
+
+    def test_yaml_absent_resolution_stays_none(self, clean_env: None, temp_dir: Path) -> None:
+        """Absent ``assumptions.resolution`` block ⇒ ``config.assumptions.resolution is None``.
+
+        Suggestions remain fully functional (they require no config);
+        only auto-resolution is inert.
+        """
+        os.chdir(temp_dir)
+        config_path = temp_dir / "maverick.yaml"
+        config_path.write_text(
+            """
+notifications:
+  enabled: false
+"""
+        )
+
+        config = load_config()
+        assert config.assumptions.resolution is None
+
+    def test_yaml_resolution_block_present_auto_resolve_low_absent_stays_none(
+        self, clean_env: None, temp_dir: Path
+    ) -> None:
+        """Block present but ``auto_resolve_low`` omitted behaves like absent."""
+        os.chdir(temp_dir)
+        config_path = temp_dir / "maverick.yaml"
+        config_path.write_text(
+            """
+assumptions:
+  resolution: {}
+"""
+        )
+
+        config = load_config()
+        resolution = config.assumptions.resolution
+        assert resolution is not None
+        assert resolution.auto_resolve_low is None
+
+    def test_yaml_invalid_confidence_threshold_fails_config_load(
+        self, clean_env: None, temp_dir: Path
+    ) -> None:
+        """FR-016: violating the ``confidence_threshold`` bounds fails config load.
+
+        ``load_config`` wraps every Pydantic ``ValidationError`` into a
+        ``ConfigError`` at the CLI boundary (see
+        ``tests/unit/test_config.py::test_invalid_config_raises_config_error``
+        for the established, codebase-wide contract) — this block is no
+        exception.
+        """
+        os.chdir(temp_dir)
+        config_path = temp_dir / "maverick.yaml"
+        config_path.write_text(
+            """
+assumptions:
+  resolution:
+    auto_resolve_low:
+      enabled: true
+      confidence_threshold: 0.5
+"""
+        )
+
+        with pytest.raises(ConfigError):
+            load_config()
+
+    def test_env_override_auto_resolve_low_enabled(
+        self, clean_env: None, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        os.chdir(temp_dir)
+        config_path = temp_dir / "maverick.yaml"
+        config_path.write_text(
+            """
+assumptions:
+  resolution:
+    auto_resolve_low:
+      enabled: false
+"""
+        )
+        monkeypatch.setenv("MAVERICK_ASSUMPTIONS__RESOLUTION__AUTO_RESOLVE_LOW__ENABLED", "true")
+
+        config = load_config()
+        assert config.assumptions.resolution is not None
+        assert config.assumptions.resolution.auto_resolve_low is not None
+        assert config.assumptions.resolution.auto_resolve_low.enabled is True
 
     def test_env_override_min_batch_size(
         self, clean_env: None, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
@@ -364,6 +580,8 @@ class TestExports:
             "AssumptionScheduleConfig",
             "QuietHoursConfig",
             "AutoWaivePolicyConfig",
+            "AssumptionResolutionConfig",
+            "AutoResolvePolicyConfig",
         ):
             assert name in config_module.__all__
             assert hasattr(config_module, name)

--- a/tests/unit/runway/test_store_decisions.py
+++ b/tests/unit/runway/test_store_decisions.py
@@ -1,0 +1,507 @@
+"""Tests for DecisionRecord storage on RunwayStore (spec 055, US1, T004).
+
+Covers:
+- DecisionRecord to_dict/from_dict round-trip.
+- RunwayStore.append_decision / get_decisions (append-only, filterable).
+- RunwayStore.initialize() touching both decisions.jsonl and
+  match-feedback.jsonl at the store root (NOT under episodic/).
+- Malformed JSONL lines in decisions.jsonl are skipped, not raised.
+- Regression: consolidate_runway() never touches decisions.jsonl or
+  match-feedback.jsonl (outside episodic/ by design, never pruned).
+
+These tests are expected to FAIL right now: DecisionRecord does not yet
+exist in maverick.runway.models, and append_decision/get_decisions do not
+yet exist on RunwayStore. Production code lands in a follow-up change.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from maverick.runway.models import DecisionRecord, MatchFeedbackRecord
+from maverick.runway.store import RunwayStore
+
+pytestmark = pytest.mark.asyncio
+
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+def _make_decision(
+    *,
+    source_entry_id: str = "mv-142",
+    question: str = "Should retries use exponential backoff?",
+    normalized_question: str = "should retries use exponential backoff",
+    adopted_answer: str = "Yes, tenacity default",
+    resolution_type: str = "answered",
+    resolution: str = "Yes — AsyncRetrying, 3 attempts",
+    severity: str = "medium",
+    owner_spec: str = "052-conditional-landing",
+    resolved_by: str = "Paul O'Fallon",
+    resolved_at: str = "2026-08-06T14:03:22+00:00",
+) -> DecisionRecord:
+    return DecisionRecord(
+        source_entry_id=source_entry_id,
+        question=question,
+        normalized_question=normalized_question,
+        adopted_answer=adopted_answer,
+        resolution_type=resolution_type,
+        resolution=resolution,
+        severity=severity,
+        owner_spec=owner_spec,
+        resolved_by=resolved_by,
+        resolved_at=resolved_at,
+    )
+
+
+@pytest.fixture
+def sample_decision_record() -> DecisionRecord:
+    """A DecisionRecord matching the example line in
+    specs/055-learned-assumption-resolution/contracts/decision-records.md.
+    """
+    return _make_decision()
+
+
+def _make_match_feedback(
+    *,
+    normalized_question: str = "should retries use exponential backoff",
+    source_entry_id: str = "mv-142",
+    outcome: str = "rejected",
+    recorded_at: str = "2026-08-07T09:15:02+00:00",
+) -> MatchFeedbackRecord:
+    return MatchFeedbackRecord(
+        normalized_question=normalized_question,
+        source_entry_id=source_entry_id,
+        outcome=outcome,
+        recorded_at=recorded_at,
+    )
+
+
+@pytest.fixture
+def sample_match_feedback_record() -> MatchFeedbackRecord:
+    """A MatchFeedbackRecord matching the example line in
+    specs/055-learned-assumption-resolution/contracts/decision-records.md.
+    """
+    return _make_match_feedback()
+
+
+# -----------------------------------------------------------------------------
+# DecisionRecord model
+# -----------------------------------------------------------------------------
+
+
+class TestDecisionRecordRoundTrip:
+    """DecisionRecord.to_dict()/from_dict() round-trip, per data-model.md."""
+
+    def test_to_dict_contains_all_fields(self, sample_decision_record: DecisionRecord) -> None:
+        data = sample_decision_record.to_dict()
+        assert data == {
+            "source_entry_id": "mv-142",
+            "question": "Should retries use exponential backoff?",
+            "normalized_question": "should retries use exponential backoff",
+            "adopted_answer": "Yes, tenacity default",
+            "resolution_type": "answered",
+            "resolution": "Yes — AsyncRetrying, 3 attempts",
+            "severity": "medium",
+            "owner_spec": "052-conditional-landing",
+            "resolved_by": "Paul O'Fallon",
+            "resolved_at": "2026-08-06T14:03:22+00:00",
+        }
+
+    def test_from_dict_round_trip(self, sample_decision_record: DecisionRecord) -> None:
+        data = sample_decision_record.to_dict()
+        restored = DecisionRecord.from_dict(data)
+        assert restored == sample_decision_record
+        assert restored.to_dict() == data
+
+    def test_resolution_type_waived(self) -> None:
+        record = _make_decision(resolution_type="waived", resolution="Accepted risk, low severity")
+        assert record.resolution_type == "waived"
+        restored = DecisionRecord.from_dict(record.to_dict())
+        assert restored.resolution_type == "waived"
+
+    def test_is_frozen(self, sample_decision_record: DecisionRecord) -> None:
+        with pytest.raises(Exception):  # noqa: B017 - pydantic ValidationError on frozen model
+            sample_decision_record.source_entry_id = "changed"  # type: ignore[misc]
+
+    def test_json_line_matches_contract_example(
+        self, sample_decision_record: DecisionRecord
+    ) -> None:
+        """The serialized line should be parseable back through the same shape
+        as the contract's example JSON line.
+        """
+        line = json.dumps(sample_decision_record.to_dict(), ensure_ascii=False)
+        reparsed = json.loads(line)
+        assert DecisionRecord.from_dict(reparsed) == sample_decision_record
+
+
+# -----------------------------------------------------------------------------
+# RunwayStore.append_decision / get_decisions
+# -----------------------------------------------------------------------------
+
+
+class TestAppendAndGetDecisions:
+    async def test_append_then_get_returns_record(
+        self, initialized_store: RunwayStore, sample_decision_record: DecisionRecord
+    ) -> None:
+        await initialized_store.append_decision(sample_decision_record)
+        decisions = await initialized_store.get_decisions()
+        assert len(decisions) == 1
+        assert decisions[0] == sample_decision_record
+
+    async def test_append_is_append_only_jsonl(
+        self, initialized_store: RunwayStore, sample_decision_record: DecisionRecord
+    ) -> None:
+        await initialized_store.append_decision(sample_decision_record)
+        await initialized_store.append_decision(sample_decision_record)
+        decisions_path = initialized_store.path / "decisions.jsonl"
+        lines = [
+            line
+            for line in decisions_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(lines) == 2
+
+    async def test_get_decisions_no_filter_returns_all(
+        self, initialized_store: RunwayStore
+    ) -> None:
+        d1 = _make_decision(source_entry_id="mv-001")
+        d2 = _make_decision(source_entry_id="mv-002")
+        d3 = _make_decision(source_entry_id="mv-003")
+        for d in (d1, d2, d3):
+            await initialized_store.append_decision(d)
+
+        results = await initialized_store.get_decisions()
+        assert len(results) == 3
+        assert {r.source_entry_id for r in results} == {"mv-001", "mv-002", "mv-003"}
+
+    async def test_get_decisions_filters_by_source_entry_id(
+        self, initialized_store: RunwayStore
+    ) -> None:
+        d1 = _make_decision(source_entry_id="mv-001", resolution="first")
+        d2 = _make_decision(source_entry_id="mv-002", resolution="second")
+        d3 = _make_decision(source_entry_id="mv-001", resolution="first-updated")
+        for d in (d1, d2, d3):
+            await initialized_store.append_decision(d)
+
+        results = await initialized_store.get_decisions(source_entry_id="mv-001")
+        assert len(results) == 2
+        assert all(r.source_entry_id == "mv-001" for r in results)
+        assert [r.resolution for r in results] == ["first", "first-updated"]
+
+    async def test_get_decisions_filter_no_match_returns_empty(
+        self, initialized_store: RunwayStore, sample_decision_record: DecisionRecord
+    ) -> None:
+        await initialized_store.append_decision(sample_decision_record)
+        results = await initialized_store.get_decisions(source_entry_id="does-not-exist")
+        assert results == []
+
+    async def test_get_decisions_empty_store_returns_empty_list(
+        self, initialized_store: RunwayStore
+    ) -> None:
+        results = await initialized_store.get_decisions()
+        assert results == []
+
+
+# -----------------------------------------------------------------------------
+# initialize() touches both new files at the store root
+# -----------------------------------------------------------------------------
+
+
+class TestInitializeTouchesDecisionFiles:
+    async def test_initialize_creates_decisions_and_match_feedback_files(
+        self, runway_path: Path
+    ) -> None:
+        store = RunwayStore(runway_path)
+        assert not (runway_path / "decisions.jsonl").exists()
+        assert not (runway_path / "match-feedback.jsonl").exists()
+
+        await store.initialize()
+
+        decisions_path = runway_path / "decisions.jsonl"
+        feedback_path = runway_path / "match-feedback.jsonl"
+        assert decisions_path.is_file()
+        assert feedback_path.is_file()
+
+        # Outside episodic/ by design (contracts/decision-records.md) —
+        # never pruned by consolidation.
+        assert decisions_path.parent == runway_path
+        assert feedback_path.parent == runway_path
+        assert not (runway_path / "episodic" / "decisions.jsonl").exists()
+        assert not (runway_path / "episodic" / "match-feedback.jsonl").exists()
+
+    async def test_initialize_idempotent_does_not_clobber_existing_content(
+        self, initialized_store: RunwayStore, sample_decision_record: DecisionRecord
+    ) -> None:
+        await initialized_store.append_decision(sample_decision_record)
+        # Re-running initialize() must not truncate/overwrite existing data.
+        await initialized_store.initialize()
+        decisions = await initialized_store.get_decisions()
+        assert len(decisions) == 1
+
+
+# -----------------------------------------------------------------------------
+# Malformed JSONL tolerance
+# -----------------------------------------------------------------------------
+
+
+class TestMalformedDecisionLinesSkipped:
+    async def test_corrupt_line_skipped_not_raised(
+        self, initialized_store: RunwayStore, sample_decision_record: DecisionRecord
+    ) -> None:
+        decisions_path = initialized_store.path / "decisions.jsonl"
+        # Write a corrupt line directly, mirroring existing _read_jsonl tolerance.
+        decisions_path.write_text("{not valid json,,,\n", encoding="utf-8")
+
+        await initialized_store.append_decision(sample_decision_record)
+
+        results = await initialized_store.get_decisions()
+        assert len(results) == 1
+        assert results[0] == sample_decision_record
+
+    async def test_corrupt_line_logs_warning(
+        self, initialized_store: RunwayStore, sample_decision_record: DecisionRecord
+    ) -> None:
+        decisions_path = initialized_store.path / "decisions.jsonl"
+        decisions_path.write_text("{totally broken\n", encoding="utf-8")
+        await initialized_store.append_decision(sample_decision_record)
+
+        with patch("maverick.runway.store.logger") as mock_logger:
+            results = await initialized_store.get_decisions()
+
+        assert len(results) == 1
+        assert mock_logger.warning.called
+
+
+# -----------------------------------------------------------------------------
+# MatchFeedbackRecord model (spec 055, US3, T023)
+# -----------------------------------------------------------------------------
+
+
+class TestMatchFeedbackRecordRoundTrip:
+    """MatchFeedbackRecord.to_dict()/from_dict() round-trip, per data-model.md."""
+
+    def test_to_dict_contains_all_fields(
+        self, sample_match_feedback_record: MatchFeedbackRecord
+    ) -> None:
+        data = sample_match_feedback_record.to_dict()
+        assert data == {
+            "normalized_question": "should retries use exponential backoff",
+            "source_entry_id": "mv-142",
+            "outcome": "rejected",
+            "recorded_at": "2026-08-07T09:15:02+00:00",
+        }
+
+    def test_from_dict_round_trip(self, sample_match_feedback_record: MatchFeedbackRecord) -> None:
+        data = sample_match_feedback_record.to_dict()
+        restored = MatchFeedbackRecord.from_dict(data)
+        assert restored == sample_match_feedback_record
+        assert restored.to_dict() == data
+
+    def test_outcome_accepted(self) -> None:
+        record = _make_match_feedback(outcome="accepted")
+        assert record.outcome == "accepted"
+        restored = MatchFeedbackRecord.from_dict(record.to_dict())
+        assert restored.outcome == "accepted"
+
+    def test_is_frozen(self, sample_match_feedback_record: MatchFeedbackRecord) -> None:
+        with pytest.raises(Exception):  # noqa: B017 - pydantic ValidationError on frozen model
+            sample_match_feedback_record.source_entry_id = "changed"  # type: ignore[misc]
+
+    def test_json_line_matches_contract_example(
+        self, sample_match_feedback_record: MatchFeedbackRecord
+    ) -> None:
+        """The serialized line should be parseable back through the same shape
+        as the contract's example JSON line.
+        """
+        line = json.dumps(sample_match_feedback_record.to_dict(), ensure_ascii=False)
+        reparsed = json.loads(line)
+        assert MatchFeedbackRecord.from_dict(reparsed) == sample_match_feedback_record
+
+
+# -----------------------------------------------------------------------------
+# RunwayStore.append_match_feedback / get_match_feedback (spec 055, US3, T023)
+# -----------------------------------------------------------------------------
+
+
+class TestAppendAndGetMatchFeedback:
+    async def test_append_then_get_returns_record(
+        self,
+        initialized_store: RunwayStore,
+        sample_match_feedback_record: MatchFeedbackRecord,
+    ) -> None:
+        await initialized_store.append_match_feedback(sample_match_feedback_record)
+        results = await initialized_store.get_match_feedback()
+        assert len(results) == 1
+        assert results[0] == sample_match_feedback_record
+
+    async def test_append_is_append_only_jsonl(
+        self,
+        initialized_store: RunwayStore,
+        sample_match_feedback_record: MatchFeedbackRecord,
+    ) -> None:
+        await initialized_store.append_match_feedback(sample_match_feedback_record)
+        await initialized_store.append_match_feedback(sample_match_feedback_record)
+        feedback_path = initialized_store.path / "match-feedback.jsonl"
+        lines = [
+            line for line in feedback_path.read_text(encoding="utf-8").splitlines() if line.strip()
+        ]
+        assert len(lines) == 2
+
+    async def test_get_match_feedback_returns_all_records_no_filter(
+        self, initialized_store: RunwayStore
+    ) -> None:
+        f1 = _make_match_feedback(source_entry_id="mv-001", outcome="rejected")
+        f2 = _make_match_feedback(source_entry_id="mv-002", outcome="accepted")
+        f3 = _make_match_feedback(source_entry_id="mv-003", outcome="rejected")
+        for f in (f1, f2, f3):
+            await initialized_store.append_match_feedback(f)
+
+        results = await initialized_store.get_match_feedback()
+        assert len(results) == 3
+        assert {r.source_entry_id for r in results} == {"mv-001", "mv-002", "mv-003"}
+
+    async def test_get_match_feedback_returns_records_in_append_order(
+        self, initialized_store: RunwayStore
+    ) -> None:
+        f1 = _make_match_feedback(source_entry_id="mv-001", outcome="rejected")
+        f2 = _make_match_feedback(source_entry_id="mv-001", outcome="accepted")
+        for f in (f1, f2):
+            await initialized_store.append_match_feedback(f)
+
+        results = await initialized_store.get_match_feedback()
+        assert [r.outcome for r in results] == ["rejected", "accepted"]
+
+    async def test_get_match_feedback_empty_store_returns_empty_list(
+        self, initialized_store: RunwayStore
+    ) -> None:
+        results = await initialized_store.get_match_feedback()
+        assert results == []
+
+
+class TestMalformedMatchFeedbackLinesSkipped:
+    async def test_corrupt_line_skipped_not_raised(
+        self,
+        initialized_store: RunwayStore,
+        sample_match_feedback_record: MatchFeedbackRecord,
+    ) -> None:
+        feedback_path = initialized_store.path / "match-feedback.jsonl"
+        feedback_path.write_text("{not valid json,,,\n", encoding="utf-8")
+
+        await initialized_store.append_match_feedback(sample_match_feedback_record)
+
+        results = await initialized_store.get_match_feedback()
+        assert len(results) == 1
+        assert results[0] == sample_match_feedback_record
+
+    async def test_corrupt_line_logs_warning(
+        self,
+        initialized_store: RunwayStore,
+        sample_match_feedback_record: MatchFeedbackRecord,
+    ) -> None:
+        feedback_path = initialized_store.path / "match-feedback.jsonl"
+        feedback_path.write_text("{totally broken\n", encoding="utf-8")
+        await initialized_store.append_match_feedback(sample_match_feedback_record)
+
+        with patch("maverick.runway.store.logger") as mock_logger:
+            results = await initialized_store.get_match_feedback()
+
+        assert len(results) == 1
+        assert mock_logger.warning.called
+
+
+# -----------------------------------------------------------------------------
+# Regression: consolidation must never touch decisions.jsonl / match-feedback.jsonl
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def runway_dir(tmp_path: Path) -> Path:
+    """Create an initialized runway directory structure (mirrors
+    tests/unit/library/actions/test_consolidation.py's fixture).
+    """
+    runway_path = tmp_path / ".maverick" / "runway"
+    episodic = runway_path / "episodic"
+    semantic = runway_path / "semantic"
+    episodic.mkdir(parents=True)
+    semantic.mkdir(parents=True)
+
+    (runway_path / "index.json").write_text(
+        json.dumps({"version": 1, "last_consolidated": "", "episodic_counts": {}})
+    )
+
+    (episodic / "bead-outcomes.jsonl").touch()
+    (episodic / "review-findings.jsonl").touch()
+    (episodic / "fix-attempts.jsonl").touch()
+
+    return tmp_path
+
+
+class TestConsolidationLeavesDecisionFilesUntouched:
+    """Regression test binding to the real consolidate_runway() action.
+
+    decisions.jsonl and match-feedback.jsonl live outside episodic/ by
+    design (contracts/decision-records.md: "Never" pruned by
+    consolidation) — this must remain byte-identical across a
+    consolidation run that actually prunes other episodic records.
+    """
+
+    async def test_consolidate_runway_does_not_modify_decision_files(
+        self, runway_dir: Path
+    ) -> None:
+        from datetime import datetime, timedelta
+
+        from maverick.library.actions.consolidation import consolidate_runway
+
+        runway_path = runway_dir / ".maverick" / "runway"
+        store = RunwayStore(runway_path)
+
+        # Populate decisions + match-feedback files with real content.
+        decision = _make_decision(source_entry_id="mv-999")
+        await store.append_decision(decision)
+
+        feedback_path = runway_path / "match-feedback.jsonl"
+        feedback_line = (
+            json.dumps(
+                {
+                    "normalized_question": "should retries use exponential backoff",
+                    "source_entry_id": "mv-999",
+                    "outcome": "rejected",
+                    "recorded_at": "2026-08-07T09:15:02+00:00",
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+        feedback_path.write_text(feedback_line, encoding="utf-8")
+
+        decisions_before = (runway_path / "decisions.jsonl").read_bytes()
+        feedback_before = feedback_path.read_bytes()
+
+        # Force real pruning: an old bead outcome ages out of episodic/.
+        old_ts = (datetime.now() - timedelta(days=120)).isoformat()
+        (runway_path / "episodic" / "bead-outcomes.jsonl").write_text(
+            json.dumps({"bead_id": "old-1", "epic_id": "e1", "timestamp": old_ts}) + "\n"
+        )
+
+        with patch(
+            "maverick.library.actions.consolidation._synthesize_summary",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await consolidate_runway(cwd=runway_dir, max_age_days=90)
+
+        assert result.success is True
+        assert result.skipped is False
+
+        decisions_after = (runway_path / "decisions.jsonl").read_bytes()
+        feedback_after = feedback_path.read_bytes()
+
+        assert decisions_after == decisions_before
+        assert feedback_after == feedback_before

--- a/tests/unit/workflows/fly_beads/test_assumption_actions.py
+++ b/tests/unit/workflows/fly_beads/test_assumption_actions.py
@@ -9,19 +9,38 @@ and stamps recorded entries non-fatally.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from burr.core import State
 
 from maverick.assumptions.errors import AssumptionLedgerError
-from maverick.assumptions.models import AssumptionRecord, Severity, StampResult
+from maverick.assumptions.models import (
+    AssumptionRecord,
+    AssumptionReportEntry,
+    Severity,
+    StampResult,
+)
 from maverick.events import ProgressEvent
 from maverick.payloads import SubmitFixResultPayload, SubmitImplementationPayload
+from maverick.runway.store import RunwayStore
 from maverick.workflows.fly_beads import actions as fly_actions
 from tests.unit.agents.airframe_stubs import StubCodingAgent
 
 pytestmark = pytest.mark.asyncio
+
+
+async def _initialized_runway_cwd(tmp_path: Path) -> str:
+    """Create a tmp checkout with an initialized runway store at ``cwd``.
+
+    Mirrors ``library.actions.runway._get_store``'s ``is_initialized``
+    contract so production code building a store from ``cwd`` finds one
+    regardless of exactly how it locates it.
+    """
+    store = RunwayStore(tmp_path / ".maverick" / "runway")
+    await store.initialize()
+    return str(tmp_path)
 
 
 class _NullCM:
@@ -184,6 +203,124 @@ class TestRecordAssumptionsAction:
             )
         # Non-fatal: no exception propagates, entry just isn't recorded.
         assert new_state["recorded_assumption_ids"] == []
+
+
+class TestRecordAssumptionsCallsAttachSuggestions:
+    """055-learned-assumption-resolution T014 (US2): after the recording
+    loop, ``record_assumptions`` hands the newly recorded entries to
+    ``assumptions.suggestions.attach_suggestions`` so a matching prior
+    resolution can be surfaced later — non-fatally (research R5, T019).
+    """
+
+    async def test_calls_attach_suggestions_with_recorded_entries(self, tmp_path: Path) -> None:
+        cwd = await _initialized_runway_cwd(tmp_path)
+        state = State(
+            {
+                "current_bead_id": "b-1",
+                "pending_assumptions": [dict(_ASSUMPTION_DICT)],
+            }
+        )
+        record = AssumptionRecord(
+            bead_id="dea-1",
+            question="Q?",
+            adopted_answer="A.",
+            alternatives=(),
+            severity=Severity.MEDIUM,
+            severity_defaulted=False,
+            status="open",
+            owner_spec="epic-1",
+            source_bead="b-1",
+            change_ids=(),
+            is_legacy=False,
+        )
+        with (
+            patch(
+                "maverick.assumptions.ledger.record_assumption",
+                new=AsyncMock(return_value=record),
+            ),
+            patch(
+                "maverick.workflows.fly_beads.actions.attach_suggestions",
+                new=AsyncMock(),
+            ) as mock_attach,
+        ):
+            _, new_state = await fly_actions.record_assumptions(
+                state, cwd=cwd, epic_id="epic-1", events=_queue()
+            )
+
+        assert new_state["recorded_assumption_ids"] == ["dea-1"]
+        mock_attach.assert_awaited_once()
+        call_args = list(mock_attach.await_args.args) + list(
+            mock_attach.await_args.kwargs.values()
+        )
+        records_arg = next((a for a in call_args if isinstance(a, (list, tuple))), None)
+        assert records_arg is not None, (
+            "expected attach_suggestions to be called with a list/tuple of "
+            f"newly recorded entries; got call args {call_args!r}"
+        )
+        # Must be `AssumptionReportEntry`s, not bare `AssumptionRecord`s:
+        # `attach_suggestions` reads `entry.record.*`, so handing it a raw
+        # record raises `AttributeError` inside its own best-effort handler
+        # and silently disables suggestions on this path.
+        assert all(isinstance(item, AssumptionReportEntry) for item in records_arg), (
+            f"expected AssumptionReportEntry instances; got {records_arg!r}"
+        )
+        assert {item.record.bead_id for item in records_arg} == {"dea-1"}
+
+    async def test_attach_suggestions_failure_is_non_fatal(self, tmp_path: Path) -> None:
+        cwd = await _initialized_runway_cwd(tmp_path)
+        state = State(
+            {
+                "current_bead_id": "b-1",
+                "pending_assumptions": [dict(_ASSUMPTION_DICT)],
+            }
+        )
+        record = AssumptionRecord(
+            bead_id="dea-1",
+            question="Q?",
+            adopted_answer="A.",
+            alternatives=(),
+            severity=Severity.MEDIUM,
+            severity_defaulted=False,
+            status="open",
+            owner_spec="epic-1",
+            source_bead="b-1",
+            change_ids=(),
+            is_legacy=False,
+        )
+        with (
+            patch(
+                "maverick.assumptions.ledger.record_assumption",
+                new=AsyncMock(return_value=record),
+            ),
+            patch(
+                "maverick.workflows.fly_beads.actions.attach_suggestions",
+                new=AsyncMock(side_effect=RuntimeError("runway unavailable")),
+            ),
+        ):
+            result_dict, new_state = await fly_actions.record_assumptions(
+                state, cwd=cwd, epic_id="epic-1", events=_queue()
+            )
+
+        # The action must still complete normally and preserve its
+        # existing return shape even though attach_suggestions blew up.
+        assert result_dict == {"recorded": 1}
+        assert new_state["recorded_assumption_ids"] == ["dea-1"]
+
+    async def test_no_pending_assumptions_does_not_call_attach_suggestions(
+        self, tmp_path: Path
+    ) -> None:
+        cwd = await _initialized_runway_cwd(tmp_path)
+        state = State({"current_bead_id": "b-1", "pending_assumptions": []})
+        with patch(
+            "maverick.workflows.fly_beads.actions.attach_suggestions",
+            new=AsyncMock(),
+        ) as mock_attach:
+            _, new_state = await fly_actions.record_assumptions(
+                state, cwd=cwd, epic_id="epic-1", events=_queue()
+            )
+
+        assert new_state["recorded_assumption_ids"] == []
+        mock_attach.assert_not_awaited()
 
 
 class TestCommitCapturesChangeIdAndStamps:

--- a/tests/unit/workflows/spec_chain/test_workflow_methods.py
+++ b/tests/unit/workflows/spec_chain/test_workflow_methods.py
@@ -223,3 +223,111 @@ class TestFileClarifyDecisionsIdempotency:
 
         assert len(new_state.clarify_decisions) == 1
         assert new_state.clarify_decisions[0].ledger_bead_id == "dea-1"
+
+
+class TestFileClarifyDecisionsCallsAttachSuggestions:
+    """055-learned-assumption-resolution T014 (US2): after filing each
+    parsed clarify/assumptions-section decision as a standalone ledger
+    entry, ``_file_clarify_decisions`` hands the newly filed entries to
+    ``assumptions.suggestions.attach_suggestions`` — non-fatally, and
+    against the user's checkout (never the hidden workspace), matching
+    the existing ``BeadClient(cwd=checkout)`` construction (research R5,
+    T020).
+    """
+
+    def _spec_md(self) -> str:
+        return (
+            "# Spec\n\n## Clarifications\n\n### Session 2026-07-24\n\n"
+            "- Q: Should exports include archived widgets? "
+            "→ A: No, exclude archived widgets.\n"
+        )
+
+    async def test_calls_attach_suggestions_with_filed_entries_against_checkout(
+        self, tmp_path: Path
+    ) -> None:
+        feature_dir = "001-widget-export"
+        workspace = tmp_path / "workspace"
+        spec_dir = workspace / "specs" / feature_dir
+        spec_dir.mkdir(parents=True)
+        (spec_dir / "spec.md").write_text(self._spec_md(), encoding="utf-8")
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+
+        state = _base_state(feature_dir=f"specs/{feature_dir}", clarify_decisions=[])
+
+        created = type("Record", (), {"bead_id": "dea-1", "severity": None})()
+        with (
+            patch(
+                "maverick.workflows.spec_chain.workflow.record_standalone_assumption",
+                new=AsyncMock(return_value=created),
+            ),
+            patch(
+                "maverick.workflows.spec_chain.workflow.attach_suggestions",
+                new=AsyncMock(),
+            ) as mock_attach,
+        ):
+            new_state = await _workflow()._file_clarify_decisions(
+                state, workspace=workspace, checkout=checkout, feature_dir_name=feature_dir
+            )
+
+        assert len(new_state.clarify_decisions) == 1
+        mock_attach.assert_awaited_once()
+        call_args = list(mock_attach.await_args.args) + list(
+            mock_attach.await_args.kwargs.values()
+        )
+
+        # The client/store passed must be rooted at the user's checkout,
+        # never the hidden spec-chain workspace (Guardrail 0's one
+        # exception still must not leak into where ledger/runway state is
+        # written).
+        client_like = next((a for a in call_args if hasattr(a, "_cwd")), None)
+        assert client_like is not None, f"expected a BeadClient-like argument among {call_args!r}"
+        assert Path(client_like._cwd) == checkout
+        assert Path(client_like._cwd) != workspace
+
+        store_like = next((a for a in call_args if hasattr(a, "path")), None)
+        if store_like is not None:
+            assert checkout in Path(store_like.path).parents or Path(store_like.path) == checkout
+            assert workspace not in Path(store_like.path).parents
+
+        records_arg = next((a for a in call_args if isinstance(a, (list, tuple))), None)
+        assert records_arg is not None, (
+            f"expected a list/tuple of newly filed entries among {call_args!r}"
+        )
+        # Must be `AssumptionReportEntry`s, not bare `AssumptionRecord`s:
+        # `attach_suggestions` reads `entry.record.*`, so handing it a raw
+        # record raises `AttributeError` inside its own best-effort handler
+        # and silently disables suggestions on this path.
+        assert {item.record.bead_id for item in records_arg} == {"dea-1"}
+
+    async def test_attach_suggestions_failure_is_non_fatal(self, tmp_path: Path) -> None:
+        feature_dir = "001-widget-export"
+        workspace = tmp_path / "workspace"
+        spec_dir = workspace / "specs" / feature_dir
+        spec_dir.mkdir(parents=True)
+        (spec_dir / "spec.md").write_text(self._spec_md(), encoding="utf-8")
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+
+        state = _base_state(feature_dir=f"specs/{feature_dir}", clarify_decisions=[])
+
+        created = type("Record", (), {"bead_id": "dea-1", "severity": None})()
+        with (
+            patch(
+                "maverick.workflows.spec_chain.workflow.record_standalone_assumption",
+                new=AsyncMock(return_value=created),
+            ),
+            patch(
+                "maverick.workflows.spec_chain.workflow.attach_suggestions",
+                new=AsyncMock(side_effect=RuntimeError("runway unavailable")),
+            ),
+        ):
+            # Must not raise even though attach_suggestions blows up.
+            new_state = await _workflow()._file_clarify_decisions(
+                state, workspace=workspace, checkout=checkout, feature_dir_name=feature_dir
+            )
+
+        # The decision-filing result is unaffected by the suggestion
+        # attachment failure.
+        assert len(new_state.clarify_decisions) == 1
+        assert new_state.clarify_decisions[0].ledger_bead_id == "dea-1"


### PR DESCRIPTION
Turn every human resolution of an assumption-ledger entry into reusable signal, so a question already answered once is proposed rather than asked again. Zero model calls — the whole matching path is deterministic (`difflib.SequenceMatcher` + token-set Jaccard, fixed contract thresholds).

## What lands

| Story | Behavior |
| --- | --- |
| **US1** | Every human `review --answer` / `--waive` / bulk-waive appends a `DecisionRecord` to `.maverick/runway/decisions.jsonl`. Best-effort (FR-004): a corpus-write failure warns but never fails the ledger write that triggered it. Machine waives (`maverick-scheduler`, `maverick-resolver`) are structurally excluded from the corpus (FR-005). |
| **US2** | New entries are matched against that corpus at recording time; a hit at or above `PRESENTATION_THRESHOLD` (0.75) persists as one JSON-encoded bd state key. `review --list` back-fills open entries listed before a relevant decision existed. `suggestion` / `auto_resolved` ride the shared entry-row projection, so `review --list --json` and the land report can't drift. |
| **US3** | Resolving an entry differently than its presented suggestion records a `MatchFeedbackRecord` that lowers that exact pairing's future effective confidence (`REJECTION_PENALTY` 0.30, sized so one net rejection always suppresses even a perfect match); accepting it restores it. |
| **US4** | Opt-in `assumptions.resolution.auto_resolve_low` (double opt-in; threshold floored at `PRESENTATION_THRESHOLD` by import, not by a duplicated literal) auto-waives high-confidence **low-severity** entries as `maverick-resolver` through the *existing* `ledger.waive()` path — so the land frontier gate needs zero changes and such an entry can never read as `VERIFIED`, only `CONDITIONALLY_VERIFIED`. |

Both JSONL stores live at the runway root, deliberately outside `episodic/`, so `runway consolidate` never prunes them.

## Two findings worth calling out

**`bd set-state` silently truncates.** Found while running the quickstart scenarios against a real `bd` sandbox rather than the (fully mocked) unit suite. `bd` stores state as a `<dimension>:<value>` label with a hard length cap and truncates past it with no error — full field names alone exhausted the budget before any real resolution text, so suggestions were being corrupted on the very next read. Fixed with a compact short-key wire format (internal to bd storage; the public row projection is unchanged) plus a defensive length guard that treats an over-long suggestion as "no suggestion" rather than storing it truncated. Verified end-to-end with a real `bd` round-trip.

**Auto-resolve write ordering.** `KEY_AUTO_RESOLVED` is stamped *before* the waive. The two `bd set-state` calls aren't atomic, and that stamp is exactly what lets a human override the machine's decision — waiving first meant a failure in between would leave an entry machine-waived that no human could ever reopen. Stamping first inverts the failure into the harmless direction. A human override also un-stamps it, so reports stop attributing a human decision to the machine.

## Verification

`make ci` green: **4896 passed, 1 xfailed**; lint, typecheck and format clean. All 37 tasks in `specs/055-learned-assumption-resolution/tasks.md` complete, TDD red→green throughout.

Quickstart scenarios were exercised with a mix of real CLI runs and direct library calls — the paths needing an LLM provider (`maverick fly`, `maverick spec`) couldn't run end-to-end in this sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U2VStxQbXt4U2bLRTPBDc
