### PR TITLE
fix(protection): give the blocks artifact a findable run directory

### DIFF
--- a/src/maverick/cli/commands/land.py
+++ b/src/maverick/cli/commands/land.py
@@ -613,13 +613,12 @@ async def _agent_curate(
         # end-of-run warning when non-empty.
         from maverick.protection.records import drain_and_report
 
-        blocked = await drain_and_report(
-            collector, cwd=cwd, run_id=run_id or "land", workflow="land"
-        )
+        blocks_run_id = run_id or "land"
+        blocked = await drain_and_report(collector, cwd=cwd, run_id=blocks_run_id, workflow="land")
         if blocked:
             out.print(
                 f"[yellow]{len(blocked)} context-file protection event(s) this run "
-                f"— see protection-blocks.json[/]"
+                f"— see .maverick/runs/{blocks_run_id}/protection-blocks.json[/]"
             )
     except SystemExit:
         raise

--- a/src/maverick/cli/commands/spec.py
+++ b/src/maverick/cli/commands/spec.py
@@ -82,7 +82,8 @@ def _render_summary_and_exit(state: object, feature: str) -> None:
     if state.protection_blocks:
         console.print(
             f"  [yellow]Context-file protection events: "
-            f"{len(state.protection_blocks)}[/] (see protection-blocks.json)"
+            f"{len(state.protection_blocks)}[/] "
+            f"(see .maverick/runs/{state.run_id}/protection-blocks.json)"
         )
 
     if state.status == "completed":

--- a/src/maverick/workflows/fly_beads/actions.py
+++ b/src/maverick/workflows/fly_beads/actions.py
@@ -1750,6 +1750,7 @@ async def aggregate_review(
     events: asyncio.Queue[ProgressEvent | None],
     cwd: str,
     epic_id: str,
+    fly_run_id: str = "",
 ) -> tuple[dict[str, Any], State]:
     """Run the epic-level cross-bead review after the bead loop ends.
 
@@ -1765,6 +1766,8 @@ async def aggregate_review(
     end-of-run ``StepOutput(level="warning", metadata={"block_count": n})``
     summarizing the whole run's context-file-protection activity
     (056-context-file-protection); a clean run emits nothing (FR-006).
+    ``fly_run_id`` is only used to name the artifact path in that warning
+    — the workflow, not this action, writes it.
     """
     result, new_state = await _with_protection_drain(
         await _aggregate_review_impl(
@@ -1775,12 +1778,16 @@ async def aggregate_review(
     )
     block_count = len(new_state.get("protection_blocks") or ())
     if block_count > 0:
+        artifact = (
+            f".maverick/runs/{fly_run_id}/protection-blocks.json"
+            if fly_run_id
+            else "protection-blocks.json"
+        )
         await events.put(
             StepOutput(
                 step_name="aggregate_review",
                 message=(
-                    f"{block_count} context-file protection event(s) this run "
-                    "— see protection-blocks.json"
+                    f"{block_count} context-file protection event(s) this run — see {artifact}"
                 ),
                 display_label="",
                 level="warning",

--- a/src/maverick/workflows/fly_beads/burr_graph.py
+++ b/src/maverick/workflows/fly_beads/burr_graph.py
@@ -191,6 +191,7 @@ def build_fly_application(
                 events=event_queue,
                 cwd=cwd,
                 epic_id=epic_id,
+                fly_run_id=fly_run_id,
             ),
             done=_done,
         )

--- a/src/maverick/workflows/generate_flight_plan/workflow.py
+++ b/src/maverick/workflows/generate_flight_plan/workflow.py
@@ -273,20 +273,30 @@ class GenerateFlightPlanWorkflow(PythonWorkflow):
 
         # 056-context-file-protection T025: drain + persist, one
         # end-of-run warning when non-empty.
-        import uuid
-
+        #
+        # This workflow has no run-metadata concept of its own, so there is
+        # no run id to reuse. A random one would put the artifact in a
+        # directory holding nothing else and named after nothing — the user
+        # is told to read a file they cannot find. Derive a stable id from
+        # the plan name instead (``name`` already names a directory under
+        # ``output_dir``, so it is filesystem-safe), matching ``land``'s
+        # fixed ``"land"`` fallback. The directory carries no
+        # ``metadata.json``, so ``find_latest_run``/``find_run_for_epic``
+        # skip it and refuel's "Next:" hint is unaffected.
         from maverick.protection.records import drain_and_report
 
+        run_id = f"plan-{name}"
         blocked = await drain_and_report(
             getattr(squadron, "block_collector", None),
             cwd=Path(cwd),
-            run_id=uuid.uuid4().hex[:8],
+            run_id=run_id,
             workflow=WORKFLOW_NAME,
         )
         if blocked:
             await self.emit_output(
                 GENERATE,
-                f"{len(blocked)} context-file protection event(s) — see protection-blocks.json",
+                f"{len(blocked)} context-file protection event(s) — see "
+                f".maverick/runs/{run_id}/protection-blocks.json",
                 level="warning",
             )
 

--- a/src/maverick/workflows/reconcile/workflow.py
+++ b/src/maverick/workflows/reconcile/workflow.py
@@ -413,7 +413,7 @@ class ReconcileWorkflow(PythonWorkflow):
                 await self.emit_output(
                     "reconcile",
                     f"{len(blocked)} context-file protection event(s) this run "
-                    "— see protection-blocks.json",
+                    f"— see .maverick/runs/{run_id}/protection-blocks.json",
                     level="warning",
                 )
 

--- a/src/maverick/workflows/refuel_speckit/workflow.py
+++ b/src/maverick/workflows/refuel_speckit/workflow.py
@@ -93,6 +93,11 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
         enrich: bool = bool(inputs.get("enrich", False))
         auto_commit: bool = bool(inputs.get("auto_commit", False))
         warnings: list[str] = []
+        # One id for the whole run, minted before any artifact is written.
+        # ``_record_run`` and ``_run_enrichment``'s protection artifact both
+        # take it, so ``protection-blocks.json`` lands next to the run's own
+        # ``metadata.json`` instead of in a directory nothing else references.
+        run_id = uuid.uuid4().hex[:8]
 
         # ------------------------------------------------------------
         # Step 1: Resolve feature
@@ -219,7 +224,9 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
 
             await self.emit_step_started(RECORD_RUN, display_label="Recording run")
             if not dry_run and existing_epic_id:
-                await self._record_run(cwd, feature_name, existing_epic_id, "refueled")
+                await self._record_run(
+                    cwd, feature_name, existing_epic_id, "refueled", run_id=run_id
+                )
             await self.emit_output(
                 RECORD_RUN,
                 f"No new tasks to ingest for {feature_name} (epic {existing_epic_id} up to date).",
@@ -242,7 +249,7 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
         # ------------------------------------------------------------
         enriched = False
         if enrich:
-            plan, enrich_warning = await self._run_enrichment(plan, cwd=cwd)
+            plan, enrich_warning = await self._run_enrichment(plan, cwd=cwd, run_id=run_id)
             if enrich_warning:
                 warnings.append(enrich_warning)
             else:
@@ -379,7 +386,7 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
         # Step 10: Record run metadata (skipped on dry-run)
         # ------------------------------------------------------------
         if not dry_run:
-            await self._record_run(cwd, feature_name, epic_id, "refueled")
+            await self._record_run(cwd, feature_name, epic_id, "refueled", run_id=run_id)
 
         # ------------------------------------------------------------
         # Step 11 (optional): Auto-commit
@@ -594,10 +601,21 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
         await self.emit_step_completed(ADOPT_REMEDIATION, output={"adopted": len(adopted)})
         return tuple(adopted)
 
-    async def _record_run(self, cwd: Path, feature_name: str, epic_id: str, status: str) -> None:
+    async def _record_run(
+        self, cwd: Path, feature_name: str, epic_id: str, status: str, *, run_id: str
+    ) -> None:
+        """Write ``metadata.json`` for this run.
+
+        Args:
+            cwd: Repository root; the run directory hangs off it.
+            feature_name: Spec Kit feature directory name.
+            epic_id: The bd epic this run created or updated.
+            status: Run status recorded in the metadata.
+            run_id: The run's id, minted once in :meth:`_run` so every
+                artifact this run writes shares one directory.
+        """
         from maverick.runway.run_metadata import RunMetadata, write_metadata
 
-        run_id = uuid.uuid4().hex[:8]
         run_dir = cwd / ".maverick" / "runs" / run_id
         meta = RunMetadata(
             run_id=run_id,
@@ -638,6 +656,7 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
         plan: IngestionPlan,
         *,
         cwd: Path,
+        run_id: str,
     ) -> tuple[IngestionPlan, str | None]:
         """Attach model-supplied verification commands to new task beads.
 
@@ -645,6 +664,13 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
         D9). Any failure degrades to a warning — ingestion proceeds
         unenriched (FR-011). Nothing here imports agent/runtime
         machinery unless this method actually runs (FR-010).
+
+        Args:
+            plan: The ingestion plan whose new tasks get enriched.
+            cwd: Repository root.
+            run_id: This run's id, shared with :meth:`_record_run` so a
+                ``protection-blocks.json`` written here lands in the same
+                run directory as the run's ``metadata.json``.
 
         Returns:
             ``(plan, warning)`` — *plan* is unchanged (with augmented
@@ -687,13 +713,13 @@ class SpeckitRefuelWorkflow(PythonWorkflow):
             from maverick.protection.records import drain_and_report
 
             blocked = await drain_and_report(
-                collector, cwd=cwd, run_id=uuid.uuid4().hex[:8], workflow=WORKFLOW_NAME
+                collector, cwd=cwd, run_id=run_id, workflow=WORKFLOW_NAME
             )
             if blocked:
                 await self.emit_output(
                     ENRICH,
                     f"{len(blocked)} context-file protection event(s) — see "
-                    "protection-blocks.json",
+                    f".maverick/runs/{run_id}/protection-blocks.json",
                     level="warning",
                 )
         except Exception as exc:

--- a/tests/unit/workflows/fly_beads/test_protection_backstop.py
+++ b/tests/unit/workflows/fly_beads/test_protection_backstop.py
@@ -334,3 +334,77 @@ class TestDegradesGracefullyWithoutCollector:
             events=events,  # type: ignore[arg-type]
         )
         assert new_state.get("protection_blocks") == []
+
+
+class TestSummaryNamesArtifactPath:
+    """The end-of-run warning must name a path the user can actually open.
+
+    Fly persists ``protection-blocks.json`` under its own run directory, so
+    the summary quotes that exact path rather than a bare filename.
+    """
+
+    async def test_warning_names_run_scoped_artifact_path(self) -> None:
+        squadron = _ProtectedStubSquadron()
+        squadron.block_collector.append(_block("CLAUDE.md"))
+        events: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        state = State(
+            {
+                "completed_bead_ids": ["b-1"],
+                "bead_events": [],
+                "succeeded_count": 1,
+                "protection_blocks": [],
+            }
+        )
+
+        await actions.aggregate_review(
+            state,
+            squadron=squadron,  # type: ignore[arg-type]
+            events=events,
+            cwd="/tmp",
+            epic_id="e-1",
+            fly_run_id="abc12345",
+        )
+
+        emitted = await _drain_queue(events)
+        summary = next(
+            e
+            for e in emitted
+            if isinstance(e, StepOutput)
+            and e.level == "warning"
+            and e.metadata is not None
+            and "block_count" in e.metadata
+        )
+        assert ".maverick/runs/abc12345/protection-blocks.json" in summary.message
+
+    async def test_falls_back_to_bare_filename_without_a_run_id(self) -> None:
+        squadron = _ProtectedStubSquadron()
+        squadron.block_collector.append(_block("CLAUDE.md"))
+        events: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
+        state = State(
+            {
+                "completed_bead_ids": ["b-1"],
+                "bead_events": [],
+                "succeeded_count": 1,
+                "protection_blocks": [],
+            }
+        )
+
+        await actions.aggregate_review(
+            state,
+            squadron=squadron,  # type: ignore[arg-type]
+            events=events,
+            cwd="/tmp",
+            epic_id="e-1",
+        )
+
+        emitted = await _drain_queue(events)
+        summary = next(
+            e
+            for e in emitted
+            if isinstance(e, StepOutput)
+            and e.level == "warning"
+            and e.metadata is not None
+            and "block_count" in e.metadata
+        )
+        assert "protection-blocks.json" in summary.message
+        assert ".maverick/runs/" not in summary.message

--- a/tests/unit/workflows/generate_flight_plan/test_workflow.py
+++ b/tests/unit/workflows/generate_flight_plan/test_workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import shutil
 from pathlib import Path
 from typing import Any
@@ -393,3 +394,82 @@ class TestGenerateFlightPlanWorkflowErrors:
                         "skip_briefing": True,
                     },
                 )
+
+
+class TestProtectionArtifactRunId:
+    """The protection artifact must land somewhere the user can find.
+
+    This workflow has no run-metadata concept, so an earlier revision minted
+    a throwaway ``uuid4()`` — the artifact landed in a
+    ``.maverick/runs/<random>/`` named after nothing and holding nothing
+    else. The id is now derived from the plan name instead.
+    """
+
+    @pytest.mark.asyncio
+    async def test_artifact_lands_under_plan_scoped_run_id(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        import json
+
+        from maverick.protection.records import BlockCollector, BlockRecord
+
+        collector = BlockCollector()
+        collector.append(
+            BlockRecord(
+                agent_role="generate",
+                workflow=WORKFLOW_NAME,
+                operation="edit",
+                path="CLAUDE.md",
+                layer="backstop",
+            )
+        )
+
+        squadron = MagicMock()
+        squadron.block_collector = collector
+        squadron.__aenter__ = AsyncMock(return_value=squadron)
+        squadron.__aexit__ = AsyncMock(return_value=False)
+
+        driver = MagicMock()
+
+        async def _events() -> Any:
+            return
+            yield  # pragma: no cover — empty async generator
+
+        driver.events = _events
+        driver.result = (None, None, {"flight_plan_path": str(tmp_path / "fp.md")})
+
+        workflow = GenerateFlightPlanWorkflow(config=mock_config)
+        # `_generate_plan` is normally reached through `execute()`, which
+        # creates the queue; this test drives the method directly.
+        workflow._event_queue = asyncio.Queue()
+        with (
+            patch("maverick.squadron.plan.PlanSquadron", return_value=squadron),
+            patch(
+                "maverick.workflows.generate_flight_plan.burr_graph.build_plan_application",
+                return_value=MagicMock(),
+            ),
+            patch("maverick.burr.BurrWorkflowDriver", return_value=driver),
+            patch(
+                "maverick.workflows.fly_beads.workflow._cost_sink_for_cwd",
+                return_value=MagicMock(),
+            ),
+        ):
+            await workflow._generate_plan(
+                prd_content="# PRD",
+                name="my-plan",
+                plan_dir=tmp_path / "plans" / "my-plan",
+                skip_briefing=True,
+                cwd=str(tmp_path),
+            )
+
+        artifact = tmp_path / ".maverick" / "runs" / "plan-my-plan" / "protection-blocks.json"
+        assert artifact.is_file()
+        body = json.loads(artifact.read_text(encoding="utf-8"))
+        assert body["run_id"] == "plan-my-plan"
+        assert body["workflow"] == WORKFLOW_NAME
+
+        # The directory carries no run metadata, so `find_latest_run` and
+        # `find_run_for_epic` skip it and refuel's "Next:" hint is unaffected.
+        from maverick.runway.run_metadata import find_latest_run
+
+        assert find_latest_run("my-plan", base=tmp_path) is None

--- a/tests/unit/workflows/refuel_speckit/test_enrichment_step.py
+++ b/tests/unit/workflows/refuel_speckit/test_enrichment_step.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -223,3 +224,82 @@ class TestDryRunWithEnrich:
         mock_client.create_bead.assert_not_called()
         mock_client.add_dependency.assert_not_called()
         mock_client.set_state.assert_not_called()
+
+
+class TestEnrichmentProtectionArtifactSharesRunDir:
+    """``protection-blocks.json`` must land in *this* run's directory.
+
+    An earlier revision minted a throwaway ``uuid4()`` for the artifact, so
+    it landed in a ``.maverick/runs/<random>/`` holding nothing else — while
+    ``_record_run`` wrote ``metadata.json`` under a *different* random id.
+    The warning told the user to read a file they could not locate.
+    """
+
+    @pytest.mark.asyncio
+    async def test_artifact_lands_beside_run_metadata(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        from maverick.protection.records import BlockCollector, BlockRecord
+
+        feature_dir = make_feature_dir(tmp_path)
+        mock_client = make_mock_bead_client()
+
+        mock_agent = MagicMock()
+        mock_agent.__aenter__ = AsyncMock(return_value=mock_agent)
+        mock_agent.__aexit__ = AsyncMock(return_value=False)
+        mock_agent.enrich = AsyncMock(return_value=_ENRICH_RESPONSE)
+
+        # A collector that already holds a block, so the drain has
+        # something to persist without needing a real protected write.
+        collector = BlockCollector()
+        collector.append(
+            BlockRecord(
+                agent_role="generate",
+                workflow="refuel-speckit",
+                operation="edit",
+                path="CLAUDE.md",
+                layer="backstop",
+            )
+        )
+
+        with (
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch("maverick.config.load_config", return_value=mock_config),
+            patch(
+                "maverick.runtime.agent_factory.runtime_for_agent",
+                return_value=(MagicMock(), MagicMock()),
+            ),
+            patch(
+                "maverick.agents.personas.SpeckitEnrichmentAgent",
+                return_value=mock_agent,
+            ),
+            patch(
+                "maverick.protection.build_ad_hoc_protection",
+                return_value=(MagicMock(), collector),
+            ),
+        ):
+            workflow = SpeckitRefuelWorkflow(config=mock_config)
+            events, result = await collect_events(
+                workflow, make_inputs(feature_dir, tmp_path, enrich=True)
+            )
+
+        assert result is not None and result.success
+
+        runs_dir = tmp_path / ".maverick" / "runs"
+        run_dirs = sorted(p for p in runs_dir.iterdir() if p.is_dir())
+        # Exactly one run directory — not one for metadata and a second,
+        # orphaned one for the protection artifact.
+        assert len(run_dirs) == 1
+        run_dir = run_dirs[0]
+        assert (run_dir / "metadata.json").is_file()
+        artifact = run_dir / "protection-blocks.json"
+        assert artifact.is_file()
+
+        # The artifact's own run_id agrees with the directory it sits in.
+        body = json.loads(artifact.read_text(encoding="utf-8"))
+        assert body["run_id"] == run_dir.name
+
+        # And the warning points at that exact path.
+        messages = [getattr(e, "message", "") for e in events if hasattr(e, "message")]
+        expected = f".maverick/runs/{run_dir.name}/protection-blocks.json"
+        assert any(expected in m for m in messages)


### PR DESCRIPTION
Follow-up to #184 — closes the one finding from that PR's review that was left open as out-of-scope.

## The bug

`refuel --enrich` and `generate_flight_plan` each minted a throwaway `uuid4()` for the protection artifact, so `protection-blocks.json` landed in a `.maverick/runs/<random>/` that held nothing else and was named after nothing.

In refuel's case it was worse: `_record_run` had *already* minted a different random id for `metadata.json`, so a single run produced two unrelated run directories. Either way the end-of-run warning told the user to read a file they could not locate.

## The fix

- **`refuel_speckit`** — mint one `run_id` at the top of `_run` and pass it to both `_record_run` and `_run_enrichment`. The artifact now lands beside the run's own `metadata.json`.
- **`generate_flight_plan`** — this workflow has no run-metadata concept, so there is no real id to reuse. Derive a stable `plan-<name>` instead, matching `land`'s existing fixed `"land"` fallback. `name` already names a directory under `output_dir`, so it is filesystem-safe.

I deliberately did *not* give `generate_flight_plan` a real `RunMetadata` record, which was the other obvious option. `find_latest_run(plan_name)` returns the newest run matching a name, and refuel's "Next: `maverick fly --epic ...`" hint reads it — a plan-generate run written after a refuel would shadow the refuel run and silently suppress that hint. Writing a directory with no `metadata.json` sidesteps it entirely: `read_metadata` returns `None`, so both `find_latest_run` and `find_run_for_epic` skip it. There's a test asserting exactly that.

Also: every warning that mentions the artifact now names the full path instead of a bare filename — fly (via a newly bound `fly_run_id`), spec-chain, reconcile, land, refuel-enrich and plan-generate.

## Testing

Both regression tests were verified to fail against the previous behavior before being committed:
- refuel: `assert 2 == 1` — two run directories where one is expected
- plan-generate: nothing written at the derived path

`make ci` green: 4949 passed (up 4 from #184's 4945), 1 skipped, 1 xfailed, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AirVWxunrmZWx2x4z46CH
