### PR TITLE
docs: correct the Python floor to 3.12+ in README and the constitution

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,23 @@
 <!--
 Sync Impact Report
 ==================
+Version change: 2.0.0 to 2.0.1 (PATCH)
+
+Bump rationale: factual correction to the Technology Stack table only -- the
+language floor is Python 3.12+, not 3.11+. No principle, guardrail, or appendix
+changed, so PATCH ("clarifications, wording improvements") applies.
+
+Corrected drift:
+  - Technology Stack: Python 3.11+ -> Python 3.12+. airframe-agents >= 0.9.2
+    requires Python >= 3.12, so 056-context-file-protection raised
+    pyproject.toml's requires-python and the CI matrix (3.12 / 3.13) to match.
+    README.md and CLAUDE.md carried the same stale floor and were corrected in
+    the same change.
+
+Source: post-merge sweep after 056-context-file-protection (PRs #184, #185).
+
+--- Previous amendment (2.0.0) -------------------------------------------------
+
 Version change: 1.11.0 to 2.0.0 (MAJOR)
 
 Bump rationale: Principle II is redefined (its TUI display-only and streaming-first
@@ -450,7 +467,7 @@ These technology choices are non-negotiable constraints for all Maverick develop
 
 | Category | Technology | Notes |
 |----------|------------|-------|
-| Language | Python 3.11+ | Use `from __future__ import annotations` |
+| Language | Python 3.12+ | Use `from __future__ import annotations` |
 | Package manager | uv | Reproducible via `uv.lock` |
 | Build | Make | AI-friendly minimal-noise targets |
 | Agent runtime | airframe (`airframe.AgentRuntime`) | `maverick.runtime.agent_factory` |
@@ -606,7 +623,7 @@ MUST comply with these principles.
   Appendix F). Adding a model call to the deterministic path requires explicit
   justification in the PR description.
 
-**Version**: 2.0.0 | **Ratified**: 2025-12-12 | **Last Amended**: 2026-07-27
+**Version**: 2.0.1 | **Ratified**: 2025-12-12 | **Last Amended**: 2026-08-11
 
 ## Appendix B: Canonical Third-Party Libraries
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ correction tasks all live in the same dependency graph.
 
 ### Prerequisites
 
-- Python 3.11+
+- Python 3.12+
 - [uv](https://docs.astral.sh/uv/) — Fast Python package manager
 - [GitHub CLI](https://cli.github.com/) (`gh`)
 - [Jujutsu](https://martinvonz.github.io/jj/) (`jj`)
@@ -376,7 +376,7 @@ doing work; the `StructuredOutput` tool is for reporting results.
 
 | Category | Technology |
 |----------|-----------|
-| Language | Python 3.11+ |
+| Language | Python 3.12+ |
 | Package Manager | uv |
 | Agent Runtime | [airframe](https://github.com/get2knowio/airframe) — one `AgentRuntime` per role, vendor SDKs behind a uniform protocol |
 | Workflow Engine | [Apache Burr](https://github.com/apache/burr) — state machines of `@action`-decorated async functions |


### PR DESCRIPTION
Post-merge sweep after #184 / #185.

#184 raised `pyproject.toml`'s `requires-python` to `>=3.12` (forced by `airframe-agents>=0.9.2`) and moved the CI matrix to 3.12/3.13. Its review caught the stale `Python 3.11+` in CLAUDE.md, but two more were left behind:

- `README.md` — the Prerequisites list and the tech-stack table
- `.specify/memory/constitution.md` — the Technology Stack table

Both are ground truth a contributor (or an agent) reads and acts on, so a stale floor points someone at a checkout that won't install.

Constitution bumped 2.0.0 → 2.0.1 per its own amendment protocol — PATCH covers "clarifications, wording improvements", and no principle, guardrail, or appendix changed. The Sync Impact Report records the correction and retains the 2.0.0 report beneath it.

Docs only; no code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AirVWxunrmZWx2x4z46CH