### PR TITLE
fix(isolation): toolchain verification placement, registry symmetry, typed seams

### DIFF
--- a/specs/057-isolated-bead-workspaces/research.md
+++ b/specs/057-isolated-bead-workspaces/research.md
@@ -218,7 +218,8 @@ spec's own criterion — does the check need state absent from committed history
 
 | fly check | Placement | Where it runs | Why |
 | --- | --- | --- | --- |
-| `ac_check` (file scope, diff overlap, grep commands) | artifact-level | workspace | Reads produced files and the working-copy diff. Needs no toolchain. |
+| `ac_check` (file scope, diff overlap, `rg`/`grep` commands) | artifact-level | workspace | Reads produced files and the working-copy diff. Needs no toolchain. |
+| `ac_check`'s `cargo`/`make` commands | environment-level | checkout, after fold-back | Shell out to an installed toolchain. Split out of the workspace-side check after the original revision of this table asserted the whole of `ac_check` was toolchain-free — `.venv`/`target` are gitignored, so running them in a workspace fails for reasons unrelated to the bead's code, burning a fix round and abandoning working work. Run by the isolated `gate`. |
 | `spec_check` | artifact-level | workspace | Same. |
 | `gate` (`format`, `lint`, `test` via `run_independent_gate`) | environment-level | checkout, after fold-back | Needs `.venv`/`uv` and the installed toolchain, which are gitignored and do not travel into a workspace. |
 | `review` (agent) | n/a — agent step | workspace | FR-032: every agent step is isolated. |

--- a/src/maverick/workflows/fly_beads/_isolation.py
+++ b/src/maverick/workflows/fly_beads/_isolation.py
@@ -57,8 +57,12 @@ from maverick.workspace.cwd_scope import chdir_scope
 
 if TYPE_CHECKING:
     import asyncio
+    from collections.abc import Callable
+    from datetime import datetime
 
     from maverick.events import ProgressEvent
+    from maverick.jj.client import JjClient
+    from maverick.protection import ProtectionPolicy
     from maverick.squadron.fly import FlySquadron
 
 __all__ = [
@@ -131,7 +135,9 @@ def _unit_for(state: State) -> UnitOfWork:
     return UnitOfWork(key=bead_id, label=bead_id)
 
 
-def _reconstruct_lease(state: State, checkout: CheckoutPath, now: Any) -> IsolationLease:
+def _reconstruct_lease(
+    state: State, checkout: CheckoutPath, now: Callable[[], datetime]
+) -> IsolationLease:
     """Rebuild the `IsolationLease` a `fold_back`/`undo_fold_back` call
     needs from state alone — cheap (a plain dataclass), and the only way
     to bridge Burr's per-action calls back to the primitive's lease shape
@@ -167,7 +173,7 @@ async def provision_workspace(
     session: IsolationSession,
     policy: IsolationPolicy,
     checkout: CheckoutPath,
-    jj_client: Any,
+    jj_client: JjClient,
     squadron: FlySquadron,
     events: asyncio.Queue[ProgressEvent | None],
 ) -> tuple[dict[str, Any], State]:
@@ -225,9 +231,9 @@ async def fold_back(
     *,
     session: IsolationSession,
     checkout: CheckoutPath,
-    now: Any,
+    now: Callable[[], datetime],
     events: asyncio.Queue[ProgressEvent | None],
-    protection_policy: Any = None,
+    protection_policy: ProtectionPolicy | None = None,
 ) -> tuple[dict[str, Any], State]:
     """Fold the bead's workspace delta into the checkout (contract C4).
 
@@ -320,7 +326,7 @@ async def undo_fold_back(
     *,
     session: IsolationSession,
     checkout: CheckoutPath,
-    now: Any,
+    now: Callable[[], datetime],
     events: asyncio.Queue[ProgressEvent | None],
 ) -> tuple[dict[str, Any], State]:
     """Undo a rejected fold-back after `gate` fails (contract C5).
@@ -455,7 +461,7 @@ async def teardown_workspace(
     session: IsolationSession,
     checkout: CheckoutPath,
     policy: IsolationPolicy,
-    jj_client: Any,
+    jj_client: JjClient,
     squadron: FlySquadron,
 ) -> tuple[dict[str, Any], State]:
     """Tear down (or retain) this bead's workspace — the universal

--- a/src/maverick/workflows/fly_beads/_isolation.py
+++ b/src/maverick/workflows/fly_beads/_isolation.py
@@ -10,9 +10,13 @@ Burr's actions are independently-invoked async functions with no shared
 lexical scope spanning a bead's provision -> fold-back -> commit sequence,
 so this module drives the primitive's lower-level lifecycle/foldback calls
 directly (`lifecycle.provision`/`teardown`/`retain`,
-`register_live_workspace`/`unregister_live_workspace`) rather than
+`session.register_unit`/`release_unit`) rather than
 `IsolationSession.lease()`'s `async with`-scoped convenience wrapper, which
-assumes a single Python scope. `session.fold_back()`/`session.undo()` still
+assumes a single Python scope. Registration goes through the *session*
+rather than the free `register_live_workspace`/`unregister_live_workspace`
+pair precisely because there is no `finally` here to guarantee the second
+call ever runs: the session's `__aexit__` is the backstop that cleans up a
+unit whose run halted mid-bead. `session.fold_back()`/`session.undo()` still
 handle the fold-back/undo mechanics themselves — each just needs a
 freshly-reconstructed `IsolationLease` per call (cheap, since it's a plain
 dataclass), rebuilt from the `workspace_path`/`current_bead_id` state slots
@@ -47,8 +51,6 @@ from maverick.workspace import (
     IsolationPolicy,
     IsolationSession,
     UnitOfWork,
-    register_live_workspace,
-    unregister_live_workspace,
 )
 from maverick.workspace import lifecycle as workspace_lifecycle
 from maverick.workspace.cwd_scope import chdir_scope
@@ -203,7 +205,11 @@ async def provision_workspace(
         )
         return {"provisioned": False, "error": str(exc)}, state.update(bead_aborted=True)
 
-    register_live_workspace(workspace_path)
+    # Session-scoped, not the free `register_live_workspace`: this action
+    # and `teardown_workspace` are independently-invoked Burr actions with
+    # no `finally` bridging them, so if the run halts in between, the
+    # session's own `__aexit__` is what unregisters and tears this down.
+    session.register_unit(unit, workspace_path)
     await squadron.retarget_protection_for_isolation(workspace_path)
     return {"workspace_path": str(workspace_path)}, state.update(
         workspace_path=str(workspace_path)
@@ -446,6 +452,7 @@ async def gate_fix(
 async def teardown_workspace(
     state: State,
     *,
+    session: IsolationSession,
     checkout: CheckoutPath,
     policy: IsolationPolicy,
     jj_client: Any,
@@ -476,7 +483,7 @@ async def teardown_workspace(
         return {"skipped": True}, state
 
     workspace_path = Path(state["workspace_path"])
-    unregister_live_workspace(workspace_path)
+    session.release_unit(workspace_path)
     await squadron.retarget_protection_for_isolation(None)
 
     unit = _unit_for(state)

--- a/src/maverick/workflows/fly_beads/_plan_parsing.py
+++ b/src/maverick/workflows/fly_beads/_plan_parsing.py
@@ -83,6 +83,29 @@ def _parse_file_scope(
     return create, modify, protect
 
 
+#: Verification commands runnable against produced files alone — they read
+#: the working copy and nothing else, so they are *artifact-level* and run
+#: wherever the artifacts are (a bead's isolated workspace, under 057).
+ARTIFACT_LEVEL_VERIFICATION = ("rg", "grep")
+
+#: Verification commands that shell out to an installed toolchain. These are
+#: *environment-level*: `.venv/`, `target/`, `node_modules/` are gitignored,
+#: so they never travel into a `jj workspace add` workspace and these
+#: commands can only run in the checkout (research.md R6).
+ENVIRONMENT_LEVEL_VERIFICATION = ("cargo", "make")
+
+#: Every command form fly knows how to run. Anything else in a bead's
+#: ``## Verification`` section is prose or an unsupported tool, and is
+#: skipped rather than executed.
+SUPPORTED_VERIFICATION = ARTIFACT_LEVEL_VERIFICATION + ENVIRONMENT_LEVEL_VERIFICATION
+
+
+def verification_tool(command: str) -> str:
+    """Return *command*'s leading tool name, or ``""`` for a blank command."""
+    parts = command.split()
+    return parts[0] if parts else ""
+
+
 def _parse_verification_commands(
     verification_text: str,
 ) -> list[str]:

--- a/src/maverick/workflows/fly_beads/actions.py
+++ b/src/maverick/workflows/fly_beads/actions.py
@@ -1801,6 +1801,7 @@ async def abandon_bead(
 async def record_outcome(
     state: State,
     *,
+    isolation_session: Any = None,
     isolation_policy: Any = None,
     checkout: CheckoutPath | None = None,
     jj_client: Any = None,
@@ -1820,6 +1821,7 @@ async def record_outcome(
         assert checkout is not None, "record_outcome(isolated=True) requires checkout"
         _, state = await teardown_workspace(
             state,
+            session=isolation_session,
             checkout=checkout,
             policy=isolation_policy,
             jj_client=jj_client,

--- a/src/maverick/workflows/fly_beads/actions.py
+++ b/src/maverick/workflows/fly_beads/actions.py
@@ -32,6 +32,12 @@ from maverick.events import (
 )
 from maverick.payloads import dump_supervisor_payload
 from maverick.squadron.tiers import DEFAULT_TIER as _DEFAULT_TIER
+from maverick.workflows.fly_beads._plan_parsing import (
+    ARTIFACT_LEVEL_VERIFICATION,
+    ENVIRONMENT_LEVEL_VERIFICATION,
+    SUPPORTED_VERIFICATION,
+    verification_tool,
+)
 
 if TYPE_CHECKING:
     from maverick.config import MaverickConfig
@@ -480,6 +486,7 @@ async def _run_fix(
 
 @action(
     reads=[
+        "current_bead",
         "current_bead_id",
         "implementer_escalation_level",
         "pending_assumptions",
@@ -543,7 +550,16 @@ async def _gate_impl_isolated(
     validation_commands: dict[str, tuple[str, ...]] | None = None,
 ) -> tuple[dict[str, Any], State]:
     """Isolated mode's single-shot gate check — see ``gate``'s docstring
-    for why retries live in the graph instead of here."""
+    for why retries live in the graph instead of here.
+
+    Also runs the bead's *environment-level* verification commands, which
+    `ac_check` deliberately skipped in the workspace because the toolchain
+    they need isn't there (research.md R6). This is the first point in an
+    isolated bead's pipeline where both the delta and the toolchain exist
+    in the same place. Their failures join `gate_failure_summary`, so they
+    route through the existing `undo_fold_back -> gate_fix -> fold_back`
+    loop and need no graph edges of their own.
+    """
     from maverick.library.actions.validation import run_independent_gate
 
     result = await run_independent_gate(
@@ -551,18 +567,56 @@ async def _gate_impl_isolated(
         cwd=cwd,
         validation_commands=validation_commands,
     )
-    if result.get("passed"):
-        # The checkout's folded-back delta just passed the gate — reset
-        # unverified_in_checkout here (not only in undo_fold_back's
-        # success path), so it doesn't stay stuck True through the rest
-        # of this bead and into the next one on the common happy path
-        # (fold_back -> gate passes first try, no undo round).
-        return {"passed": True}, state.update(
-            gate_passed=True, gate_failure_summary="", unverified_in_checkout=False
+    if not result.get("passed"):
+        summary = result.get("summary") or "gate failed"
+        return {"passed": False}, state.update(gate_passed=False, gate_failure_summary=summary)
+
+    verification_summary = await _run_environment_verification(state, cwd=cwd)
+    if verification_summary:
+        return {"passed": False}, state.update(
+            gate_passed=False, gate_failure_summary=verification_summary
         )
 
-    summary = result.get("summary") or "gate failed"
-    return {"passed": False}, state.update(gate_passed=False, gate_failure_summary=summary)
+    # The checkout's folded-back delta just passed the gate — reset
+    # unverified_in_checkout here (not only in undo_fold_back's
+    # success path), so it doesn't stay stuck True through the rest
+    # of this bead and into the next one on the common happy path
+    # (fold_back -> gate passes first try, no undo round).
+    return {"passed": True}, state.update(
+        gate_passed=True, gate_failure_summary="", unverified_in_checkout=False
+    )
+
+
+async def _run_environment_verification(state: State, *, cwd: str) -> str:
+    """Run this bead's toolchain-dependent verification commands in *cwd*.
+
+    Returns a joined failure summary, or ``""`` when everything passed (or
+    the bead declared no such commands, which is the common case).
+    """
+    from maverick.runners.command import CommandRunner
+    from maverick.workflows.fly_beads.steps import (
+        _parse_verification_commands,
+        _parse_work_unit_sections,
+    )
+
+    bead = state["current_bead"] or {}
+    sections = _parse_work_unit_sections(bead.get("description", ""))
+    verification_text = sections.get("verification", "")
+    if not verification_text:
+        return ""
+
+    runner = CommandRunner(cwd=Path(cwd))
+    reasons: list[str] = []
+    for cmd_str in _parse_verification_commands(verification_text):
+        if verification_tool(cmd_str) not in ENVIRONMENT_LEVEL_VERIFICATION:
+            continue
+        try:
+            result = await runner.run(["sh", "-c", cmd_str])
+            if result.returncode != 0:
+                reasons.append(f"Verification failed: `{cmd_str}`")
+        except Exception as exc:  # noqa: BLE001 — mirrors _ac_check_impl
+            reasons.append(f"Verification error: `{cmd_str}`: {exc}")
+    return "; ".join(reasons)
 
 
 async def _gate_impl(
@@ -669,13 +723,26 @@ async def ac_check(
     workspace, not the checkout (research.md R6) — and any fix round
     stays there too (FR-032). Delegation only, see
     ``_isolation.effective_check_cwd``/``agent_step_scope``.
+
+    R6 places this check in the workspace on the grounds that it "needs no
+    toolchain". That is only true of its `rg`/`grep` commands: `cargo` and
+    `make` shell out to an installed toolchain, and `.venv`/`target` are
+    gitignored, so they never travel into a workspace. Running them there
+    fails for reasons that have nothing to do with the bead's code — which
+    would burn a fix round on an agent trying to repair working code, then
+    abandon it. So under isolation this runs the artifact-level subset
+    only, and `gate` picks the environment-level commands back up in the
+    checkout after fold-back.
     """
     from maverick.workflows.fly_beads._isolation import agent_step_scope, effective_check_cwd
 
     effective_cwd = effective_check_cwd(state, cwd)
+    tools = ARTIFACT_LEVEL_VERIFICATION if state.get("isolated") else SUPPORTED_VERIFICATION
     async with agent_step_scope(state):
         return await _with_protection_drain(
-            await _ac_check_impl(state, squadron=squadron, events=events, cwd=effective_cwd),
+            await _ac_check_impl(
+                state, squadron=squadron, events=events, cwd=effective_cwd, tools=tools
+            ),
             squadron=squadron,
             events=events,
         )
@@ -687,6 +754,7 @@ async def _ac_check_impl(
     squadron: FlySquadron,
     events: asyncio.Queue[ProgressEvent | None],
     cwd: str,
+    tools: tuple[str, ...] = SUPPORTED_VERIFICATION,
 ) -> tuple[dict[str, Any], State]:
     from maverick.runners.command import CommandRunner
     from maverick.workflows.fly_beads.steps import (
@@ -708,8 +776,7 @@ async def _ac_check_impl(
         runner = CommandRunner(cwd=Path(cwd))
         reasons: list[str] = []
         for cmd_str in _parse_verification_commands(verification_text):
-            first_word = cmd_str.split()[0] if cmd_str.split() else ""
-            if first_word not in ("rg", "grep", "cargo", "make"):
+            if verification_tool(cmd_str) not in tools:
                 continue
             try:
                 result = await runner.run(["sh", "-c", cmd_str])

--- a/src/maverick/workflows/fly_beads/actions.py
+++ b/src/maverick/workflows/fly_beads/actions.py
@@ -41,8 +41,9 @@ from maverick.workflows.fly_beads._plan_parsing import (
 
 if TYPE_CHECKING:
     from maverick.config import MaverickConfig
+    from maverick.jj.client import JjClient
     from maverick.squadron.fly import FlySquadron
-    from maverick.workspace import CheckoutPath
+    from maverick.workspace import CheckoutPath, IsolationPolicy, IsolationSession
 
 
 __all__ = [
@@ -1801,11 +1802,11 @@ async def abandon_bead(
 async def record_outcome(
     state: State,
     *,
-    isolation_session: Any = None,
-    isolation_policy: Any = None,
+    isolation_session: IsolationSession | None = None,
+    isolation_policy: IsolationPolicy | None = None,
     checkout: CheckoutPath | None = None,
-    jj_client: Any = None,
-    squadron: Any = None,
+    jj_client: JjClient | None = None,
+    squadron: FlySquadron | None = None,
 ) -> tuple[dict[str, Any], State]:
     """Append a per-bead summary and advance counters before the loop cycles.
 
@@ -1818,7 +1819,16 @@ async def record_outcome(
     if state.get("isolated"):
         from maverick.workflows.fly_beads._isolation import teardown_workspace
 
+        # Isolated mode binds all five in `burr_graph.py`; the defaults
+        # exist only so the non-isolated binding can omit them entirely.
+        # Narrowing here is what lets mypy check the call below at all —
+        # this delegation seam is precisely where a wrong binding would
+        # otherwise go unnoticed until runtime.
+        assert isolation_session is not None, "record_outcome(isolated=True) requires session"
+        assert isolation_policy is not None, "record_outcome(isolated=True) requires policy"
         assert checkout is not None, "record_outcome(isolated=True) requires checkout"
+        assert jj_client is not None, "record_outcome(isolated=True) requires jj_client"
+        assert squadron is not None, "record_outcome(isolated=True) requires squadron"
         _, state = await teardown_workspace(
             state,
             session=isolation_session,

--- a/src/maverick/workflows/fly_beads/burr_graph.py
+++ b/src/maverick/workflows/fly_beads/burr_graph.py
@@ -355,6 +355,7 @@ def build_fly_application(
                 fold_back_protection_policy = None
 
         actions["record_outcome"] = fly_actions.record_outcome.bind(
+            isolation_session=isolation_session,
             isolation_policy=isolation_policy,
             checkout=checkout,
             jj_client=jj_client,

--- a/src/maverick/workspace/session.py
+++ b/src/maverick/workspace/session.py
@@ -132,6 +132,13 @@ class IsolationSession:
         self._run_id = run_id
         self._now = now
         self._home = home
+        #: Workspaces this session registered that have not been released
+        #: yet, keyed by resolved root. `lease()` keeps this empty by
+        #: construction; a consumer driving `provision`/`teardown` across
+        #: separate call sites (Burr actions have no shared lexical scope
+        #: spanning a unit) can leave entries here if the run halts
+        #: mid-unit, and `__aexit__` is where those get cleaned up.
+        self._live_units: dict[Path, UnitOfWork] = {}
 
     async def __aenter__(self) -> IsolationSession:
         """Acquire this checkout's run-scoped exclusivity (contract C1) and
@@ -178,7 +185,68 @@ class IsolationSession:
         return self
 
     async def __aexit__(self, *exc: object) -> None:
-        await journal.release_lock(self._checkout)
+        """Release this checkout's lock, after cleaning up any unit still
+        holding a workspace.
+
+        `lease()` unregisters and tears down in its own `finally`, so it
+        never leaves anything here. A consumer that cannot use it —
+        fly's Burr actions register in `provision_workspace` and release in
+        `teardown_workspace`, two independently-invoked functions with no
+        `finally` bridging them — leaves both the registration and the
+        workspace behind whenever the run halts between the two. This is
+        the one place with a real `finally` spanning the whole run, so the
+        symmetry is restored here rather than left to the next run's sweep
+        (which only happens if there *is* a next isolated run).
+        """
+        try:
+            await self._release_live_units(failed=any(e is not None for e in exc))
+        finally:
+            await journal.release_lock(self._checkout)
+
+    async def _release_live_units(self, *, failed: bool) -> None:
+        """Unregister and tear down (or retain) every still-live unit."""
+        for path, unit in list(self._live_units.items()):
+            self.release_unit(path)
+            try:
+                if failed and self._policy.retain_on_failure:
+                    await lifecycle.retain(checkout=self._checkout, policy=self._policy, unit=unit)
+                else:
+                    await lifecycle.teardown(
+                        checkout=self._checkout,
+                        policy=self._policy,
+                        unit=unit,
+                        jj_client=self._jj_client,
+                    )
+            except Exception as exc:  # noqa: BLE001 — cleanup must not mask the real error
+                logger.warning(
+                    "isolation_session_cleanup_failed",
+                    workflow=self._policy.workflow,
+                    unit_key=unit.key,
+                    workspace_path=str(path),
+                    error=str(exc),
+                )
+
+    def register_unit(self, unit: UnitOfWork, path: Path) -> Path:
+        """Register *path* as live for *unit*, session-scoped.
+
+        Prefer this over the free :func:`register_live_workspace` — it adds
+        the same process-global guard entry, and additionally makes
+        `__aexit__` responsible for the unit if the caller never releases
+        it.
+
+        Returns:
+            The resolved path, for the caller to pass to
+            :meth:`release_unit`.
+        """
+        resolved = register_live_workspace(path)
+        self._live_units[resolved] = unit
+        return resolved
+
+    def release_unit(self, path: Path) -> None:
+        """Undo :meth:`register_unit`. Idempotent."""
+        resolved = path.resolve()
+        unregister_live_workspace(resolved)
+        self._live_units.pop(resolved, None)
 
     @asynccontextmanager
     async def lease(self, unit: UnitOfWork) -> AsyncIterator[IsolationLease]:
@@ -204,7 +272,7 @@ class IsolationSession:
             checkout=self._checkout,
             created_at=self._now(),
         )
-        resolved_workspace_path = register_live_workspace(workspace_path)
+        resolved_workspace_path = self.register_unit(unit, workspace_path)
         failed = False
         try:
             yield lease
@@ -212,7 +280,7 @@ class IsolationSession:
             failed = True
             raise
         finally:
-            unregister_live_workspace(resolved_workspace_path)
+            self.release_unit(resolved_workspace_path)
             if failed and self._policy.retain_on_failure:
                 await lifecycle.retain(checkout=checkout_path, policy=self._policy, unit=unit)
             else:

--- a/tests/integration/fly/test_isolated_serialization.py
+++ b/tests/integration/fly/test_isolated_serialization.py
@@ -55,6 +55,7 @@ from burr.core import State, action
 
 from maverick.workflows.fly_beads import _isolation as fly_isolation_module
 from maverick.workflows.fly_beads import actions as fly_actions_module
+from maverick.workspace import IsolationSession
 
 if TYPE_CHECKING:
     from maverick.events import ProgressEvent
@@ -98,14 +99,18 @@ _REAL_COMMIT = fly_actions_module.commit
 
 @dataclass
 class LiveWorkspaceTracker:
-    """Instrumented stand-in for the ``register_live_workspace``/
-    ``unregister_live_workspace`` free functions (contract C6's seam).
+    """Instrumented wrapper around ``IsolationSession.register_unit``/
+    ``release_unit`` (contract C6's seam).
 
     Tracks the running set of live workspace roots and asserts — at every
     single registration — that no *different* workspace root is already
     live (the direct proxy for "at most one workspace is live at a time").
     Also records a ``max_concurrent`` high-water mark for a final sanity
     assertion.
+
+    Wraps rather than replaces: the real registration must still happen, or
+    the boundary guard is inert for the run and the session has nothing to
+    clean up at exit.
     """
 
     live: set[Path] = field(default_factory=set)
@@ -245,8 +250,19 @@ async def test_beads_remain_strictly_serial_under_isolated_mode(
     stub_fly_runtime_factory(monkeypatch)
 
     tracker = LiveWorkspaceTracker()
-    monkeypatch.setattr(fly_isolation_module, "register_live_workspace", tracker.register)
-    monkeypatch.setattr(fly_isolation_module, "unregister_live_workspace", tracker.unregister)
+    real_register = IsolationSession.register_unit
+    real_release = IsolationSession.release_unit
+
+    def _tracked_register(self: IsolationSession, unit: object, path: Path) -> Path:
+        tracker.register(path)
+        return real_register(self, unit, path)  # type: ignore[arg-type]
+
+    def _tracked_release(self: IsolationSession, path: Path) -> None:
+        tracker.unregister(path)
+        real_release(self, path)
+
+    monkeypatch.setattr(IsolationSession, "register_unit", _tracked_register)
+    monkeypatch.setattr(IsolationSession, "release_unit", _tracked_release)
 
     event_log: list[tuple[str, str]] = []
     tracking_provision, tracking_fold_back, tracking_commit = _make_tracking_actions(event_log)

--- a/tests/integration/workspace/test_session_cleanup.py
+++ b/tests/integration/workspace/test_session_cleanup.py
@@ -1,0 +1,167 @@
+"""A run that halts mid-unit must not leave the guard armed or the
+workspace behind.
+
+`IsolationSession.lease()` registers and releases in one `finally`, so it
+is symmetric by construction. Fly cannot use it: its Burr actions are
+independently-invoked functions, and a bead's span runs
+`provision_workspace -> ... -> record_outcome` with no shared lexical
+scope, so registration and release sit in two different call sites with
+nothing bridging them. Any action raising in between means `record_outcome`
+never runs.
+
+The session's `__aexit__` is the one place with a real `finally` spanning
+the whole run, so that is where the symmetry is restored (finding 1 of the
+057 review follow-ups).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from maverick.exceptions import IsolationBoundaryError
+from maverick.jj.client import JjClient
+from maverick.workspace import IsolationPolicy, IsolationSession, UnitOfWork, assert_checkout
+from maverick.workspace import lifecycle as workspace_lifecycle
+
+
+def _now() -> datetime:
+    return datetime(2026, 8, 21, 12, 0, 0, tzinfo=UTC)
+
+
+def _session(checkout: Path, home: Path, *, retain_on_failure: bool = False) -> IsolationSession:
+    return IsolationSession(
+        checkout=checkout,
+        policy=IsolationPolicy(
+            workflow="fly", root=home, reuse=False, retain_on_failure=retain_on_failure
+        ),
+        jj_client=JjClient(cwd=checkout),
+        run_id="run-1",
+        now=_now,
+        home=home,
+    )
+
+
+async def _provision_without_releasing(
+    session: IsolationSession, checkout: Path, key: str
+) -> Path:
+    """Exactly what fly's `provision_workspace` action does, with the
+    matching `teardown_workspace` never reached."""
+    unit = UnitOfWork(key=key, label=key)
+    path = await workspace_lifecycle.provision(
+        checkout=checkout,
+        policy=session._policy,
+        unit=unit,
+        jj_client=session._jj_client,
+    )
+    session.register_unit(unit, path)
+    return path
+
+
+class TestHaltedRunCleansUp:
+    @pytest.mark.asyncio
+    async def test_workspace_is_torn_down_when_the_run_halts_mid_unit(
+        self, colocated_repo: JjClient, isolation_home: Path
+    ) -> None:
+        checkout = colocated_repo.cwd
+        session = _session(checkout, isolation_home)
+
+        async with session:
+            path = await _provision_without_releasing(session, checkout, "bd-halted")
+            assert path.exists()
+
+        assert not path.exists()
+
+    @pytest.mark.asyncio
+    async def test_guard_disarms_so_a_stale_root_stops_being_rejected(
+        self, colocated_repo: JjClient, isolation_home: Path
+    ) -> None:
+        checkout = colocated_repo.cwd
+        session = _session(checkout, isolation_home)
+
+        async with session:
+            path = await _provision_without_releasing(session, checkout, "bd-halted")
+            # While live, the guard rejects anything inside it.
+            with pytest.raises(IsolationBoundaryError):
+                assert_checkout(path / "nested")
+
+        # Once the run is over, the entry is gone from the process-global
+        # registry — no stale root outlives the session that made it.
+        assert_checkout(path / "nested")
+
+    @pytest.mark.asyncio
+    async def test_an_exception_propagates_and_cleanup_still_runs(
+        self, colocated_repo: JjClient, isolation_home: Path
+    ) -> None:
+        """Cleanup must not swallow the failure that caused the halt."""
+        checkout = colocated_repo.cwd
+        session = _session(checkout, isolation_home)
+        path: Path | None = None
+
+        with pytest.raises(RuntimeError, match="bead exploded"):
+            async with session:
+                path = await _provision_without_releasing(session, checkout, "bd-boom")
+                raise RuntimeError("bead exploded")
+
+        assert path is not None
+        assert not path.exists()
+        assert_checkout(path)
+
+    @pytest.mark.asyncio
+    async def test_retain_on_failure_keeps_the_workspace_for_inspection(
+        self, colocated_repo: JjClient, isolation_home: Path
+    ) -> None:
+        """spec-chain's policy — a halted step's workspace is the only copy
+        of its partial output, so cleanup must retain rather than delete."""
+        checkout = colocated_repo.cwd
+        session = _session(checkout, isolation_home, retain_on_failure=True)
+        path: Path | None = None
+
+        with pytest.raises(RuntimeError):
+            async with session:
+                path = await _provision_without_releasing(session, checkout, "bd-retained")
+                raise RuntimeError("step failed")
+
+        assert path is not None
+        assert path.exists()
+        # Still disarmed even though the directory survives.
+        assert_checkout(path)
+
+    @pytest.mark.asyncio
+    async def test_a_released_unit_is_not_cleaned_up_twice(
+        self, colocated_repo: JjClient, isolation_home: Path
+    ) -> None:
+        """The happy path already tore down in `teardown_workspace`;
+        `__aexit__` must find nothing left to do."""
+        checkout = colocated_repo.cwd
+        session = _session(checkout, isolation_home)
+
+        async with session:
+            path = await _provision_without_releasing(session, checkout, "bd-normal")
+            session.release_unit(path)
+            await workspace_lifecycle.teardown(
+                checkout=checkout,
+                policy=session._policy,
+                unit=UnitOfWork(key="bd-normal", label="bd-normal"),
+                jj_client=session._jj_client,
+            )
+
+        assert not path.exists()
+
+    @pytest.mark.asyncio
+    async def test_lease_leaves_nothing_for_aexit_to_clean(
+        self, colocated_repo: JjClient, isolation_home: Path
+    ) -> None:
+        """The symmetric path stays symmetric — no double teardown."""
+        checkout = colocated_repo.cwd
+        session = _session(checkout, isolation_home)
+
+        async with session:
+            async with session.lease(UnitOfWork(key="bd-leased", label="leased")) as lease:
+                (lease.workspace_path / "f.txt").write_text("x\n", encoding="utf-8")
+                await session.fold_back(lease)
+            assert session._live_units == {}
+
+        assert not lease.workspace_path.exists()

--- a/tests/unit/workflows/fly_beads/test_verification_placement.py
+++ b/tests/unit/workflows/fly_beads/test_verification_placement.py
@@ -1,0 +1,225 @@
+"""Where a bead's ``## Verification`` commands run, and why it differs
+under isolation.
+
+research.md R6 places `ac_check` in the bead's workspace on the grounds
+that it "needs no toolchain". That holds for its `rg`/`grep` commands but
+not for `cargo`/`make`: `.venv/`, `target/` and friends are gitignored, so
+they never travel into a `jj workspace add` workspace. Running them there
+fails for reasons that have nothing to do with the bead's code — which
+costs a fix round on an agent asked to repair working code, then abandons
+the bead.
+
+So under isolation the workspace-side check runs the artifact-level subset
+only, and `gate` picks the environment-level commands back up in the
+checkout after fold-back, where the toolchain actually exists.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from burr.core import State
+
+from maverick.workflows.fly_beads._plan_parsing import (
+    ARTIFACT_LEVEL_VERIFICATION,
+    ENVIRONMENT_LEVEL_VERIFICATION,
+    SUPPORTED_VERIFICATION,
+    verification_tool,
+)
+from maverick.workflows.fly_beads.actions import (
+    _ac_check_impl,
+    _gate_impl_isolated,
+    _run_environment_verification,
+)
+
+_DESCRIPTION = """## Verification
+
+- rg "fn handle" src/
+- cargo test --lib
+- make lint
+- grep -q TODO src/lib.rs
+"""
+
+
+def _state(**overrides: Any) -> State:
+    base: dict[str, Any] = {
+        "current_bead": {"id": "bd-1", "description": _DESCRIPTION},
+        "current_bead_id": "bd-1",
+        "implementer_escalation_level": 0,
+        "pending_assumptions": (),
+        "isolated": False,
+    }
+    base.update(overrides)
+    return State(base)
+
+
+class _RecordingRunner:
+    """Captures every command a check actually executes."""
+
+    def __init__(self, *, returncode: int = 0) -> None:
+        self.commands: list[str] = []
+        self._returncode = returncode
+
+    def __call__(self, *_args: Any, **_kwargs: Any) -> _RecordingRunner:
+        return self
+
+    async def run(self, argv: list[str]) -> Any:
+        self.commands.append(argv[-1])
+
+        class _Result:
+            returncode = self._returncode
+
+        return _Result()
+
+
+class TestCommandClassification:
+    def test_the_two_tiers_partition_the_supported_set(self) -> None:
+        assert set(ARTIFACT_LEVEL_VERIFICATION).isdisjoint(ENVIRONMENT_LEVEL_VERIFICATION)
+        assert set(SUPPORTED_VERIFICATION) == set(ARTIFACT_LEVEL_VERIFICATION) | set(
+            ENVIRONMENT_LEVEL_VERIFICATION
+        )
+
+    def test_toolchain_commands_are_environment_level(self) -> None:
+        assert verification_tool("cargo test --lib") in ENVIRONMENT_LEVEL_VERIFICATION
+        assert verification_tool("make lint") in ENVIRONMENT_LEVEL_VERIFICATION
+
+    def test_reading_commands_are_artifact_level(self) -> None:
+        assert verification_tool('rg "fn handle" src/') in ARTIFACT_LEVEL_VERIFICATION
+        assert verification_tool("grep -q TODO src/lib.rs") in ARTIFACT_LEVEL_VERIFICATION
+
+    def test_blank_command_yields_no_tool(self) -> None:
+        assert verification_tool("   ") == ""
+
+
+class TestIsolatedAcCheckSkipsTheToolchain:
+    @pytest.mark.asyncio
+    async def test_isolated_runs_only_artifact_level_commands(self) -> None:
+        runner = _RecordingRunner()
+        with patch("maverick.runners.command.CommandRunner", runner):
+            await _ac_check_impl(
+                _state(isolated=True),
+                squadron=AsyncMock(),
+                events=AsyncMock(),
+                cwd="/ws/bd-1",
+                tools=ARTIFACT_LEVEL_VERIFICATION,
+            )
+
+        assert runner.commands == ['rg "fn handle" src/', "grep -q TODO src/lib.rs"]
+
+    @pytest.mark.asyncio
+    async def test_non_isolated_still_runs_every_supported_command(self) -> None:
+        """FR-035: the default path is byte-identical to before 057."""
+        runner = _RecordingRunner()
+        with patch("maverick.runners.command.CommandRunner", runner):
+            await _ac_check_impl(
+                _state(),
+                squadron=AsyncMock(),
+                events=AsyncMock(),
+                cwd="/checkout",
+            )
+
+        assert runner.commands == [
+            'rg "fn handle" src/',
+            "cargo test --lib",
+            "make lint",
+            "grep -q TODO src/lib.rs",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_failing_toolchain_command_cannot_fail_an_isolated_bead(self) -> None:
+        """The regression this split exists to prevent: `make lint` exiting
+        non-zero purely because the workspace has no `.venv` must not mark
+        the bead's AC check failed."""
+        runner = _RecordingRunner(returncode=1)
+        with patch("maverick.runners.command.CommandRunner", runner):
+            result, state = await _ac_check_impl(
+                _state(
+                    isolated=True,
+                    current_bead={"id": "bd-1", "description": "## Verification\n\n- make lint\n"},
+                ),
+                squadron=AsyncMock(),
+                events=AsyncMock(),
+                cwd="/ws/bd-1",
+                tools=ARTIFACT_LEVEL_VERIFICATION,
+            )
+
+        assert runner.commands == []  # never executed in the workspace at all
+        assert result == {"passed": True}
+        assert state["ac_passed"] is True
+
+
+class TestIsolatedGatePicksThemBackUp:
+    @pytest.mark.asyncio
+    async def test_environment_commands_run_in_the_checkout(self) -> None:
+        runner = _RecordingRunner()
+        with patch("maverick.runners.command.CommandRunner", runner):
+            summary = await _run_environment_verification(_state(), cwd="/checkout")
+
+        assert runner.commands == ["cargo test --lib", "make lint"]
+        assert summary == ""
+
+    @pytest.mark.asyncio
+    async def test_failure_joins_the_gate_summary_and_fails_the_gate(self) -> None:
+        runner = _RecordingRunner(returncode=1)
+        with (
+            patch("maverick.runners.command.CommandRunner", runner),
+            patch(
+                "maverick.library.actions.validation.run_independent_gate",
+                AsyncMock(return_value={"passed": True}),
+            ),
+        ):
+            result, state = await _gate_impl_isolated(_state(isolated=True), cwd="/checkout")
+
+        assert result == {"passed": False}
+        assert state["gate_passed"] is False
+        # Routes through the existing undo -> gate_fix -> fold_back loop.
+        assert "cargo test --lib" in state["gate_failure_summary"]
+        assert "make lint" in state["gate_failure_summary"]
+
+    @pytest.mark.asyncio
+    async def test_a_failing_gate_short_circuits_before_verification(self) -> None:
+        """No point shelling out to the toolchain when format/lint/test
+        already failed — and the summary must stay the gate's own."""
+        runner = _RecordingRunner()
+        with (
+            patch("maverick.runners.command.CommandRunner", runner),
+            patch(
+                "maverick.library.actions.validation.run_independent_gate",
+                AsyncMock(return_value={"passed": False, "summary": "lint failed"}),
+            ),
+        ):
+            result, state = await _gate_impl_isolated(_state(isolated=True), cwd="/checkout")
+
+        assert result == {"passed": False}
+        assert state["gate_failure_summary"] == "lint failed"
+        assert runner.commands == []
+
+    @pytest.mark.asyncio
+    async def test_all_green_clears_unverified_in_checkout(self) -> None:
+        runner = _RecordingRunner()
+        with (
+            patch("maverick.runners.command.CommandRunner", runner),
+            patch(
+                "maverick.library.actions.validation.run_independent_gate",
+                AsyncMock(return_value={"passed": True}),
+            ),
+        ):
+            result, state = await _gate_impl_isolated(_state(isolated=True), cwd="/checkout")
+
+        assert result == {"passed": True}
+        assert state["gate_passed"] is True
+        assert state["unverified_in_checkout"] is False
+
+    @pytest.mark.asyncio
+    async def test_a_bead_with_no_verification_section_runs_nothing(self) -> None:
+        runner = _RecordingRunner()
+        with patch("maverick.runners.command.CommandRunner", runner):
+            summary = await _run_environment_verification(
+                _state(current_bead={"id": "bd-1", "description": "no sections here"}),
+                cwd="/checkout",
+            )
+
+        assert summary == ""
+        assert runner.commands == []


### PR DESCRIPTION
The three follow-ups left open from the 057 review, in ascending order of how badly they'd bite.

## 1. `ac_check` ran toolchain commands where the toolchain doesn't exist

`research.md` R6 placed `ac_check` inside the bead's workspace on the stated grounds that it "needs no toolchain". That's true of its `rg`/`grep` commands and false of `cargo`/`make` — the allowlist has always been `("rg", "grep", "cargo", "make")`.

`.venv/`, `target/` and `node_modules/` are gitignored, so they never travel into a `jj workspace add` workspace. The consequence was a **false negative that discarded good work**: `make test` in a workspace resolves to `uv run pytest` with no `.venv`, exits non-zero, and `ac_check` reads that as the bead failing its own acceptance criteria — spending a fix round asking an agent to repair code that was never broken, then abandoning the bead. `cargo` fared better but rebuilt from cold on every bead, since `target/` doesn't travel either.

Split at the parser (`ARTIFACT_LEVEL_VERIFICATION` vs `ENVIRONMENT_LEVEL_VERIFICATION`) and routed to where each can actually run:

- Isolated `ac_check` runs the artifact-level subset in the workspace.
- The isolated `gate` runs the environment-level commands in the checkout after fold-back — the first point in the pipeline where the delta and the toolchain are in the same place.

Their failures join `gate_failure_summary`, so they route through the existing `undo_fold_back → gate_fix → fold_back` loop and need **no graph edges of their own**. A failing gate short-circuits before them, keeping the summary the gate's own.

The non-isolated path is unchanged and asserted so directly (FR-035). R6's table is corrected rather than left asserting the premise this change disproves.

## 2. Registry symmetry across the bead span

`IsolationSession.lease()` registers, yields, and unregisters in a `finally` — symmetric by construction, and what `maverick spec` uses. Fly can't use it: Burr actions are independently-invoked functions, so a bead's `provision_workspace → … → record_outcome` span has no shared lexical scope to wrap. Registration and release sat in two separate actions with nothing bridging them.

Any action raising in between meant the driver deferred the exception, halted the run, and `record_outcome` never executed — leaving a stale entry in the process-global guard registry *and* an un-torn-down workspace plus its jj registration. The orphan was only collected by the next isolated run's start-of-run sweep, which happens only if there *is* a next isolated run.

The session's `__aexit__` is the one place with a real `finally` spanning a whole run, so that's where the symmetry is restored: `register_unit`/`release_unit` track what the session registered, and `__aexit__` unregisters and tears down (or retains, honoring `retain_on_failure` when exiting with an exception) anything still live before releasing the lock in its own `finally`. Cleanup failures warn rather than raise, so they can't mask the error that caused the halt.

`lease()` routes through the same pair, so the symmetric path stays symmetric with no double teardown.

**Verified non-vacuous:** 4 of the 6 new tests fail with the cleanup stubbed out; the 2 that don't are the deliberate controls (already-released unit, and `lease()`'s own symmetry).

## 3. `Any` on the delegation seams

I'd assumed the `Any` annotations were dodging a circular import. They weren't — `protection/policy.py` imports only from `maverick.logging` and `maverick.protection.*`, and both modules already had a `TYPE_CHECKING` block.

These are exactly the seams a wrong binding slips through: `_reconstruct_lease` needed an explicit `# type: ignore[arg-type]` to bridge into the `CheckoutPath`-typed `IsolationLease.checkout`, silencing the compile-time guard in the module most dependent on it. Narrowing `record_outcome`'s optionals is what lets mypy check the `teardown_workspace` call at all — it flagged all four arguments the moment the annotations landed, which is the point. No behavior change.

## Testing

`ruff check` clean · `ruff format --check` clean · `mypy src/` clean (298 files) · **5109 passed, 1 skipped, 1 xfailed**, run against **jj 0.43** — the version CI pins, not the 0.44 in the dev container. See #190 for why that distinction now gets checked explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bv92TT8YaoeRLz6FBAEfkK
